### PR TITLE
Security: enforce mandatory first-login password replacement

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilter.java
@@ -1,0 +1,80 @@
+package com.taxonomy.security.config;
+
+import com.taxonomy.security.service.PasswordChangeService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Restricts authenticated local users to password replacement until their
+ * bootstrap or administrator-assigned password has been changed.
+ */
+@Component
+@Profile("!keycloak")
+public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
+
+    private final PasswordChangeService passwordChangeService;
+    private final boolean enforcementEnabled;
+
+    public PasswordChangeRequiredFilter(
+            PasswordChangeService passwordChangeService,
+            @Value("${taxonomy.security.require-password-change:false}") boolean enforcementEnabled) {
+        this.passwordChangeService = passwordChangeService;
+        this.enforcementEnabled = enforcementEnabled;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        if (!enforcementEnabled) {
+            return true;
+        }
+        String path = request.getRequestURI();
+        return path.equals("/login")
+                || path.startsWith("/login/")
+                || path.equals("/logout")
+                || path.equals("/change-password")
+                || path.equals("/api/account/change-password")
+                || path.equals("/error")
+                || path.startsWith("/css/")
+                || path.startsWith("/js/")
+                || path.startsWith("/images/")
+                || path.startsWith("/webjars/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())
+                || !passwordChangeService.isPasswordChangeRequired(authentication.getName())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (request.getRequestURI().startsWith("/api/")) {
+            response.setStatus(428); // RFC 6585: Precondition Required
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.getWriter().write("{\"error\":\"PASSWORD_CHANGE_REQUIRED\","
+                    + "\"message\":\"Change the temporary password before using the API\","
+                    + "\"changePasswordEndpoint\":\"/api/account/change-password\"}");
+            return;
+        }
+
+        response.sendRedirect(request.getContextPath() + "/change-password");
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordEncodingConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordEncodingConfig.java
@@ -1,0 +1,18 @@
+package com.taxonomy.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/** Password primitives kept independent from the web security filter graph. */
+@Configuration
+@Profile("!keycloak")
+public class PasswordEncodingConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
@@ -7,8 +7,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
@@ -66,10 +64,5 @@ public class SecurityConfig {
         return authorization != null
                 && (authorization.regionMatches(true, 0, "Basic ", 0, 6)
                 || authorization.regionMatches(true, 0, "Bearer ", 0, 7));
-    }
-
-    @Bean
-    PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
@@ -10,26 +10,23 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
-/**
- * Spring Security configuration for form-login mode (default, without Keycloak).
- *
- * <p>The GUI uses form-login sessions and therefore keeps CSRF protection for
- * state-changing API calls. Only programmatic API clients authenticated with an
- * explicit Basic or Bearer Authorization header are treated as stateless and
- * may call the REST API without a CSRF token.</p>
- */
+/** Spring Security configuration for local form-login/HTTP-Basic mode. */
 @Configuration
 @EnableMethodSecurity
 @Profile("!keycloak")
 public class SecurityConfig {
 
     private final AuthorizationRulesConfigurer authRules;
+    private final PasswordChangeRequiredFilter passwordChangeRequiredFilter;
 
-    public SecurityConfig(AuthorizationRulesConfigurer authRules) {
+    public SecurityConfig(AuthorizationRulesConfigurer authRules,
+                          PasswordChangeRequiredFilter passwordChangeRequiredFilter) {
         this.authRules = authRules;
+        this.passwordChangeRequiredFilter = passwordChangeRequiredFilter;
     }
 
     @Bean
@@ -50,16 +47,16 @@ public class SecurityConfig {
             )
             .formLogin(Customizer.withDefaults())
             .httpBasic(Customizer.withDefaults())
-            .logout(Customizer.withDefaults());
+            .logout(Customizer.withDefaults())
+            .addFilterAfter(passwordChangeRequiredFilter, BasicAuthenticationFilter.class);
 
         return http.build();
     }
 
     /**
-     * A request is stateless only when it carries an explicit HTTP
-     * authentication scheme. The absence of an existing session is not enough:
-     * otherwise a browser request made before session resolution could bypass
-     * CSRF protection.
+     * A request is stateless only when it targets the API and carries an
+     * explicit HTTP authentication scheme. Browser session requests retain
+     * normal CSRF protection.
      */
     static boolean isStatelessApiClient(HttpServletRequest request) {
         if (!request.getRequestURI().startsWith("/api/")) {

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityDataInitializer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityDataInitializer.java
@@ -12,19 +12,11 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Set;
 
-/**
- * Seeds the default roles and an initial admin user on first startup.
- * <p>
- * If the roles or admin user already exist (e.g. persistent database) this is a no-op.
- * The default admin password can be overridden via the {@code TAXONOMY_ADMIN_PASSWORD}
- * environment variable (or the equivalent Spring property {@code taxonomy.admin-password}).
- * <p>
- * Only active in form-login mode (without Keycloak). In the Keycloak profile,
- * users and roles are managed by the identity provider.
- */
+/** Seeds local roles and the initial administrator in form-login mode. */
 @Component
 @Profile("!keycloak")
 public class SecurityDataInitializer implements ApplicationRunner {
@@ -35,37 +27,50 @@ public class SecurityDataInitializer implements ApplicationRunner {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final String adminPassword;
+    private final boolean requirePasswordChange;
 
     public SecurityDataInitializer(RoleRepository roleRepository,
                                    UserRepository userRepository,
                                    PasswordEncoder passwordEncoder,
-                                   @Value("${taxonomy.admin-password:admin}") String adminPassword) {
+                                   @Value("${taxonomy.admin-password:admin}") String adminPassword,
+                                   @Value("${taxonomy.security.require-password-change:false}")
+                                   boolean requirePasswordChange) {
         this.roleRepository = roleRepository;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.adminPassword = adminPassword;
+        this.requirePasswordChange = requirePasswordChange;
     }
 
     @Override
+    @Transactional
     public void run(ApplicationArguments args) {
-        // Seed roles
         AppRole roleUser = findOrCreateRole("ROLE_USER");
         AppRole roleArchitect = findOrCreateRole("ROLE_ARCHITECT");
         AppRole roleAdmin = findOrCreateRole("ROLE_ADMIN");
 
-        // Seed default admin user (if not present)
-        if (userRepository.findByUsername("admin").isEmpty()) {
-            AppUser admin = new AppUser();
+        AppUser admin = userRepository.findByUsername("admin").orElse(null);
+        if (admin == null) {
+            admin = new AppUser();
             admin.setUsername("admin");
             admin.setPasswordHash(passwordEncoder.encode(adminPassword));
             admin.setEnabled(true);
             admin.setDisplayName("Administrator");
             admin.setRoles(Set.of(roleUser, roleArchitect, roleAdmin));
+            admin.setMustChangePassword(requirePasswordChange);
             userRepository.save(admin);
-            log.info("Created default admin user (username=admin). Change the password immediately.");
+            log.info("Created default admin user (username=admin, passwordChangeRequired={}).",
+                    requirePasswordChange);
+        } else if (requirePasswordChange
+                && passwordEncoder.matches("admin", admin.getPasswordHash())
+                && !admin.isMustChangePassword()) {
+            // Upgrade existing installations that still use the documented
+            // bootstrap credential when enforcement is enabled later.
+            admin.setMustChangePassword(true);
+            userRepository.save(admin);
+            log.warn("Marked existing admin account for mandatory password replacement.");
         }
 
-        // Warn if the default password is still in use
         if ("admin".equals(adminPassword)) {
             log.warn("SECURITY WARNING: Default admin password 'admin' is in use. "
                     + "Set TAXONOMY_ADMIN_PASSWORD environment variable to change it.");

--- a/taxonomy-app/src/main/java/com/taxonomy/security/controller/AccountApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/controller/AccountApiController.java
@@ -1,0 +1,66 @@
+package com.taxonomy.security.controller;
+
+import com.taxonomy.security.service.PasswordChangeService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/** Self-service account operations for local API clients. */
+@RestController
+@RequestMapping("/api/account")
+@Profile("!keycloak")
+@ConditionalOnProperty(name = "taxonomy.security.change-password-enabled",
+        havingValue = "true", matchIfMissing = true)
+public class AccountApiController {
+
+    private final PasswordChangeService passwordChangeService;
+
+    public AccountApiController(PasswordChangeService passwordChangeService) {
+        this.passwordChangeService = passwordChangeService;
+    }
+
+    @PostMapping("/change-password")
+    public ResponseEntity<Map<String, String>> changePassword(
+            Authentication authentication,
+            @RequestBody Map<String, String> body) {
+        if (authentication == null) {
+            return ResponseEntity.status(401).body(Map.of(
+                    "error", "AUTHENTICATION_REQUIRED"));
+        }
+
+        PasswordChangeService.Result result = passwordChangeService.changePassword(
+                authentication.getName(),
+                body.get("currentPassword"),
+                body.get("newPassword"),
+                body.get("confirmPassword"));
+
+        if (result == PasswordChangeService.Result.CHANGED) {
+            return ResponseEntity.ok(Map.of(
+                    "status", "PASSWORD_CHANGED",
+                    "message", "Password changed successfully"));
+        }
+
+        return ResponseEntity.badRequest().body(Map.of(
+                "error", result.name(),
+                "message", messageFor(result)));
+    }
+
+    private static String messageFor(PasswordChangeService.Result result) {
+        return switch (result) {
+            case USER_NOT_FOUND -> "User not found";
+            case CURRENT_PASSWORD_INCORRECT -> "Current password is incorrect";
+            case TOO_SHORT -> "New password must be at least "
+                    + PasswordChangeService.MINIMUM_PASSWORD_LENGTH + " characters";
+            case CONFIRMATION_MISMATCH -> "New passwords do not match";
+            case SAME_AS_CURRENT -> "New password must differ from the current password";
+            case CHANGED -> "Password changed successfully";
+        };
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/controller/ChangePasswordController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/controller/ChangePasswordController.java
@@ -11,10 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-/**
- * Form-login controller for local-user password changes. Validation and
- * persistence are delegated to {@link PasswordChangeService}.
- */
+/** Form-login controller for local-user password changes. */
 @Controller
 @ConditionalOnProperty(name = "taxonomy.security.change-password-enabled",
         havingValue = "true", matchIfMissing = true)
@@ -50,7 +47,7 @@ public class ChangePasswordController {
         switch (result) {
             case CHANGED -> {
                 log.info("PASSWORD_CHANGED user={}", username);
-                model.addAttribute("success", "Password changed successfully.");
+                return "redirect:/?passwordChanged=true";
             }
             case USER_NOT_FOUND -> model.addAttribute("error", "User not found.");
             case CURRENT_PASSWORD_INCORRECT ->

--- a/taxonomy-app/src/main/java/com/taxonomy/security/model/AppUser.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/model/AppUser.java
@@ -1,14 +1,20 @@
 package com.taxonomy.security.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * Application user stored in the database.
- * Linked to {@link AppRole} via a many-to-many join table.
- */
+/** Application user stored in the database. */
 @Entity
 @Table(name = "app_user")
 public class AppUser {
@@ -26,6 +32,13 @@ public class AppUser {
     @Column(nullable = false)
     private boolean enabled = true;
 
+    /**
+     * When set, the user may authenticate but cannot use the application until
+     * the temporary/bootstrap password has been replaced.
+     */
+    @Column(name = "must_change_password", nullable = false)
+    private boolean mustChangePassword;
+
     @Column(name = "display_name")
     private String displayName;
 
@@ -42,59 +55,29 @@ public class AppUser {
     public AppUser() {
     }
 
-    public Long getId() {
-        return id;
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public boolean isMustChangePassword() { return mustChangePassword; }
+    public void setMustChangePassword(boolean mustChangePassword) {
+        this.mustChangePassword = mustChangePassword;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
 
-    public String getUsername() {
-        return username;
-    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getPasswordHash() {
-        return passwordHash;
-    }
-
-    public void setPasswordHash(String passwordHash) {
-        this.passwordHash = passwordHash;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public Set<AppRole> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(Set<AppRole> roles) {
-        this.roles = roles;
-    }
+    public Set<AppRole> getRoles() { return roles; }
+    public void setRoles(Set<AppRole> roles) { this.roles = roles; }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/service/PasswordChangeService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/service/PasswordChangeService.java
@@ -29,6 +29,13 @@ public class PasswordChangeService {
         this.passwordEncoder = passwordEncoder;
     }
 
+    @Transactional(readOnly = true)
+    public boolean isPasswordChangeRequired(String username) {
+        return username != null && userRepository.findByUsername(username)
+                .map(AppUser::isMustChangePassword)
+                .orElse(false);
+    }
+
     @Transactional
     public Result changePassword(String username,
                                  String currentPassword,
@@ -52,6 +59,7 @@ public class PasswordChangeService {
             return Result.SAME_AS_CURRENT;
         }
         user.setPasswordHash(passwordEncoder.encode(newPassword));
+        user.setMustChangePassword(false);
         userRepository.save(user);
         return Result.CHANGED;
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/PasswordChangeEnforcementTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/PasswordChangeEnforcementTest.java
@@ -1,0 +1,94 @@
+package com.taxonomy.security;
+
+import com.taxonomy.security.model.AppRole;
+import com.taxonomy.security.model.AppUser;
+import com.taxonomy.security.repository.RoleRepository;
+import com.taxonomy.security.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = "taxonomy.security.require-password-change=true")
+@AutoConfigureMockMvc
+class PasswordChangeEnforcementTest {
+
+    private static final String USERNAME = "password-restricted-user";
+    private static final String TEMPORARY_PASSWORD = "TemporaryPassword1";
+    private static final String REPLACEMENT_PASSWORD = "ReplacementPassword1";
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private RoleRepository roleRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        AppRole userRole = roleRepository.findByName("ROLE_USER")
+                .orElseGet(() -> roleRepository.save(new AppRole("ROLE_USER")));
+        AppUser user = userRepository.findByUsername(USERNAME).orElseGet(AppUser::new);
+        user.setUsername(USERNAME);
+        user.setPasswordHash(passwordEncoder.encode(TEMPORARY_PASSWORD));
+        user.setEnabled(true);
+        user.setMustChangePassword(true);
+        user.setRoles(Set.of(userRole));
+        userRepository.save(user);
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME, roles = "USER")
+    void browserUserIsRedirectedUntilPasswordChanges() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/change-password"));
+
+        mockMvc.perform(get("/change-password"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void basicClientReceivesPreconditionAndCanReplacePasswordThroughApi() throws Exception {
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(httpBasic(USERNAME, TEMPORARY_PASSWORD)))
+                .andExpect(status().is(428))
+                .andExpect(jsonPath("$.error").value("PASSWORD_CHANGE_REQUIRED"))
+                .andExpect(jsonPath("$.changePasswordEndpoint")
+                        .value("/api/account/change-password"));
+
+        mockMvc.perform(post("/api/account/change-password")
+                        .with(httpBasic(USERNAME, TEMPORARY_PASSWORD))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "currentPassword": "TemporaryPassword1",
+                                  "newPassword": "ReplacementPassword1",
+                                  "confirmPassword": "ReplacementPassword1"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PASSWORD_CHANGED"));
+
+        AppUser updated = userRepository.findByUsername(USERNAME).orElseThrow();
+        assertThat(updated.isMustChangePassword()).isFalse();
+        assertThat(passwordEncoder.matches(REPLACEMENT_PASSWORD, updated.getPasswordHash())).isTrue();
+
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(httpBasic(USERNAME, REPLACEMENT_PASSWORD)))
+                .andExpect(status().isOk());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/controller/ChangePasswordControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/controller/ChangePasswordControllerTest.java
@@ -11,9 +11,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -39,6 +41,7 @@ class ChangePasswordControllerTest {
                     return created;
                 });
         user.setPasswordHash(passwordEncoder.encode(CURRENT_PASSWORD));
+        user.setMustChangePassword(true);
         userRepository.save(user);
     }
 
@@ -50,14 +53,17 @@ class ChangePasswordControllerTest {
     }
 
     @Test
-    void changePasswordWithValidInputSucceeds() throws Exception {
+    void changePasswordWithValidInputClearsFlagAndRedirects() throws Exception {
         mockMvc.perform(post("/change-password")
                         .param("currentPassword", CURRENT_PASSWORD)
                         .param("newPassword", NEW_PASSWORD)
                         .param("confirmPassword", NEW_PASSWORD))
-                .andExpect(status().isOk())
-                .andExpect(view().name("change-password"))
-                .andExpect(model().attribute("success", "Password changed successfully."));
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/?passwordChanged=true"));
+
+        AppUser updated = userRepository.findByUsername("testuser").orElseThrow();
+        assertThat(updated.isMustChangePassword()).isFalse();
+        assertThat(passwordEncoder.matches(NEW_PASSWORD, updated.getPasswordHash())).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the previously documented but inactive `taxonomy.security.require-password-change` contract from #421.

### Changes

- adds persisted `AppUser.mustChangePassword` state;
- marks newly bootstrapped administrators when enforcement is enabled;
- upgrades an existing admin still using `admin` when enforcement is enabled later;
- installs an authenticated-request filter in local form-login/HTTP-Basic mode;
- redirects browser users to `/change-password` until replacement succeeds;
- returns HTTP 428 with a stable `PASSWORD_CHANGE_REQUIRED` body for API clients;
- adds `POST /api/account/change-password` so HTTP Basic clients can satisfy the precondition without a browser CSRF exchange;
- clears the flag transactionally with the password update;
- redirects browser users to the application after success;
- adds end-to-end tests for browser and real HTTP Basic authentication behavior.

## Keycloak

The enforcement filter and local account API are inactive under the `keycloak` profile; password lifecycle remains the responsibility of the identity provider.

## Migration

The JPA model adds the non-null `must_change_password` column with the Java default `false`. Production schema migration evidence is required before release; do not rely solely on `ddl-auto=update` for controlled deployments.

## Verification

Opened as draft until CI and database-profile tests pass.

Addresses #421.