### PR TITLE
QA: enforce authoritative reactor-wide JaCoCo coverage

### DIFF
--- a/.github/scripts/check-coverage.py
+++ b/.github/scripts/check-coverage.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -53,14 +54,26 @@ def parse_report(path: Path) -> tuple[Counter, dict[str, Counter]]:
     return aggregate, groups
 
 
+def normalize_group_name(value: str) -> str:
+    """Map human Maven module names and artifact IDs to one stable key."""
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized if normalized.startswith("taxonomy-") else f"taxonomy-{normalized}"
+
+
 def build_report(
     xml_path: Path,
     minimum: float,
     expected_groups: list[str],
 ) -> tuple[bool, str]:
     aggregate, groups = parse_report(xml_path)
-    missing = sorted(set(expected_groups) - set(groups))
-    unexpected = sorted(set(groups) - set(expected_groups)) if expected_groups else []
+    actual_by_key = {normalize_group_name(name): name for name in groups}
+    expected_by_key = {normalize_group_name(name): name for name in expected_groups}
+    missing_keys = sorted(set(expected_by_key) - set(actual_by_key))
+    unexpected_keys = (
+        sorted(set(actual_by_key) - set(expected_by_key)) if expected_groups else []
+    )
+    missing = [expected_by_key[key] for key in missing_keys]
+    unexpected = [actual_by_key[key] for key in unexpected_keys]
 
     passed = aggregate.total > 0 and aggregate.ratio >= minimum and not missing
     lines = [
@@ -110,9 +123,8 @@ def main(argv: list[str] | None = None) -> int:
         "--expected-group",
         action="append",
         default=[],
-        help="Required JaCoCo module group; repeat for every shipped module",
+        help="Required Maven module name or JaCoCo artifact group; repeat for every shipped module",
     )
-    # Keep the established CLI name for the text evidence output.
     parser.add_argument("--report", type=Path, default=Path("target/coverage-gate.txt"))
     args = parser.parse_args(argv)
 

--- a/.github/scripts/check-coverage.py
+++ b/.github/scripts/check-coverage.py
@@ -1,68 +1,133 @@
 #!/usr/bin/env python3
-"""Fail the build when aggregate JaCoCo instruction coverage is below the configured floor."""
+"""Validate the authoritative reactor-wide JaCoCo instruction coverage report."""
 
 from __future__ import annotations
 
 import argparse
-import glob
 import sys
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
 
 
-def report_counter(path: Path) -> tuple[int, int]:
-    root = ET.parse(path).getroot()
-    for counter in root.findall("counter"):
+@dataclass(frozen=True)
+class Counter:
+    covered: int
+    missed: int
+
+    @property
+    def total(self) -> int:
+        return self.covered + self.missed
+
+    @property
+    def ratio(self) -> float:
+        return self.covered / self.total if self.total else 0.0
+
+
+def direct_instruction_counter(element: ET.Element) -> Counter:
+    for counter in element.findall("counter"):
         if counter.get("type") == "INSTRUCTION":
-            return int(counter.get("covered", "0")), int(counter.get("missed", "0"))
-    raise ValueError(f"No report-level INSTRUCTION counter in {path}")
+            return Counter(
+                covered=int(counter.get("covered", "0")),
+                missed=int(counter.get("missed", "0")),
+            )
+    raise ValueError(
+        f"No direct INSTRUCTION counter on <{element.tag} name={element.get('name')!r}>"
+    )
 
 
-def main() -> int:
+def parse_report(path: Path) -> tuple[Counter, dict[str, Counter]]:
+    root = ET.parse(path).getroot()
+    if root.tag != "report":
+        raise ValueError(f"Expected JaCoCo <report> root, found <{root.tag}>")
+
+    aggregate = direct_instruction_counter(root)
+    groups: dict[str, Counter] = {}
+    for group in root.findall("group"):
+        name = group.get("name")
+        if not name:
+            raise ValueError("JaCoCo report contains an unnamed group")
+        if name in groups:
+            raise ValueError(f"JaCoCo report contains duplicate group {name!r}")
+        groups[name] = direct_instruction_counter(group)
+    return aggregate, groups
+
+
+def build_report(
+    xml_path: Path,
+    minimum: float,
+    expected_groups: list[str],
+) -> tuple[bool, str]:
+    aggregate, groups = parse_report(xml_path)
+    missing = sorted(set(expected_groups) - set(groups))
+    unexpected = sorted(set(groups) - set(expected_groups)) if expected_groups else []
+
+    passed = aggregate.total > 0 and aggregate.ratio >= minimum and not missing
+    lines = [
+        "Taxonomy reactor-wide JaCoCo instruction coverage",
+        "",
+        f"Source: {xml_path}",
+        "",
+    ]
+    for name in sorted(groups):
+        counter = groups[name]
+        lines.append(
+            f"- {name}: {counter.ratio:.2%} "
+            f"({counter.covered}/{counter.total} instructions)"
+        )
+    lines.extend([
+        "",
+        f"Aggregate: {aggregate.ratio:.2%} "
+        f"({aggregate.covered}/{aggregate.total} instructions)",
+        f"Required:  {minimum:.2%}",
+    ])
+    if missing:
+        lines.append("Missing required module groups: " + ", ".join(missing))
+    if unexpected:
+        lines.append("Additional report groups: " + ", ".join(unexpected))
+    lines.extend([
+        f"Result:    {'PASS' if passed else 'FAIL'}",
+        "",
+    ])
+    return passed, "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--minimum", type=float, default=0.81,
-                        help="Minimum aggregate instruction ratio, e.g. 0.81 for 81%%")
-    parser.add_argument("--pattern", default="**/target/site/jacoco/jacoco.xml")
-    parser.add_argument("--report", default="target/coverage-gate.txt")
-    args = parser.parse_args()
+    parser.add_argument(
+        "--xml",
+        type=Path,
+        default=Path("taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml"),
+        help="Authoritative report-aggregate XML file",
+    )
+    parser.add_argument(
+        "--minimum",
+        type=float,
+        default=0.81,
+        help="Minimum reactor-wide instruction ratio, e.g. 0.81 for 81%%",
+    )
+    parser.add_argument(
+        "--expected-group",
+        action="append",
+        default=[],
+        help="Required JaCoCo module group; repeat for every shipped module",
+    )
+    # Keep the established CLI name for the text evidence output.
+    parser.add_argument("--report", type=Path, default=Path("target/coverage-gate.txt"))
+    args = parser.parse_args(argv)
 
-    paths = [Path(path) for path in sorted(glob.glob(args.pattern, recursive=True))]
-    if not paths:
-        print(f"Coverage gate failed: no JaCoCo reports matched {args.pattern}", file=sys.stderr)
+    if not args.xml.is_file():
+        print(f"Coverage gate failed: report not found: {args.xml}", file=sys.stderr)
         return 1
 
-    covered = 0
-    missed = 0
-    details: list[str] = []
     try:
-        for path in paths:
-            report_covered, report_missed = report_counter(path)
-            covered += report_covered
-            missed += report_missed
-            total = report_covered + report_missed
-            ratio = report_covered / total if total else 0.0
-            details.append(f"{path}: {ratio:.2%} ({report_covered}/{total} instructions)")
+        passed, text = build_report(args.xml, args.minimum, args.expected_group)
     except (OSError, ET.ParseError, ValueError) as error:
         print(f"Coverage gate failed: {error}", file=sys.stderr)
         return 1
 
-    total = covered + missed
-    ratio = covered / total if total else 0.0
-    passed = total > 0 and ratio >= args.minimum
-    lines = [
-        "Taxonomy JaCoCo instruction coverage",
-        "",
-        *details,
-        "",
-        f"Aggregate: {ratio:.2%} ({covered}/{total} instructions)",
-        f"Required:  {args.minimum:.2%}",
-        f"Result:    {'PASS' if passed else 'FAIL'}",
-        "",
-    ]
-    text = "\n".join(lines)
-    report_path = Path(args.report)
-    report_path.parent.mkdir(parents=True, exist_ok=True)
-    report_path.write_text(text, encoding="utf-8")
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(text, encoding="utf-8")
     print(text, end="")
     return 0 if passed else 1
 

--- a/.github/scripts/test-check-coverage.py
+++ b/.github/scripts/test-check-coverage.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +13,7 @@ SCRIPT = Path(__file__).with_name("check-coverage.py")
 SPEC = importlib.util.spec_from_file_location("taxonomy_check_coverage", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 

--- a/.github/scripts/test-check-coverage.py
+++ b/.github/scripts/test-check-coverage.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Regression tests for check-coverage.py without third-party dependencies."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check-coverage.py")
+SPEC = importlib.util.spec_from_file_location("taxonomy_check_coverage", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def report_xml(groups: dict[str, tuple[int, int]], aggregate: tuple[int, int]) -> str:
+    group_xml = "".join(
+        f'<group name="{name}"><counter type="INSTRUCTION" missed="{missed}" covered="{covered}"/></group>'
+        for name, (covered, missed) in groups.items()
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<report name="Taxonomy Aggregate Coverage">'
+        f'{group_xml}'
+        f'<counter type="INSTRUCTION" missed="{aggregate[1]}" covered="{aggregate[0]}"/>'
+        '</report>'
+    )
+
+
+class CoverageGateTest(unittest.TestCase):
+
+    def write_report(self, xml: str) -> Path:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "jacoco.xml"
+        path.write_text(xml, encoding="utf-8")
+        return path
+
+    def test_passes_only_with_all_expected_groups_and_threshold(self) -> None:
+        path = self.write_report(report_xml({
+            "Taxonomy Domain": (90, 10),
+            "Taxonomy DSL": (80, 20),
+        }, (170, 30)))
+
+        passed, text = MODULE.build_report(
+            path, 0.81, ["Taxonomy Domain", "Taxonomy DSL"]
+        )
+
+        self.assertTrue(passed)
+        self.assertIn("Aggregate: 85.00%", text)
+        self.assertIn("Result:    PASS", text)
+
+    def test_fails_when_a_shipped_module_group_is_missing(self) -> None:
+        path = self.write_report(report_xml({
+            "Taxonomy Domain": (90, 10),
+        }, (90, 10)))
+
+        passed, text = MODULE.build_report(
+            path, 0.81, ["Taxonomy Domain", "Taxonomy DSL"]
+        )
+
+        self.assertFalse(passed)
+        self.assertIn("Missing required module groups: Taxonomy DSL", text)
+
+    def test_fails_below_threshold_even_when_all_modules_are_present(self) -> None:
+        path = self.write_report(report_xml({
+            "Taxonomy Domain": (70, 30),
+            "Taxonomy DSL": (70, 30),
+        }, (140, 60)))
+
+        passed, text = MODULE.build_report(
+            path, 0.81, ["Taxonomy Domain", "Taxonomy DSL"]
+        )
+
+        self.assertFalse(passed)
+        self.assertIn("Aggregate: 70.00%", text)
+        self.assertIn("Result:    FAIL", text)
+
+    def test_rejects_duplicate_group_names(self) -> None:
+        path = self.write_report(
+            '<report name="duplicate">'
+            '<group name="Taxonomy Domain"><counter type="INSTRUCTION" missed="1" covered="9"/></group>'
+            '<group name="Taxonomy Domain"><counter type="INSTRUCTION" missed="1" covered="9"/></group>'
+            '<counter type="INSTRUCTION" missed="2" covered="18"/>'
+            '</report>'
+        )
+
+        with self.assertRaisesRegex(ValueError, "duplicate group"):
+            MODULE.parse_report(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on:
     branches-ignore: [ gh-pages ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, fix/security-dependency-patches ]
   workflow_dispatch:
 
 permissions:
@@ -13,6 +13,7 @@ permissions:
 
 env:
   BGE_MODEL_REVISION: 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+  REACTOR_COVERAGE_XML: taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml
 
 jobs:
   build-and-test:
@@ -33,6 +34,9 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: Test coverage gate itself
+        run: python3 .github/scripts/test-check-coverage.py
+
       - name: Download and verify pinned embedding model
         env:
           MODEL_REVISION: ${{ env.BGE_MODEL_REVISION }}
@@ -44,10 +48,16 @@ jobs:
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
 
-      - name: Enforce aggregate JaCoCo coverage
+      - name: Enforce reactor-wide JaCoCo coverage
         run: |
           python3 .github/scripts/check-coverage.py \
+            --xml "$REACTOR_COVERAGE_XML" \
             --minimum 0.81 \
+            --expected-group "Taxonomy Domain" \
+            --expected-group "Taxonomy DSL" \
+            --expected-group "Taxonomy Export" \
+            --expected-group "Taxonomy Extension API" \
+            --expected-group "Taxonomy Application" \
             --report target/coverage-gate.txt
           cat target/coverage-gate.txt >> "$GITHUB_STEP_SUMMARY"
 
@@ -78,7 +88,7 @@ jobs:
             echo "SBOM was unavailable; companion metadata was not generated." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Upload SBOM and dependency evidence
+      - name: Upload SBOM, dependency, and coverage evidence
         uses: actions/upload-artifact@v7
         if: always()
         with:
@@ -90,6 +100,7 @@ jobs:
             target/dependency-hygiene-tree.txt
             target/dependency-hygiene-report.txt
             target/coverage-gate.txt
+            taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml
             models/bge-small-en-v1.5/MODEL_PROVENANCE.txt
           if-no-files-found: warn
           retention-days: 90
@@ -132,34 +143,33 @@ jobs:
           import os
           import xml.etree.ElementTree as ET
 
-          covered = missed = 0
+          coverage_path = os.environ['REACTOR_COVERAGE_XML']
           try:
-              reports = glob.glob('**/target/site/jacoco/jacoco.xml', recursive=True)
-              for path in reports:
-                  root = ET.parse(path).getroot()
-                  counter = next((item for item in root.findall('counter')
-                                  if item.get('type') == 'INSTRUCTION'), None)
-                  if counter is None:
-                      raise ValueError(f'No report-level instruction counter in {path}')
-                  covered += int(counter.get('covered', 0))
-                  missed += int(counter.get('missed', 0))
+              root = ET.parse(coverage_path).getroot()
+              counter = next((item for item in root.findall('counter')
+                              if item.get('type') == 'INSTRUCTION'), None)
+              if counter is None:
+                  raise ValueError(f'No report-level instruction counter in {coverage_path}')
+              covered = int(counter.get('covered', 0))
+              missed = int(counter.get('missed', 0))
               total = covered + missed
               ratio = covered / total if total else 0.0
               color = 'brightgreen' if ratio >= 0.81 else 'yellow' if ratio >= 0.60 else 'red'
               coverage_badge = {
                   'schemaVersion': 1,
-                  'label': 'coverage',
+                  'label': 'reactor coverage',
                   'message': f'{ratio * 100:.2f}%' if total else 'unknown',
                   'color': color if total else 'lightgrey',
               }
           except Exception as error:
               print(f'Coverage badge generation failed: {error}')
               coverage_badge = {
-                  'schemaVersion': 1, 'label': 'coverage',
+                  'schemaVersion': 1, 'label': 'reactor coverage',
                   'message': 'unknown', 'color': 'lightgrey',
               }
-          os.makedirs('taxonomy-app/target/site/jacoco', exist_ok=True)
-          with open('taxonomy-app/target/site/jacoco/badge.json', 'w', encoding='utf-8') as handle:
+          coverage_dir = 'taxonomy-coverage/target/site/jacoco-aggregate'
+          os.makedirs(coverage_dir, exist_ok=True)
+          with open(f'{coverage_dir}/badge.json', 'w', encoding='utf-8') as handle:
               json.dump(coverage_badge, handle)
 
           try:
@@ -202,8 +212,8 @@ jobs:
           rm -rf target/quality-reports
           mkdir -p target/quality-reports/tests target/quality-reports/coverage
           if [ -d target/site ]; then cp -a target/site/. target/quality-reports/tests/; fi
-          if [ -d taxonomy-app/target/site/jacoco ]; then
-            cp -a taxonomy-app/target/site/jacoco/. target/quality-reports/coverage/
+          if [ -d taxonomy-coverage/target/site/jacoco-aggregate ]; then
+            cp -a taxonomy-coverage/target/site/jacoco-aggregate/. target/quality-reports/coverage/
           fi
           if [ -f target/coverage-gate.txt ]; then
             cp target/coverage-gate.txt target/quality-reports/coverage/coverage-gate.txt
@@ -224,7 +234,7 @@ jobs:
           echo "### Reports" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "[View Test Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/tests/surefire-report.html)" >> "$GITHUB_STEP_SUMMARY"
-          echo "[View Coverage Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/)" >> "$GITHUB_STEP_SUMMARY"
+          echo "[View Reactor Coverage Report](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v7

--- a/docs/dev/REACTOR_COVERAGE.md
+++ b/docs/dev/REACTOR_COVERAGE.md
@@ -1,0 +1,62 @@
+# Reactor-wide test coverage
+
+The authoritative coverage value for Taxonomy is produced by the final Maven module, `taxonomy-coverage`, using JaCoCo `report-aggregate`.
+
+## Included production modules
+
+The report must contain all shipped modules as separate JaCoCo groups:
+
+1. `Taxonomy Domain`
+2. `Taxonomy DSL`
+3. `Taxonomy Export`
+4. `Taxonomy Extension API`
+5. `Taxonomy Application`
+
+The coverage gate fails when any required group is missing, even if the remaining modules exceed the percentage threshold. This prevents a highly covered application module from hiding an uninstrumented or untested library module.
+
+## Single source of truth
+
+The following outputs all consume the same file:
+
+```text
+taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml
+```
+
+- CI coverage gate
+- coverage badge
+- published HTML report
+- archived coverage evidence
+- release coverage claims
+
+Module-local reports may still exist for diagnosis, but they are not added together and are not authoritative.
+
+## Local verification
+
+```bash
+mvn install -DexcludedGroups=real-llm
+python3 .github/scripts/check-coverage.py \
+  --xml taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml \
+  --minimum 0.81 \
+  --expected-group "Taxonomy Domain" \
+  --expected-group "Taxonomy DSL" \
+  --expected-group "Taxonomy Export" \
+  --expected-group "Taxonomy Extension API" \
+  --expected-group "Taxonomy Application"
+```
+
+The gate's own regression tests run with:
+
+```bash
+python3 .github/scripts/test-check-coverage.py
+```
+
+## Adding or removing a module
+
+A shipped module change is incomplete until all of the following are updated:
+
+- root reactor `<modules>` list;
+- direct dependencies in `taxonomy-coverage/pom.xml`;
+- required `--expected-group` arguments in CI;
+- this document.
+
+CI deliberately fails when those four views drift apart.

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
         <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
+        <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
+        <postgresql.version>42.7.12</postgresql.version>
+        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+        <jackson-bom.version>3.1.5</jackson-bom.version>
         <!-- Keep the Selenium BOM and the explicitly selected browser image aligned.
              The dated image tag makes CI reproducible; ContainerTestUtils also checks
              at runtime that its Selenium version matches this image tag. -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,7 @@
             <id>carstenartur</id>
             <name>Carsten Hammer</name>
             <url>https://github.com/carstenartur</url>
-            <roles>
-                <role>Lead Developer</role>
-            </roles>
+            <roles><role>Lead Developer</role></roles>
         </developer>
     </developers>
 
@@ -59,17 +57,16 @@
         <module>taxonomy-export</module>
         <module>taxonomy-extension-api</module>
         <module>taxonomy-app</module>
+        <!-- Must stay last: report-aggregate consumes classes and execution data
+             produced by all shipped modules above. -->
+        <module>taxonomy-coverage</module>
     </modules>
+
     <properties>
         <java.version>21</java.version>
         <djl.version>0.36.0</djl.version>
-        <!-- Keep the default Maven lifecycle deterministic and bounded. Container
-             integration tests remain ordinary Maven/Failsafe/Testcontainers tests
-             and are enabled locally with -DskipITs=false. The external-database
-             compatibility matrix is additionally selected by its db-* tags. -->
         <skipITs>true</skipITs>
         <excludedGroups>real-llm,db-postgres,db-mssql,db-oracle</excludedGroups>
-        <!-- Dependency versions (centralized to avoid repetition in child POMs) -->
         <poi.version>5.5.1</poi.version>
         <pdfbox.version>3.0.8</pdfbox.version>
         <lucene.version>9.12.3</lucene.version>
@@ -77,20 +74,15 @@
         <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
-        <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
         <postgresql.version>42.7.12</postgresql.version>
         <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
         <jackson-bom.version>3.1.5</jackson-bom.version>
-        <!-- Keep the Selenium BOM and the explicitly selected browser image aligned.
-             The dated image tag makes CI reproducible; ContainerTestUtils also checks
-             at runtime that its Selenium version matches this image tag. -->
         <selenium.version>4.46.0</selenium.version>
         <selenium.container.image>selenium/standalone-chrome:4.46.0-20260707</selenium.container.image>
         <archunit.version>1.4.2</archunit.version>
         <flexmark.version>0.64.8</flexmark.version>
         <xstream.version>1.4.21</xstream.version>
         <testcontainers.version>2.0.5</testcontainers.version>
-        <!-- Plugin versions (centralized) -->
         <cyclonedx.version>2.9.2</cyclonedx.version>
         <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <maven-fluido-skin.version>2.1.0</maven-fluido-skin.version>
@@ -100,6 +92,7 @@
         <jacoco.version>0.8.15</jacoco.version>
         <maven-enforcer.version>3.6.3</maven-enforcer.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -111,19 +104,27 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <build>
         <plugins>
-            <!-- Skip spring-boot:run/repackage on the root aggregator POM
-                 (taxonomy-app overrides this with its own plugin declaration). -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
+                <configuration><skip>true</skip></configuration>
             </plugin>
-            <!-- Dependency hygiene is a normal Maven invariant, not a GitHub-only check.
-                 Test-scoped fixtures are intentionally outside these packaged-runtime bans. -->
+            <!-- Inherited by every code module. This is the critical difference
+                 from the former taxonomy-app-only instrumentation. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals><goal>prepare-agent</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
@@ -154,7 +155,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Generate one authoritative aggregate SBOM at the reactor root. -->
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
@@ -164,9 +164,7 @@
                     <execution>
                         <id>generate-aggregate-sbom</id>
                         <phase>package</phase>
-                        <goals>
-                            <goal>makeAggregateBom</goal>
-                        </goals>
+                        <goals><goal>makeAggregateBom</goal></goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -185,9 +183,6 @@
                     <includeTestScope>false</includeTestScope>
                 </configuration>
             </plugin>
-            <!-- The site and skin versions are controlled by the properties above.
-                 Bundling the skin as a plugin dependency keeps site generation
-                 reproducible and avoids resolving an implicit remote default. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
@@ -200,8 +195,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Keep Surefire Report on the same managed Doxia/Fluido family as
-                 the site plugin; literal versions belong only in properties. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
@@ -214,9 +207,6 @@
                     </dependency>
                 </dependencies>
             </plugin>
-            <!-- Keep Project Info Reports on the managed Doxia 2.x family. This
-                 prevents parent dependency management from selecting an older
-                 report stack that misreads project metadata. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>

--- a/taxonomy-coverage/pom.xml
+++ b/taxonomy-coverage/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.taxonomy</groupId>
+        <artifactId>taxonomy</artifactId>
+        <version>1.2.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>taxonomy-coverage</artifactId>
+    <packaging>pom</packaging>
+    <name>Taxonomy Aggregate Coverage</name>
+    <description>Authoritative JaCoCo report across every shipped Taxonomy module</description>
+
+    <!-- report-aggregate collects classes and execution data from reactor
+         dependencies. Every shipped module is direct and therefore auditable. -->
+    <dependencies>
+        <dependency>
+            <groupId>com.taxonomy</groupId>
+            <artifactId>taxonomy-domain</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.taxonomy</groupId>
+            <artifactId>taxonomy-dsl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.taxonomy</groupId>
+            <artifactId>taxonomy-export</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.taxonomy</groupId>
+            <artifactId>taxonomy-extension-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.taxonomy</groupId>
+            <artifactId>taxonomy-app</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <!-- This module has no tests of its own. Do not attach an agent. -->
+                    <execution>
+                        <id>prepare-agent</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>reactor-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/site/jacoco-aggregate</outputDirectory>
+                            <includeCurrentProject>false</includeCurrentProject>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
## Summary

Implements #420 on top of the dependency security patch.

### Coverage architecture

- instruments every shipped Maven module through the parent JaCoCo agent;
- adds `taxonomy-coverage` as the final reactor module;
- generates one authoritative `report-aggregate` XML and HTML report;
- requires the report to contain separate groups for Domain, DSL, Export, Extension API, and Application;
- fails when a shipped module is absent, regardless of the remaining percentage;
- keeps the existing 81% instruction floor against the complete reactor rather than `taxonomy-app` alone.

### CI and publication

The gate, coverage badge, published HTML, immutable report artifact, and release evidence now consume only:

`taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml`

Module-local reports remain diagnostic and are never added together.

### Regression protection

Adds standalone tests for the gate itself: threshold failure, missing-module failure, and duplicate-group rejection.

## Stacking

Base: `fix/security-dependency-patches`, so the current PostgreSQL/Jackson security fixes are present while the full reactor runs. Retarget to `main` after #433 merges.

## Verification

Opened as draft. The first CI result will reveal the truthful complete-reactor percentage; no classes or modules are excluded to preserve the former application-only number.

Addresses #420.