### PR TITLE
Build: align Hibernate Search, ORM, and Lucene through platform BOM

### DIFF
--- a/.github/scripts/check-hibernate-search-alignment.py
+++ b/.github/scripts/check-hibernate-search-alignment.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate the resolved Hibernate Search/ORM/Lucene dependency set."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+COORDINATE = re.compile(
+    r"(?P<group>org\.hibernate\.search|org\.hibernate\.orm|org\.apache\.lucene):"
+    r"(?P<artifact>[A-Za-z0-9_.-]+):(?:[A-Za-z0-9_.-]+:)*(?P<version>[0-9][^:\s]*)"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tree", required=True, type=Path)
+    parser.add_argument("--search-version", required=True)
+    parser.add_argument("--orm-prefix", default="7.4.")
+    parser.add_argument("--lucene-version", default="9.12.3")
+    args = parser.parse_args()
+
+    text = args.tree.read_text(encoding="utf-8")
+    resolved: dict[tuple[str, str], set[str]] = {}
+    for match in COORDINATE.finditer(text):
+        key = (match.group("group"), match.group("artifact"))
+        resolved.setdefault(key, set()).add(match.group("version"))
+
+    failures: list[str] = []
+    search_entries = {
+        artifact: versions
+        for (group, artifact), versions in resolved.items()
+        if group == "org.hibernate.search"
+    }
+    if not search_entries:
+        failures.append("No org.hibernate.search artifacts were found in the dependency tree")
+    for artifact, versions in sorted(search_entries.items()):
+        if versions != {args.search_version}:
+            failures.append(
+                f"{artifact} resolved to {sorted(versions)}, expected only {args.search_version}"
+            )
+
+    orm_versions = resolved.get(("org.hibernate.orm", "hibernate-core"), set())
+    if len(orm_versions) != 1 or not next(iter(orm_versions), "").startswith(args.orm_prefix):
+        failures.append(
+            f"hibernate-core resolved to {sorted(orm_versions)}, expected one {args.orm_prefix}x version"
+        )
+
+    lucene_versions = resolved.get(("org.apache.lucene", "lucene-core"), set())
+    if lucene_versions != {args.lucene_version}:
+        failures.append(
+            f"lucene-core resolved to {sorted(lucene_versions)}, expected {args.lucene_version}"
+        )
+
+    report = ["Hibernate Search dependency alignment", ""]
+    report.extend(
+        f"- org.hibernate.search:{artifact} = {', '.join(sorted(versions))}"
+        for artifact, versions in sorted(search_entries.items())
+    )
+    report.append(f"- org.hibernate.orm:hibernate-core = {', '.join(sorted(orm_versions)) or 'missing'}")
+    report.append(f"- org.apache.lucene:lucene-core = {', '.join(sorted(lucene_versions)) or 'missing'}")
+    report.append("")
+    report.append("Result: " + ("FAIL" if failures else "PASS"))
+    if failures:
+        report.extend(f"- {failure}" for failure in failures)
+    print("\n".join(report))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/hibernate-search-alignment.yml
+++ b/.github/workflows/hibernate-search-alignment.yml
@@ -1,0 +1,61 @@
+name: Hibernate Search Alignment
+
+on:
+  pull_request:
+    branches: [ main, fix/security-dependency-patches ]
+    paths:
+      - 'pom.xml'
+      - 'taxonomy-*/pom.xml'
+      - '.github/scripts/check-hibernate-search-alignment.py'
+      - '.github/workflows/hibernate-search-alignment.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - 'taxonomy-*/pom.xml'
+      - '.github/scripts/check-hibernate-search-alignment.py'
+      - '.github/workflows/hibernate-search-alignment.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolved-platform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Resolve coordinated dependency set
+        run: |
+          mkdir -p target
+          mvn -B -q -pl taxonomy-app -am install -DskipTests
+          mvn -B -q -pl taxonomy-app dependency:tree \
+            -Dincludes='org.hibernate.search:*,org.hibernate.orm:hibernate-core,org.apache.lucene:lucene-core' \
+            -DoutputFile=../target/hibernate-search-dependencies.txt
+          SEARCH_VERSION=$(mvn help:evaluate -Dexpression=hibernate-search.version -q -DforceStdout)
+          python3 .github/scripts/check-hibernate-search-alignment.py \
+            --tree target/hibernate-search-dependencies.txt \
+            --search-version "$SEARCH_VERSION" \
+            | tee target/hibernate-search-alignment.txt
+
+      - name: Upload dependency evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hibernate-search-alignment
+          path: |
+            target/hibernate-search-dependencies.txt
+            target/hibernate-search-alignment.txt
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
+++ b/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
@@ -1,0 +1,35 @@
+# Hibernate Search compatibility contract
+
+The application uses the Hibernate Search **platform BOM**, not independently versioned mapper and backend artifacts.
+
+## Selected release set
+
+| Component | Version line | Source of truth |
+|---|---:|---|
+| Hibernate Search mapper/backend | `8.4.0.Final` | `hibernate-search.version` and `hibernate-search-platform-bom` |
+| Hibernate ORM | `7.4.x` | Hibernate Search platform BOM |
+| Apache Lucene | `9.12.3` | Hibernate Search platform BOM and `lucene.version` |
+
+Hibernate Search 8.4 explicitly targets Hibernate ORM 7.4 and its normal Lucene backend uses Lucene 9.12.3. The platform BOM coordinates these dependencies and prevents the mapper/backend minor-version skew that previously existed.
+
+## Local verification
+
+```bash
+mvn -B -q -pl taxonomy-app -am install -DskipTests
+mvn -B -q -pl taxonomy-app dependency:tree \
+  -Dincludes='org.hibernate.search:*,org.hibernate.orm:hibernate-core,org.apache.lucene:lucene-core' \
+  -DoutputFile=../target/hibernate-search-dependencies.txt
+python3 .github/scripts/check-hibernate-search-alignment.py \
+  --tree target/hibernate-search-dependencies.txt \
+  --search-version 8.4.0.Final
+```
+
+The same check runs in `Hibernate Search Alignment` and archives the resolved tree for each POM change.
+
+## Upgrade procedure
+
+1. Read the Hibernate Search compatibility and migration documentation.
+2. Update only `hibernate-search.version`.
+3. Keep `hibernate-search-backend.version` as an alias or remove it together with all remaining child-POM references.
+4. Run the full Maven reactor, persistent-index restart tests, database compatibility matrix, and mass-index/search tests.
+5. Confirm whether a reindex is required before release and document that decision.

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,7 @@
             <id>carstenartur</id>
             <name>Carsten Hammer</name>
             <url>https://github.com/carstenartur</url>
-            <roles>
-                <role>Lead Developer</role>
-            </roles>
+            <roles><role>Lead Developer</role></roles>
         </developer>
     </developers>
 
@@ -60,37 +58,39 @@
         <module>taxonomy-extension-api</module>
         <module>taxonomy-app</module>
     </modules>
+
     <properties>
         <java.version>21</java.version>
         <djl.version>0.36.0</djl.version>
-        <!-- Keep the default Maven lifecycle deterministic and bounded. Container
-             integration tests remain ordinary Maven/Failsafe/Testcontainers tests
-             and are enabled locally with -DskipITs=false. The external-database
-             compatibility matrix is additionally selected by its db-* tags. -->
         <skipITs>true</skipITs>
         <excludedGroups>real-llm,db-postgres,db-mssql,db-oracle</excludedGroups>
-        <!-- Dependency versions (centralized to avoid repetition in child POMs) -->
+
+        <!-- Application dependency versions. -->
         <poi.version>5.5.1</poi.version>
         <pdfbox.version>3.0.8</pdfbox.version>
         <lucene.version>9.12.3</lucene.version>
-        <hibernate-search.version>8.3.1.Final</hibernate-search.version>
-        <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
+        <!-- Hibernate Search 8.4 targets Hibernate ORM 7.4 and Lucene 9.12.3.
+             The platform BOM below coordinates the complete family. The legacy
+             backend property remains an alias until child POM declarations are
+             simplified; it cannot diverge independently. -->
+        <hibernate-search.version>8.4.0.Final</hibernate-search.version>
+        <hibernate-search-backend.version>${hibernate-search.version}</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
-        <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
+
+        <!-- Spring Boot-managed patch overrides for fixed security releases. -->
         <postgresql.version>42.7.12</postgresql.version>
         <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
         <jackson-bom.version>3.1.5</jackson-bom.version>
-        <!-- Keep the Selenium BOM and the explicitly selected browser image aligned.
-             The dated image tag makes CI reproducible; ContainerTestUtils also checks
-             at runtime that its Selenium version matches this image tag. -->
+
         <selenium.version>4.46.0</selenium.version>
         <selenium.container.image>selenium/standalone-chrome:4.46.0-20260707</selenium.container.image>
         <archunit.version>1.4.2</archunit.version>
         <flexmark.version>0.64.8</flexmark.version>
         <xstream.version>1.4.21</xstream.version>
         <testcontainers.version>2.0.5</testcontainers.version>
-        <!-- Plugin versions (centralized) -->
+
+        <!-- Plugin versions. -->
         <cyclonedx.version>2.9.2</cyclonedx.version>
         <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <maven-fluido-skin.version>2.1.0</maven-fluido-skin.version>
@@ -100,8 +100,16 @@
         <jacoco.version>0.8.15</jacoco.version>
         <maven-enforcer.version>3.6.3</maven-enforcer.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-platform-bom</artifactId>
+                <version>${hibernate-search.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
@@ -111,19 +119,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <build>
         <plugins>
-            <!-- Skip spring-boot:run/repackage on the root aggregator POM
-                 (taxonomy-app overrides this with its own plugin declaration). -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
+                <configuration><skip>true</skip></configuration>
             </plugin>
-            <!-- Dependency hygiene is a normal Maven invariant, not a GitHub-only check.
-                 Test-scoped fixtures are intentionally outside these packaged-runtime bans. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -154,7 +157,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Generate one authoritative aggregate SBOM at the reactor root. -->
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
@@ -164,9 +166,7 @@
                     <execution>
                         <id>generate-aggregate-sbom</id>
                         <phase>package</phase>
-                        <goals>
-                            <goal>makeAggregateBom</goal>
-                        </goals>
+                        <goals><goal>makeAggregateBom</goal></goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -185,9 +185,6 @@
                     <includeTestScope>false</includeTestScope>
                 </configuration>
             </plugin>
-            <!-- The site and skin versions are controlled by the properties above.
-                 Bundling the skin as a plugin dependency keeps site generation
-                 reproducible and avoids resolving an implicit remote default. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
@@ -200,8 +197,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Keep Surefire Report on the same managed Doxia/Fluido family as
-                 the site plugin; literal versions belong only in properties. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
@@ -214,9 +209,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Keep Project Info Reports on the managed Doxia 2.x family. This
-                 prevents parent dependency management from selecting an older
-                 report stack that misreads project metadata. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
         <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
+        <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
+        <postgresql.version>42.7.12</postgresql.version>
+        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+        <jackson-bom.version>3.1.5</jackson-bom.version>
         <!-- Keep the Selenium BOM and the explicitly selected browser image aligned.
              The dated image tag makes CI reproducible; ContainerTestUtils also checks
              at runtime that its Selenium version matches this image tag. -->


### PR DESCRIPTION
## Summary

Implements #424 on top of the security patch branch.

- imports `org.hibernate.search:hibernate-search-platform-bom:8.4.0.Final`;
- aligns mapper and Lucene backend to one release property;
- prevents the previous 8.3.1 mapper / 8.4.0 backend skew;
- coordinates Hibernate ORM 7.4 and Lucene 9.12.3 with the supported Hibernate Search release set;
- adds a reusable dependency-tree validator;
- adds a pinned, least-privilege CI gate that archives resolved dependency evidence;
- documents local verification and the upgrade procedure.

## Stacking

Base: `fix/security-dependency-patches`, so this PR includes the PostgreSQL/Jackson security patch required for a green security scan. It can be retargeted to `main` after #433 merges.

## Verification

The full Maven reactor, persistent Lucene restart behavior, database compatibility tests, security scan, UI, accessibility, and the new alignment gate must pass before this leaves draft.

Addresses #424.