### PR TITLE
Keep citation metadata aligned during releases

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -80,6 +80,19 @@ if release_mode and not has_date_released:
 if not release_mode and has_date_released:
     raise SystemExit('CITATION.cff still contains date-released for a development snapshot')
 
+citation_md = Path('CITATION.md').read_text(encoding='utf-8')
+preferred = re.search(r'Taxonomy Architecture Analyzer\*\*\. Version ([^.]+(?:\.[^.]+){1,2}(?:-SNAPSHOT)?)\.', citation_md)
+bibtex = re.search(r'^\s*version\s+= \{([^}]+)\},$', citation_md, flags=re.MULTILINE)
+if not preferred or preferred.group(1) != expected:
+    raise SystemExit(f'CITATION.md preferred citation version does not match {expected!r}')
+if not bibtex or bibtex.group(1) != expected:
+    raise SystemExit(f'CITATION.md BibTeX version does not match {expected!r}')
+has_bibtex_date = bool(re.search(r'^\s*date\s+= \{[^}]+\},$', citation_md, flags=re.MULTILINE))
+if release_mode and not has_bibtex_date:
+    raise SystemExit('CITATION.md BibTeX release date is missing')
+if not release_mode and has_bibtex_date:
+    raise SystemExit('CITATION.md still contains a BibTeX release date for a development snapshot')
+
 with open('.zenodo.json', encoding='utf-8') as handle:
     zenodo = json.load(handle)
 if zenodo.get('version') != expected:
@@ -245,7 +258,7 @@ if [[ "$STATE" == "new" ]]; then
   python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
   verify_metadata "$RELEASE_VERSION" true
   ensure_no_snapshot_poms
-  git add pom.xml */pom.xml CITATION.cff .zenodo.json codemeta.json
+  git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
   git commit -m "Release version $RELEASE_VERSION"
 else
   git checkout --detach "$TAG_NAME"
@@ -314,7 +327,7 @@ verify_metadata "$NEXT_VERSION" false
 
 NEXT_BRANCH="release/prepare-next-${NEXT_VERSION}"
 git switch -C "$NEXT_BRANCH"
-git add pom.xml */pom.xml CITATION.cff .zenodo.json codemeta.json
+git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
 if git diff --cached --quiet; then
   echo "No next-development version changes to commit"
 else
@@ -335,6 +348,7 @@ Automated follow-up after release ${RELEASE_VERSION}.
 ## Changes
 - Bump all Maven modules to ${NEXT_VERSION}
 - Update CITATION.cff to ${NEXT_VERSION}
+- Update CITATION.md to ${NEXT_VERSION}
 - Update .zenodo.json to ${NEXT_VERSION}
 - Update codemeta.json to ${NEXT_VERSION}
 - Remove release-only date metadata from the development snapshot

--- a/.github/scripts/update-release-metadata.py
+++ b/.github/scripts/update-release-metadata.py
@@ -12,6 +12,8 @@ from typing import Any
 
 
 ROOT = Path.cwd()
+ORCID_ID = "0009-0005-1047-6381"
+ORCID_URL = "https://orcid.org/" + ORCID_ID
 
 
 def set_cff_key(text: str, key: str, value: str) -> str:
@@ -69,20 +71,42 @@ def update_codemeta(version: str, release_date: str | None) -> None:
     write_json(path, data)
 
 
+def update_citation_md(version: str, release_date: str | None) -> None:
+    path = ROOT / "CITATION.md"
+    text = path.read_text(encoding="utf-8")
+    text = re.sub(
+        r"(Carsten Hammer\. \*\*Taxonomy Architecture Analyzer\*\*\. Version )[0-9A-Za-z.-]+(\. 2026\.)",
+        rf"\g<1>{version}\2",
+        text,
+    )
+    text = re.sub(r"(  version\s+= \{)[^}]+(\},)", rf"\g<1>{version}\2", text)
+    if release_date:
+        if re.search(r"^  date\s+= \{[^}]+\},$", text, flags=re.MULTILINE):
+            text = re.sub(r"^  date\s+= \{[^}]+\},$", f"  date         = {{{release_date}}},", text, flags=re.MULTILINE)
+        else:
+            text = re.sub(r"^(  version\s+= \{[^}]+\},)$", rf"\1\n  date         = {{{release_date}}},", text, flags=re.MULTILINE)
+    else:
+        text = re.sub(r"^  date\s+= \{[^}]+\},\n", "", text, flags=re.MULTILINE)
+    if "ORCID" not in text:
+        text = text.replace(
+            "## What to cite\n",
+            f"## Author identifier\n\nCarsten Hammer's ORCID iD is [{ORCID_URL}]({ORCID_URL}).\n\n## What to cite\n",
+        )
+    if "  orcid" not in text:
+        text = re.sub(r"(  author\s+= \{Hammer, Carsten\},)", rf"\1\n  orcid        = {{{ORCID_URL}}},", text, flags=re.MULTILINE)
+    path.write_text(text, encoding="utf-8")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("version", help="Version to write to metadata files")
-    parser.add_argument(
-        "--release",
-        action="store_true",
-        help="Set release date fields; otherwise remove release-only date fields for a development snapshot.",
-    )
+    parser.add_argument("--release", action="store_true", help="Set release date fields; otherwise remove release-only date fields for a development snapshot.")
     args = parser.parse_args()
-
     release_date = dt.date.today().isoformat() if args.release else None
     update_citation(args.version, release_date)
     update_zenodo(args.version, release_date)
     update_codemeta(args.version, release_date)
+    update_citation_md(args.version, release_date)
 
 
 if __name__ == "__main__":

--- a/CITATION.md
+++ b/CITATION.md
@@ -4,7 +4,7 @@ If you use **Taxonomy Architecture Analyzer** in research, teaching, public-sect
 
 ## Preferred citation
 
-Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.2.2. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
+Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.2.4-SNAPSHOT. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
 
 When a Zenodo DOI is minted for a release, prefer the Zenodo citation shown on the release page and keep the GitHub repository URL as the code source.
 
@@ -13,14 +13,18 @@ When a Zenodo DOI is minted for a release, prefer the Zenodo citation shown on t
 ```bibtex
 @software{hammer_taxonomy_2026,
   author       = {Hammer, Carsten},
+  orcid        = {https://orcid.org/0009-0005-1047-6381},
   title        = {Taxonomy Architecture Analyzer},
-  version      = {1.2.2},
-  date         = {2026-06-22},
+  version      = {1.2.4-SNAPSHOT},
   publisher    = {GitHub and Zenodo},
   url          = {https://github.com/carstenartur/Taxonomy},
   license      = {MIT}
 }
 ```
+
+## Author identifier
+
+Carsten Hammer's ORCID iD is [https://orcid.org/0009-0005-1047-6381](https://orcid.org/0009-0005-1047-6381).
 
 ## What to cite
 


### PR DESCRIPTION
## Summary

- add the ORCID iD to `CITATION.md`
- align `CITATION.md` with the current development version (`1.2.4-SNAPSHOT`)
- extend the release metadata helper so `CITATION.md` is updated together with `CITATION.cff`, `.zenodo.json`, and `codemeta.json`
- include `CITATION.md` in release and next-development commits
- verify `CITATION.md` versions during the release workflow

## Safety notes

- Existing ORCID entries in `CITATION.cff`, `codemeta.json`, and `.zenodo.json` were already present and were not changed unnecessarily.
- `release.sh` was syntax-checked locally with `bash -n` before writing the update.
- `update-release-metadata.py` was Python-compiled locally before writing the update.

## Why

This prevents future releases from updating only machine-readable metadata while leaving the human-readable citation guide stale.