### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete HTML attribute sanitization

### DIFF
--- a/src/main/resources/static/js/taxonomy-graph.js
+++ b/src/main/resources/static/js/taxonomy-graph.js
@@ -9,7 +9,12 @@
 
     function escapeHtml(s) {
         if (!s) return '';
-        return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     function safeLen(arr) {


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Taxonomy/security/code-scanning/4](https://github.com/carstenartur/Taxonomy/security/code-scanning/4)

In general, to fix this kind of issue you must ensure that all characters that can break out of the HTML attribute context are properly escaped. For double-quoted attributes, that means escaping `&`, `<`, `>`, and `"` at a minimum; escaping `'` as well is a good practice and harmless for text nodes.

The best targeted fix here is to strengthen the existing `escapeHtml` function so that it also escapes double quotes and, optionally, single quotes. Since all uses of `escapeHtml` in the snippet are for HTML content (including attribute values), making this function safer will improve all call sites without changing the intended semantics: the only observable change is that any literal `"` (and optionally `'`) in the input will appear as `&quot;` (and `&#39;`) in the DOM, which is correct HTML encoding. We do not need to change how it is called on line 72 or elsewhere, just its implementation.

Concretely, in `src/main/resources/static/js/taxonomy-graph.js`, update the body of `escapeHtml` (around lines 10–13) to add `.replace(/"/g, '&quot;')` and, ideally, `.replace(/'/g, '&#39;')` to the existing chain of replacements. No new imports or helper methods are required; this is pure JavaScript string manipulation. All other code remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
