### PR TITLE
Import: make ArchiMate materialization atomic and workspace-scoped

### DIFF
--- a/.github/workflows/qa-test-evidence.yml
+++ b/.github/workflows/qa-test-evidence.yml
@@ -1,0 +1,57 @@
+name: QA Test Evidence
+
+on:
+  push:
+    branches:
+      - fix/proposal-workspace-authorization
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BGE_MODEL_REVISION: 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+
+jobs:
+  maven-test-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download and verify pinned embedding model
+        env:
+          MODEL_REVISION: ${{ env.BGE_MODEL_REVISION }}
+        run: bash .github/scripts/download-embedding-model.sh
+
+      - name: Run Maven verification
+        id: verify
+        continue-on-error: true
+        env:
+          TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
+          TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
+        run: mvn -q install -DexcludedGroups="real-llm"
+
+      - name: Upload raw Maven reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: qa-maven-test-evidence
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Propagate verification result
+        if: steps.verify.outcome != 'success'
+        run: exit 1

--- a/docs/internal/qa-progress-placeholder.md
+++ b/docs/internal/qa-progress-placeholder.md
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/internal/qa-progress-placeholder.md
+++ b/docs/internal/qa-progress-placeholder.md
@@ -1,1 +1,0 @@
-placeholder

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/controller/ArchiMateImportController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/controller/ArchiMateImportController.java
@@ -1,24 +1,25 @@
 package com.taxonomy.catalog.controller;
 
-import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.catalog.service.ArchiMateImportException;
 import com.taxonomy.catalog.service.ArchiMateXmlImporter;
+import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-/**
- * REST API for ArchiMate XML import.
- *
- * <p>Endpoints:
- * <ul>
- *   <li>{@code POST /api/import/archimate} — Import ArchiMate XML file</li>
- * </ul>
- */
+import java.util.Map;
+
+/** REST API for previewing and importing ArchiMate 3.x XML models. */
 @RestController
 @RequestMapping("/api/import")
 @Tag(name = "ArchiMate Import")
@@ -27,30 +28,55 @@ public class ArchiMateImportController {
     private static final Logger log = LoggerFactory.getLogger(ArchiMateImportController.class);
 
     private final ArchiMateXmlImporter importer;
+    private final WorkspaceContextResolver contextResolver;
 
-    public ArchiMateImportController(ArchiMateXmlImporter importer) {
+    public ArchiMateImportController(ArchiMateXmlImporter importer,
+                                     WorkspaceContextResolver contextResolver) {
         this.importer = importer;
+        this.contextResolver = contextResolver;
     }
 
-    /**
-     * Imports an ArchiMate 3.x Model Exchange Format XML file.
-     */
+    @Operation(summary = "Preview ArchiMate XML import",
+            description = "Parses, matches, and checks duplicates for the active workspace without writing relations")
+    @PostMapping(value = "/preview/archimate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> previewArchiMate(@RequestParam("file") MultipartFile file) {
+        return process(file, true);
+    }
+
     @Operation(summary = "Import ArchiMate XML",
-               description = "Parses an ArchiMate 3.x XML file and creates taxonomy relations from matched elements")
+            description = "Atomically creates matched taxonomy relations in the active workspace")
     @PostMapping(value = "/archimate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ArchiMateImportResult> importArchiMate(
-            @RequestParam("file") MultipartFile file) {
+    public ResponseEntity<?> importArchiMate(@RequestParam("file") MultipartFile file) {
+        return process(file, false);
+    }
+
+    private ResponseEntity<?> process(MultipartFile file, boolean preview) {
         if (file.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "EMPTY_FILE",
+                    "message", "The uploaded ArchiMate XML file is empty"));
         }
+
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         try {
-            ArchiMateImportResult result = importer.importXml(file.getInputStream());
+            ArchiMateImportResult result = preview
+                    ? importer.previewXml(file.getInputStream(), context)
+                    : importer.importXml(file.getInputStream(), context);
             return ResponseEntity.ok(result);
-        } catch (Exception e) {
-            log.error("ArchiMate import failed for file: {}", file.getOriginalFilename(), e);
-            ArchiMateImportResult error = new ArchiMateImportResult();
-            error.getNotes().add("Import failed: unable to process the uploaded file");
-            return ResponseEntity.badRequest().body(error);
+        } catch (ArchiMateImportException error) {
+            log.warn("ArchiMate {} rejected for file '{}' in workspace '{}': {}",
+                    preview ? "preview" : "import", file.getOriginalFilename(),
+                    context.workspaceId(), error.getMessage());
+            return ResponseEntity.status(422).body(Map.of(
+                    "error", "INVALID_ARCHIMATE_XML",
+                    "message", error.getMessage()));
+        } catch (Exception error) {
+            log.error("ArchiMate {} failed for file '{}' in workspace '{}'",
+                    preview ? "preview" : "import", file.getOriginalFilename(),
+                    context.workspaceId(), error);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "error", "ARCHIMATE_IMPORT_FAILED",
+                    "message", "The ArchiMate model could not be processed"));
         }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
@@ -45,6 +45,15 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
     List<TaxonomyRelation> findVisibleByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
                                                                   @Param("type") RelationType type);
 
+    @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
+           "AND r.sourceNode.code = :sourceCode AND r.targetNode.code = :targetCode " +
+           "AND r.relationType = :type")
+    List<TaxonomyRelation> findVisibleByWorkspaceAndSourceTargetType(
+            @Param("wsId") String workspaceId,
+            @Param("sourceCode") String sourceCode,
+            @Param("targetCode") String targetCode,
+            @Param("type") RelationType type);
+
     @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
     long countVisibleByWorkspace(@Param("wsId") String workspaceId);
 
@@ -100,12 +109,7 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
                                                                        String sourceCode,
                                                                        String targetCode,
                                                                        RelationType type) {
-        List<TaxonomyRelation> visible = findVisibleByWorkspace(workspaceId);
-        return visible.stream()
-                .filter(relation -> relation.getSourceNode().getCode().equals(sourceCode))
-                .filter(relation -> relation.getTargetNode().getCode().equals(targetCode))
-                .filter(relation -> relation.getRelationType() == type)
-                .toList();
+        return findVisibleByWorkspaceAndSourceTargetType(workspaceId, sourceCode, targetCode, type);
     }
 
     default long countByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
@@ -1,13 +1,14 @@
 package com.taxonomy.catalog.repository;
 
-import com.taxonomy.model.RelationType;
 import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.model.RelationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelation, Long> {
@@ -29,31 +30,85 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
     List<TaxonomyRelation> findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
             String sourceCode, String targetCode, RelationType relationType);
 
-    // ── Workspace-scoped queries ─────────────────────────────────────
+    // ── Visible workspace scope: shared baseline + current workspace ──
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
            "AND (r.sourceNode.code = :code OR r.targetNode.code = :code)")
-    List<TaxonomyRelation> findByWorkspaceAndNodeCode(@Param("wsId") String workspaceId,
-                                                       @Param("code") String code);
+    List<TaxonomyRelation> findVisibleByWorkspaceAndNodeCode(@Param("wsId") String workspaceId,
+                                                              @Param("code") String code);
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
-    List<TaxonomyRelation> findByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);
+    List<TaxonomyRelation> findVisibleByWorkspace(@Param("wsId") String workspaceId);
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
            "AND r.relationType = :type")
-    List<TaxonomyRelation> findByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
-                                                           @Param("type") RelationType type);
+    List<TaxonomyRelation> findVisibleByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
+                                                                  @Param("type") RelationType type);
+
+    @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
+    long countVisibleByWorkspace(@Param("wsId") String workspaceId);
+
+    // ── Shared scope only ────────────────────────────────────────────
+
+    List<TaxonomyRelation> findByWorkspaceIdIsNull();
+
+    List<TaxonomyRelation> findByRelationTypeAndWorkspaceIdIsNull(RelationType relationType);
+
+    @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId IS NULL " +
+           "AND (r.sourceNode.code = :code OR r.targetNode.code = :code)")
+    List<TaxonomyRelation> findSharedByNodeCode(@Param("code") String code);
+
+    long countByWorkspaceIdIsNull();
+
+    // ── Exact mutable workspace scope ────────────────────────────────
+
+    @Query("""
+            SELECT r FROM TaxonomyRelation r
+            WHERE r.id = :id
+              AND ((:wsId IS NULL AND r.workspaceId IS NULL) OR r.workspaceId = :wsId)
+            """)
+    Optional<TaxonomyRelation> findByIdInWorkspace(@Param("id") Long id,
+                                                    @Param("wsId") String workspaceId);
 
     List<TaxonomyRelation> findByWorkspaceId(String workspaceId);
 
-    @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
+    List<TaxonomyRelation> findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+            String workspaceId, String sourceCode, String targetCode, RelationType type);
+
+    @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId IS NULL " +
            "AND r.sourceNode.code = :sourceCode AND r.targetNode.code = :targetCode " +
            "AND r.relationType = :type")
-    List<TaxonomyRelation> findByWorkspaceAndSourceTargetType(@Param("wsId") String workspaceId,
-                                                               @Param("sourceCode") String sourceCode,
-                                                               @Param("targetCode") String targetCode,
-                                                               @Param("type") RelationType type);
+    List<TaxonomyRelation> findSharedBySourceTargetType(@Param("sourceCode") String sourceCode,
+                                                         @Param("targetCode") String targetCode,
+                                                         @Param("type") RelationType type);
 
-    @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
-    long countByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);
+    // ── Backward-compatible aliases for visible-scope callers ───────
+
+    default List<TaxonomyRelation> findByWorkspaceAndNodeCode(String workspaceId, String code) {
+        return findVisibleByWorkspaceAndNodeCode(workspaceId, code);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {
+        return findVisibleByWorkspace(workspaceId);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceAndRelationType(String workspaceId, RelationType type) {
+        return findVisibleByWorkspaceAndRelationType(workspaceId, type);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceAndSourceTargetType(String workspaceId,
+                                                                       String sourceCode,
+                                                                       String targetCode,
+                                                                       RelationType type) {
+        List<TaxonomyRelation> visible = findVisibleByWorkspace(workspaceId);
+        return visible.stream()
+                .filter(relation -> relation.getSourceNode().getCode().equals(sourceCode))
+                .filter(relation -> relation.getTargetNode().getCode().equals(targetCode))
+                .filter(relation -> relation.getRelationType() == type)
+                .toList();
+    }
+
+    default long countByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {
+        return countVisibleByWorkspace(workspaceId);
+    }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateImportException.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateImportException.java
@@ -1,0 +1,20 @@
+package com.taxonomy.catalog.service;
+
+/**
+ * Stable failure type for ArchiMate parsing or materialization errors.
+ *
+ * <p>Throwing a runtime exception from the transactional importer guarantees
+ * that partially created relations are rolled back. Controllers can map this
+ * exception to a deterministic non-2xx response without exposing stack traces
+ * or provider-specific parser messages.</p>
+ */
+public class ArchiMateImportException extends RuntimeException {
+
+    public ArchiMateImportException(String message) {
+        super(message);
+    }
+
+    public ArchiMateImportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateXmlImporter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateXmlImporter.java
@@ -1,12 +1,11 @@
 package com.taxonomy.catalog.service;
 
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.dto.ArchiMateImportResult;
 import com.taxonomy.dsl.mapping.profiles.ArchiMateMappingProfile;
 import com.taxonomy.model.RelationType;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.catalog.model.TaxonomyRelation;
-import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.workspace.service.WorkspaceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -14,120 +13,197 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
-import java.util.*;
-import com.taxonomy.export.ArchiMateDiagramService;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Imports an ArchiMate 3.x Model Exchange Format XML file and maps its
- * elements and relationships to taxonomy nodes and relations.
+ * Parses ArchiMate 3.x Model Exchange XML and materializes matched relations in
+ * an explicit workspace.
  *
- * <p>The importer performs the following steps:
- * <ol>
- *   <li>Parse elements from the XML and extract id, type, and label.</li>
- *   <li>Parse relationships from the XML and extract source, target, and type.</li>
- *   <li>Map each ArchiMate element type to a taxonomy root code using the
- *       reverse of {@link ArchiMateDiagramService#toArchiMateType(String)}.</li>
- *   <li>Match elements to existing taxonomy nodes by name similarity.</li>
- *   <li>Create new relations for matched elements.</li>
- * </ol>
+ * <p>Parsing/matching and persistence are deliberately separated. Preview uses
+ * the same parser and duplicate policy but performs no writes. Import runs in a
+ * single transaction; a fatal materialization error therefore rolls back every
+ * relation created by that request.</p>
  */
 @Service
 public class ArchiMateXmlImporter {
 
     private static final Logger log = LoggerFactory.getLogger(ArchiMateXmlImporter.class);
-
-    private final TaxonomyNodeRepository nodeRepository;
-    private final TaxonomyRelationRepository relationRepository;
-
-    /** Shared mapping profile for ArchiMate types. */
     private static final ArchiMateMappingProfile PROFILE = new ArchiMateMappingProfile();
 
+    private final TaxonomyNodeRepository nodeRepository;
+    private final TaxonomyRelationService relationService;
+
     public ArchiMateXmlImporter(TaxonomyNodeRepository nodeRepository,
-                                 TaxonomyRelationRepository relationRepository) {
+                                TaxonomyRelationService relationService) {
         this.nodeRepository = nodeRepository;
-        this.relationRepository = relationRepository;
+        this.relationService = relationService;
+    }
+
+    /** Parses and validates the model without mutating architecture state. */
+    @Transactional(readOnly = true)
+    public ArchiMateImportResult previewXml(InputStream inputStream, WorkspaceContext context) {
+        return execute(inputStream, requireContext(context), false);
     }
 
     /**
-     * Imports an ArchiMate XML file and creates taxonomy relations.
-     *
-     * @param inputStream the XML input stream
-     * @return the import result with statistics
+     * Parses, validates, and atomically creates relations in the exact active
+     * workspace. Shared baseline relations are visible to personal workspaces
+     * and therefore count as duplicates rather than being copied locally.
      */
     @Transactional
+    public ArchiMateImportResult importXml(InputStream inputStream, WorkspaceContext context) {
+        return execute(inputStream, requireContext(context), true);
+    }
+
+    /** Backward-compatible shared-scope overload for non-request callers. */
+    @Transactional
     public ArchiMateImportResult importXml(InputStream inputStream) {
-        ArchiMateImportResult result = new ArchiMateImportResult();
+        return importXml(inputStream, WorkspaceContext.SHARED);
+    }
+
+    private ArchiMateImportResult execute(InputStream inputStream,
+                                          WorkspaceContext context,
+                                          boolean materialize) {
+        ParsedModel model = parseModel(inputStream);
         List<String> notes = new ArrayList<>();
+        notes.add("Parsed " + model.elements().size() + " elements and "
+                + model.relationships().size() + " relationships from XML");
 
-        try {
-            // Parse XML
-            Map<String, ParsedElement> elements = new LinkedHashMap<>();
-            List<ParsedRelationship> relationships = new ArrayList<>();
-            parseXml(inputStream, elements, relationships);
+        Map<String, TaxonomyNode> matchedNodes = matchElements(model.elements(), notes);
 
-            notes.add("Parsed " + elements.size() + " elements and " + relationships.size() + " relationships from XML");
+        ArchiMateImportResult result = new ArchiMateImportResult();
+        result.setPreview(!materialize);
+        result.setElementsImported(model.elements().size());
+        result.setElementsMatched(matchedNodes.size());
+        result.setElementsUnmatched(model.elements().size() - matchedNodes.size());
+        result.setRelationsParsed(model.relationships().size());
 
-            // Match elements to taxonomy nodes
-            Map<String, TaxonomyNode> matchedNodes = matchElements(elements, notes);
-            result.setElementsMatched(matchedNodes.size());
-            result.setElementsUnmatched(elements.size() - matchedNodes.size());
-            result.setElementsImported(elements.size());
+        int created = 0;
+        int skipped = 0;
+        int rejected = 0;
 
-            // Create relations for matched element pairs
-            int relationsCreated = createRelations(relationships, elements, matchedNodes, notes);
-            result.setRelationsImported(relationsCreated);
+        for (ParsedRelationship relation : model.relationships()) {
+            TaxonomyNode sourceNode = matchedNodes.get(relation.sourceId());
+            TaxonomyNode targetNode = matchedNodes.get(relation.targetId());
+            if (sourceNode == null || targetNode == null) {
+                rejected++;
+                continue;
+            }
 
-        } catch (Exception e) {
-            log.error("ArchiMate import failed", e);
-            notes.add("Import error: " + e.getMessage());
+            String mappedType = PROFILE.mapRelationType(relation.type());
+            RelationType relationType = mappedType != null
+                    ? RelationType.valueOf(mappedType)
+                    : RelationType.RELATED_TO;
+
+            boolean exists = relationService.relationExistsVisible(
+                    sourceNode.getCode(), targetNode.getCode(), relationType, context.workspaceId());
+            if (exists) {
+                skipped++;
+                continue;
+            }
+
+            if (!materialize) {
+                continue;
+            }
+
+            try {
+                relationService.createRelation(
+                        sourceNode.getCode(), targetNode.getCode(), relationType,
+                        "Imported from ArchiMate XML", "ARCHIMATE_IMPORT",
+                        context.workspaceId(), context.username());
+                created++;
+            } catch (IllegalArgumentException error) {
+                // Treat only a concurrent duplicate as a skip. Any other failure
+                // is fatal and must roll the complete import transaction back.
+                if (relationService.relationExistsVisible(
+                        sourceNode.getCode(), targetNode.getCode(), relationType, context.workspaceId())) {
+                    skipped++;
+                } else {
+                    throw new ArchiMateImportException(
+                            "Unable to materialize ArchiMate relation", error);
+                }
+            } catch (RuntimeException error) {
+                throw new ArchiMateImportException(
+                        "Unable to materialize ArchiMate relation", error);
+            }
         }
 
+        result.setRelationsImported(created);
+        result.setRelationsSkipped(skipped);
+        result.setRelationsRejected(rejected);
         result.setNotes(notes);
+
+        int eligible = model.relationships().size() - skipped - rejected;
+        notes.add(materialize
+                ? "Created " + created + " relation(s) in workspace " + scopeName(context)
+                        + "; skipped " + skipped + " duplicate(s); rejected " + rejected
+                        + " relation(s) with unmatched endpoints"
+                : "Preview found " + eligible + " relation(s) eligible for workspace "
+                        + scopeName(context) + "; " + skipped + " duplicate(s); "
+                        + rejected + " relation(s) with unmatched endpoints");
+
+        log.info("ArchiMate {} complete: elements={}, matched={}, relations={}, created={}, skipped={}, rejected={}, workspace={}",
+                materialize ? "import" : "preview", model.elements().size(), matchedNodes.size(),
+                model.relationships().size(), created, skipped, rejected, context.workspaceId());
         return result;
     }
 
-    private void parseXml(InputStream inputStream,
-                          Map<String, ParsedElement> elements,
-                          List<ParsedRelationship> relationships) throws Exception {
+    private ParsedModel parseModel(InputStream inputStream) {
+        if (inputStream == null) {
+            throw new ArchiMateImportException("No ArchiMate XML input was provided");
+        }
+
+        Map<String, ParsedElement> elements = new LinkedHashMap<>();
+        List<ParsedRelationship> relationships = new ArrayList<>();
 
         XMLInputFactory factory = XMLInputFactory.newInstance();
-        // Security: disable external entities
+        // XXE hardening: never resolve DTDs or external entities.
         factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
 
-        XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
-
-        while (reader.hasNext()) {
-            int event = reader.next();
-            if (event == XMLStreamConstants.START_ELEMENT) {
-                String localName = reader.getLocalName();
-
-                if ("element".equals(localName)) {
-                    parseElement(reader, elements);
-                } else if ("relationship".equals(localName)) {
-                    parseRelationship(reader, relationships);
+        try {
+            XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
+            try {
+                while (reader.hasNext()) {
+                    int event = reader.next();
+                    if (event != XMLStreamConstants.START_ELEMENT) {
+                        continue;
+                    }
+                    if ("element".equals(reader.getLocalName())) {
+                        parseElement(reader, elements);
+                    } else if ("relationship".equals(reader.getLocalName())) {
+                        parseRelationship(reader, relationships);
+                    }
                 }
+            } finally {
+                reader.close();
             }
+        } catch (XMLStreamException error) {
+            throw new ArchiMateImportException("Malformed ArchiMate XML", error);
         }
-        reader.close();
+
+        return new ParsedModel(elements, relationships);
     }
 
-    private void parseElement(XMLStreamReader reader, Map<String, ParsedElement> elements) throws Exception {
+    private void parseElement(XMLStreamReader reader,
+                              Map<String, ParsedElement> elements) throws XMLStreamException {
         String identifier = reader.getAttributeValue(null, "identifier");
         String xsiType = reader.getAttributeValue(
                 "http://www.w3.org/2001/XMLSchema-instance", "type");
+        if (identifier == null || xsiType == null) {
+            return;
+        }
 
-        if (identifier == null || xsiType == null) return;
-
-        // Strip "id-" prefix if present
-        String id = identifier.startsWith("id-") ? identifier.substring(3) : identifier;
-
+        String id = stripIdentifierPrefix(identifier);
         String label = null;
         String documentation = null;
-
-        // Read child elements for name and documentation
         int depth = 1;
         while (reader.hasNext() && depth > 0) {
             int event = reader.next();
@@ -135,7 +211,7 @@ public class ArchiMateXmlImporter {
                 depth++;
                 if ("name".equals(reader.getLocalName())) {
                     label = reader.getElementText();
-                    depth--; // getElementText consumes the end element
+                    depth--;
                 } else if ("documentation".equals(reader.getLocalName())) {
                     documentation = reader.getElementText();
                     depth--;
@@ -144,126 +220,97 @@ public class ArchiMateXmlImporter {
                 depth--;
             }
         }
-
         elements.put(id, new ParsedElement(id, xsiType, label, documentation));
     }
 
-    private void parseRelationship(XMLStreamReader reader, List<ParsedRelationship> relationships) throws Exception {
+    private void parseRelationship(XMLStreamReader reader,
+                                   List<ParsedRelationship> relationships) {
         String identifier = reader.getAttributeValue(null, "identifier");
         String xsiType = reader.getAttributeValue(
                 "http://www.w3.org/2001/XMLSchema-instance", "type");
         String source = reader.getAttributeValue(null, "source");
         String target = reader.getAttributeValue(null, "target");
+        if (identifier == null || source == null || target == null) {
+            return;
+        }
 
-        if (identifier == null || source == null || target == null) return;
-
-        // Strip "id-" prefix variants
-        String sourceId = source.startsWith("id-") ? source.substring(3) : source;
-        String targetId = target.startsWith("id-") ? target.substring(3) : target;
-        String type = xsiType != null ? xsiType : "Association";
-
-        relationships.add(new ParsedRelationship(identifier, sourceId, targetId, type));
+        relationships.add(new ParsedRelationship(
+                identifier,
+                stripIdentifierPrefix(source),
+                stripIdentifierPrefix(target),
+                xsiType != null ? xsiType : "Association"));
     }
 
     private Map<String, TaxonomyNode> matchElements(Map<String, ParsedElement> elements,
-                                                      List<String> notes) {
+                                                     List<String> notes) {
         Map<String, TaxonomyNode> matched = new LinkedHashMap<>();
-
-        for (ParsedElement el : elements.values()) {
-            String taxonomyRoot = PROFILE.mapElementType(el.type);
+        for (ParsedElement element : elements.values()) {
+            String taxonomyRoot = PROFILE.mapElementType(element.type());
             if (taxonomyRoot == null) {
-                notes.add("Unknown ArchiMate type: " + el.type + " for element " + el.label);
+                notes.add("Unknown ArchiMate type: " + element.type() + " for element " + element.label());
+                continue;
+            }
+            if (element.label() == null || element.label().isBlank()) {
                 continue;
             }
 
-            // Try to find a matching taxonomy node by name in the expected root
-            if (el.label != null && !el.label.isBlank()) {
-                List<TaxonomyNode> candidates = nodeRepository
-                        .findByTaxonomyRootOrderByLevelAscNameEnAsc(taxonomyRoot);
-
-                TaxonomyNode bestMatch = findBestMatch(el.label, candidates);
-                if (bestMatch != null) {
-                    matched.put(el.id, bestMatch);
-                }
+            List<TaxonomyNode> candidates = nodeRepository
+                    .findByTaxonomyRootOrderByLevelAscNameEnAsc(taxonomyRoot);
+            TaxonomyNode bestMatch = findBestMatch(element.label(), candidates);
+            if (bestMatch != null) {
+                matched.put(element.id(), bestMatch);
             }
         }
-
-        notes.add("Matched " + matched.size() + " of " + elements.size() + " elements to taxonomy nodes");
+        notes.add("Matched " + matched.size() + " of " + elements.size()
+                + " elements to taxonomy nodes");
         return matched;
     }
 
     private TaxonomyNode findBestMatch(String label, List<TaxonomyNode> candidates) {
-        if (candidates.isEmpty()) return null;
-
+        if (candidates.isEmpty()) {
+            return null;
+        }
         String normalizedLabel = label.toLowerCase(Locale.ROOT).trim();
-
-        // First: exact name match
         for (TaxonomyNode node : candidates) {
-            if (node.getNameEn() != null &&
-                    node.getNameEn().toLowerCase(Locale.ROOT).trim().equals(normalizedLabel)) {
+            if (node.getNameEn() != null
+                    && node.getNameEn().toLowerCase(Locale.ROOT).trim().equals(normalizedLabel)) {
                 return node;
             }
         }
-
-        // Second: contains match
         for (TaxonomyNode node : candidates) {
-            if (node.getNameEn() != null) {
-                String nodeName = node.getNameEn().toLowerCase(Locale.ROOT).trim();
-                if (nodeName.contains(normalizedLabel) || normalizedLabel.contains(nodeName)) {
-                    return node;
-                }
+            if (node.getNameEn() == null) {
+                continue;
+            }
+            String nodeName = node.getNameEn().toLowerCase(Locale.ROOT).trim();
+            if (nodeName.contains(normalizedLabel) || normalizedLabel.contains(nodeName)) {
+                return node;
             }
         }
-
         return null;
     }
 
-    private int createRelations(List<ParsedRelationship> relationships,
-                                 Map<String, ParsedElement> elements,
-                                 Map<String, TaxonomyNode> matchedNodes,
-                                 List<String> notes) {
-        int created = 0;
-
-        for (ParsedRelationship rel : relationships) {
-            TaxonomyNode sourceNode = matchedNodes.get(rel.sourceId);
-            TaxonomyNode targetNode = matchedNodes.get(rel.targetId);
-
-            if (sourceNode == null || targetNode == null) continue;
-
-            String relTypeName = PROFILE.mapRelationType(rel.type);
-            RelationType relationType = relTypeName != null
-                    ? RelationType.valueOf(relTypeName)
-                    : RelationType.RELATED_TO;
-
-            // Check if relation already exists
-            List<TaxonomyRelation> existing = relationRepository
-                    .findBySourceNodeCode(sourceNode.getCode());
-            boolean alreadyExists = existing.stream()
-                    .anyMatch(r -> r.getTargetNode().getCode().equals(targetNode.getCode()) &&
-                            r.getRelationType() == relationType);
-
-            if (!alreadyExists) {
-                TaxonomyRelation newRel = new TaxonomyRelation();
-                newRel.setSourceNode(sourceNode);
-                newRel.setTargetNode(targetNode);
-                newRel.setRelationType(relationType);
-                newRel.setDescription("Imported from ArchiMate XML");
-                newRel.setProvenance("ARCHIMATE_IMPORT");
-                relationRepository.save(newRel);
-                created++;
-            }
+    private static WorkspaceContext requireContext(WorkspaceContext context) {
+        if (context == null) {
+            throw new ArchiMateImportException("An explicit workspace context is required");
         }
-
-        notes.add("Created " + created + " new relations (" +
-                (relationships.size() - created) + " already existed or had unmatched endpoints)");
-        return created;
+        return context;
     }
 
-    // ── Internal record types ─────────────────────────────────────────────────
+    private static String stripIdentifierPrefix(String value) {
+        return value.startsWith("id-") ? value.substring(3) : value;
+    }
 
-    /** Represents a parsed ArchiMate element with its id, ArchiMate type, display label, and optional documentation text. */
-    private record ParsedElement(String id, String type, String label, String documentation) {}
+    private static String scopeName(WorkspaceContext context) {
+        return context.workspaceId() != null ? context.workspaceId() : "shared";
+    }
 
-    /** Represents a parsed ArchiMate relationship linking a source element to a target element via a specific relationship type. */
-    private record ParsedRelationship(String id, String sourceId, String targetId, String type) {}
+    private record ParsedModel(Map<String, ParsedElement> elements,
+                               List<ParsedRelationship> relationships) {
+    }
+
+    private record ParsedElement(String id, String type, String label, String documentation) {
+    }
+
+    private record ParsedRelationship(String id, String sourceId, String targetId, String type) {
+    }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/CatalogFacade.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/CatalogFacade.java
@@ -47,9 +47,14 @@ public class CatalogFacade {
         return dto;
     }
 
-    public ArchiMateImportResult importAndValidate(InputStream xmlStream) {
-        log.info("Starting ArchiMate XML import via facade");
-        ArchiMateImportResult result = archiMateXmlImporter.importXml(xmlStream);
+    public ArchiMateImportResult importAndValidate(InputStream xmlStream,
+                                                    WorkspaceContext workspaceContext) {
+        if (workspaceContext == null) {
+            throw new IllegalArgumentException("Workspace context is required for ArchiMate import");
+        }
+        log.info("Starting ArchiMate XML import via facade for workspace {}",
+                workspaceContext.workspaceId());
+        ArchiMateImportResult result = archiMateXmlImporter.importXml(xmlStream, workspaceContext);
         log.info("ArchiMate import complete – {} elements matched, {} relations created",
                 result.getElementsMatched(), result.getRelationsImported());
         return result;
@@ -57,8 +62,8 @@ public class CatalogFacade {
 
     @Transactional(readOnly = true)
     public List<TaxonomyNodeDto> searchWithContext(String query,
-                                                    int maxResults,
-                                                    WorkspaceContext workspaceContext) {
+                                                   int maxResults,
+                                                   WorkspaceContext workspaceContext) {
         List<TaxonomyNodeDto> results = searchService.search(query, maxResults);
         results.forEach(dto -> attachRelations(dto, workspaceContext));
         return results;

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -55,6 +55,22 @@ public class TaxonomyRelationService {
         return toDtos(relations);
     }
 
+    /**
+     * Returns whether an equivalent relation is already visible in the target
+     * workspace. Personal workspaces inherit shared baseline relations, while a
+     * null workspace checks shared rows only and never scans personal data.
+     */
+    @Transactional(readOnly = true)
+    public boolean relationExistsVisible(String sourceCode, String targetCode,
+                                         RelationType type,
+                                         @Nullable String workspaceId) {
+        List<TaxonomyRelation> existing = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndSourceTargetType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
+        return !existing.isEmpty();
+    }
+
     // ── Legacy delegating read methods (shared scope) ───────────────
 
     @Transactional(readOnly = true)
@@ -85,14 +101,7 @@ public class TaxonomyRelationService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        // Workspace overlays inherit shared relations, so an equivalent shared
-        // relation remains a duplicate for creation. Shared mode checks shared
-        // rows only and never scans personal workspaces.
-        List<TaxonomyRelation> existing = workspaceId != null
-                ? relationRepository.findByWorkspaceAndSourceTargetType(
-                        workspaceId, sourceCode, targetCode, type)
-                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
-        if (!existing.isEmpty()) {
+        if (relationExistsVisible(sourceCode, targetCode, type, workspaceId)) {
             throw new IllegalArgumentException(String.format(
                     "Relation already exists: %s --[%s]--> %s (workspace=%s)",
                     sourceCode, type, targetCode, workspaceId));

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -1,11 +1,11 @@
 package com.taxonomy.catalog.service;
 
-import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.RelationType;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.catalog.model.TaxonomyRelation;
 import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.RelationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -178,18 +178,39 @@ public class TaxonomyRelationService {
     }
 
     /**
-     * Delete all relations matching a specific source, target, and type combination.
-     * Used by the proposal revert mechanism to remove accepted relations.
+     * Delete relations matching a specific source, target, type, and exact
+     * workspace. A null workspace ID means shared relations only, never all
+     * workspaces.
+     */
+    @Transactional
+    public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
+                                                  RelationType type,
+                                                  @Nullable String workspaceId) {
+        List<TaxonomyRelation> matches;
+        if (workspaceId != null) {
+            matches = relationRepository.findByWorkspaceAndSourceTargetType(
+                    workspaceId, sourceCode, targetCode, type);
+        } else {
+            matches = relationRepository
+                    .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type)
+                    .stream()
+                    .filter(relation -> relation.getWorkspaceId() == null)
+                    .toList();
+        }
+        if (!matches.isEmpty()) {
+            relationRepository.deleteAll(matches);
+            log.info("Deleted {} relation(s): {} --[{}]--> {} (workspace={})",
+                    matches.size(), sourceCode, type, targetCode, workspaceId);
+        }
+    }
+
+    /**
+     * Legacy overload — operates on shared relations only.
      */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type) {
-        List<TaxonomyRelation> matches = relationRepository
-                .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type);
-        if (!matches.isEmpty()) {
-            relationRepository.deleteAll(matches);
-            log.info("Deleted {} relation(s): {} --[{}]--> {}", matches.size(), sourceCode, type, targetCode);
-        }
+        deleteRelationBySourceTargetType(sourceCode, targetCode, type, null);
     }
 
     public TaxonomyRelationDto toDto(TaxonomyRelation relation) {

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -33,50 +33,29 @@ public class TaxonomyRelationService {
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsForNode(String code, @Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceAndNodeCode(workspaceId, code);
-        } else {
-            relations = relationRepository.findBySourceNodeCodeOrTargetNodeCode(code, code);
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndNodeCode(workspaceId, code)
+                : relationRepository.findSharedByNodeCode(code);
+        return toDtos(relations);
     }
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsByType(RelationType type, @Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceAndRelationType(workspaceId, type);
-        } else {
-            relations = relationRepository.findByRelationType(type);
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndRelationType(workspaceId, type)
+                : relationRepository.findByRelationTypeAndWorkspaceIdIsNull(type);
+        return toDtos(relations);
     }
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getAllRelations(@Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceIdIsNullOrWorkspaceId(workspaceId);
-        } else {
-            relations = relationRepository.findAll();
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspace(workspaceId)
+                : relationRepository.findByWorkspaceIdIsNull();
+        return toDtos(relations);
     }
 
-    // ── Legacy delegating read methods (backward-compatible) ─────────
+    // ── Legacy delegating read methods (shared scope) ───────────────
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsForNode(String code) {
@@ -106,19 +85,13 @@ public class TaxonomyRelationService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        // Programmatic duplicate check (covers NULL workspace_id in unique constraint)
-        List<TaxonomyRelation> existing;
-        if (workspaceId != null) {
-            existing = relationRepository.findByWorkspaceAndSourceTargetType(
-                    workspaceId, sourceCode, targetCode, type);
-        } else {
-            existing = relationRepository.findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                    sourceCode, targetCode, type);
-            // Filter to only those with null workspace for exact match
-            existing = existing.stream()
-                    .filter(r -> r.getWorkspaceId() == null)
-                    .toList();
-        }
+        // Workspace overlays inherit shared relations, so an equivalent shared
+        // relation remains a duplicate for creation. Shared mode checks shared
+        // rows only and never scans personal workspaces.
+        List<TaxonomyRelation> existing = workspaceId != null
+                ? relationRepository.findByWorkspaceAndSourceTargetType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
         if (!existing.isEmpty()) {
             throw new IllegalArgumentException(String.format(
                     "Relation already exists: %s --[%s]--> %s (workspace=%s)",
@@ -139,9 +112,7 @@ public class TaxonomyRelationService {
         return toDto(saved);
     }
 
-    /**
-     * Legacy overload — delegates to workspace-aware method with null workspace.
-     */
+    /** Legacy overload — creates a shared relation. */
     @Transactional
     public TaxonomyRelationDto createRelation(String sourceCode, String targetCode,
                                               RelationType type, String description,
@@ -150,53 +121,37 @@ public class TaxonomyRelationService {
     }
 
     /**
-     * Delete a relation by ID, with optional workspace ownership check.
-     *
-     * <p>If {@code workspaceId} is non-null, the relation must either belong to
-     * the given workspace or be a shared (null workspace) relation. If it belongs
-     * to a different workspace, an {@link IllegalArgumentException} is thrown.
+     * Deletes a relation only when it belongs to the exact active workspace.
+     * A null workspace ID means shared scope only; a personal workspace can
+     * never delete a shared or foreign-workspace relation by guessing its ID.
      */
     @Transactional
     public void deleteRelation(Long id, @Nullable String workspaceId) {
-        if (workspaceId != null) {
-            TaxonomyRelation relation = relationRepository.findById(id).orElse(null);
-            if (relation != null && relation.getWorkspaceId() != null
-                    && !workspaceId.equals(relation.getWorkspaceId())) {
-                throw new IllegalArgumentException(
-                        "Relation " + id + " belongs to workspace '" + relation.getWorkspaceId()
-                                + "', not '" + workspaceId + "'");
-            }
-        }
-        relationRepository.deleteById(id);
+        TaxonomyRelation relation = relationRepository.findByIdInWorkspace(id, workspaceId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Relation not found in active workspace: " + id));
+        relationRepository.delete(relation);
         log.info("Deleted relation with id: {} (workspace={})", id, workspaceId);
     }
 
-    /** Legacy overload — deletes without workspace ownership check. */
+    /** Legacy overload — deletes a shared relation only. */
     @Transactional
     public void deleteRelation(Long id) {
         deleteRelation(id, null);
     }
 
     /**
-     * Delete relations matching a specific source, target, type, and exact
-     * workspace. A null workspace ID means shared relations only, never all
-     * workspaces.
+     * Deletes relations matching a source, target, type, and exact workspace.
+     * A null workspace ID means shared relations only, never all workspaces.
      */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type,
                                                   @Nullable String workspaceId) {
-        List<TaxonomyRelation> matches;
-        if (workspaceId != null) {
-            matches = relationRepository.findByWorkspaceAndSourceTargetType(
-                    workspaceId, sourceCode, targetCode, type);
-        } else {
-            matches = relationRepository
-                    .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type)
-                    .stream()
-                    .filter(relation -> relation.getWorkspaceId() == null)
-                    .toList();
-        }
+        List<TaxonomyRelation> matches = workspaceId != null
+                ? relationRepository.findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
         if (!matches.isEmpty()) {
             relationRepository.deleteAll(matches);
             log.info("Deleted {} relation(s): {} --[{}]--> {} (workspace={})",
@@ -204,9 +159,7 @@ public class TaxonomyRelationService {
         }
     }
 
-    /**
-     * Legacy overload — operates on shared relations only.
-     */
+    /** Legacy overload — operates on shared relations only. */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type) {
@@ -230,15 +183,22 @@ public class TaxonomyRelationService {
 
     @Transactional(readOnly = true)
     public long countRelations(@Nullable String workspaceId) {
-        if (workspaceId != null) {
-            return relationRepository.countByWorkspaceIdIsNullOrWorkspaceId(workspaceId);
-        }
-        return relationRepository.count();
+        return workspaceId != null
+                ? relationRepository.countVisibleByWorkspace(workspaceId)
+                : relationRepository.countByWorkspaceIdIsNull();
     }
 
-    /** Legacy overload — counts all relations. */
+    /** Legacy overload — counts shared relations only. */
     @Transactional(readOnly = true)
     public long countRelations() {
         return countRelations(null);
+    }
+
+    private List<TaxonomyRelationDto> toDtos(List<TaxonomyRelation> relations) {
+        List<TaxonomyRelationDto> dtos = new ArrayList<>(relations.size());
+        for (TaxonomyRelation relation : relations) {
+            dtos.add(toDto(relation));
+        }
+        return dtos;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
@@ -1,11 +1,12 @@
 package com.taxonomy.relations.model;
 
-import jakarta.persistence.*;
-import org.hibernate.annotations.Nationalized;
-import java.time.Instant;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Nationalized;
+
+import java.time.Instant;
 
 /**
  * A proposed relation between two taxonomy nodes, awaiting human review.
@@ -14,7 +15,11 @@ import com.taxonomy.model.RelationType;
 @Entity
 @Table(name = "relation_proposal",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"source_node_id", "target_node_id", "relation_type"}))
+                columnNames = {"source_node_id", "target_node_id", "relation_type", "workspace_id"}),
+        indexes = {
+                @Index(name = "idx_proposal_workspace", columnList = "workspace_id"),
+                @Index(name = "idx_proposal_owner", columnList = "owner_username")
+        })
 public class RelationProposal {
 
     @Id

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RelationProposalRepository extends JpaRepository<RelationProposal, Long> {
@@ -44,10 +45,45 @@ public interface RelationProposalRepository extends JpaRepository<RelationPropos
 
     // ── Workspace-scoped queries ─────────────────────────────────────
 
+    /**
+     * Looks up a proposal in exactly one workspace. A null workspace ID means
+     * shared scope only; it never means all workspaces.
+     */
+    @Query("""
+            SELECT p FROM RelationProposal p
+            WHERE p.id = :id
+              AND ((:wsId IS NULL AND p.workspaceId IS NULL) OR p.workspaceId = :wsId)
+            """)
+    Optional<RelationProposal> findByIdInWorkspace(@Param("id") Long id,
+                                                    @Param("wsId") String workspaceId);
+
+    /**
+     * Checks a proposal triple in exactly one workspace. A null workspace ID
+     * is matched with IS NULL so shared mode cannot observe foreign workspaces.
+     */
+    @Query("""
+            SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END
+            FROM RelationProposal p
+            WHERE p.sourceNode.code = :sourceCode
+              AND p.targetNode.code = :targetCode
+              AND p.relationType = :relationType
+              AND ((:wsId IS NULL AND p.workspaceId IS NULL) OR p.workspaceId = :wsId)
+            """)
+    boolean existsInWorkspace(@Param("sourceCode") String sourceCode,
+                              @Param("targetCode") String targetCode,
+                              @Param("relationType") RelationType relationType,
+                              @Param("wsId") String workspaceId);
+
     boolean existsBySourceNodeCodeAndTargetNodeCodeAndRelationTypeAndWorkspaceId(
             String sourceCode, String targetCode, RelationType relationType, String workspaceId);
 
     List<RelationProposal> findByWorkspaceId(String workspaceId);
+
+    List<RelationProposal> findByWorkspaceIdIsNull();
+
+    List<RelationProposal> findByStatusAndWorkspaceIdIsNull(ProposalStatus status);
+
+    List<RelationProposal> findBySourceNodeCodeAndWorkspaceIdIsNull(String sourceCode);
 
     @Query("SELECT p FROM RelationProposal p WHERE p.workspaceId = :wsId OR p.workspaceId IS NULL")
     List<RelationProposal> findByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
@@ -1,10 +1,13 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyNodeDto;
-import com.taxonomy.model.*;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
-import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import org.slf4j.Logger;
@@ -14,10 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.model.ProposalStatus;
-import com.taxonomy.model.RelationType;
-import com.taxonomy.relations.model.RelationProposal;
 
 /**
  * Orchestrator for the Relation Proposal Pipeline.
@@ -78,25 +77,18 @@ public class RelationProposalService {
 
         List<RelationProposalDto> proposals = new ArrayList<>();
 
-        // Resolve workspace context
+        // Resolve workspace context once for the complete operation.
         WorkspaceContext ctx = contextResolver.resolveCurrentContext();
 
         // 2–4. Validate each candidate and create proposals
         for (int i = 0; i < candidates.size(); i++) {
             TaxonomyNodeDto candidate = candidates.get(i);
 
-            // Skip if a proposal already exists for this triple in this workspace
-            if (ctx.workspaceId() != null) {
-                if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationTypeAndWorkspaceId(
-                        sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId())) {
-                    log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
-                            sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId());
-                    continue;
-                }
-            } else if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                    sourceNodeCode, candidate.getCode(), relationType)) {
-                log.debug("Proposal already exists: {} → {} [{}]",
-                        sourceNodeCode, candidate.getCode(), relationType);
+            // A null workspace means the shared scope only, never all workspaces.
+            if (proposalRepository.existsInWorkspace(
+                    sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId())) {
+                log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
+                        sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId());
                 continue;
             }
 
@@ -122,14 +114,14 @@ public class RelationProposalService {
 
                 RelationProposal saved = proposalRepository.save(proposal);
                 proposals.add(toDto(saved));
-                log.debug("Created proposal: {} → {} [{}] confidence={}",
+                log.debug("Created proposal: {} → {} [{}] confidence={} (workspace={})",
                         sourceNodeCode, candidate.getCode(), relationType,
-                        result.getConfidence());
+                        result.getConfidence(), ctx.workspaceId());
             }
         }
 
-        log.info("Proposed {} relations for node '{}' [{}]",
-                proposals.size(), sourceNodeCode, relationType);
+        log.info("Proposed {} relations for node '{}' [{}] (workspace={})",
+                proposals.size(), sourceNodeCode, relationType, ctx.workspaceId());
         return proposals;
     }
 
@@ -140,7 +132,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findByStatusAndWorkspace(ProposalStatus.PENDING, ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findByStatus(ProposalStatus.PENDING);
+            proposals = proposalRepository.findByStatusAndWorkspaceIdIsNull(ProposalStatus.PENDING);
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -152,7 +144,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findByWorkspaceIdIsNullOrWorkspaceId(ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findAll();
+            proposals = proposalRepository.findByWorkspaceIdIsNull();
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -164,7 +156,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findBySourceNodeCodeAndWorkspace(sourceCode, ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findBySourceNodeCode(sourceCode);
+            proposals = proposalRepository.findBySourceNodeCodeAndWorkspaceIdIsNull(sourceCode);
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -189,9 +181,11 @@ public class RelationProposalService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                sourceCode, targetCode, relationType)) {
-            log.debug("Proposal already exists: {} → {} [{}]", sourceCode, targetCode, relationType);
+        WorkspaceContext ctx = contextResolver.resolveCurrentContext();
+        if (proposalRepository.existsInWorkspace(
+                sourceCode, targetCode, relationType, ctx.workspaceId())) {
+            log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
+                    sourceCode, targetCode, relationType, ctx.workspaceId());
             return null;
         }
 
@@ -203,14 +197,12 @@ public class RelationProposalService {
         proposal.setRationale(rationale);
         proposal.setProvenance("analysis-hypothesis");
         proposal.setStatus(ProposalStatus.PENDING);
-
-        WorkspaceContext ctx = contextResolver.resolveCurrentContext();
         proposal.setWorkspaceId(ctx.workspaceId());
         proposal.setOwnerUsername(ctx.username());
 
         RelationProposal saved = proposalRepository.save(proposal);
-        log.info("Created proposal from hypothesis: {} → {} [{}] confidence={}",
-                sourceCode, targetCode, relationType, confidence);
+        log.info("Created proposal from hypothesis: {} → {} [{}] confidence={} (workspace={})",
+                sourceCode, targetCode, relationType, confidence, ctx.workspaceId());
         return toDto(saved);
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
@@ -1,19 +1,20 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.*;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import com.taxonomy.catalog.model.TaxonomyRelation;
-import com.taxonomy.catalog.service.TaxonomyRelationService;
-import com.taxonomy.model.ProposalStatus;
-import com.taxonomy.relations.model.RelationProposal;
 
 /**
  * Handles the human review workflow for relation proposals.
@@ -27,66 +28,61 @@ public class RelationReviewService {
     private final RelationProposalRepository proposalRepository;
     private final TaxonomyRelationService relationService;
     private final RelationProposalService proposalService;
+    private final WorkspaceContextResolver contextResolver;
 
     public RelationReviewService(RelationProposalRepository proposalRepository,
                                  TaxonomyRelationService relationService,
-                                 RelationProposalService proposalService) {
+                                 RelationProposalService proposalService,
+                                 WorkspaceContextResolver contextResolver) {
         this.proposalRepository = proposalRepository;
         this.relationService = relationService;
         this.proposalService = proposalService;
+        this.contextResolver = contextResolver;
     }
 
     /**
-     * Accept a proposal: creates a real TaxonomyRelation and marks the proposal as ACCEPTED.
-     *
-     * <p>The relation is created in the proposal's workspace (using the proposal's stored
-     * {@code workspaceId}/{@code ownerUsername}). For legacy proposals with null workspace,
-     * the relation is created in the shared/legacy scope.
+     * Accept a proposal in the active workspace: creates a real TaxonomyRelation
+     * and marks the proposal as ACCEPTED.
      */
     @Transactional
     public TaxonomyRelationDto acceptProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
                     "Proposal " + proposalId + " is already " + proposal.getStatus());
         }
 
-        // Create the real relation in the proposal's workspace (not the current user's)
-        String workspaceId = proposal.getWorkspaceId();
-        String ownerUsername = proposal.getOwnerUsername();
         TaxonomyRelationDto relation = relationService.createRelation(
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
                 proposal.getRelationType(),
                 proposal.getRationale(),
                 "proposal-pipeline",
-                workspaceId, ownerUsername);
+                context.workspaceId(), context.username());
 
-        // Mark proposal as accepted
         proposal.setStatus(ProposalStatus.ACCEPTED);
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
 
-        log.info("Accepted proposal {}: {} → {} [{}]",
+        log.info("Accepted proposal {}: {} → {} [{}] (workspace={})",
                 proposalId,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return relation;
     }
 
     /**
-     * Reject a proposal.
+     * Reject a proposal in the active workspace.
      */
     @Transactional
     public RelationProposalDto rejectProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
@@ -97,24 +93,25 @@ public class RelationReviewService {
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
 
-        log.info("Rejected proposal {}: {} → {} [{}]",
+        log.info("Rejected proposal {}: {} → {} [{}] (workspace={})",
                 proposalId,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return proposalService.toDto(proposal);
     }
 
     /**
-     * Revert a previously accepted or rejected proposal back to PENDING status.
-     * If the proposal was accepted, the corresponding relation is deleted.
+     * Revert a previously accepted or rejected proposal in the active workspace
+     * back to PENDING status. If the proposal was accepted, only the relation in
+     * that exact workspace is deleted.
      */
     @Transactional
     public RelationProposalDto revertProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() == ProposalStatus.PENDING) {
             throw new IllegalStateException(
@@ -123,24 +120,32 @@ public class RelationReviewService {
 
         ProposalStatus oldStatus = proposal.getStatus();
 
-        // If accepted, remove the created relation
         if (oldStatus == ProposalStatus.ACCEPTED) {
             relationService.deleteRelationBySourceTargetType(
                     proposal.getSourceNode().getCode(),
                     proposal.getTargetNode().getCode(),
-                    proposal.getRelationType());
+                    proposal.getRelationType(),
+                    context.workspaceId());
         }
 
         proposal.setStatus(ProposalStatus.PENDING);
         proposal.setReviewedAt(null);
         proposalRepository.save(proposal);
 
-        log.info("Reverted proposal {} from {} to PENDING: {} → {} [{}]",
+        log.info("Reverted proposal {} from {} to PENDING: {} → {} [{}] (workspace={})",
                 proposalId, oldStatus,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return proposalService.toDto(proposal);
+    }
+
+    private RelationProposal findProposalInActiveWorkspace(Long proposalId,
+                                                            WorkspaceContext context) {
+        return proposalRepository.findByIdInWorkspace(proposalId, context.workspaceId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Proposal not found in active workspace: " + proposalId));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -48,6 +48,13 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.PUT,    "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
 
+        // Proposal generation and review mutate proposal state and can create or
+        // delete real relations. Keep these endpoints out of the generic
+        // authenticated-user fallback.
+        auth.requestMatchers(HttpMethod.POST,   "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT,    "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.DELETE, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+
         auth.requestMatchers(HttpMethod.POST,   "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PUT,    "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
@@ -1,0 +1,153 @@
+package com.taxonomy;
+
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.catalog.service.ArchiMateImportException;
+import com.taxonomy.catalog.service.ArchiMateXmlImporter;
+import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@WithMockUser(username = "qa-architect", roles = {"USER", "ARCHITECT"})
+class ArchiMateWorkspaceImportTests {
+
+    @Autowired
+    private ArchiMateXmlImporter importer;
+
+    @Autowired
+    private TaxonomyRelationRepository relationRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void previewReportsEligibleRelationWithoutWriting() {
+        WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        long before = relationRepository.count();
+
+        ArchiMateImportResult result = importer.previewXml(stream(validModel()), context);
+
+        assertThat(result.isPreview()).isTrue();
+        assertThat(result.getElementsMatched()).isEqualTo(2);
+        assertThat(result.getRelationsParsed()).isEqualTo(1);
+        assertThat(result.getRelationsImported()).isZero();
+        assertThat(result.getRelationsSkipped()).isZero();
+        assertThat(result.getRelationsRejected()).isZero();
+        assertThat(relationRepository.count()).isEqualTo(before);
+    }
+
+    @Test
+    void equivalentModelsCanBeImportedIntoSeparateWorkspaces() {
+        WorkspaceContext firstContext = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        WorkspaceContext secondContext = new WorkspaceContext("bob", "qa-archimate-b", "draft");
+
+        ArchiMateImportResult first = importer.importXml(stream(validModel()), firstContext);
+        ArchiMateImportResult second = importer.importXml(stream(validModel()), secondContext);
+
+        assertThat(first.getRelationsImported()).isEqualTo(1);
+        assertThat(second.getRelationsImported()).isEqualTo(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-b")).hasSize(1);
+        assertThat(relationRepository.findByWorkspaceIdIsNull()).isEmpty();
+    }
+
+    @Test
+    void repeatedImportInSameWorkspaceIsReportedAsDuplicate() {
+        WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        importer.importXml(stream(validModel()), context);
+
+        ArchiMateImportResult duplicate = importer.importXml(stream(validModel()), context);
+
+        assertThat(duplicate.getRelationsImported()).isZero();
+        assertThat(duplicate.getRelationsSkipped()).isEqualTo(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
+    }
+
+    @Test
+    void malformedXmlFailsInsteadOfReturningSuccessfulResult() {
+        assertThatThrownBy(() -> importer.importXml(
+                stream("<model><elements>"), WorkspaceContext.SHARED))
+                .isInstanceOf(ArchiMateImportException.class)
+                .hasMessageContaining("Malformed");
+    }
+
+    @Test
+    void endpointReturns422ForMalformedXmlAndDoesNotMutateRelations() throws Exception {
+        long before = relationRepository.count();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "broken.xml", MediaType.APPLICATION_XML_VALUE,
+                "<model><elements>".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/api/import/archimate").file(file))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error").value("INVALID_ARCHIMATE_XML"));
+
+        assertThat(relationRepository.count()).isEqualTo(before);
+    }
+
+    @Test
+    void endpointRejectsDoctypeAndExternalEntityInput() throws Exception {
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE model [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                  <elements>
+                    <element identifier="id-e1" xsi:type="Capability"><name>&xxe;</name></element>
+                  </elements>
+                </model>
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "xxe.xml", MediaType.APPLICATION_XML_VALUE,
+                xml.getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/api/import/preview/archimate").file(file))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error").value("INVALID_ARCHIMATE_XML"));
+    }
+
+    private static ByteArrayInputStream stream(String xml) {
+        return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String validModel() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       identifier="id-model-1">
+                  <elements>
+                    <element identifier="id-e1" xsi:type="Capability">
+                      <name xml:lang="en">Capabilities</name>
+                    </element>
+                    <element identifier="id-e2" xsi:type="ApplicationService">
+                      <name xml:lang="en">Core Services</name>
+                    </element>
+                  </elements>
+                  <relationships>
+                    <relationship identifier="id-r1" xsi:type="Realization"
+                                  source="id-e1" target="id-e2"/>
+                  </relationships>
+                </model>
+                """;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
@@ -59,6 +59,7 @@ class ArchiMateWorkspaceImportTests {
     void equivalentModelsCanBeImportedIntoSeparateWorkspaces() {
         WorkspaceContext firstContext = new WorkspaceContext("alice", "qa-archimate-a", "draft");
         WorkspaceContext secondContext = new WorkspaceContext("bob", "qa-archimate-b", "draft");
+        long sharedBefore = relationRepository.countByWorkspaceIdIsNull();
 
         ArchiMateImportResult first = importer.importXml(stream(validModel()), firstContext);
         ArchiMateImportResult second = importer.importXml(stream(validModel()), secondContext);
@@ -67,7 +68,7 @@ class ArchiMateWorkspaceImportTests {
         assertThat(second.getRelationsImported()).isEqualTo(1);
         assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
         assertThat(relationRepository.findByWorkspaceId("qa-archimate-b")).hasSize(1);
-        assertThat(relationRepository.findByWorkspaceIdIsNull()).isEmpty();
+        assertThat(relationRepository.countByWorkspaceIdIsNull()).isEqualTo(sharedBefore);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/SecurityTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/SecurityTests.java
@@ -8,6 +8,8 @@ import com.taxonomy.security.repository.RoleRepository;
 import com.taxonomy.security.repository.UserRepository;
 import com.taxonomy.security.service.DatabaseUserDetailsService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -21,8 +23,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for Spring Security configuration: authentication, authorization,
@@ -143,7 +146,7 @@ class SecurityTests {
                 .andExpect(status().isOk());
     }
 
-    // ── Role-based access: USER cannot write relations ────────────────────────
+    // ── Role-based access: USER cannot mutate architecture state ─────────────
 
     @Test
     @WithMockUser(roles = "USER")
@@ -163,7 +166,25 @@ class SecurityTests {
                 .andExpect(status().isForbidden());
     }
 
-    // ── Role-based access: ARCHITECT can write relations ──────────────────────
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/proposals/propose",
+            "/api/proposals/from-hypothesis",
+            "/api/proposals/999/accept",
+            "/api/proposals/999/reject",
+            "/api/proposals/999/revert",
+            "/api/proposals/bulk/accept",
+            "/api/proposals/bulk/reject"
+    })
+    @WithMockUser(roles = "USER")
+    void userCannotMutateRelationProposals(String endpoint) throws Exception {
+        mockMvc.perform(post(endpoint)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Role-based access: ARCHITECT can write architecture state ────────────
 
     @Test
     @WithMockUser(roles = "ARCHITECT")
@@ -172,6 +193,13 @@ class SecurityTests {
                         .contentType(MediaType.TEXT_PLAIN)
                         .content("meta { }"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "ARCHITECT")
+    void architectReachesProposalController() throws Exception {
+        mockMvc.perform(post("/api/proposals/999/accept"))
+                .andExpect(status().isBadRequest());
     }
 
     // ── Role-based access: Admin-only endpoints ───────────────────────────────

--- a/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
@@ -1,0 +1,146 @@
+package com.taxonomy;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.relations.service.RelationProposalService;
+import com.taxonomy.relations.service.RelationReviewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for exact-scope proposal and relation access.
+ *
+ * <p>The mock user has no provisioned workspace and therefore resolves to the
+ * shared context. Shared context must never mean unrestricted access to all
+ * personal workspaces.
+ */
+@SpringBootTest
+@Transactional
+@WithMockUser(username = "qa-admin", roles = {"USER", "ARCHITECT", "ADMIN"})
+class WorkspaceRelationIsolationTests {
+
+    @Autowired
+    private TaxonomyNodeRepository nodeRepository;
+
+    @Autowired
+    private RelationProposalRepository proposalRepository;
+
+    @Autowired
+    private TaxonomyRelationRepository relationRepository;
+
+    @Autowired
+    private RelationProposalService proposalService;
+
+    @Autowired
+    private RelationReviewService reviewService;
+
+    @Autowired
+    private TaxonomyRelationService relationService;
+
+    @Test
+    void sharedContextCannotReviewForeignWorkspaceProposal() {
+        RelationProposal foreign = proposalRepository.saveAndFlush(
+                newProposal("qa-foreign-workspace", "other-user"));
+
+        assertThatThrownBy(() -> reviewService.acceptProposal(foreign.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("active workspace");
+
+        RelationProposal unchanged = proposalRepository.findById(foreign.getId()).orElseThrow();
+        assertThat(unchanged.getStatus()).isEqualTo(ProposalStatus.PENDING);
+    }
+
+    @Test
+    void identicalProposalTriplesCanExistInSeparateWorkspaces() {
+        RelationProposal first = proposalRepository.save(newProposal("qa-workspace-a", "alice"));
+        RelationProposal second = proposalRepository.save(newProposal("qa-workspace-b", "bob"));
+        proposalRepository.flush();
+
+        assertThat(first.getId()).isNotEqualTo(second.getId());
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-a")).isTrue();
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-b")).isTrue();
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, null)).isFalse();
+    }
+
+    @Test
+    void sharedProposalReadsDoNotExposeForeignWorkspaceRows() {
+        RelationProposal foreign = proposalRepository.saveAndFlush(
+                newProposal("qa-private-workspace", "private-user"));
+
+        assertThat(proposalService.getAllProposals())
+                .noneMatch(dto -> dto.getId().equals(foreign.getId()));
+    }
+
+    @Test
+    void exactWorkspaceDeletePreservesEquivalentRelationInOtherWorkspace() {
+        relationService.createRelation(
+                "BP", "BP", RelationType.RELATED_TO, "workspace A", "qa-test",
+                "qa-workspace-a", "alice");
+        relationService.createRelation(
+                "BP", "BP", RelationType.RELATED_TO, "workspace B", "qa-test",
+                "qa-workspace-b", "bob");
+
+        relationService.deleteRelationBySourceTargetType(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-a");
+
+        assertThat(relationRepository
+                .findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "qa-workspace-a", "BP", "BP", RelationType.RELATED_TO))
+                .isEmpty();
+        assertThat(relationRepository
+                .findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "qa-workspace-b", "BP", "BP", RelationType.RELATED_TO))
+                .hasSize(1);
+    }
+
+    @Test
+    void sharedRelationReadsDoNotExposeForeignWorkspaceRows() {
+        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
+        TaxonomyRelation foreign = new TaxonomyRelation();
+        foreign.setSourceNode(node);
+        foreign.setTargetNode(node);
+        foreign.setRelationType(RelationType.RELATED_TO);
+        foreign.setDescription("private relation");
+        foreign.setProvenance("qa-test");
+        foreign.setWorkspaceId("qa-private-workspace");
+        foreign.setOwnerUsername("private-user");
+        foreign = relationRepository.saveAndFlush(foreign);
+
+        Long foreignId = foreign.getId();
+        assertThat(relationService.getAllRelations(null))
+                .noneMatch(dto -> dto.getId().equals(foreignId));
+        assertThat(relationService.countRelations(null))
+                .isEqualTo(relationRepository.countByWorkspaceIdIsNull());
+    }
+
+    private RelationProposal newProposal(String workspaceId, String owner) {
+        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
+        RelationProposal proposal = new RelationProposal();
+        proposal.setSourceNode(node);
+        proposal.setTargetNode(node);
+        proposal.setRelationType(RelationType.RELATED_TO);
+        proposal.setStatus(ProposalStatus.PENDING);
+        proposal.setConfidence(0.75);
+        proposal.setRationale("workspace isolation regression test");
+        proposal.setProvenance("qa-test");
+        proposal.setWorkspaceId(workspaceId);
+        proposal.setOwnerUsername(owner);
+        return proposal;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/catalog/service/CatalogFacadeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/catalog/service/CatalogFacadeTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -83,12 +84,23 @@ class CatalogFacadeTest {
     }
 
     @Test
-    void importDelegatesAndReturnsImportResult() {
+    void importDelegatesWithExplicitWorkspaceAndReturnsResult() {
         ByteArrayInputStream stream = new ByteArrayInputStream("<model/>".getBytes());
+        WorkspaceContext context = new WorkspaceContext("alice", "ws-1", "draft");
         ArchiMateImportResult expected = new ArchiMateImportResult();
-        when(archiMateXmlImporter.importXml(stream)).thenReturn(expected);
+        when(archiMateXmlImporter.importXml(stream, context)).thenReturn(expected);
 
-        assertThat(facade.importAndValidate(stream)).isSameAs(expected);
+        assertThat(facade.importAndValidate(stream, context)).isSameAs(expected);
+    }
+
+    @Test
+    void importRejectsMissingWorkspaceContext() {
+        ByteArrayInputStream stream = new ByteArrayInputStream("<model/>".getBytes());
+
+        assertThatThrownBy(() -> facade.importAndValidate(stream, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Workspace context");
+        verify(archiMateXmlImporter, never()).importXml(stream, WorkspaceContext.SHARED);
     }
 
     private static TaxonomyNodeDto dto(String code) {

--- a/taxonomy-domain/src/main/java/com/taxonomy/dto/ArchiMateImportResult.java
+++ b/taxonomy-domain/src/main/java/com/taxonomy/dto/ArchiMateImportResult.java
@@ -4,30 +4,50 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Result of an ArchiMate XML import operation.
- * Describes how many elements and relations were imported or matched.
+ * Result of an ArchiMate XML preview or import operation.
+ *
+ * <p>The counters deliberately distinguish parsing/matching from mutation so
+ * clients can tell whether a model was understood, skipped as a duplicate, or
+ * materialized into the active workspace.</p>
  */
 public class ArchiMateImportResult {
 
     private int elementsImported;
-    private int relationsImported;
     private int elementsMatched;
     private int elementsUnmatched;
+    private int relationsParsed;
+    private int relationsImported;
+    private int relationsSkipped;
+    private int relationsRejected;
+    private boolean preview;
     private List<String> notes = new ArrayList<>();
 
-    public ArchiMateImportResult() {}
+    public ArchiMateImportResult() {
+    }
 
     public int getElementsImported() { return elementsImported; }
     public void setElementsImported(int elementsImported) { this.elementsImported = elementsImported; }
-
-    public int getRelationsImported() { return relationsImported; }
-    public void setRelationsImported(int relationsImported) { this.relationsImported = relationsImported; }
 
     public int getElementsMatched() { return elementsMatched; }
     public void setElementsMatched(int elementsMatched) { this.elementsMatched = elementsMatched; }
 
     public int getElementsUnmatched() { return elementsUnmatched; }
     public void setElementsUnmatched(int elementsUnmatched) { this.elementsUnmatched = elementsUnmatched; }
+
+    public int getRelationsParsed() { return relationsParsed; }
+    public void setRelationsParsed(int relationsParsed) { this.relationsParsed = relationsParsed; }
+
+    public int getRelationsImported() { return relationsImported; }
+    public void setRelationsImported(int relationsImported) { this.relationsImported = relationsImported; }
+
+    public int getRelationsSkipped() { return relationsSkipped; }
+    public void setRelationsSkipped(int relationsSkipped) { this.relationsSkipped = relationsSkipped; }
+
+    public int getRelationsRejected() { return relationsRejected; }
+    public void setRelationsRejected(int relationsRejected) { this.relationsRejected = relationsRejected; }
+
+    public boolean isPreview() { return preview; }
+    public void setPreview(boolean preview) { this.preview = preview; }
 
     public List<String> getNotes() { return notes; }
     public void setNotes(List<String> notes) { this.notes = notes; }


### PR DESCRIPTION
## Summary

Implements the P0 data-isolation work from #422 as a stacked PR on top of #428.

### Changes

- resolves `WorkspaceContext` at the ArchiMate request boundary;
- adds `POST /api/import/preview/archimate` for parse/match/duplicate preview without writes;
- imports through `TaxonomyRelationService` instead of writing entities directly through the repository;
- treats shared baseline relations as visible duplicates for personal workspaces;
- creates imported relations with exact `workspaceId` and `ownerUsername`;
- separates parsing/matching from materialization;
- removes the previous catch-and-return-success failure behavior;
- maps malformed/unsafe XML to a stable HTTP 422 error response;
- preserves DTD/external-entity blocking;
- expands the result DTO with parsed, created, skipped, rejected, and preview counters;
- requires explicit workspace context in `CatalogFacade` import operations;
- adds integration tests for preview non-mutation, two-workspace isolation, duplicate handling, malformed XML, and XXE rejection.

## Transaction semantics

The importer is one Spring transaction. Unexpected materialization failures are wrapped in `ArchiMateImportException` and propagate, causing the complete import to roll back instead of returning a partially successful HTTP 200 result.

## Stacking

Base branch: `fix/proposal-workspace-authorization` because this change relies on the exact visible/mutable relation-scope APIs introduced by #428.

## Verification

CI is authoritative. Keep draft until the stacked base is green and all checks for this branch pass.

Addresses #422.