### PR TITLE
build(deps): complete PDFBox 3.0.8 update on current main

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -12,7 +12,7 @@ Taxonomy Architecture Analyzer incorporates components from the following third-
 
 | License | Components | Government Use |
 |---|---|---|
-| Apache License 2.0 | Spring Boot, Apache POI, Lucene, Hibernate, springdoc, DJL, Micrometer, JaCoCo | ✅ Permissive, no restrictions |
+| Apache License 2.0 | Spring Boot, Apache POI, Apache PDFBox, Lucene, Hibernate, springdoc, DJL, Micrometer, JaCoCo | ✅ Permissive, no restrictions |
 | MIT License | Bootstrap, jsPDF, svg2pdf.js, ONNX Runtime, CodeMirror | ✅ Permissive, no restrictions |
 | ISC License | D3.js | ✅ Permissive, no restrictions |
 | BSD Licenses | HSQLDB, PostgreSQL JDBC, XStream, Flexmark-java | ✅ Permissive, no restrictions |
@@ -36,6 +36,10 @@ https://spring.io/
 ### Apache POI
 Copyright © The Apache Software Foundation
 https://poi.apache.org/
+
+### Apache PDFBox
+Copyright © The Apache Software Foundation
+https://pdfbox.apache.org/
 
 ### Apache Lucene
 Copyright © The Apache Software Foundation

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <excludedGroups>real-llm,db-postgres,db-mssql,db-oracle</excludedGroups>
         <!-- Dependency versions (centralized to avoid repetition in child POMs) -->
         <poi.version>5.5.1</poi.version>
-        <pdfbox.version>3.0.7</pdfbox.version>
+        <pdfbox.version>3.0.8</pdfbox.version>
         <lucene.version>9.12.3</lucene.version>
         <hibernate-search.version>8.3.1.Final</hibernate-search.version>
         <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -250,10 +250,27 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Markdown → HTML rendering for in-app help -->
+        <!-- Markdown → HTML rendering for in-app help. Keep this list limited to
+             the extensions used by HelpController; flexmark-all also pulls the
+             unused PDF converter and its legacy PDFBox 2.x dependency family. -->
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
-            <artifactId>flexmark-all</artifactId>
+            <artifactId>flexmark</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-autolink</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-ext-tables</artifactId>
             <version>${flexmark.version}</version>
         </dependency>
     </dependencies>

--- a/taxonomy-app/src/test/java/com/taxonomy/provenance/DocumentParserServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/provenance/DocumentParserServiceTest.java
@@ -2,12 +2,21 @@ package com.taxonomy.provenance;
 
 import com.taxonomy.dto.RequirementCandidate;
 import com.taxonomy.provenance.service.DocumentParserService;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for the {@link DocumentParserService} text extraction and
@@ -144,6 +153,32 @@ class DocumentParserServiceTest {
     }
 
     @Test
+    void parseExtractsTextAndPageCountFromRealPdf() throws IOException {
+        String requirement = "The system shall retain an auditable history of every architecture change "
+                + "and make the responsible actor and timestamp available for review.";
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "requirements.pdf", "application/pdf", createPdf(requirement));
+
+        var result = parserService.parse(file);
+
+        assertThat(result.getMimeType()).isEqualTo("application/pdf");
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.getRawTextPreview()).contains(requirement);
+        assertThat(result.getCandidates())
+                .extracting(RequirementCandidate::getText)
+                .anySatisfy(text -> assertThat(text).contains(requirement));
+    }
+
+    @Test
+    void parseRejectsMalformedPdf() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "broken.pdf", "application/pdf", "%PDF-1.7\ntruncated".getBytes());
+
+        assertThatThrownBy(() -> parserService.parse(file))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
     void longParagraphsAreSplitNotTruncated() {
         // Build a paragraph well over 2000 chars with distinct sentences
         StringBuilder sb = new StringBuilder();
@@ -255,6 +290,23 @@ class DocumentParserServiceTest {
         // Each chunk must respect the max length
         for (RequirementCandidate c : candidates) {
             assertThat(c.getText().length()).isLessThanOrEqualTo(2000);
+        }
+    }
+
+    private static byte[] createPdf(String text) throws IOException {
+        try (PDDocument document = new PDDocument();
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream content = new PDPageContentStream(document, page)) {
+                content.beginText();
+                content.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                content.newLineAtOffset(72, 720);
+                content.showText(text);
+                content.endText();
+            }
+            document.save(output);
+            return output.toByteArray();
         }
     }
 }


### PR DESCRIPTION
## Summary

This supersedes #405 with a conflict-free implementation based on the current `main` branch after #406 and #408.

- update Apache PDFBox from 3.0.7 to 3.0.8
- replace `flexmark-all` with the exact Markdown modules used by `HelpController`, removing the unused PDF converter and its legacy PDFBox 2.x/XMPBox dependency chain
- retain all production, offline-asset, database-compatibility, Selenium, and test-isolation hardening already present on `main`
- add a real in-memory PDF parsing regression test and malformed-PDF coverage
- add Apache PDFBox to `THIRD-PARTY-NOTICES.md`

## Build-problem assessment

The JGit/HSQLDB test-context isolation fix (`spring.test.context.cache.maxSize=1`) from the original #405 is already present on `main` through #406. It is intentionally preserved rather than reintroduced here. Therefore this PR completes the dependency/parser work but is not a separate fix for an unresolved main-branch JGit build failure.

## Validation required before merge

- standard CI/CD lifecycle
- dependency/classpath verification
- PDF parser tests
- Help controller tests
- security scan
- documentation link check
- UI/accessibility gates triggered by the current workflow configuration

## Supersedes

- #405