### PR TITLE
Security: update PostgreSQL and Jackson to fixed patch releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
         <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
+        <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
+        <postgresql.version>42.7.12</postgresql.version>
+        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+        <jackson-bom.version>3.1.5</jackson-bom.version>
         <!-- Keep the Selenium BOM and the explicitly selected browser image aligned.
              The dated image tag makes CI reproducible; ContainerTestUtils also checks
              at runtime that its Selenium version matches this image tag. -->


### PR DESCRIPTION
## Summary

Applies the fixed patch versions identified by the current Trivy security gate.

- PostgreSQL JDBC: `42.7.11` → `42.7.12` for CVE-2026-54291 (HIGH)
- Jackson 2 BOM: `2.21.4` → `2.21.5`
- Jackson 3 BOM: `3.1.4` → `3.1.5`

The overrides use Spring Boot 4.1's managed-version properties (`postgresql.version`, `jackson-2-bom.version`, and `jackson-bom.version`) so each dependency family remains coordinated rather than overriding one transitive JAR in isolation.

## Verified

- CI / CD — success
- Security Scan — success
- Database Compatibility — success
- Core Integration — success, including the repeated `ProductionPersistenceRestartIT`

The first restart-test attempt hit a transient container startup timeout; rerunning exactly that failed job completed successfully without code changes.