### PR TITLE
Potential fix for code scanning alert no. 2: Clear text storage of sensitive information

### DIFF
--- a/src/main/resources/static/js/taxonomy.js
+++ b/src/main/resources/static/js/taxonomy.js
@@ -295,8 +295,8 @@
         })
         .then(r => r.json())
         .then(data => {
-            if (data.valid) {
-                sessionStorage.setItem('adminToken', password);
+            if (data.valid && data.token) {
+                sessionStorage.setItem('adminToken', data.token);
                 updateAdminVisibility();
             }
             return data.valid;


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Taxonomy/security/code-scanning/2](https://github.com/carstenartur/Taxonomy/security/code-scanning/2)

In general, the fix is to avoid storing the plaintext password in `sessionStorage`. Instead, the password should only be used to authenticate with the server; if authentication succeeds, the server should issue a non‑sensitive token (e.g., a random session/admin token) that the client can store and reuse. On the frontend, this means changing `unlockAdmin` so that after verifying the password, it stores `data.token` (or similar) in `sessionStorage` under `adminToken`, rather than the password.

Concretely, in `src/main/resources/static/js/taxonomy.js`:

- Update `unlockAdmin` so it expects the `/api/admin/verify` response to contain something like `{ valid: boolean, token: string }`.
- After `if (data.valid) {`, replace `sessionStorage.setItem('adminToken', password);` with `sessionStorage.setItem('adminToken', data.token || '');`.
- Optionally, guard against a missing token by only setting it when present.

This preserves the existing behavior of: (1) sending the typed password to the backend for verification; (2) toggling admin UI visibility based on a value in `sessionStorage`; but no longer stores the actual password. The rest of the code that calls `getAdminToken()` will now work with an opaque admin token instead of the password. No new imports are needed; we only change the value being written to `sessionStorage`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
