### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete HTML attribute sanitization

### DIFF
--- a/src/main/resources/static/js/taxonomy.js
+++ b/src/main/resources/static/js/taxonomy.js
@@ -1717,7 +1717,11 @@
     }
 
     function escapeHtml(s) {
-        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        return s
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
     }
 
     // ── Relation Proposal Review ──────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/carstenartur/Taxonomy/security/code-scanning/5](https://github.com/carstenartur/Taxonomy/security/code-scanning/5)

In general, when constructing HTML attributes with dynamic content, you must escape all characters that can alter attribute structure, notably `"`, `'`, `<`, `>`, and `&`. Here, `escapeHtml` is the central sanitizer and is already used consistently for string interpolation into HTML, including attribute values. The best fix is to strengthen `escapeHtml` to also escape double quotes (`"`). This way, all existing call sites—including the one that uses `rationale` inside a `title="..."` attribute—become safe without further changes.

Concretely, in `src/main/resources/static/js/taxonomy.js`, modify the `escapeHtml` function at lines 1719–1721 to add `.replace(/"/g, '&quot;')`. No other code needs to change, since all places that rely on `escapeHtml` will automatically benefit. This preserves existing functionality, except that any literal `"` in displayed text will now appear as `&quot;` in the underlying HTML (which is correct and still renders as `"` to users in attributes such as `title`).

No new imports or helper methods are necessary; we just extend the existing regular-expression-based escaping.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
