### PR TITLE
Align database compatibility testing and HSQLDB documentation after QA hardening

### DIFF
--- a/.github/workflows/database-compatibility.yml
+++ b/.github/workflows/database-compatibility.yml
@@ -1,0 +1,110 @@
+name: Database Compatibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      database:
+        description: Database family to test
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - postgres
+          - mssql
+          - oracle
+  schedule:
+    - cron: '17 2 * * 0'
+
+permissions:
+  contents: read
+
+env:
+  BGE_MODEL_REVISION: 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+
+jobs:
+  select-matrix:
+    name: Select database tests
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - id: matrix
+        env:
+          DATABASE: ${{ inputs.database || 'all' }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
+
+          selected = os.environ.get('DATABASE', 'all')
+          tests = {
+              'postgres': [
+                  'DiagnosticsPostgresContainerIT',
+                  'SeleniumPostgresContainerIT',
+              ],
+              'mssql': [
+                  'DiagnosticsMssqlContainerIT',
+                  'SeleniumMssqlContainerIT',
+              ],
+              'oracle': [
+                  'DiagnosticsOracleContainerIT',
+                  'SeleniumOracleContainerIT',
+              ],
+          }
+          families = tests if selected == 'all' else {selected: tests[selected]}
+          include = [
+              {'database': database, 'test': test}
+              for database, database_tests in families.items()
+              for test in database_tests
+          ]
+          print('matrix=' + json.dumps({'include': include}, separators=(',', ':')))
+          PY
+
+  database-testcontainers:
+    name: ${{ matrix.database }} / ${{ matrix.test }}
+    needs: select-matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.select-matrix.outputs.matrix) }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download and verify pinned embedding model
+        env:
+          MODEL_REVISION: ${{ env.BGE_MODEL_REVISION }}
+        run: bash .github/scripts/download-embedding-model.sh
+
+      - name: Install reactor without running tests
+        run: mvn -B -pl taxonomy-app -am install -DskipTests
+
+      - name: Run database compatibility test
+        env:
+          TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
+          TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
+        run: >-
+          mvn -B -pl taxonomy-app
+          failsafe:integration-test failsafe:verify
+          -DskipITs=false
+          -Dit.test=${{ matrix.test }}
+          -DfailIfNoTests=false
+          -DexcludedGroups=real-llm
+
+      - name: Upload database compatibility evidence on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: database-${{ matrix.database }}-${{ matrix.test }}
+          path: taxonomy-app/target/failsafe-reports/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/dev/06-testing-by-change-type.md
+++ b/docs/dev/06-testing-by-change-type.md
@@ -1,148 +1,168 @@
 # Testing by Change Type
 
-This page maps common change types to the Maven commands and likely test classes
-you should run to verify your change.
+This page maps common changes to the smallest useful verification command and
+explains how the standard, core-integration, and database-compatibility suites
+fit together.
+
+All commands below run from a normal Git checkout. GitHub Actions invokes the
+same Maven/Failsafe/Testcontainers contracts; the tests do not depend on GitHub.
+
+---
+
+## Test layers
+
+| Layer | Purpose | Default command |
+|---|---|---|
+| Standard lifecycle | Unit, Spring context, controller, architecture, contract, and module tests | `mvn verify` |
+| Core integration | Production-like HSQLDB, diagnostics, real browser, and persistence-restart tests | `mvn verify -DskipITs=false -Dit.test=<class>` |
+| Database compatibility | PostgreSQL, MSSQL, and Oracle diagnostics plus Selenium flows | `mvn verify -DskipITs=false -Dit.test=<class> -DexcludedGroups=real-llm` |
+| Real LLM | Explicit provider integration against live credentials | Select the required test and remove `real-llm` from `excludedGroups` |
+| Documentation screenshots | Deterministic documentation fixtures, not acceptance evidence | `mvn verify -DskipITs=false -DgenerateScreenshots -Dit.test=ScreenshotGeneratorIT` |
+
+The root POM sets `skipITs=true` so `mvn verify` remains deterministic and
+bounded. Failsafe/Testcontainers tests are enabled explicitly with
+`-DskipITs=false`.
+
+The heavyweight external-database tags are excluded by default:
+
+```text
+real-llm,db-postgres,db-mssql,db-oracle
+```
+
+Supplying `-DexcludedGroups=real-llm` includes the database tags while still
+excluding live LLM calls.
 
 ---
 
 ## Quick reference
 
-| Change type | Minimum command | Also run if… |
+| Change type | Minimum command | Additional verification |
 |---|---|---|
-| Pure domain type (DTO, enum) | `mvn test -pl taxonomy-domain` | …it is used in a controller response → also run `mvn test -pl taxonomy-app` |
-| DSL parser / serializer | `mvn test -pl taxonomy-dsl` | …you changed property ordering or block types → also run `mvn test -pl taxonomy-app` |
-| Export service | `mvn test -pl taxonomy-export` | …you changed the controller or `ExportConfig` → also run `mvn test -pl taxonomy-app` |
-| Spring service (no controller change) | `mvn test -pl taxonomy-app` | Always sufficient for service-only changes |
-| REST controller | `mvn test -pl taxonomy-app` | …you added a new endpoint → also update `API_REFERENCE.md` |
-| UI template or JS module | `mvn verify -DexcludedGroups=real-llm` | Always run full verify for any UI change |
-| Spring configuration (`application.properties`, `@Configuration` class) | `mvn verify -DexcludedGroups=real-llm` | Always run full verify for config changes |
-| JPA entity or repository | `mvn verify -DexcludedGroups=real-llm` | Always run full verify for schema changes |
-| LLM provider addition | `mvn test -pl taxonomy-app` | …you changed `application.properties` → also run `mvn verify -DexcludedGroups=real-llm` |
-| Workspace operation | `mvn test -pl taxonomy-app` | …you changed the controller or UI → also run `mvn verify -DexcludedGroups=real-llm` |
-| Document import mapping | `mvn test -pl taxonomy-app` | …you changed the controller → also run `mvn verify -DexcludedGroups=real-llm` |
+| Pure domain type, DTO, or enum | `mvn test -pl taxonomy-domain` | Run `mvn test -pl taxonomy-app` when used in API responses |
+| DSL parser or serializer | `mvn test -pl taxonomy-dsl` | Run `mvn test -pl taxonomy-app` for controller/materialization changes |
+| Export model or serializer | `mvn test -pl taxonomy-export` | Run app tests for endpoint or adapter changes |
+| Extension contract | `mvn test -pl taxonomy-extension-api` | Run the affected registry/adapter tests in `taxonomy-app` |
+| Spring service | `mvn test -pl taxonomy-app` | Standard lifecycle for configuration or persistence changes |
+| REST controller | `mvn test -pl taxonomy-app` | Update API documentation and run `mvn verify` |
+| UI template or JavaScript | `mvn verify` | Also run `CoreUiAcceptanceIT` and the Playwright/axe workflows |
+| Security configuration | `mvn verify` | Also run `CoreUiAcceptanceIT` and security-focused MockMvc tests |
+| HSQLDB or production persistence | `mvn verify` | Also run `ProductionPersistenceRestartIT` |
+| External database mapping | `mvn verify` | Run both diagnostics and Selenium tests for that database family |
+| LLM provider | `mvn test -pl taxonomy-app` | Run provider-specific record/replay tests; live calls remain opt-in |
+| Documentation only | `python3 .github/scripts/check-doc-links.py` | Regenerate screenshots only when visible UI changed |
 
 ---
 
-## Full CI command
+## Standard lifecycle
 
-The authoritative build command (identical to what GitHub Actions runs) is:
+The standard pull-request build is:
 
 ```bash
-mvn -q verify -DexcludedGroups="real-llm"
+mvn verify
 ```
 
-Run this before opening a pull request if your change touches:
-- A REST controller or API endpoint
-- A UI template (`index.html`) or any JS module
-- Application startup, configuration, or Spring context
-- `pom.xml` or any dependency version
-- A Dockerfile or container configuration
+It compiles all modules and runs deterministic tests without starting Docker
+containers or contacting external LLM providers.
 
----
-
-## Test class reference by area
-
-### Analysis / LLM
-
-| Test class | What it covers |
-|---|---|
-| `AnalysisApiControllerTest` | `/api/analysis` endpoint, mock LLM responses |
-| `LlmServiceTest` | Provider selection, response parsing, rate-limit handling |
-| `LlmRecordReplayServiceTest` | Record/replay mode for offline LLM testing |
-
-### Taxonomy catalog
-
-| Test class | What it covers |
-|---|---|
-| `TaxonomyServiceTest` | Node lookup, scoring, hierarchy traversal |
-| `ApiControllerTest` | `/api/taxonomy` endpoint |
-| `SearchApiControllerTest` | Full-text and KNN search endpoints |
-
-### Relations
-
-| Test class | What it covers |
-|---|---|
-| `RelationApiControllerTest` | CRUD for `TaxonomyRelation` |
-| `ProposalApiControllerTest` | Proposal lifecycle (propose → accept/reject) |
-| `RelationValidationServiceTest` | Type-combination compatibility rules |
-| `CoverageApiControllerTest` | Requirement coverage calculations |
-
-### Export
-
-| Test class | What it covers |
-|---|---|
-| `ExportApiControllerTest` | Export endpoint routing |
-| `ArchiMateRoundtripTest` | ArchiMate XML round-trip correctness |
-| `MermaidExportServiceTest` | Mermaid output correctness |
-| `VisioPackageBuilderTest` | Visio `.vsdx` package structure |
-
-### Architecture / views
-
-| Test class | What it covers |
-|---|---|
-| `GapAnalysisApiControllerTest` | Gap analysis computation |
-| `ReportApiControllerTest` | Architecture report generation |
-| `ArchitectureSummaryApiControllerTest` | Summary endpoint |
-| `ReadmeShowcaseDriftTest` | README diagram stays in sync with code |
-
-### DSL
-
-| Test class | What it covers |
-|---|---|
-| `TaxDslParserTest` | Parser correctness for all block types |
-| `TaxDslSerializerTest` | Serializer round-trip and canonical ordering |
-| `DslValidatorTest` | Semantic validation rules |
-| `ModelDifferTest` | Semantic diff between two models |
-| `DslGitRepositoryTest` | JGit DFS storage commit/read/branch |
-
-### Provenance / document import
-
-| Test class | What it covers |
-|---|---|
-| `DocumentImportControllerTest` | Upload and parsing endpoint |
-| `DocumentAnalysisServiceTest` | Chunk extraction and mapping logic |
-
-### Workspace
-
-| Test class | What it covers |
-|---|---|
-| `WorkspaceControllerTest` | Workspace CRUD, context switching |
-| `DslApiControllerTest` | DSL commit, read, diff endpoints |
-
----
-
-## Integration tests (require Docker)
-
-Integration tests follow the `*IT.java` naming convention and are run by
-`maven-failsafe-plugin` during `mvn verify`.
-
-| Pattern | Coverage |
-|---|---|
-| `*PostgresContainerIT` | Full stack against PostgreSQL |
-| `*MssqlContainerIT` | Full stack against Microsoft SQL Server |
-| `*OracleContainerIT` | Full stack against Oracle (opt-in, tag `db-oracle`) |
-| `ScreenshotGeneratorIT` | Selenium screenshot regeneration |
-
-Run a specific integration test:
+For a clean release-style build:
 
 ```bash
-# Run only PostgreSQL integration tests
-mvn verify -DexcludedGroups=real-llm -Dit.test="*Postgres*IT"
-
-# Regenerate screenshots
-mvn failsafe:integration-test -DgenerateScreenshots=true -Dit.test=ScreenshotGeneratorIT
+mvn clean verify
 ```
 
 ---
 
-## Test annotations reference
+## Core Testcontainers integration
 
-| Annotation | Usage |
+The `Core Integration` workflow runs these tests independently and in parallel,
+with a timeout per test:
+
+| Test class | Coverage |
 |---|---|
-| `@SpringBootTest` + `@AutoConfigureMockMvc` | Standard unit test with full Spring context |
-| `@WithMockUser(roles = "ADMIN")` | Simulate an authenticated admin user |
-| `@Tag("real-llm")` | LLM tests excluded from CI by default |
-| `@Tag("db-oracle")` | Oracle tests excluded from CI by default |
+| `DiagnosticsContainerIT` | Packaged application and diagnostics on embedded HSQLDB |
+| `DiagnosticsWithApiKeyContainerIT` | Provider-key detection and masked diagnostics values |
+| `CoreUiAcceptanceIT` | Real login, onboarding, local assets, and keyboard navigation through Selenium |
+| `ProductionPersistenceRestartIT` | File HSQLDB and Lucene data survive application-container replacement |
 
-All `@SpringBootTest` test classes **must** include `@WithMockUser(…)` or
-`@WithAnonymousUser`; without it, MockMvc requests return HTTP 401.
+Run one locally:
+
+```bash
+mvn -B -pl taxonomy-app -am install -DskipTests
+mvn -B -pl taxonomy-app \
+  failsafe:integration-test failsafe:verify \
+  -DskipITs=false \
+  -Dit.test=ProductionPersistenceRestartIT \
+  -DfailIfNoTests=false \
+  -DexcludedGroups=real-llm,db-postgres,db-mssql,db-oracle
+```
+
+Replace the class name to run another core scenario.
+
+---
+
+## Database compatibility matrix
+
+The `Database Compatibility` workflow is scheduled weekly and can be started
+manually for `all`, `postgres`, `mssql`, or `oracle`. It runs the same commands
+available locally.
+
+| Database | Diagnostics test | Browser test | Tag |
+|---|---|---|---|
+| PostgreSQL | `DiagnosticsPostgresContainerIT` | `SeleniumPostgresContainerIT` | `db-postgres` |
+| Microsoft SQL Server | `DiagnosticsMssqlContainerIT` | `SeleniumMssqlContainerIT` | `db-mssql` |
+| Oracle Database Free | `DiagnosticsOracleContainerIT` | `SeleniumOracleContainerIT` | `db-oracle` |
+
+Run a complete family locally:
+
+```bash
+# PostgreSQL
+mvn -B -pl taxonomy-app -am install -DskipTests
+mvn -B -pl taxonomy-app \
+  failsafe:integration-test failsafe:verify \
+  -DskipITs=false \
+  -Dit.test='*Postgres*IT' \
+  -DfailIfNoTests=false \
+  -DexcludedGroups=real-llm
+```
+
+Use `*Mssql*IT` or `*Oracle*IT` for the other families. Testcontainers starts
+the database, application, and browser containers; no preinstalled database is
+required.
+
+---
+
+## Documentation screenshots
+
+Screenshot generation is opt-in and intentionally separate from acceptance
+testing:
+
+```bash
+mvn -B verify \
+  -DskipITs=false \
+  -DgenerateScreenshots \
+  -Dit.test=ScreenshotGeneratorIT \
+  -DfailIfNoTests=false
+```
+
+Screenshot fixtures may use deterministic mock data. They do not prove that
+live search backends, external AI providers, or production infrastructure are
+healthy.
+
+---
+
+## Test annotations
+
+| Annotation or property | Usage |
+|---|---|
+| `@SpringBootTest` + `@AutoConfigureMockMvc` | Spring integration without external containers |
+| `@WithMockUser(...)` | Authenticated MockMvc request context |
+| `@Testcontainers` | Docker-backed integration test |
+| `@Tag("real-llm")` | Live provider test, excluded by default |
+| `@Tag("db-postgres")` | PostgreSQL compatibility matrix |
+| `@Tag("db-mssql")` | MSSQL compatibility matrix |
+| `@Tag("db-oracle")` | Oracle compatibility matrix |
+| `@EnabledIfSystemProperty` | Explicit opt-in tests such as screenshots or local ONNX |
+
+All Spring MockMvc tests must establish an explicit security context. Browser
+and container acceptance tests must use real application contracts and must not
+inject result DOM or fake service-health state.


### PR DESCRIPTION
## Purpose

Follow-up to #406. This PR addresses the non-blocking database/testing documentation and compatibility-matrix work deliberately kept out of the already large hardening merge.

## Implemented

- add one bounded `Database Compatibility` workflow instead of putting PostgreSQL, MSSQL, and Oracle Selenium/diagnostics suites into every pull request
- allow manual selection of `all`, `postgres`, `mssql`, or `oracle`
- run the complete matrix weekly
- keep every workflow test as a normal Maven Failsafe/Testcontainers command that can be executed from a plain Git checkout
- document the three test layers:
  - deterministic standard Maven lifecycle
  - critical core Testcontainers integration
  - external database compatibility matrix
- document exact local commands for core, PostgreSQL, MSSQL, Oracle, screenshots, and opt-in LLM tests

## Remaining work in this PR

- [ ] replace stale `SimpleDriverDataSource` descriptions with the bounded Hikari/HSQLDB lifecycle in English database documentation
- [ ] apply the same correction to German database documentation
- [ ] align EN/DE configuration-reference entries for `skipITs`, database tags, Hikari minimum-idle/maximum-pool-size, and catalogue reload behavior
- [ ] align architecture/developer-guide references to the new standard/core/database test separation
- [ ] run documentation links, standard CI, and a manually selected PostgreSQL compatibility job

## Design rationale

External database compatibility remains important, but six heavyweight database/browser suites should not run serially inside the authoritative standard build. The new workflow keeps those tests visible and scheduled while preserving these properties:

- no GitHub-specific test implementation
- Testcontainers provisions every dependency
- exact Maven commands are documented
- each database/test combination has an independent timeout and report
- standard pull-request feedback remains bounded

## Related

- follows #406
- complements `Core Integration`
- updates `docs/dev/06-testing-by-change-type.md`
