### PR TITLE
QA: expand UI and accessibility acceptance across roles and dynamic states

### DIFF
--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -1,0 +1,272 @@
+import { chromium, firefox, webkit, request } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
+const adminUsername = process.env.TAXONOMY_UI_ADMIN_USERNAME || 'admin';
+const adminPassword = process.env.TAXONOMY_UI_ADMIN_PASSWORD || 'ui-state-admin-password';
+const profileId = process.env.TAXONOMY_UI_PROFILE || 'desktop-user-chromium';
+const browserName = process.env.TAXONOMY_BROWSER || 'chromium';
+const role = process.env.TAXONOMY_ROLE || 'USER';
+const physicalWidth = Number.parseInt(process.env.TAXONOMY_VIEWPORT_WIDTH || '1440', 10);
+const physicalHeight = Number.parseInt(process.env.TAXONOMY_VIEWPORT_HEIGHT || '1000', 10);
+const zoom = Number.parseFloat(process.env.TAXONOMY_ZOOM || '1');
+const forcedColors = process.env.TAXONOMY_FORCED_COLORS === 'true';
+const outputDir = process.env.TAXONOMY_UI_OUTPUT_DIR || `/tmp/taxonomy-ui-state-${profileId}`;
+const matrixPath = process.env.TAXONOMY_UI_MATRIX || '.github/ui-acceptance-matrix.json';
+
+const browserType = { chromium, firefox, webkit }[browserName];
+if (!browserType) throw new Error(`Unsupported browser: ${browserName}`);
+if (!['USER', 'ARCHITECT', 'ADMIN'].includes(role)) throw new Error(`Unsupported role: ${role}`);
+if (!Number.isFinite(zoom) || zoom < 1) throw new Error(`Invalid zoom factor: ${zoom}`);
+
+const matrix = JSON.parse(await readFile(matrixPath, 'utf8'));
+if (matrix.schemaVersion !== 1) throw new Error(`Unsupported UI matrix schema: ${matrix.schemaVersion}`);
+const declaredProfile = matrix.profiles.find(profile => profile.id === profileId);
+if (!declaredProfile) throw new Error(`Profile ${profileId} is missing from ${matrixPath}`);
+if (declaredProfile.browser !== browserName || declaredProfile.role !== role
+    || declaredProfile.zoom !== zoom || Boolean(declaredProfile.forcedColors) !== forcedColors) {
+  throw new Error(`Workflow/profile drift for ${profileId}`);
+}
+
+const effectiveViewport = {
+  width: Math.max(320, Math.floor(physicalWidth / zoom)),
+  height: Math.max(240, Math.floor(physicalHeight / zoom))
+};
+const credentials = {
+  USER: { username: 'qa-ui-user', password: 'qa-ui-user-password-2026', roles: ['USER'] },
+  ARCHITECT: {
+    username: 'qa-ui-architect', password: 'qa-ui-architect-password-2026',
+    roles: ['USER', 'ARCHITECT']
+  },
+  ADMIN: { username: adminUsername, password: adminPassword, roles: ['USER', 'ARCHITECT', 'ADMIN'] }
+};
+const account = credentials[role];
+const checks = [];
+const findings = [];
+const consoleErrors = [];
+const externalRequests = [];
+let auditError = null;
+
+function passed(name) {
+  checks.push(name);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function ensureRoleAccounts() {
+  const api = await request.newContext({
+    baseURL: baseUrl,
+    httpCredentials: { username: adminUsername, password: adminPassword }
+  });
+  try {
+    for (const value of [credentials.USER, credentials.ARCHITECT]) {
+      const response = await api.post('/api/admin/users', {
+        data: {
+          username: value.username,
+          password: value.password,
+          displayName: `QA ${value.roles.at(-1)}`,
+          email: `${value.username}@example.invalid`,
+          roles: value.roles
+        }
+      });
+      if (![200, 201, 409].includes(response.status())) {
+        throw new Error(`Unable to provision ${value.username}: ${response.status()} ${await response.text()}`);
+      }
+    }
+  } finally {
+    await api.dispose();
+  }
+}
+
+async function saveState(page, state) {
+  const prefix = path.join(outputDir, state);
+  await page.screenshot({ path: `${prefix}.png`, fullPage: true });
+  await writeFile(`${prefix}.html`, await page.content(), 'utf8');
+  const body = page.locator('body');
+  const aria = typeof body.ariaSnapshot === 'function'
+    ? await body.ariaSnapshot().catch(error => `ARIA snapshot unavailable: ${error}`)
+    : 'ARIA snapshot API unavailable';
+  await writeFile(`${prefix}.aria.txt`, `${aria}\n`, 'utf8');
+}
+
+async function runAxe(page, state) {
+  const result = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  const blocking = result.violations.filter(violation =>
+    ['critical', 'serious', 'moderate'].includes(violation.impact));
+  findings.push({ state, violations: result.violations, blocking });
+  if (blocking.length) {
+    const summary = blocking.map(item => `${item.impact}:${item.id}`).join(', ');
+    throw new Error(`Blocking axe findings in ${state}: ${summary}`);
+  }
+  passed(`axe ${state}`);
+}
+
+async function csrfPost(page, endpoint, body) {
+  return page.evaluate(async ({ endpoint, body }) => {
+    const token = document.querySelector('meta[name="_csrf"]')?.content;
+    const header = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers[header] = token;
+    const response = await fetch(endpoint, {
+      method: 'POST', headers, body: JSON.stringify(body)
+    });
+    const text = await response.text();
+    let json = null;
+    try { json = text ? JSON.parse(text) : null; } catch { /* stable status remains authoritative */ }
+    return { status: response.status, json, text };
+  }, { endpoint, body });
+}
+
+await mkdir(outputDir, { recursive: true });
+await ensureRoleAccounts();
+
+const browser = await browserType.launch({ headless: true });
+const context = await browser.newContext({
+  viewport: effectiveViewport,
+  reducedMotion: 'reduce',
+  forcedColors: forcedColors ? 'active' : 'none'
+});
+const page = await context.newPage();
+const baseOrigin = new URL(baseUrl).origin;
+page.on('request', requestEvent => {
+  const url = requestEvent.url();
+  if (url.startsWith('data:') || url.startsWith('blob:')) return;
+  if (new URL(url).origin !== baseOrigin) externalRequests.push(url);
+});
+page.on('console', message => {
+  if (message.type() === 'error') consoleErrors.push(message.text());
+});
+page.on('pageerror', error => consoleErrors.push(error.message));
+
+try {
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'networkidle' });
+  await page.locator('input[name="username"]').fill(account.username);
+  await page.locator('input[name="password"]').fill(account.password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.endsWith('/login'), { timeout: 30_000 }),
+    page.keyboard.press('Enter')
+  ]);
+  await page.locator('#mainContent').waitFor({ state: 'visible', timeout: 60_000 });
+  const onboardingDismiss = page.locator('#onboardingDismiss');
+  if (await onboardingDismiss.isVisible().catch(() => false)) {
+    await onboardingDismiss.focus();
+    await page.keyboard.press('Enter');
+  }
+  passed('keyboard authentication');
+
+  const adminTab = page.locator('#adminNavTab');
+  const adminVisible = await adminTab.isVisible().catch(() => false);
+  assert(role === 'ADMIN' ? adminVisible : !adminVisible,
+    `${role} admin navigation visibility is incorrect`);
+  passed('role-specific navigation');
+
+  await page.locator('#mainNavTabs [data-page="analyze"]').click();
+  await page.locator('#businessText').fill(
+    'Provide resilient hospital communications with traceable architecture decisions.');
+  await page.locator('#analyzeBtn').focus();
+  await page.keyboard.press('Enter');
+  await page.locator('#statusArea').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForFunction(() => {
+    const text = document.querySelector('#statusArea')?.textContent?.toLowerCase() || '';
+    return text.includes('complete') || text.includes('completed');
+  }, null, { timeout: 120_000 });
+  assert(await page.locator('.tax-pct').count() > 0, 'Analysis produced no scored nodes');
+  passed('analysis loading and success');
+  await runAxe(page, 'analysis-success');
+  await saveState(page, 'analysis-success');
+
+  await page.locator('#businessText').fill(
+    'Provide resilient hospital communications with an emergency notification capability.');
+  await page.locator('#businessText.stale-results').waitFor({ state: 'visible', timeout: 10_000 });
+  passed('stale-result indication');
+
+  await page.route('**/api/analyze', async route => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'QA_PROVIDER_UNAVAILABLE', message: 'Deterministic QA failure' })
+    });
+  }, { times: 1 });
+  await page.locator('#analyzeBtn').click();
+  await page.waitForFunction(() => {
+    const text = document.querySelector('#statusArea')?.textContent?.toLowerCase() || '';
+    return text.includes('error') || text.includes('failed') || text.includes('503')
+      || text.includes('unavailable');
+  }, null, { timeout: 30_000 });
+  passed('analysis provider error state');
+  await runAxe(page, 'analysis-error');
+  await saveState(page, 'analysis-error');
+
+  const proposal = await csrfPost(page, '/api/proposals/from-hypothesis', {
+    sourceCode: 'BP', targetCode: 'BR', relationType: 'RELATED_TO',
+    confidence: 0.72, rationale: 'Role acceptance test'
+  });
+  if (role === 'USER') {
+    assert(proposal.status === 403, `USER proposal mutation returned ${proposal.status}, expected 403`);
+    passed('user proposal mutation forbidden');
+  } else {
+    assert([200, 409].includes(proposal.status),
+      `${role} proposal creation returned ${proposal.status}`);
+    if (proposal.status === 200 && proposal.json?.id) {
+      const accepted = await csrfPost(page, `/api/proposals/${proposal.json.id}/accept`, {});
+      assert(accepted.status === 200, `Proposal acceptance returned ${accepted.status}`);
+    }
+    passed('architectural proposal review');
+  }
+  await runAxe(page, 'role-operation-feedback');
+  await saveState(page, 'role-operation-feedback');
+
+  const businessText = page.locator('#businessText');
+  await businessText.focus();
+  await page.evaluate(() => window.TaxonomyUtils.showMessage('Accessible QA dialog', 'QA notice'));
+  const dialog = page.locator('#taxonomyAccessibleDialog');
+  await dialog.waitFor({ state: 'visible' });
+  assert(await page.evaluate(() => document.activeElement?.id === 'taxonomyAccessibleDialogConfirm'),
+    'Dialog did not move focus to its confirmation control');
+  await runAxe(page, 'dialog-open');
+  await saveState(page, 'dialog-open');
+  await page.keyboard.press('Enter');
+  await dialog.waitFor({ state: 'hidden' });
+  assert(await page.evaluate(() => document.activeElement?.id === 'businessText'),
+    'Dialog did not restore focus to its invoker');
+  passed('dialog focus entry and restoration');
+
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    forcedColors: matchMedia('(forced-colors: active)').matches,
+    reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches
+  }));
+  assert(overflow.scrollWidth <= overflow.clientWidth + 2,
+    `Viewport reflow failed at ${zoom}x: ${overflow.scrollWidth} > ${overflow.clientWidth}`);
+  assert(overflow.reducedMotion, 'Reduced motion preference was not active');
+  assert(forcedColors ? overflow.forcedColors : true, 'Forced-colors profile was not active');
+  passed(`reflow at ${zoom}x`);
+  if (forcedColors) passed('forced-colors media state');
+
+  assert(externalRequests.length === 0,
+    `External browser requests detected: ${externalRequests.join(', ')}`);
+  assert(consoleErrors.length === 0,
+    `Browser console errors: ${consoleErrors.join(' | ')}`);
+  passed('local assets and clean console');
+} catch (error) {
+  auditError = error?.stack || String(error);
+  process.exitCode = 1;
+} finally {
+  await writeFile(path.join(outputDir, 'report.json'), JSON.stringify({
+    profileId, browserName, role, physicalViewport: { width: physicalWidth, height: physicalHeight },
+    effectiveViewport, zoom, forcedColors, checks, findings,
+    externalRequests, consoleErrors, auditError
+  }, null, 2) + '\n', 'utf8');
+  await context.close();
+  await browser.close();
+}
+
+if (auditError) throw new Error(auditError);
+console.log(`UI role/state acceptance passed for ${profileId}: ${checks.join(', ')}`);

--- a/.github/ui-acceptance-matrix.json
+++ b/.github/ui-acceptance-matrix.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "roles": ["USER", "ARCHITECT", "ADMIN"],
+  "workflows": [
+    {
+      "id": "authentication-and-navigation",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["success", "keyboard-only", "role-specific-surface"]
+    },
+    {
+      "id": "requirement-analysis",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["loading", "success", "stale", "provider-error"]
+    },
+    {
+      "id": "proposal-review",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["forbidden", "created", "accepted-or-rejected"]
+    },
+    {
+      "id": "accessible-dialog",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["opened", "focus-contained", "closed", "focus-restored"]
+    },
+    {
+      "id": "responsive-reflow",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["mobile", "zoom-200", "zoom-400", "forced-colors"]
+    }
+  ],
+  "profiles": [
+    {"id": "desktop-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 1, "forcedColors": false},
+    {"id": "desktop-architect-firefox", "browser": "firefox", "role": "ARCHITECT", "width": 1440, "height": 1000, "zoom": 1, "forcedColors": false},
+    {"id": "mobile-admin-webkit", "browser": "webkit", "role": "ADMIN", "width": 390, "height": 844, "zoom": 1, "forcedColors": false},
+    {"id": "zoom-200-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 2, "forcedColors": false},
+    {"id": "zoom-400-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 4, "forcedColors": false},
+    {"id": "forced-colors-architect-chromium", "browser": "chromium", "role": "ARCHITECT", "width": 1024, "height": 768, "zoom": 1, "forcedColors": true}
+  ]
+}

--- a/.github/workflows/qa-test-evidence.yml
+++ b/.github/workflows/qa-test-evidence.yml
@@ -1,0 +1,57 @@
+name: QA Test Evidence
+
+on:
+  push:
+    branches:
+      - fix/proposal-workspace-authorization
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BGE_MODEL_REVISION: 5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+
+jobs:
+  maven-test-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Download and verify pinned embedding model
+        env:
+          MODEL_REVISION: ${{ env.BGE_MODEL_REVISION }}
+        run: bash .github/scripts/download-embedding-model.sh
+
+      - name: Run Maven verification
+        id: verify
+        continue-on-error: true
+        env:
+          TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
+          TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
+        run: mvn -q install -DexcludedGroups="real-llm"
+
+      - name: Upload raw Maven reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: qa-maven-test-evidence
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Propagate verification result
+        if: steps.verify.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/qa-test-evidence.yml
+++ b/.github/workflows/qa-test-evidence.yml
@@ -1,9 +1,8 @@
 name: QA Test Evidence
 
 on:
-  push:
-    branches:
-      - fix/proposal-workspace-authorization
+  pull_request:
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ui-role-state-acceptance.yml
+++ b/.github/workflows/ui-role-state-acceptance.yml
@@ -1,0 +1,142 @@
+name: UI Role and State Acceptance
+
+on:
+  pull_request:
+    branches: [ main, fix/proposal-workspace-authorization ]
+    paths:
+      - 'taxonomy-app/src/main/**'
+      - 'taxonomy-app/src/test/**'
+      - '.github/ui-acceptance-matrix.json'
+      - '.github/scripts/ui-role-state-acceptance.mjs'
+      - '.github/workflows/ui-role-state-acceptance.yml'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  role-state-flow:
+    name: ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: desktop-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 1
+            forced_colors: false
+          - profile: desktop-architect-firefox
+            browser: firefox
+            role: ARCHITECT
+            width: 1440
+            height: 1000
+            zoom: 1
+            forced_colors: false
+          - profile: mobile-admin-webkit
+            browser: webkit
+            role: ADMIN
+            width: 390
+            height: 844
+            zoom: 1
+            forced_colors: false
+          - profile: zoom-200-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 2
+            forced_colors: false
+          - profile: zoom-400-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 4
+            forced_colors: false
+          - profile: forced-colors-architect-chromium
+            browser: chromium
+            role: ARCHITECT
+            width: 1024
+            height: 768
+            zoom: 1
+            forced_colors: true
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Build application
+        run: mvn -q -pl taxonomy-app -am package -DskipTests
+
+      - name: Start deterministic application
+        env:
+          TAXONOMY_ADMIN_PASSWORD: ui-state-admin-password
+          TAXONOMY_REQUIRE_PASSWORD_CHANGE: 'false'
+          TAXONOMY_EMBEDDING_ENABLED: 'false'
+          TAXONOMY_INIT_ASYNC: 'true'
+          TAXONOMY_THYMELEAF_CACHE: 'false'
+          LLM_MOCK: 'true'
+        run: |
+          JAR=$(find taxonomy-app/target -maxdepth 1 -name 'taxonomy-app-*.jar' ! -name 'original-*' | head -n 1)
+          test -n "$JAR"
+          java -jar "$JAR" > /tmp/taxonomy-ui-state.log 2>&1 &
+          echo $! > /tmp/taxonomy-ui-state.pid
+          for i in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:8080/login >/dev/null; then exit 0; fi
+            sleep 2
+          done
+          cat /tmp/taxonomy-ui-state.log
+          exit 1
+
+      - name: Install pinned browser tools
+        run: |
+          npm install --no-save --no-audit --no-fund \
+            @playwright/test@1.61.1 \
+            @axe-core/playwright@4.12.1
+          npx playwright install --with-deps "${{ matrix.browser }}"
+
+      - name: Run role and state acceptance
+        env:
+          TAXONOMY_BASE_URL: http://127.0.0.1:8080
+          TAXONOMY_UI_ADMIN_USERNAME: admin
+          TAXONOMY_UI_ADMIN_PASSWORD: ui-state-admin-password
+          TAXONOMY_UI_PROFILE: ${{ matrix.profile }}
+          TAXONOMY_BROWSER: ${{ matrix.browser }}
+          TAXONOMY_ROLE: ${{ matrix.role }}
+          TAXONOMY_VIEWPORT_WIDTH: ${{ matrix.width }}
+          TAXONOMY_VIEWPORT_HEIGHT: ${{ matrix.height }}
+          TAXONOMY_ZOOM: ${{ matrix.zoom }}
+          TAXONOMY_FORCED_COLORS: ${{ matrix.forced_colors }}
+          TAXONOMY_UI_OUTPUT_DIR: /tmp/taxonomy-ui-state-${{ matrix.profile }}
+        run: node .github/scripts/ui-role-state-acceptance.mjs
+
+      - name: Upload per-state evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-state-${{ matrix.profile }}
+          path: |
+            /tmp/taxonomy-ui-state-${{ matrix.profile }}/**
+            /tmp/taxonomy-ui-state.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/dev/UI_ACCEPTANCE_MATRIX.md
+++ b/docs/dev/UI_ACCEPTANCE_MATRIX.md
@@ -1,0 +1,46 @@
+# UI, role, state, and accessibility acceptance matrix
+
+The checked matrix lives in `.github/ui-acceptance-matrix.json`. The workflow and browser script reject profile drift rather than silently running an undeclared combination.
+
+## Roles
+
+- **USER** — read, analyse, search, and export; architecture mutations must return 403 and mutation controls must not imply availability.
+- **ARCHITECT** — architecture and proposal mutations are available; administrator navigation remains hidden.
+- **ADMIN** — administrator navigation and all architecture workflows are available.
+
+Each run provisions deterministic local USER and ARCHITECT accounts through the real admin API. Browser authentication remains form-based and keyboard-only; API setup uses explicit HTTP Basic credentials, preserving CSRF protection for browser sessions.
+
+## Dynamic states
+
+The browser test captures DOM, screenshot, ARIA snapshot, and axe evidence after:
+
+1. successful scored analysis;
+2. stale results after requirement editing;
+3. deterministic provider failure;
+4. role-appropriate proposal mutation feedback;
+5. an open application dialog with focus inside it;
+6. dialog close and focus restoration.
+
+Critical, serious, and moderate axe findings fail the run. Browser console errors and any external browser request also fail.
+
+## Browser and visual profiles
+
+- desktop Chromium / USER;
+- desktop Firefox / ARCHITECT;
+- mobile WebKit / ADMIN;
+- Chromium reflow equivalent to 200% zoom;
+- Chromium reflow equivalent to 400% zoom;
+- Chromium Forced Colors / ARCHITECT.
+
+Browser zoom reduces the CSS layout viewport. The tests use the equivalent effective viewport and assert that document-level horizontal scrolling is not introduced. Reduced Motion is active in every profile.
+
+## Evidence retention
+
+Every state produces:
+
+- full-page PNG;
+- serialized DOM HTML;
+- ARIA snapshot when supported by Playwright;
+- one machine-readable report containing checks, axe findings, viewport data, console errors, external requests, and any failure stack.
+
+Artifacts are retained for 30 days to make UI regressions reviewable rather than relying only on a green check name.

--- a/docs/internal/qa-progress-placeholder.md
+++ b/docs/internal/qa-progress-placeholder.md
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/internal/qa-progress-placeholder.md
+++ b/docs/internal/qa-progress-placeholder.md
@@ -1,1 +1,0 @@
-placeholder

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/model/TaxonomyRelation.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/model/TaxonomyRelation.java
@@ -1,17 +1,41 @@
 package com.taxonomy.catalog.model;
 
+import com.taxonomy.model.RelationType;
 import com.taxonomy.search.RelationEmbeddingBinder;
-import jakarta.persistence.*;
+import com.taxonomy.shared.model.FloatArrayConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.Nationalized;
 import org.hibernate.search.mapper.pojo.bridge.mapping.annotation.TypeBinderRef;
-import org.hibernate.search.mapper.pojo.mapping.definition.annotation.*;
-import com.taxonomy.model.RelationType;
-import com.taxonomy.shared.model.FloatArrayConverter;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.FullTextField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.IndexedEmbedded;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.KeywordField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.TypeBinding;
 
 @Entity
 @Table(name = "taxonomy_relation",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"source_node_id", "target_node_id", "relation_type", "workspace_id"}),
+                name = "uk_taxonomy_relation_scope",
+                columnNames = {
+                        "source_node_id", "target_node_id", "relation_type", "workspace_scope_key"
+                }),
         indexes = {
                 @Index(name = "idx_rel_workspace", columnList = "workspace_id"),
                 @Index(name = "idx_rel_owner", columnList = "owner_username")
@@ -19,6 +43,8 @@ import com.taxonomy.shared.model.FloatArrayConverter;
 @Indexed
 @TypeBinding(binder = @TypeBinderRef(type = RelationEmbeddingBinder.class))
 public class TaxonomyRelation {
+
+    public static final String SHARED_SCOPE_KEY = "__shared__";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,6 +68,11 @@ public class TaxonomyRelation {
     @Column(name = "workspace_id")
     @KeywordField
     private String workspaceId;
+
+    /** Non-null uniqueness key for both shared and personal workspace rows. */
+    @Column(name = "workspace_scope_key", length = 255)
+    @KeywordField
+    private String workspaceScopeKey = SHARED_SCOPE_KEY;
 
     @Column(name = "owner_username")
     @KeywordField
@@ -67,6 +98,17 @@ public class TaxonomyRelation {
     @GenericField
     @Column(name = "has_embedding")
     private boolean hasEmbedding;
+
+    @PrePersist
+    @PreUpdate
+    void synchronizeWorkspaceScopeKey() {
+        workspaceScopeKey = scopeKeyFor(workspaceId);
+    }
+
+    public static String scopeKeyFor(String workspaceId) {
+        return workspaceId == null || workspaceId.isBlank()
+                ? SHARED_SCOPE_KEY : workspaceId;
+    }
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -95,14 +137,19 @@ public class TaxonomyRelation {
     public float[] getSemanticEmbedding() { return semanticEmbedding; }
     public void setSemanticEmbedding(float[] semanticEmbedding) {
         this.semanticEmbedding = semanticEmbedding;
-        this.hasEmbedding = (semanticEmbedding != null);
+        this.hasEmbedding = semanticEmbedding != null;
     }
 
     public boolean isHasEmbedding() { return hasEmbedding; }
     private void setHasEmbedding(boolean hasEmbedding) { this.hasEmbedding = hasEmbedding; }
 
     public String getWorkspaceId() { return workspaceId; }
-    public void setWorkspaceId(String workspaceId) { this.workspaceId = workspaceId; }
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = workspaceId;
+        synchronizeWorkspaceScopeKey();
+    }
+
+    public String getWorkspaceScopeKey() { return workspaceScopeKey; }
 
     public String getOwnerUsername() { return ownerUsername; }
     public void setOwnerUsername(String ownerUsername) { this.ownerUsername = ownerUsername; }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
@@ -45,6 +45,15 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
     List<TaxonomyRelation> findVisibleByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
                                                                   @Param("type") RelationType type);
 
+    @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
+           "AND r.sourceNode.code = :sourceCode AND r.targetNode.code = :targetCode " +
+           "AND r.relationType = :type")
+    List<TaxonomyRelation> findVisibleByWorkspaceAndSourceTargetType(
+            @Param("wsId") String workspaceId,
+            @Param("sourceCode") String sourceCode,
+            @Param("targetCode") String targetCode,
+            @Param("type") RelationType type);
+
     @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
     long countVisibleByWorkspace(@Param("wsId") String workspaceId);
 
@@ -100,12 +109,7 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
                                                                        String sourceCode,
                                                                        String targetCode,
                                                                        RelationType type) {
-        List<TaxonomyRelation> visible = findVisibleByWorkspace(workspaceId);
-        return visible.stream()
-                .filter(relation -> relation.getSourceNode().getCode().equals(sourceCode))
-                .filter(relation -> relation.getTargetNode().getCode().equals(targetCode))
-                .filter(relation -> relation.getRelationType() == type)
-                .toList();
+        return findVisibleByWorkspaceAndSourceTargetType(workspaceId, sourceCode, targetCode, type);
     }
 
     default long countByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyRelationRepository.java
@@ -1,13 +1,14 @@
 package com.taxonomy.catalog.repository;
 
-import com.taxonomy.model.RelationType;
 import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.model.RelationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelation, Long> {
@@ -29,31 +30,85 @@ public interface TaxonomyRelationRepository extends JpaRepository<TaxonomyRelati
     List<TaxonomyRelation> findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
             String sourceCode, String targetCode, RelationType relationType);
 
-    // ── Workspace-scoped queries ─────────────────────────────────────
+    // ── Visible workspace scope: shared baseline + current workspace ──
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
            "AND (r.sourceNode.code = :code OR r.targetNode.code = :code)")
-    List<TaxonomyRelation> findByWorkspaceAndNodeCode(@Param("wsId") String workspaceId,
-                                                       @Param("code") String code);
+    List<TaxonomyRelation> findVisibleByWorkspaceAndNodeCode(@Param("wsId") String workspaceId,
+                                                              @Param("code") String code);
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
-    List<TaxonomyRelation> findByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);
+    List<TaxonomyRelation> findVisibleByWorkspace(@Param("wsId") String workspaceId);
 
     @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
            "AND r.relationType = :type")
-    List<TaxonomyRelation> findByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
-                                                           @Param("type") RelationType type);
+    List<TaxonomyRelation> findVisibleByWorkspaceAndRelationType(@Param("wsId") String workspaceId,
+                                                                  @Param("type") RelationType type);
+
+    @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
+    long countVisibleByWorkspace(@Param("wsId") String workspaceId);
+
+    // ── Shared scope only ────────────────────────────────────────────
+
+    List<TaxonomyRelation> findByWorkspaceIdIsNull();
+
+    List<TaxonomyRelation> findByRelationTypeAndWorkspaceIdIsNull(RelationType relationType);
+
+    @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId IS NULL " +
+           "AND (r.sourceNode.code = :code OR r.targetNode.code = :code)")
+    List<TaxonomyRelation> findSharedByNodeCode(@Param("code") String code);
+
+    long countByWorkspaceIdIsNull();
+
+    // ── Exact mutable workspace scope ────────────────────────────────
+
+    @Query("""
+            SELECT r FROM TaxonomyRelation r
+            WHERE r.id = :id
+              AND ((:wsId IS NULL AND r.workspaceId IS NULL) OR r.workspaceId = :wsId)
+            """)
+    Optional<TaxonomyRelation> findByIdInWorkspace(@Param("id") Long id,
+                                                    @Param("wsId") String workspaceId);
 
     List<TaxonomyRelation> findByWorkspaceId(String workspaceId);
 
-    @Query("SELECT r FROM TaxonomyRelation r WHERE (r.workspaceId = :wsId OR r.workspaceId IS NULL) " +
+    List<TaxonomyRelation> findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+            String workspaceId, String sourceCode, String targetCode, RelationType type);
+
+    @Query("SELECT r FROM TaxonomyRelation r WHERE r.workspaceId IS NULL " +
            "AND r.sourceNode.code = :sourceCode AND r.targetNode.code = :targetCode " +
            "AND r.relationType = :type")
-    List<TaxonomyRelation> findByWorkspaceAndSourceTargetType(@Param("wsId") String workspaceId,
-                                                               @Param("sourceCode") String sourceCode,
-                                                               @Param("targetCode") String targetCode,
-                                                               @Param("type") RelationType type);
+    List<TaxonomyRelation> findSharedBySourceTargetType(@Param("sourceCode") String sourceCode,
+                                                         @Param("targetCode") String targetCode,
+                                                         @Param("type") RelationType type);
 
-    @Query("SELECT COUNT(r) FROM TaxonomyRelation r WHERE r.workspaceId = :wsId OR r.workspaceId IS NULL")
-    long countByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);
+    // ── Backward-compatible aliases for visible-scope callers ───────
+
+    default List<TaxonomyRelation> findByWorkspaceAndNodeCode(String workspaceId, String code) {
+        return findVisibleByWorkspaceAndNodeCode(workspaceId, code);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {
+        return findVisibleByWorkspace(workspaceId);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceAndRelationType(String workspaceId, RelationType type) {
+        return findVisibleByWorkspaceAndRelationType(workspaceId, type);
+    }
+
+    default List<TaxonomyRelation> findByWorkspaceAndSourceTargetType(String workspaceId,
+                                                                       String sourceCode,
+                                                                       String targetCode,
+                                                                       RelationType type) {
+        List<TaxonomyRelation> visible = findVisibleByWorkspace(workspaceId);
+        return visible.stream()
+                .filter(relation -> relation.getSourceNode().getCode().equals(sourceCode))
+                .filter(relation -> relation.getTargetNode().getCode().equals(targetCode))
+                .filter(relation -> relation.getRelationType() == type)
+                .toList();
+    }
+
+    default long countByWorkspaceIdIsNullOrWorkspaceId(String workspaceId) {
+        return countVisibleByWorkspace(workspaceId);
+    }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -1,11 +1,11 @@
 package com.taxonomy.catalog.service;
 
-import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.RelationType;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.catalog.model.TaxonomyRelation;
 import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.RelationType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -178,18 +178,39 @@ public class TaxonomyRelationService {
     }
 
     /**
-     * Delete all relations matching a specific source, target, and type combination.
-     * Used by the proposal revert mechanism to remove accepted relations.
+     * Delete relations matching a specific source, target, type, and exact
+     * workspace. A null workspace ID means shared relations only, never all
+     * workspaces.
+     */
+    @Transactional
+    public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
+                                                  RelationType type,
+                                                  @Nullable String workspaceId) {
+        List<TaxonomyRelation> matches;
+        if (workspaceId != null) {
+            matches = relationRepository.findByWorkspaceAndSourceTargetType(
+                    workspaceId, sourceCode, targetCode, type);
+        } else {
+            matches = relationRepository
+                    .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type)
+                    .stream()
+                    .filter(relation -> relation.getWorkspaceId() == null)
+                    .toList();
+        }
+        if (!matches.isEmpty()) {
+            relationRepository.deleteAll(matches);
+            log.info("Deleted {} relation(s): {} --[{}]--> {} (workspace={})",
+                    matches.size(), sourceCode, type, targetCode, workspaceId);
+        }
+    }
+
+    /**
+     * Legacy overload — operates on shared relations only.
      */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type) {
-        List<TaxonomyRelation> matches = relationRepository
-                .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type);
-        if (!matches.isEmpty()) {
-            relationRepository.deleteAll(matches);
-            log.info("Deleted {} relation(s): {} --[{}]--> {}", matches.size(), sourceCode, type, targetCode);
-        }
+        deleteRelationBySourceTargetType(sourceCode, targetCode, type, null);
     }
 
     public TaxonomyRelationDto toDto(TaxonomyRelation relation) {

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -33,50 +33,29 @@ public class TaxonomyRelationService {
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsForNode(String code, @Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceAndNodeCode(workspaceId, code);
-        } else {
-            relations = relationRepository.findBySourceNodeCodeOrTargetNodeCode(code, code);
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndNodeCode(workspaceId, code)
+                : relationRepository.findSharedByNodeCode(code);
+        return toDtos(relations);
     }
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsByType(RelationType type, @Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceAndRelationType(workspaceId, type);
-        } else {
-            relations = relationRepository.findByRelationType(type);
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndRelationType(workspaceId, type)
+                : relationRepository.findByRelationTypeAndWorkspaceIdIsNull(type);
+        return toDtos(relations);
     }
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getAllRelations(@Nullable String workspaceId) {
-        List<TaxonomyRelation> relations;
-        if (workspaceId != null) {
-            relations = relationRepository.findByWorkspaceIdIsNullOrWorkspaceId(workspaceId);
-        } else {
-            relations = relationRepository.findAll();
-        }
-        List<TaxonomyRelationDto> dtos = new ArrayList<>();
-        for (TaxonomyRelation relation : relations) {
-            dtos.add(toDto(relation));
-        }
-        return dtos;
+        List<TaxonomyRelation> relations = workspaceId != null
+                ? relationRepository.findVisibleByWorkspace(workspaceId)
+                : relationRepository.findByWorkspaceIdIsNull();
+        return toDtos(relations);
     }
 
-    // ── Legacy delegating read methods (backward-compatible) ─────────
+    // ── Legacy delegating read methods (shared scope) ───────────────
 
     @Transactional(readOnly = true)
     public List<TaxonomyRelationDto> getRelationsForNode(String code) {
@@ -106,19 +85,13 @@ public class TaxonomyRelationService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        // Programmatic duplicate check (covers NULL workspace_id in unique constraint)
-        List<TaxonomyRelation> existing;
-        if (workspaceId != null) {
-            existing = relationRepository.findByWorkspaceAndSourceTargetType(
-                    workspaceId, sourceCode, targetCode, type);
-        } else {
-            existing = relationRepository.findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                    sourceCode, targetCode, type);
-            // Filter to only those with null workspace for exact match
-            existing = existing.stream()
-                    .filter(r -> r.getWorkspaceId() == null)
-                    .toList();
-        }
+        // Workspace overlays inherit shared relations, so an equivalent shared
+        // relation remains a duplicate for creation. Shared mode checks shared
+        // rows only and never scans personal workspaces.
+        List<TaxonomyRelation> existing = workspaceId != null
+                ? relationRepository.findByWorkspaceAndSourceTargetType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
         if (!existing.isEmpty()) {
             throw new IllegalArgumentException(String.format(
                     "Relation already exists: %s --[%s]--> %s (workspace=%s)",
@@ -139,9 +112,7 @@ public class TaxonomyRelationService {
         return toDto(saved);
     }
 
-    /**
-     * Legacy overload — delegates to workspace-aware method with null workspace.
-     */
+    /** Legacy overload — creates a shared relation. */
     @Transactional
     public TaxonomyRelationDto createRelation(String sourceCode, String targetCode,
                                               RelationType type, String description,
@@ -150,53 +121,37 @@ public class TaxonomyRelationService {
     }
 
     /**
-     * Delete a relation by ID, with optional workspace ownership check.
-     *
-     * <p>If {@code workspaceId} is non-null, the relation must either belong to
-     * the given workspace or be a shared (null workspace) relation. If it belongs
-     * to a different workspace, an {@link IllegalArgumentException} is thrown.
+     * Deletes a relation only when it belongs to the exact active workspace.
+     * A null workspace ID means shared scope only; a personal workspace can
+     * never delete a shared or foreign-workspace relation by guessing its ID.
      */
     @Transactional
     public void deleteRelation(Long id, @Nullable String workspaceId) {
-        if (workspaceId != null) {
-            TaxonomyRelation relation = relationRepository.findById(id).orElse(null);
-            if (relation != null && relation.getWorkspaceId() != null
-                    && !workspaceId.equals(relation.getWorkspaceId())) {
-                throw new IllegalArgumentException(
-                        "Relation " + id + " belongs to workspace '" + relation.getWorkspaceId()
-                                + "', not '" + workspaceId + "'");
-            }
-        }
-        relationRepository.deleteById(id);
+        TaxonomyRelation relation = relationRepository.findByIdInWorkspace(id, workspaceId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Relation not found in active workspace: " + id));
+        relationRepository.delete(relation);
         log.info("Deleted relation with id: {} (workspace={})", id, workspaceId);
     }
 
-    /** Legacy overload — deletes without workspace ownership check. */
+    /** Legacy overload — deletes a shared relation only. */
     @Transactional
     public void deleteRelation(Long id) {
         deleteRelation(id, null);
     }
 
     /**
-     * Delete relations matching a specific source, target, type, and exact
-     * workspace. A null workspace ID means shared relations only, never all
-     * workspaces.
+     * Deletes relations matching a source, target, type, and exact workspace.
+     * A null workspace ID means shared relations only, never all workspaces.
      */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type,
                                                   @Nullable String workspaceId) {
-        List<TaxonomyRelation> matches;
-        if (workspaceId != null) {
-            matches = relationRepository.findByWorkspaceAndSourceTargetType(
-                    workspaceId, sourceCode, targetCode, type);
-        } else {
-            matches = relationRepository
-                    .findBySourceNodeCodeAndTargetNodeCodeAndRelationType(sourceCode, targetCode, type)
-                    .stream()
-                    .filter(relation -> relation.getWorkspaceId() == null)
-                    .toList();
-        }
+        List<TaxonomyRelation> matches = workspaceId != null
+                ? relationRepository.findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
         if (!matches.isEmpty()) {
             relationRepository.deleteAll(matches);
             log.info("Deleted {} relation(s): {} --[{}]--> {} (workspace={})",
@@ -204,9 +159,7 @@ public class TaxonomyRelationService {
         }
     }
 
-    /**
-     * Legacy overload — operates on shared relations only.
-     */
+    /** Legacy overload — operates on shared relations only. */
     @Transactional
     public void deleteRelationBySourceTargetType(String sourceCode, String targetCode,
                                                   RelationType type) {
@@ -230,15 +183,22 @@ public class TaxonomyRelationService {
 
     @Transactional(readOnly = true)
     public long countRelations(@Nullable String workspaceId) {
-        if (workspaceId != null) {
-            return relationRepository.countByWorkspaceIdIsNullOrWorkspaceId(workspaceId);
-        }
-        return relationRepository.count();
+        return workspaceId != null
+                ? relationRepository.countVisibleByWorkspace(workspaceId)
+                : relationRepository.countByWorkspaceIdIsNull();
     }
 
-    /** Legacy overload — counts all relations. */
+    /** Legacy overload — counts shared relations only. */
     @Transactional(readOnly = true)
     public long countRelations() {
         return countRelations(null);
+    }
+
+    private List<TaxonomyRelationDto> toDtos(List<TaxonomyRelation> relations) {
+        List<TaxonomyRelationDto> dtos = new ArrayList<>(relations.size());
+        for (TaxonomyRelation relation : relations) {
+            dtos.add(toDto(relation));
+        }
+        return dtos;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
@@ -5,29 +5,23 @@ import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.service.RelationProposalService;
 import com.taxonomy.relations.service.RelationReviewService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import com.taxonomy.catalog.model.TaxonomyRelation;
 
-/**
- * REST API for the Relation Proposal Pipeline.
- *
- * <p>Endpoints:
- * <ul>
- *   <li>{@code POST /api/proposals/propose} — trigger proposal generation</li>
- *   <li>{@code GET  /api/proposals} — list all proposals (optionally filter by status)</li>
- *   <li>{@code GET  /api/proposals/pending} — list pending proposals</li>
- *   <li>{@code GET  /api/node/{code}/proposals} — proposals for a specific node</li>
- *   <li>{@code POST /api/proposals/{id}/accept} — accept a proposal</li>
- *   <li>{@code POST /api/proposals/{id}/reject} — reject a proposal</li>
- * </ul>
- */
+/** REST API for workspace-scoped relation proposals and review. */
 @RestController
 @RequestMapping("/api")
 @Tag(name = "Proposals")
@@ -35,199 +29,159 @@ public class ProposalApiController {
 
     private final RelationProposalService proposalService;
     private final RelationReviewService reviewService;
+    private final WorkspaceContextResolver contextResolver;
 
     public ProposalApiController(RelationProposalService proposalService,
-                                  RelationReviewService reviewService) {
+                                 RelationReviewService reviewService,
+                                 WorkspaceContextResolver contextResolver) {
         this.proposalService = proposalService;
         this.reviewService = reviewService;
+        this.contextResolver = contextResolver;
     }
 
-    /**
-     * Trigger the proposal pipeline for a source node and relation type.
-     */
-    @Operation(summary = "Propose relations", description = "Trigger the proposal pipeline for a source node and relation type")
+    @Operation(summary = "Propose relations")
     @PostMapping("/proposals/propose")
     public ResponseEntity<List<RelationProposalDto>> proposeRelations(
             @RequestBody Map<String, String> body) {
         String sourceCode = body.get("sourceCode");
-        String relationTypeStr = body.get("relationType");
-        String limitStr = body.getOrDefault("limit", "10");
-
-        if (sourceCode == null || sourceCode.isBlank() ||
-                relationTypeStr == null || relationTypeStr.isBlank()) {
+        String relationTypeText = body.get("relationType");
+        if (sourceCode == null || sourceCode.isBlank()
+                || relationTypeText == null || relationTypeText.isBlank()) {
             return ResponseEntity.badRequest().build();
         }
 
         RelationType relationType;
         try {
-            relationType = RelationType.valueOf(relationTypeStr.toUpperCase());
-        } catch (IllegalArgumentException e) {
+            relationType = RelationType.valueOf(relationTypeText.toUpperCase());
+        } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
 
-        int limit;
+        int limit = parseLimit(body.getOrDefault("limit", "10"));
         try {
-            limit = Integer.parseInt(limitStr);
-            if (limit < 1 || limit > 100) limit = 10;
-        } catch (NumberFormatException e) {
-            limit = 10;
-        }
-
-        try {
-            List<RelationProposalDto> proposals =
-                    proposalService.proposeRelations(sourceCode, relationType, limit);
-            return ResponseEntity.ok(proposals);
-        } catch (IllegalArgumentException e) {
+            return ResponseEntity.ok(
+                    proposalService.proposeRelations(sourceCode, relationType, limit));
+        } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
     }
 
-    /**
-     * List all proposals.
-     */
-    @Operation(summary = "List all proposals", description = "Returns all relation proposals")
+    @Operation(summary = "List all proposals")
     @GetMapping("/proposals")
     public ResponseEntity<List<RelationProposalDto>> getAllProposals() {
         return ResponseEntity.ok(proposalService.getAllProposals());
     }
 
-    /**
-     * List pending proposals (review queue).
-     */
-    @Operation(summary = "List pending proposals", description = "Returns all proposals with PENDING status (review queue)")
+    @Operation(summary = "List pending proposals")
     @GetMapping("/proposals/pending")
     public ResponseEntity<List<RelationProposalDto>> getPendingProposals() {
         return ResponseEntity.ok(proposalService.getPendingProposals());
     }
 
-    /**
-     * List proposals for a specific source node.
-     */
-    @Operation(summary = "List node proposals", description = "Returns all proposals for a specific source node")
+    @Operation(summary = "List node proposals")
     @GetMapping("/node/{code}/proposals")
     public ResponseEntity<List<RelationProposalDto>> getProposalsForNode(
             @PathVariable String code) {
         return ResponseEntity.ok(proposalService.getProposalsForNode(code));
     }
 
-    /**
-     * Accept a pending proposal — creates the actual TaxonomyRelation.
-     */
-    @Operation(summary = "Accept proposal", description = "Accepts a pending proposal and creates the actual taxonomy relation")
+    @Operation(summary = "Accept proposal")
     @PostMapping("/proposals/{id}/accept")
     public ResponseEntity<TaxonomyRelationDto> acceptProposal(@PathVariable Long id) {
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         try {
-            TaxonomyRelationDto relation = reviewService.acceptProposal(id);
-            return ResponseEntity.ok(relation);
-        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.ok(reviewService.acceptProposal(id, context));
+        } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
     }
 
-    /**
-     * Reject a pending proposal.
-     */
-    @Operation(summary = "Reject proposal", description = "Rejects a pending proposal")
+    @Operation(summary = "Reject proposal")
     @PostMapping("/proposals/{id}/reject")
     public ResponseEntity<RelationProposalDto> rejectProposal(@PathVariable Long id) {
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         try {
-            RelationProposalDto dto = reviewService.rejectProposal(id);
-            return ResponseEntity.ok(dto);
-        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.ok(reviewService.rejectProposal(id, context));
+        } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
     }
 
-    /**
-     * Create a proposal directly from an analysis hypothesis.
-     * Request body: {@code { "sourceCode": "CP", "targetCode": "CR",
-     *   "relationType": "REALIZES", "confidence": 0.56, "rationale": "..." }}
-     */
-    @Operation(summary = "Create proposal from hypothesis",
-            description = "Creates a proposal from an AI-generated relation hypothesis")
+    @Operation(summary = "Create proposal from hypothesis")
     @PostMapping("/proposals/from-hypothesis")
-    public ResponseEntity<RelationProposalDto> createFromHypothesis(@RequestBody Map<String, Object> body) {
-        String sourceCode = (String) body.get("sourceCode");
-        String targetCode = (String) body.get("targetCode");
-        String relationTypeStr = (String) body.get("relationType");
-        Number confidenceNum = (Number) body.get("confidence");
-        String rationale = (String) body.get("rationale");
-
+    public ResponseEntity<RelationProposalDto> createFromHypothesis(
+            @RequestBody Map<String, Object> body) {
+        String sourceCode = body.get("sourceCode") instanceof String value ? value : null;
+        String targetCode = body.get("targetCode") instanceof String value ? value : null;
+        String relationTypeText = body.get("relationType") instanceof String value ? value : null;
+        Number confidenceNumber = body.get("confidence") instanceof Number value ? value : null;
+        String rationale = body.get("rationale") instanceof String value ? value : null;
         if (sourceCode == null || sourceCode.isBlank()
                 || targetCode == null || targetCode.isBlank()
-                || relationTypeStr == null || relationTypeStr.isBlank()) {
+                || relationTypeText == null || relationTypeText.isBlank()) {
             return ResponseEntity.badRequest().build();
         }
 
         RelationType relationType;
         try {
-            relationType = RelationType.valueOf(relationTypeStr.toUpperCase());
-        } catch (IllegalArgumentException e) {
+            relationType = RelationType.valueOf(relationTypeText.toUpperCase());
+        } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
 
-        double confidence = confidenceNum != null ? confidenceNum.doubleValue() : 0.5;
-
+        double confidence = confidenceNumber != null ? confidenceNumber.doubleValue() : 0.5;
         try {
-            RelationProposalDto dto = proposalService.createFromHypothesis(
+            RelationProposalDto proposal = proposalService.createFromHypothesis(
                     sourceCode, targetCode, relationType, confidence, rationale);
-            if (dto == null) {
-                // Proposal already exists
-                Map<String, Object> msg = new LinkedHashMap<>();
-                msg.put("message", "Proposal already exists for this source, target, and relation type");
-                return ResponseEntity.status(409).body(null);
-            }
-            return ResponseEntity.ok(dto);
-        } catch (IllegalArgumentException e) {
+            return proposal != null
+                    ? ResponseEntity.ok(proposal)
+                    : ResponseEntity.status(409).build();
+        } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
     }
 
-    /**
-     * Revert a proposal back to PENDING status (undo accept/reject).
-     * If the proposal was accepted, the corresponding relation is deleted.
-     */
-    @Operation(summary = "Revert proposal", description = "Reverts a proposal back to PENDING status (undo last action)")
+    @Operation(summary = "Revert proposal")
     @PostMapping("/proposals/{id}/revert")
     public ResponseEntity<RelationProposalDto> revertProposal(@PathVariable Long id) {
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         try {
-            RelationProposalDto dto = reviewService.revertProposal(id);
-            return ResponseEntity.ok(dto);
-        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.ok(reviewService.revertProposal(id, context));
+        } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
     }
 
-    /**
-     * Bulk accept or reject multiple proposals.
-     * Request body: {@code { "ids": [1, 2, 3], "action": "ACCEPT" | "REJECT" }}
-     */
-    @Operation(summary = "Bulk action on proposals", description = "Accept or reject multiple proposals at once")
+    @Operation(summary = "Bulk action on proposals")
     @PostMapping("/proposals/bulk")
-    public ResponseEntity<Map<String, Object>> bulkAction(@RequestBody Map<String, Object> body) {
+    public ResponseEntity<Map<String, Object>> bulkAction(
+            @RequestBody Map<String, Object> body) {
         @SuppressWarnings("unchecked")
-        List<Number> ids = (List<Number>) body.get("ids");
-        String action = (String) body.get("action");
-
+        List<Number> ids = body.get("ids") instanceof List<?> list
+                ? (List<Number>) list : null;
+        String action = body.get("action") instanceof String value ? value : null;
         if (ids == null || ids.isEmpty() || action == null || action.isBlank()) {
             return ResponseEntity.badRequest().build();
         }
 
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         int success = 0;
         int failed = 0;
-
-        for (Number idNum : ids) {
-            Long id = idNum.longValue();
+        for (Number idNumber : ids) {
+            if (idNumber == null) {
+                failed++;
+                continue;
+            }
             try {
                 if ("ACCEPT".equalsIgnoreCase(action)) {
-                    reviewService.acceptProposal(id);
+                    reviewService.acceptProposal(idNumber.longValue(), context);
                 } else if ("REJECT".equalsIgnoreCase(action)) {
-                    reviewService.rejectProposal(id);
+                    reviewService.rejectProposal(idNumber.longValue(), context);
                 } else {
                     return ResponseEntity.badRequest().build();
                 }
                 success++;
-            } catch (IllegalArgumentException | IllegalStateException e) {
+            } catch (IllegalArgumentException | IllegalStateException error) {
                 failed++;
             }
         }
@@ -238,5 +192,14 @@ public class ProposalApiController {
         result.put("failed", failed);
         result.put("total", ids.size());
         return ResponseEntity.ok(result);
+    }
+
+    private static int parseLimit(String value) {
+        try {
+            int limit = Integer.parseInt(value);
+            return limit >= 1 && limit <= 100 ? limit : 10;
+        } catch (NumberFormatException error) {
+            return 10;
+        }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
@@ -3,24 +3,40 @@ package com.taxonomy.relations.model;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import org.hibernate.annotations.Nationalized;
 
 import java.time.Instant;
 
-/**
- * A proposed relation between two taxonomy nodes, awaiting human review.
- * Created by the Relation Proposal Pipeline.
- */
+/** A proposed relation awaiting human review. */
 @Entity
 @Table(name = "relation_proposal",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"source_node_id", "target_node_id", "relation_type", "workspace_id"}),
+                name = "uk_relation_proposal_scope",
+                columnNames = {
+                        "source_node_id", "target_node_id", "relation_type", "workspace_scope_key"
+                }),
         indexes = {
                 @Index(name = "idx_proposal_workspace", columnList = "workspace_id"),
                 @Index(name = "idx_proposal_owner", columnList = "owner_username")
         })
 public class RelationProposal {
+
+    public static final String SHARED_SCOPE_KEY = "__shared__";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,16 +58,13 @@ public class RelationProposal {
     @Column(nullable = false)
     private ProposalStatus status = ProposalStatus.PENDING;
 
-    /** Confidence score between 0.0 and 1.0. */
     @Column(nullable = false)
     private double confidence;
 
-    /** Human-readable explanation of why this relation was proposed. */
     @Nationalized
     @Column(length = 2000)
     private String rationale;
 
-    /** How this proposal was generated (e.g. "hybrid-search", "embedding-similarity"). */
     @Nationalized
     private String provenance;
 
@@ -64,6 +77,13 @@ public class RelationProposal {
     @Column(name = "workspace_id")
     private String workspaceId;
 
+    /**
+     * Non-null database uniqueness key. SQL UNIQUE permits repeated NULL values,
+     * so nullable workspace_id cannot by itself protect shared-scope proposals.
+     */
+    @Column(name = "workspace_scope_key", length = 255)
+    private String workspaceScopeKey = SHARED_SCOPE_KEY;
+
     @Column(name = "owner_username")
     private String ownerUsername;
 
@@ -72,9 +92,22 @@ public class RelationProposal {
         if (createdAt == null) {
             createdAt = Instant.now();
         }
+        synchronizeWorkspaceScopeKey();
     }
 
-    // ── Getters / Setters ─────────────────────────────────────────────────────
+    @PreUpdate
+    void onUpdate() {
+        synchronizeWorkspaceScopeKey();
+    }
+
+    private void synchronizeWorkspaceScopeKey() {
+        workspaceScopeKey = scopeKeyFor(workspaceId);
+    }
+
+    public static String scopeKeyFor(String workspaceId) {
+        return workspaceId == null || workspaceId.isBlank()
+                ? SHARED_SCOPE_KEY : workspaceId;
+    }
 
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
@@ -107,7 +140,12 @@ public class RelationProposal {
     public void setReviewedAt(Instant reviewedAt) { this.reviewedAt = reviewedAt; }
 
     public String getWorkspaceId() { return workspaceId; }
-    public void setWorkspaceId(String workspaceId) { this.workspaceId = workspaceId; }
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = workspaceId;
+        synchronizeWorkspaceScopeKey();
+    }
+
+    public String getWorkspaceScopeKey() { return workspaceScopeKey; }
 
     public String getOwnerUsername() { return ownerUsername; }
     public void setOwnerUsername(String ownerUsername) { this.ownerUsername = ownerUsername; }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProposal.java
@@ -1,11 +1,12 @@
 package com.taxonomy.relations.model;
 
-import jakarta.persistence.*;
-import org.hibernate.annotations.Nationalized;
-import java.time.Instant;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Nationalized;
+
+import java.time.Instant;
 
 /**
  * A proposed relation between two taxonomy nodes, awaiting human review.
@@ -14,7 +15,11 @@ import com.taxonomy.model.RelationType;
 @Entity
 @Table(name = "relation_proposal",
         uniqueConstraints = @UniqueConstraint(
-                columnNames = {"source_node_id", "target_node_id", "relation_type"}))
+                columnNames = {"source_node_id", "target_node_id", "relation_type", "workspace_id"}),
+        indexes = {
+                @Index(name = "idx_proposal_workspace", columnList = "workspace_id"),
+                @Index(name = "idx_proposal_owner", columnList = "owner_username")
+        })
 public class RelationProposal {
 
     @Id

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RelationProposalRepository extends JpaRepository<RelationProposal, Long> {
@@ -44,10 +45,45 @@ public interface RelationProposalRepository extends JpaRepository<RelationPropos
 
     // ── Workspace-scoped queries ─────────────────────────────────────
 
+    /**
+     * Looks up a proposal in exactly one workspace. A null workspace ID means
+     * shared scope only; it never means all workspaces.
+     */
+    @Query("""
+            SELECT p FROM RelationProposal p
+            WHERE p.id = :id
+              AND ((:wsId IS NULL AND p.workspaceId IS NULL) OR p.workspaceId = :wsId)
+            """)
+    Optional<RelationProposal> findByIdInWorkspace(@Param("id") Long id,
+                                                    @Param("wsId") String workspaceId);
+
+    /**
+     * Checks a proposal triple in exactly one workspace. A null workspace ID
+     * is matched with IS NULL so shared mode cannot observe foreign workspaces.
+     */
+    @Query("""
+            SELECT CASE WHEN COUNT(p) > 0 THEN true ELSE false END
+            FROM RelationProposal p
+            WHERE p.sourceNode.code = :sourceCode
+              AND p.targetNode.code = :targetCode
+              AND p.relationType = :relationType
+              AND ((:wsId IS NULL AND p.workspaceId IS NULL) OR p.workspaceId = :wsId)
+            """)
+    boolean existsInWorkspace(@Param("sourceCode") String sourceCode,
+                              @Param("targetCode") String targetCode,
+                              @Param("relationType") RelationType relationType,
+                              @Param("wsId") String workspaceId);
+
     boolean existsBySourceNodeCodeAndTargetNodeCodeAndRelationTypeAndWorkspaceId(
             String sourceCode, String targetCode, RelationType relationType, String workspaceId);
 
     List<RelationProposal> findByWorkspaceId(String workspaceId);
+
+    List<RelationProposal> findByWorkspaceIdIsNull();
+
+    List<RelationProposal> findByStatusAndWorkspaceIdIsNull(ProposalStatus status);
+
+    List<RelationProposal> findBySourceNodeCodeAndWorkspaceIdIsNull(String sourceCode);
 
     @Query("SELECT p FROM RelationProposal p WHERE p.workspaceId = :wsId OR p.workspaceId IS NULL")
     List<RelationProposal> findByWorkspaceIdIsNullOrWorkspaceId(@Param("wsId") String workspaceId);

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
@@ -1,10 +1,13 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyNodeDto;
-import com.taxonomy.model.*;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
-import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import org.slf4j.Logger;
@@ -14,10 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.model.ProposalStatus;
-import com.taxonomy.model.RelationType;
-import com.taxonomy.relations.model.RelationProposal;
 
 /**
  * Orchestrator for the Relation Proposal Pipeline.
@@ -78,25 +77,18 @@ public class RelationProposalService {
 
         List<RelationProposalDto> proposals = new ArrayList<>();
 
-        // Resolve workspace context
+        // Resolve workspace context once for the complete operation.
         WorkspaceContext ctx = contextResolver.resolveCurrentContext();
 
         // 2–4. Validate each candidate and create proposals
         for (int i = 0; i < candidates.size(); i++) {
             TaxonomyNodeDto candidate = candidates.get(i);
 
-            // Skip if a proposal already exists for this triple in this workspace
-            if (ctx.workspaceId() != null) {
-                if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationTypeAndWorkspaceId(
-                        sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId())) {
-                    log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
-                            sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId());
-                    continue;
-                }
-            } else if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                    sourceNodeCode, candidate.getCode(), relationType)) {
-                log.debug("Proposal already exists: {} → {} [{}]",
-                        sourceNodeCode, candidate.getCode(), relationType);
+            // A null workspace means the shared scope only, never all workspaces.
+            if (proposalRepository.existsInWorkspace(
+                    sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId())) {
+                log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
+                        sourceNodeCode, candidate.getCode(), relationType, ctx.workspaceId());
                 continue;
             }
 
@@ -122,14 +114,14 @@ public class RelationProposalService {
 
                 RelationProposal saved = proposalRepository.save(proposal);
                 proposals.add(toDto(saved));
-                log.debug("Created proposal: {} → {} [{}] confidence={}",
+                log.debug("Created proposal: {} → {} [{}] confidence={} (workspace={})",
                         sourceNodeCode, candidate.getCode(), relationType,
-                        result.getConfidence());
+                        result.getConfidence(), ctx.workspaceId());
             }
         }
 
-        log.info("Proposed {} relations for node '{}' [{}]",
-                proposals.size(), sourceNodeCode, relationType);
+        log.info("Proposed {} relations for node '{}' [{}] (workspace={})",
+                proposals.size(), sourceNodeCode, relationType, ctx.workspaceId());
         return proposals;
     }
 
@@ -140,7 +132,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findByStatusAndWorkspace(ProposalStatus.PENDING, ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findByStatus(ProposalStatus.PENDING);
+            proposals = proposalRepository.findByStatusAndWorkspaceIdIsNull(ProposalStatus.PENDING);
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -152,7 +144,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findByWorkspaceIdIsNullOrWorkspaceId(ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findAll();
+            proposals = proposalRepository.findByWorkspaceIdIsNull();
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -164,7 +156,7 @@ public class RelationProposalService {
         if (ctx.workspaceId() != null) {
             proposals = proposalRepository.findBySourceNodeCodeAndWorkspace(sourceCode, ctx.workspaceId());
         } else {
-            proposals = proposalRepository.findBySourceNodeCode(sourceCode);
+            proposals = proposalRepository.findBySourceNodeCodeAndWorkspaceIdIsNull(sourceCode);
         }
         return proposals.stream().map(this::toDto).toList();
     }
@@ -189,9 +181,11 @@ public class RelationProposalService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        if (proposalRepository.existsBySourceNodeCodeAndTargetNodeCodeAndRelationType(
-                sourceCode, targetCode, relationType)) {
-            log.debug("Proposal already exists: {} → {} [{}]", sourceCode, targetCode, relationType);
+        WorkspaceContext ctx = contextResolver.resolveCurrentContext();
+        if (proposalRepository.existsInWorkspace(
+                sourceCode, targetCode, relationType, ctx.workspaceId())) {
+            log.debug("Proposal already exists: {} → {} [{}] (workspace={})",
+                    sourceCode, targetCode, relationType, ctx.workspaceId());
             return null;
         }
 
@@ -203,14 +197,12 @@ public class RelationProposalService {
         proposal.setRationale(rationale);
         proposal.setProvenance("analysis-hypothesis");
         proposal.setStatus(ProposalStatus.PENDING);
-
-        WorkspaceContext ctx = contextResolver.resolveCurrentContext();
         proposal.setWorkspaceId(ctx.workspaceId());
         proposal.setOwnerUsername(ctx.username());
 
         RelationProposal saved = proposalRepository.save(proposal);
-        log.info("Created proposal from hypothesis: {} → {} [{}] confidence={}",
-                sourceCode, targetCode, relationType, confidence);
+        log.info("Created proposal from hypothesis: {} → {} [{}] confidence={} (workspace={})",
+                sourceCode, targetCode, relationType, confidence, ctx.workspaceId());
         return toDto(saved);
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
@@ -1,19 +1,20 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.*;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import com.taxonomy.catalog.model.TaxonomyRelation;
-import com.taxonomy.catalog.service.TaxonomyRelationService;
-import com.taxonomy.model.ProposalStatus;
-import com.taxonomy.relations.model.RelationProposal;
 
 /**
  * Handles the human review workflow for relation proposals.
@@ -27,66 +28,61 @@ public class RelationReviewService {
     private final RelationProposalRepository proposalRepository;
     private final TaxonomyRelationService relationService;
     private final RelationProposalService proposalService;
+    private final WorkspaceContextResolver contextResolver;
 
     public RelationReviewService(RelationProposalRepository proposalRepository,
                                  TaxonomyRelationService relationService,
-                                 RelationProposalService proposalService) {
+                                 RelationProposalService proposalService,
+                                 WorkspaceContextResolver contextResolver) {
         this.proposalRepository = proposalRepository;
         this.relationService = relationService;
         this.proposalService = proposalService;
+        this.contextResolver = contextResolver;
     }
 
     /**
-     * Accept a proposal: creates a real TaxonomyRelation and marks the proposal as ACCEPTED.
-     *
-     * <p>The relation is created in the proposal's workspace (using the proposal's stored
-     * {@code workspaceId}/{@code ownerUsername}). For legacy proposals with null workspace,
-     * the relation is created in the shared/legacy scope.
+     * Accept a proposal in the active workspace: creates a real TaxonomyRelation
+     * and marks the proposal as ACCEPTED.
      */
     @Transactional
     public TaxonomyRelationDto acceptProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
                     "Proposal " + proposalId + " is already " + proposal.getStatus());
         }
 
-        // Create the real relation in the proposal's workspace (not the current user's)
-        String workspaceId = proposal.getWorkspaceId();
-        String ownerUsername = proposal.getOwnerUsername();
         TaxonomyRelationDto relation = relationService.createRelation(
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
                 proposal.getRelationType(),
                 proposal.getRationale(),
                 "proposal-pipeline",
-                workspaceId, ownerUsername);
+                context.workspaceId(), context.username());
 
-        // Mark proposal as accepted
         proposal.setStatus(ProposalStatus.ACCEPTED);
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
 
-        log.info("Accepted proposal {}: {} → {} [{}]",
+        log.info("Accepted proposal {}: {} → {} [{}] (workspace={})",
                 proposalId,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return relation;
     }
 
     /**
-     * Reject a proposal.
+     * Reject a proposal in the active workspace.
      */
     @Transactional
     public RelationProposalDto rejectProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
@@ -97,24 +93,25 @@ public class RelationReviewService {
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
 
-        log.info("Rejected proposal {}: {} → {} [{}]",
+        log.info("Rejected proposal {}: {} → {} [{}] (workspace={})",
                 proposalId,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return proposalService.toDto(proposal);
     }
 
     /**
-     * Revert a previously accepted or rejected proposal back to PENDING status.
-     * If the proposal was accepted, the corresponding relation is deleted.
+     * Revert a previously accepted or rejected proposal in the active workspace
+     * back to PENDING status. If the proposal was accepted, only the relation in
+     * that exact workspace is deleted.
      */
     @Transactional
     public RelationProposalDto revertProposal(Long proposalId) {
-        RelationProposal proposal = proposalRepository.findById(proposalId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Proposal not found: " + proposalId));
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
+        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
 
         if (proposal.getStatus() == ProposalStatus.PENDING) {
             throw new IllegalStateException(
@@ -123,24 +120,32 @@ public class RelationReviewService {
 
         ProposalStatus oldStatus = proposal.getStatus();
 
-        // If accepted, remove the created relation
         if (oldStatus == ProposalStatus.ACCEPTED) {
             relationService.deleteRelationBySourceTargetType(
                     proposal.getSourceNode().getCode(),
                     proposal.getTargetNode().getCode(),
-                    proposal.getRelationType());
+                    proposal.getRelationType(),
+                    context.workspaceId());
         }
 
         proposal.setStatus(ProposalStatus.PENDING);
         proposal.setReviewedAt(null);
         proposalRepository.save(proposal);
 
-        log.info("Reverted proposal {} from {} to PENDING: {} → {} [{}]",
+        log.info("Reverted proposal {} from {} to PENDING: {} → {} [{}] (workspace={})",
                 proposalId, oldStatus,
                 proposal.getSourceNode().getCode(),
                 proposal.getTargetNode().getCode(),
-                proposal.getRelationType());
+                proposal.getRelationType(),
+                context.workspaceId());
 
         return proposalService.toDto(proposal);
+    }
+
+    private RelationProposal findProposalInActiveWorkspace(Long proposalId,
+                                                            WorkspaceContext context) {
+        return proposalRepository.findByIdInWorkspace(proposalId, context.workspaceId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Proposal not found in active workspace: " + proposalId));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationReviewService.java
@@ -8,18 +8,15 @@ import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
 import com.taxonomy.workspace.service.WorkspaceContext;
-import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.Objects;
 
-/**
- * Handles the human review workflow for relation proposals.
- * Accepted proposals are converted into actual {@link TaxonomyRelation} entities.
- */
+/** Handles human review of relation proposals in an explicit workspace. */
 @Service
 public class RelationReviewService {
 
@@ -28,27 +25,20 @@ public class RelationReviewService {
     private final RelationProposalRepository proposalRepository;
     private final TaxonomyRelationService relationService;
     private final RelationProposalService proposalService;
-    private final WorkspaceContextResolver contextResolver;
 
     public RelationReviewService(RelationProposalRepository proposalRepository,
                                  TaxonomyRelationService relationService,
-                                 RelationProposalService proposalService,
-                                 WorkspaceContextResolver contextResolver) {
+                                 RelationProposalService proposalService) {
         this.proposalRepository = proposalRepository;
         this.relationService = relationService;
         this.proposalService = proposalService;
-        this.contextResolver = contextResolver;
     }
 
-    /**
-     * Accept a proposal in the active workspace: creates a real TaxonomyRelation
-     * and marks the proposal as ACCEPTED.
-     */
+    /** Accepts a proposal and creates the relation in the exact supplied workspace. */
     @Transactional
-    public TaxonomyRelationDto acceptProposal(Long proposalId) {
-        WorkspaceContext context = contextResolver.resolveCurrentContext();
-        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
-
+    public TaxonomyRelationDto acceptProposal(Long proposalId, WorkspaceContext context) {
+        WorkspaceContext requiredContext = requireContext(context);
+        RelationProposal proposal = findProposalInWorkspace(proposalId, requiredContext);
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
                     "Proposal " + proposalId + " is already " + proposal.getStatus());
@@ -60,30 +50,23 @@ public class RelationReviewService {
                 proposal.getRelationType(),
                 proposal.getRationale(),
                 "proposal-pipeline",
-                context.workspaceId(), context.username());
+                requiredContext.workspaceId(), requiredContext.username());
 
         proposal.setStatus(ProposalStatus.ACCEPTED);
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
-
         log.info("Accepted proposal {}: {} → {} [{}] (workspace={})",
-                proposalId,
-                proposal.getSourceNode().getCode(),
-                proposal.getTargetNode().getCode(),
-                proposal.getRelationType(),
-                context.workspaceId());
-
+                proposalId, proposal.getSourceNode().getCode(),
+                proposal.getTargetNode().getCode(), proposal.getRelationType(),
+                requiredContext.workspaceId());
         return relation;
     }
 
-    /**
-     * Reject a proposal in the active workspace.
-     */
+    /** Rejects a proposal in the exact supplied workspace. */
     @Transactional
-    public RelationProposalDto rejectProposal(Long proposalId) {
-        WorkspaceContext context = contextResolver.resolveCurrentContext();
-        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
-
+    public RelationProposalDto rejectProposal(Long proposalId, WorkspaceContext context) {
+        WorkspaceContext requiredContext = requireContext(context);
+        RelationProposal proposal = findProposalInWorkspace(proposalId, requiredContext);
         if (proposal.getStatus() != ProposalStatus.PENDING) {
             throw new IllegalStateException(
                     "Proposal " + proposalId + " is already " + proposal.getStatus());
@@ -92,60 +75,52 @@ public class RelationReviewService {
         proposal.setStatus(ProposalStatus.REJECTED);
         proposal.setReviewedAt(Instant.now());
         proposalRepository.save(proposal);
-
         log.info("Rejected proposal {}: {} → {} [{}] (workspace={})",
-                proposalId,
-                proposal.getSourceNode().getCode(),
-                proposal.getTargetNode().getCode(),
-                proposal.getRelationType(),
-                context.workspaceId());
-
+                proposalId, proposal.getSourceNode().getCode(),
+                proposal.getTargetNode().getCode(), proposal.getRelationType(),
+                requiredContext.workspaceId());
         return proposalService.toDto(proposal);
     }
 
     /**
-     * Revert a previously accepted or rejected proposal in the active workspace
-     * back to PENDING status. If the proposal was accepted, only the relation in
-     * that exact workspace is deleted.
+     * Reverts a reviewed proposal in the exact supplied workspace. If accepted,
+     * only the relation in that same workspace is removed.
      */
     @Transactional
-    public RelationProposalDto revertProposal(Long proposalId) {
-        WorkspaceContext context = contextResolver.resolveCurrentContext();
-        RelationProposal proposal = findProposalInActiveWorkspace(proposalId, context);
-
+    public RelationProposalDto revertProposal(Long proposalId, WorkspaceContext context) {
+        WorkspaceContext requiredContext = requireContext(context);
+        RelationProposal proposal = findProposalInWorkspace(proposalId, requiredContext);
         if (proposal.getStatus() == ProposalStatus.PENDING) {
-            throw new IllegalStateException(
-                    "Proposal " + proposalId + " is already PENDING");
+            throw new IllegalStateException("Proposal " + proposalId + " is already PENDING");
         }
 
         ProposalStatus oldStatus = proposal.getStatus();
-
         if (oldStatus == ProposalStatus.ACCEPTED) {
             relationService.deleteRelationBySourceTargetType(
                     proposal.getSourceNode().getCode(),
                     proposal.getTargetNode().getCode(),
                     proposal.getRelationType(),
-                    context.workspaceId());
+                    requiredContext.workspaceId());
         }
 
         proposal.setStatus(ProposalStatus.PENDING);
         proposal.setReviewedAt(null);
         proposalRepository.save(proposal);
-
         log.info("Reverted proposal {} from {} to PENDING: {} → {} [{}] (workspace={})",
-                proposalId, oldStatus,
-                proposal.getSourceNode().getCode(),
-                proposal.getTargetNode().getCode(),
-                proposal.getRelationType(),
-                context.workspaceId());
-
+                proposalId, oldStatus, proposal.getSourceNode().getCode(),
+                proposal.getTargetNode().getCode(), proposal.getRelationType(),
+                requiredContext.workspaceId());
         return proposalService.toDto(proposal);
     }
 
-    private RelationProposal findProposalInActiveWorkspace(Long proposalId,
-                                                            WorkspaceContext context) {
+    private RelationProposal findProposalInWorkspace(Long proposalId,
+                                                       WorkspaceContext context) {
         return proposalRepository.findByIdInWorkspace(proposalId, context.workspaceId())
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Proposal not found in active workspace: " + proposalId));
+    }
+
+    private static WorkspaceContext requireContext(WorkspaceContext context) {
+        return Objects.requireNonNull(context, "Workspace context is required");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -48,6 +48,13 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.PUT,    "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
 
+        // Proposal generation and review mutate proposal state and can create or
+        // delete real relations. Keep these endpoints out of the generic
+        // authenticated-user fallback.
+        auth.requestMatchers(HttpMethod.POST,   "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT,    "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.DELETE, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+
         auth.requestMatchers(HttpMethod.POST,   "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PUT,    "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/SchemaContractMigration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/SchemaContractMigration.java
@@ -12,13 +12,11 @@ import org.springframework.stereotype.Component;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,12 +29,11 @@ import java.util.TreeMap;
  * Idempotent schema contract migration for deployments that predate workspace
  * isolation and mandatory password replacement.
  *
- * <p>The project historically used Hibernate {@code ddl-auto=update}. That is
- * unable to remove obsolete unique constraints reliably. This runner inspects
- * JDBC metadata, drops only constraints with the proven legacy column sets,
- * backfills a non-null workspace scope key, and creates named constraints that
- * protect both shared and personal rows. It also prepares the local-user
- * password-change column used by the security hardening follow-up.</p>
+ * <p>Hibernate {@code ddl-auto=update} cannot remove obsolete unique
+ * constraints reliably. This runner inspects JDBC metadata, drops only
+ * constraints with proven legacy column sets, backfills a non-null workspace
+ * scope key, and creates named constraints that protect both shared and
+ * personal rows. It also prepares the local-user password-change column.</p>
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -106,14 +103,11 @@ public class SchemaContractMigration implements ApplicationRunner {
 
         ensureColumn(connection, table, "workspace_scope_key", "VARCHAR(255)");
         execute(connection, "UPDATE " + qualified(connection, table)
-                + " SET " + quoted(connection, "workspace_scope_key")
-                + " = COALESCE(NULLIF(TRIM(" + quoted(connection, "workspace_id")
-                + "), ''), '" + SHARED_SCOPE + "')");
+                + " SET workspace_scope_key = " + scopeExpression());
 
         assertNoScopedDuplicates(connection, table);
 
-        List<IndexDefinition> indexes = uniqueIndexes(connection, table);
-        for (IndexDefinition index : indexes) {
+        for (IndexDefinition index : uniqueIndexes(connection, table)) {
             Set<String> columns = new LinkedHashSet<>(index.columns());
             if (legacyColumnSets.contains(columns)) {
                 dropConstraintOrIndex(connection, table, index.name());
@@ -127,11 +121,7 @@ public class SchemaContractMigration implements ApplicationRunner {
         if (!targetExists) {
             execute(connection, "ALTER TABLE " + qualified(connection, table)
                     + " ADD CONSTRAINT " + quoted(connection, targetConstraint)
-                    + " UNIQUE ("
-                    + quoted(connection, "source_node_id") + ", "
-                    + quoted(connection, "target_node_id") + ", "
-                    + quoted(connection, "relation_type") + ", "
-                    + quoted(connection, "workspace_scope_key") + ")");
+                    + " UNIQUE (source_node_id, target_node_id, relation_type, workspace_scope_key)");
             log.info("Created workspace-scoped unique constraint {} on {}",
                     targetConstraint, logicalTableName);
         }
@@ -143,7 +133,8 @@ public class SchemaContractMigration implements ApplicationRunner {
             return;
         }
 
-        String product = connection.getMetaData().getDatabaseProductName().toLowerCase(Locale.ROOT);
+        String product = connection.getMetaData().getDatabaseProductName()
+                .toLowerCase(Locale.ROOT);
         String definition;
         if (product.contains("microsoft")) {
             definition = "BIT DEFAULT 0 NOT NULL";
@@ -163,25 +154,20 @@ public class SchemaContractMigration implements ApplicationRunner {
         if (columnExists(connection, table, column)) {
             return;
         }
+        // Logical model identifiers are intentionally unquoted: each database
+        // applies its normal case folding, matching Hibernate-created columns.
         execute(connection, "ALTER TABLE " + qualified(connection, table)
-                + " ADD " + quoted(connection, column) + " " + definition);
+                + " ADD " + column + " " + definition);
     }
 
     private void assertNoScopedDuplicates(Connection connection,
                                           TableRef table) throws SQLException {
-        String scopeExpression = "COALESCE(NULLIF(TRIM(" + quoted(connection, "workspace_id")
-                + "), ''), '" + SHARED_SCOPE + "')";
         String sql = "SELECT COUNT(*) FROM (SELECT "
-                + quoted(connection, "source_node_id") + ", "
-                + quoted(connection, "target_node_id") + ", "
-                + quoted(connection, "relation_type") + ", "
-                + scopeExpression + " AS scope_key, COUNT(*) AS duplicate_count FROM "
+                + "source_node_id, target_node_id, relation_type, "
+                + scopeExpression() + " AS scope_key, COUNT(*) AS duplicate_count FROM "
                 + qualified(connection, table)
-                + " GROUP BY "
-                + quoted(connection, "source_node_id") + ", "
-                + quoted(connection, "target_node_id") + ", "
-                + quoted(connection, "relation_type") + ", "
-                + scopeExpression
+                + " GROUP BY source_node_id, target_node_id, relation_type, "
+                + scopeExpression()
                 + " HAVING COUNT(*) > 1) taxonomy_duplicates";
         try (Statement statement = connection.createStatement();
              ResultSet result = statement.executeQuery(sql)) {
@@ -194,6 +180,10 @@ public class SchemaContractMigration implements ApplicationRunner {
                         + "Resolve them before starting the upgraded application.");
             }
         }
+    }
+
+    private static String scopeExpression() {
+        return "COALESCE(NULLIF(TRIM(workspace_id), ''), '" + SHARED_SCOPE + "')";
     }
 
     private void dropConstraintOrIndex(Connection connection,
@@ -210,11 +200,10 @@ public class SchemaContractMigration implements ApplicationRunner {
 
         String product = connection.getMetaData().getDatabaseProductName()
                 .toLowerCase(Locale.ROOT);
-        String indexName = qualifiedIndex(connection, table, name);
         String sql = product.contains("microsoft")
                 ? "DROP INDEX " + quoted(connection, name)
                         + " ON " + qualified(connection, table)
-                : "DROP INDEX " + indexName;
+                : "DROP INDEX " + qualifiedIndex(connection, table, name);
         try {
             execute(connection, sql);
         } catch (SQLException indexFailure) {

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/SchemaContractMigration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/SchemaContractMigration.java
@@ -1,0 +1,342 @@
+package com.taxonomy.shared.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Idempotent schema contract migration for deployments that predate workspace
+ * isolation and mandatory password replacement.
+ *
+ * <p>The project historically used Hibernate {@code ddl-auto=update}. That is
+ * unable to remove obsolete unique constraints reliably. This runner inspects
+ * JDBC metadata, drops only constraints with the proven legacy column sets,
+ * backfills a non-null workspace scope key, and creates named constraints that
+ * protect both shared and personal rows. It also prepares the local-user
+ * password-change column used by the security hardening follow-up.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ConditionalOnProperty(name = "taxonomy.schema-migration.enabled",
+        havingValue = "true", matchIfMissing = true)
+public class SchemaContractMigration implements ApplicationRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(SchemaContractMigration.class);
+    private static final String SHARED_SCOPE = "__shared__";
+
+    private static final Set<String> PROPOSAL_LEGACY_COLUMNS = Set.of(
+            "source_node_id", "target_node_id", "relation_type");
+    private static final Set<String> PROPOSAL_WORKSPACE_NULLABLE_COLUMNS = Set.of(
+            "source_node_id", "target_node_id", "relation_type", "workspace_id");
+    private static final Set<String> RELATION_WORKSPACE_NULLABLE_COLUMNS = Set.of(
+            "source_node_id", "target_node_id", "relation_type", "workspace_id");
+    private static final Set<String> SCOPE_KEY_COLUMNS = Set.of(
+            "source_node_id", "target_node_id", "relation_type", "workspace_scope_key");
+
+    private final DataSource dataSource;
+
+    public SchemaContractMigration(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        migrate();
+    }
+
+    /** Runs the complete idempotent contract migration. */
+    public void migrate() {
+        try (Connection connection = dataSource.getConnection()) {
+            boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                migrateScopedUniqueness(connection,
+                        "relation_proposal", "uk_relation_proposal_scope",
+                        List.of(PROPOSAL_LEGACY_COLUMNS, PROPOSAL_WORKSPACE_NULLABLE_COLUMNS));
+                migrateScopedUniqueness(connection,
+                        "taxonomy_relation", "uk_taxonomy_relation_scope",
+                        List.of(RELATION_WORKSPACE_NULLABLE_COLUMNS));
+                ensurePasswordChangeColumn(connection);
+                connection.commit();
+                log.info("Verified workspace and account schema contracts");
+            } catch (SQLException | RuntimeException error) {
+                rollbackQuietly(connection, error);
+                throw new IllegalStateException(
+                        "Unable to migrate Taxonomy schema contracts safely", error);
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        } catch (SQLException error) {
+            throw new IllegalStateException("Unable to open database for schema migration", error);
+        }
+    }
+
+    private void migrateScopedUniqueness(Connection connection,
+                                         String logicalTableName,
+                                         String targetConstraint,
+                                         List<Set<String>> legacyColumnSets) throws SQLException {
+        TableRef table = findTable(connection, logicalTableName);
+        if (table == null) {
+            log.debug("Schema migration skipped: table {} does not exist", logicalTableName);
+            return;
+        }
+
+        ensureColumn(connection, table, "workspace_scope_key", "VARCHAR(255)");
+        execute(connection, "UPDATE " + qualified(connection, table)
+                + " SET " + quoted(connection, "workspace_scope_key")
+                + " = COALESCE(NULLIF(TRIM(" + quoted(connection, "workspace_id")
+                + "), ''), '" + SHARED_SCOPE + "')");
+
+        assertNoScopedDuplicates(connection, table);
+
+        List<IndexDefinition> indexes = uniqueIndexes(connection, table);
+        for (IndexDefinition index : indexes) {
+            Set<String> columns = new LinkedHashSet<>(index.columns());
+            if (legacyColumnSets.contains(columns)) {
+                dropConstraintOrIndex(connection, table, index.name());
+                log.info("Dropped legacy unique constraint/index {} on {} columns {}",
+                        index.name(), logicalTableName, index.columns());
+            }
+        }
+
+        boolean targetExists = uniqueIndexes(connection, table).stream()
+                .anyMatch(index -> new LinkedHashSet<>(index.columns()).equals(SCOPE_KEY_COLUMNS));
+        if (!targetExists) {
+            execute(connection, "ALTER TABLE " + qualified(connection, table)
+                    + " ADD CONSTRAINT " + quoted(connection, targetConstraint)
+                    + " UNIQUE ("
+                    + quoted(connection, "source_node_id") + ", "
+                    + quoted(connection, "target_node_id") + ", "
+                    + quoted(connection, "relation_type") + ", "
+                    + quoted(connection, "workspace_scope_key") + ")");
+            log.info("Created workspace-scoped unique constraint {} on {}",
+                    targetConstraint, logicalTableName);
+        }
+    }
+
+    private void ensurePasswordChangeColumn(Connection connection) throws SQLException {
+        TableRef appUser = findTable(connection, "app_user");
+        if (appUser == null || columnExists(connection, appUser, "must_change_password")) {
+            return;
+        }
+
+        String product = connection.getMetaData().getDatabaseProductName().toLowerCase(Locale.ROOT);
+        String definition;
+        if (product.contains("microsoft")) {
+            definition = "BIT DEFAULT 0 NOT NULL";
+        } else if (product.contains("oracle")) {
+            definition = "NUMBER(1) DEFAULT 0 NOT NULL";
+        } else {
+            definition = "BOOLEAN DEFAULT FALSE NOT NULL";
+        }
+        ensureColumn(connection, appUser, "must_change_password", definition);
+        log.info("Added app_user.must_change_password with a safe false default");
+    }
+
+    private void ensureColumn(Connection connection,
+                              TableRef table,
+                              String column,
+                              String definition) throws SQLException {
+        if (columnExists(connection, table, column)) {
+            return;
+        }
+        execute(connection, "ALTER TABLE " + qualified(connection, table)
+                + " ADD " + quoted(connection, column) + " " + definition);
+    }
+
+    private void assertNoScopedDuplicates(Connection connection,
+                                          TableRef table) throws SQLException {
+        String scopeExpression = "COALESCE(NULLIF(TRIM(" + quoted(connection, "workspace_id")
+                + "), ''), '" + SHARED_SCOPE + "')";
+        String sql = "SELECT COUNT(*) FROM (SELECT "
+                + quoted(connection, "source_node_id") + ", "
+                + quoted(connection, "target_node_id") + ", "
+                + quoted(connection, "relation_type") + ", "
+                + scopeExpression + " AS scope_key, COUNT(*) AS duplicate_count FROM "
+                + qualified(connection, table)
+                + " GROUP BY "
+                + quoted(connection, "source_node_id") + ", "
+                + quoted(connection, "target_node_id") + ", "
+                + quoted(connection, "relation_type") + ", "
+                + scopeExpression
+                + " HAVING COUNT(*) > 1) taxonomy_duplicates";
+        try (Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            long duplicateGroups = result.getLong(1);
+            if (duplicateGroups > 0) {
+                throw new IllegalStateException("Table " + table.name()
+                        + " contains " + duplicateGroups
+                        + " duplicate source/target/type/workspace groups. "
+                        + "Resolve them before starting the upgraded application.");
+            }
+        }
+    }
+
+    private void dropConstraintOrIndex(Connection connection,
+                                       TableRef table,
+                                       String name) throws SQLException {
+        SQLException constraintFailure;
+        try {
+            execute(connection, "ALTER TABLE " + qualified(connection, table)
+                    + " DROP CONSTRAINT " + quoted(connection, name));
+            return;
+        } catch (SQLException error) {
+            constraintFailure = error;
+        }
+
+        String product = connection.getMetaData().getDatabaseProductName()
+                .toLowerCase(Locale.ROOT);
+        String indexName = qualifiedIndex(connection, table, name);
+        String sql = product.contains("microsoft")
+                ? "DROP INDEX " + quoted(connection, name)
+                        + " ON " + qualified(connection, table)
+                : "DROP INDEX " + indexName;
+        try {
+            execute(connection, sql);
+        } catch (SQLException indexFailure) {
+            indexFailure.addSuppressed(constraintFailure);
+            throw indexFailure;
+        }
+    }
+
+    private List<IndexDefinition> uniqueIndexes(Connection connection,
+                                                 TableRef table) throws SQLException {
+        Map<String, Map<Short, String>> byName = new LinkedHashMap<>();
+        DatabaseMetaData metadata = connection.getMetaData();
+        try (ResultSet indexes = metadata.getIndexInfo(
+                table.catalog(), table.schema(), table.name(), true, false)) {
+            while (indexes.next()) {
+                String name = indexes.getString("INDEX_NAME");
+                String column = indexes.getString("COLUMN_NAME");
+                short type = indexes.getShort("TYPE");
+                if (name == null || column == null
+                        || type == DatabaseMetaData.tableIndexStatistic) {
+                    continue;
+                }
+                short ordinal = indexes.getShort("ORDINAL_POSITION");
+                byName.computeIfAbsent(name, ignored -> new TreeMap<>())
+                        .put(ordinal, column.toLowerCase(Locale.ROOT));
+            }
+        }
+        List<IndexDefinition> result = new ArrayList<>();
+        byName.forEach((name, columns) ->
+                result.add(new IndexDefinition(name, List.copyOf(columns.values()))));
+        result.sort(Comparator.comparing(IndexDefinition::name));
+        return result;
+    }
+
+    private TableRef findTable(Connection connection,
+                               String logicalName) throws SQLException {
+        DatabaseMetaData metadata = connection.getMetaData();
+        String preferredSchema = safeSchema(connection);
+        List<TableRef> matches = new ArrayList<>();
+        try (ResultSet tables = metadata.getTables(
+                connection.getCatalog(), null, "%", new String[]{"TABLE"})) {
+            while (tables.next()) {
+                String name = tables.getString("TABLE_NAME");
+                if (name != null && name.equalsIgnoreCase(logicalName)) {
+                    matches.add(new TableRef(
+                            tables.getString("TABLE_CAT"),
+                            tables.getString("TABLE_SCHEM"),
+                            name));
+                }
+            }
+        }
+        return matches.stream()
+                .sorted(Comparator.comparing(table ->
+                        preferredSchema != null
+                                && preferredSchema.equalsIgnoreCase(table.schema()) ? 0 : 1))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean columnExists(Connection connection,
+                                 TableRef table,
+                                 String logicalColumn) throws SQLException {
+        try (ResultSet columns = connection.getMetaData().getColumns(
+                table.catalog(), table.schema(), table.name(), "%")) {
+            while (columns.next()) {
+                String name = columns.getString("COLUMN_NAME");
+                if (name != null && name.equalsIgnoreCase(logicalColumn)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void execute(Connection connection, String sql) throws SQLException {
+        log.debug("Schema migration SQL: {}", sql);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private String qualified(Connection connection, TableRef table) throws SQLException {
+        String tableName = quoted(connection, table.name());
+        return table.schema() == null || table.schema().isBlank()
+                ? tableName : quoted(connection, table.schema()) + "." + tableName;
+    }
+
+    private String qualifiedIndex(Connection connection,
+                                  TableRef table,
+                                  String indexName) throws SQLException {
+        String quotedIndex = quoted(connection, indexName);
+        return table.schema() == null || table.schema().isBlank()
+                ? quotedIndex : quoted(connection, table.schema()) + "." + quotedIndex;
+    }
+
+    private String quoted(Connection connection, String identifier) throws SQLException {
+        String quote = connection.getMetaData().getIdentifierQuoteString();
+        if (quote == null || quote.isBlank()) {
+            return identifier;
+        }
+        return quote + identifier.replace(quote, quote + quote) + quote;
+    }
+
+    private String safeSchema(Connection connection) {
+        try {
+            return connection.getSchema();
+        } catch (SQLException | AbstractMethodError ignored) {
+            return null;
+        }
+    }
+
+    private void rollbackQuietly(Connection connection, Throwable original) {
+        try {
+            connection.rollback();
+        } catch (SQLException rollbackFailure) {
+            original.addSuppressed(rollbackFailure);
+        }
+    }
+
+    private record TableRef(String catalog, String schema, String name) {
+    }
+
+    private record IndexDefinition(String name, List<String> columns) {
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
@@ -7,6 +7,7 @@ import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.repository.RelationProposalRepository;
 import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.relations.service.RelationProposalService;
+import com.taxonomy.workspace.service.WorkspaceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,20 +24,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import org.springframework.security.test.context.support.WithMockUser;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.dto.TaxonomyNodeDto;
-import com.taxonomy.relations.controller.ProposalApiController;
 import com.taxonomy.relations.service.RelationCandidateService;
 import com.taxonomy.relations.service.RelationCompatibilityMatrix;
-import com.taxonomy.relations.service.RelationProposalService;
 import com.taxonomy.relations.service.RelationReviewService;
 import com.taxonomy.relations.service.RelationValidationService;
 
-/**
- * Tests for the Relation Proposal Pipeline:
- * RelationProposalService, RelationCandidateService, RelationValidationService,
- * RelationReviewService, RelationCompatibilityMatrix, and ProposalApiController.
- */
+/** Tests for the relation proposal pipeline and REST API. */
 @SpringBootTest
 @AutoConfigureMockMvc
 @WithMockUser(roles = "ADMIN")
@@ -57,25 +50,19 @@ class RelationProposalTests {
         relationRepository.deleteAll();
     }
 
-    // ── Compatibility Matrix ──────────────────────────────────────────────────
-
     @Test
     void compatibilityMatrixAllowsCorrectPairs() {
-        // CP → CR is valid for REALIZES
         assertThat(compatibilityMatrix.isCompatible("CP", "CR", RelationType.REALIZES)).isTrue();
-        // CR → BP is valid for SUPPORTS
         assertThat(compatibilityMatrix.isCompatible("CR", "BP", RelationType.SUPPORTS)).isTrue();
     }
 
     @Test
     void compatibilityMatrixRejectsIncorrectPairs() {
-        // BP → CR should not be valid for REALIZES (source must be CP)
         assertThat(compatibilityMatrix.isCompatible("BP", "CR", RelationType.REALIZES)).isFalse();
     }
 
     @Test
     void compatibilityMatrixRelatedToHasNoRestrictions() {
-        // RELATED_TO should allow any combination
         assertThat(compatibilityMatrix.isCompatible("BP", "CR", RelationType.RELATED_TO)).isTrue();
         assertThat(compatibilityMatrix.isCompatible("CP", "CI", RelationType.RELATED_TO)).isTrue();
     }
@@ -86,28 +73,24 @@ class RelationProposalTests {
         assertThat(targets).containsExactly("CR");
     }
 
-    // ── Validation Service ────────────────────────────────────────────────────
-
     @Test
     void validationRejectsSelfRelation() {
         var source = new com.taxonomy.catalog.model.TaxonomyNode();
         source.setCode("BP");
         source.setTaxonomyRoot("BP");
-
         var candidate = new com.taxonomy.dto.TaxonomyNodeDto();
         candidate.setCode("BP");
         candidate.setTaxonomyRoot("BP");
 
         var result = validationService.validate(source, candidate, RelationType.RELATED_TO, 0, 1);
+
         assertThat(result.isValid()).isFalse();
         assertThat(result.getRationale()).contains("Self-relation");
     }
 
     @Test
     void confidenceComputationBounds() {
-        // Rank 0 of 5 should be high
         double high = validationService.computeConfidence(0, 5);
-        // Rank 4 of 5 should be low
         double low = validationService.computeConfidence(4, 5);
         assertThat(high).isGreaterThan(0.8);
         assertThat(low).isGreaterThan(0.2);
@@ -116,11 +99,8 @@ class RelationProposalTests {
 
     @Test
     void confidenceSingleCandidate() {
-        double c = validationService.computeConfidence(0, 1);
-        assertThat(c).isEqualTo(0.9);
+        assertThat(validationService.computeConfidence(0, 1)).isEqualTo(0.9);
     }
-
-    // ── Proposal Service ──────────────────────────────────────────────────────
 
     @Test
     void contextLoadsWithProposalServices() {
@@ -133,18 +113,15 @@ class RelationProposalTests {
 
     @Test
     void proposeRelationsReturnsProposals() {
-        // RELATED_TO has no root restriction, so should find candidates
         List<RelationProposalDto> proposals =
                 proposalService.proposeRelations("BP", RelationType.RELATED_TO, 5);
         assertThat(proposals).isNotNull();
-        // With full-text search, there should be at least some candidates
-        // (embedding may not be available in test)
     }
 
     @Test
     void proposeRelationsRejectsUnknownNode() {
-        assertThatThrownBy(() ->
-                proposalService.proposeRelations("NONEXISTENT", RelationType.RELATED_TO, 5))
+        assertThatThrownBy(() -> proposalService.proposeRelations(
+                "NONEXISTENT", RelationType.RELATED_TO, 5))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -158,23 +135,18 @@ class RelationProposalTests {
         assertThat(proposalService.getAllProposals()).isEmpty();
     }
 
-    // ── Review Service ────────────────────────────────────────────────────────
-
     @Test
     void acceptProposalCreatesRelation() {
-        // Generate proposals first
         List<RelationProposalDto> proposals =
                 proposalService.proposeRelations("BP", RelationType.RELATED_TO, 5);
-
         if (!proposals.isEmpty()) {
             Long proposalId = proposals.get(0).getId();
-            TaxonomyRelationDto relation = reviewService.acceptProposal(proposalId);
+            TaxonomyRelationDto relation = reviewService.acceptProposal(
+                    proposalId, WorkspaceContext.SHARED);
             assertThat(relation).isNotNull();
             assertThat(relation.getSourceCode()).isEqualTo("BP");
             assertThat(relation.getRelationType()).isEqualTo("RELATED_TO");
             assertThat(relation.getProvenance()).isEqualTo("proposal-pipeline");
-
-            // Verify proposal status changed
             var updated = proposalRepository.findById(proposalId).orElseThrow();
             assertThat(updated.getStatus()).isEqualTo(ProposalStatus.ACCEPTED);
             assertThat(updated.getReviewedAt()).isNotNull();
@@ -185,12 +157,11 @@ class RelationProposalTests {
     void rejectProposalChangesStatus() {
         List<RelationProposalDto> proposals =
                 proposalService.proposeRelations("BP", RelationType.RELATED_TO, 5);
-
         if (!proposals.isEmpty()) {
             Long proposalId = proposals.get(0).getId();
-            RelationProposalDto rejected = reviewService.rejectProposal(proposalId);
+            RelationProposalDto rejected = reviewService.rejectProposal(
+                    proposalId, WorkspaceContext.SHARED);
             assertThat(rejected.getStatus()).isEqualTo("REJECTED");
-
             var updated = proposalRepository.findById(proposalId).orElseThrow();
             assertThat(updated.getStatus()).isEqualTo(ProposalStatus.REJECTED);
             assertThat(updated.getReviewedAt()).isNotNull();
@@ -199,17 +170,17 @@ class RelationProposalTests {
 
     @Test
     void acceptNonExistentProposalThrows() {
-        assertThatThrownBy(() -> reviewService.acceptProposal(999L))
+        assertThatThrownBy(() -> reviewService.acceptProposal(
+                999L, WorkspaceContext.SHARED))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void rejectNonExistentProposalThrows() {
-        assertThatThrownBy(() -> reviewService.rejectProposal(999L))
+        assertThatThrownBy(() -> reviewService.rejectProposal(
+                999L, WorkspaceContext.SHARED))
                 .isInstanceOf(IllegalArgumentException.class);
     }
-
-    // ── REST API ──────────────────────────────────────────────────────────────
 
     @Test
     void proposalsApiGetAllReturnsEmptyList() throws Exception {

--- a/taxonomy-app/src/test/java/com/taxonomy/SecurityTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/SecurityTests.java
@@ -8,6 +8,8 @@ import com.taxonomy.security.repository.RoleRepository;
 import com.taxonomy.security.repository.UserRepository;
 import com.taxonomy.security.service.DatabaseUserDetailsService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -21,8 +23,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for Spring Security configuration: authentication, authorization,
@@ -143,7 +146,7 @@ class SecurityTests {
                 .andExpect(status().isOk());
     }
 
-    // ── Role-based access: USER cannot write relations ────────────────────────
+    // ── Role-based access: USER cannot mutate architecture state ─────────────
 
     @Test
     @WithMockUser(roles = "USER")
@@ -163,7 +166,25 @@ class SecurityTests {
                 .andExpect(status().isForbidden());
     }
 
-    // ── Role-based access: ARCHITECT can write relations ──────────────────────
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/api/proposals/propose",
+            "/api/proposals/from-hypothesis",
+            "/api/proposals/999/accept",
+            "/api/proposals/999/reject",
+            "/api/proposals/999/revert",
+            "/api/proposals/bulk/accept",
+            "/api/proposals/bulk/reject"
+    })
+    @WithMockUser(roles = "USER")
+    void userCannotMutateRelationProposals(String endpoint) throws Exception {
+        mockMvc.perform(post(endpoint)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // ── Role-based access: ARCHITECT can write architecture state ────────────
 
     @Test
     @WithMockUser(roles = "ARCHITECT")
@@ -172,6 +193,13 @@ class SecurityTests {
                         .contentType(MediaType.TEXT_PLAIN)
                         .content("meta { }"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "ARCHITECT")
+    void architectReachesProposalController() throws Exception {
+        mockMvc.perform(post("/api/proposals/999/accept"))
+                .andExpect(status().isBadRequest());
     }
 
     // ── Role-based access: Admin-only endpoints ───────────────────────────────

--- a/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
@@ -1,0 +1,146 @@
+package com.taxonomy;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.relations.service.RelationProposalService;
+import com.taxonomy.relations.service.RelationReviewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression tests for exact-scope proposal and relation access.
+ *
+ * <p>The mock user has no provisioned workspace and therefore resolves to the
+ * shared context. Shared context must never mean unrestricted access to all
+ * personal workspaces.
+ */
+@SpringBootTest
+@Transactional
+@WithMockUser(username = "qa-admin", roles = {"USER", "ARCHITECT", "ADMIN"})
+class WorkspaceRelationIsolationTests {
+
+    @Autowired
+    private TaxonomyNodeRepository nodeRepository;
+
+    @Autowired
+    private RelationProposalRepository proposalRepository;
+
+    @Autowired
+    private TaxonomyRelationRepository relationRepository;
+
+    @Autowired
+    private RelationProposalService proposalService;
+
+    @Autowired
+    private RelationReviewService reviewService;
+
+    @Autowired
+    private TaxonomyRelationService relationService;
+
+    @Test
+    void sharedContextCannotReviewForeignWorkspaceProposal() {
+        RelationProposal foreign = proposalRepository.saveAndFlush(
+                newProposal("qa-foreign-workspace", "other-user"));
+
+        assertThatThrownBy(() -> reviewService.acceptProposal(foreign.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("active workspace");
+
+        RelationProposal unchanged = proposalRepository.findById(foreign.getId()).orElseThrow();
+        assertThat(unchanged.getStatus()).isEqualTo(ProposalStatus.PENDING);
+    }
+
+    @Test
+    void identicalProposalTriplesCanExistInSeparateWorkspaces() {
+        RelationProposal first = proposalRepository.save(newProposal("qa-workspace-a", "alice"));
+        RelationProposal second = proposalRepository.save(newProposal("qa-workspace-b", "bob"));
+        proposalRepository.flush();
+
+        assertThat(first.getId()).isNotEqualTo(second.getId());
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-a")).isTrue();
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-b")).isTrue();
+        assertThat(proposalRepository.existsInWorkspace(
+                "BP", "BP", RelationType.RELATED_TO, null)).isFalse();
+    }
+
+    @Test
+    void sharedProposalReadsDoNotExposeForeignWorkspaceRows() {
+        RelationProposal foreign = proposalRepository.saveAndFlush(
+                newProposal("qa-private-workspace", "private-user"));
+
+        assertThat(proposalService.getAllProposals())
+                .noneMatch(dto -> dto.getId().equals(foreign.getId()));
+    }
+
+    @Test
+    void exactWorkspaceDeletePreservesEquivalentRelationInOtherWorkspace() {
+        relationService.createRelation(
+                "BP", "BP", RelationType.RELATED_TO, "workspace A", "qa-test",
+                "qa-workspace-a", "alice");
+        relationService.createRelation(
+                "BP", "BP", RelationType.RELATED_TO, "workspace B", "qa-test",
+                "qa-workspace-b", "bob");
+
+        relationService.deleteRelationBySourceTargetType(
+                "BP", "BP", RelationType.RELATED_TO, "qa-workspace-a");
+
+        assertThat(relationRepository
+                .findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "qa-workspace-a", "BP", "BP", RelationType.RELATED_TO))
+                .isEmpty();
+        assertThat(relationRepository
+                .findByWorkspaceIdAndSourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "qa-workspace-b", "BP", "BP", RelationType.RELATED_TO))
+                .hasSize(1);
+    }
+
+    @Test
+    void sharedRelationReadsDoNotExposeForeignWorkspaceRows() {
+        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
+        TaxonomyRelation foreign = new TaxonomyRelation();
+        foreign.setSourceNode(node);
+        foreign.setTargetNode(node);
+        foreign.setRelationType(RelationType.RELATED_TO);
+        foreign.setDescription("private relation");
+        foreign.setProvenance("qa-test");
+        foreign.setWorkspaceId("qa-private-workspace");
+        foreign.setOwnerUsername("private-user");
+        foreign = relationRepository.saveAndFlush(foreign);
+
+        Long foreignId = foreign.getId();
+        assertThat(relationService.getAllRelations(null))
+                .noneMatch(dto -> dto.getId().equals(foreignId));
+        assertThat(relationService.countRelations(null))
+                .isEqualTo(relationRepository.countByWorkspaceIdIsNull());
+    }
+
+    private RelationProposal newProposal(String workspaceId, String owner) {
+        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
+        RelationProposal proposal = new RelationProposal();
+        proposal.setSourceNode(node);
+        proposal.setTargetNode(node);
+        proposal.setRelationType(RelationType.RELATED_TO);
+        proposal.setStatus(ProposalStatus.PENDING);
+        proposal.setConfidence(0.75);
+        proposal.setRationale("workspace isolation regression test");
+        proposal.setProvenance("qa-test");
+        proposal.setWorkspaceId(workspaceId);
+        proposal.setOwnerUsername(owner);
+        return proposal;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/WorkspaceRelationIsolationTests.java
@@ -11,6 +11,7 @@ import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
 import com.taxonomy.relations.service.RelationProposalService;
 import com.taxonomy.relations.service.RelationReviewService;
+import com.taxonomy.workspace.service.WorkspaceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,42 +21,26 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * Regression tests for exact-scope proposal and relation access.
- *
- * <p>The mock user has no provisioned workspace and therefore resolves to the
- * shared context. Shared context must never mean unrestricted access to all
- * personal workspaces.
- */
+/** Regression tests for exact-scope proposal and relation access. */
 @SpringBootTest
 @Transactional
 @WithMockUser(username = "qa-admin", roles = {"USER", "ARCHITECT", "ADMIN"})
 class WorkspaceRelationIsolationTests {
 
-    @Autowired
-    private TaxonomyNodeRepository nodeRepository;
-
-    @Autowired
-    private RelationProposalRepository proposalRepository;
-
-    @Autowired
-    private TaxonomyRelationRepository relationRepository;
-
-    @Autowired
-    private RelationProposalService proposalService;
-
-    @Autowired
-    private RelationReviewService reviewService;
-
-    @Autowired
-    private TaxonomyRelationService relationService;
+    @Autowired private TaxonomyNodeRepository nodeRepository;
+    @Autowired private RelationProposalRepository proposalRepository;
+    @Autowired private TaxonomyRelationRepository relationRepository;
+    @Autowired private RelationProposalService proposalService;
+    @Autowired private RelationReviewService reviewService;
+    @Autowired private TaxonomyRelationService relationService;
 
     @Test
     void sharedContextCannotReviewForeignWorkspaceProposal() {
         RelationProposal foreign = proposalRepository.saveAndFlush(
                 newProposal("qa-foreign-workspace", "other-user"));
 
-        assertThatThrownBy(() -> reviewService.acceptProposal(foreign.getId()))
+        assertThatThrownBy(() -> reviewService.acceptProposal(
+                foreign.getId(), WorkspaceContext.SHARED))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("active workspace");
 

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/SchemaContractMigrationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/SchemaContractMigrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@Transactional
 class SchemaContractMigrationTest {
 
     private static final Set<String> EXPECTED_SCOPE_COLUMNS = Set.of(
@@ -53,19 +55,26 @@ class SchemaContractMigrationTest {
 
     @Test
     void sharedRelationDuplicatesAreRejectedByDatabaseConstraint() {
-        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
-        TaxonomyRelation first = relation(node, "schema-contract-first");
-        relationRepository.saveAndFlush(first);
+        TaxonomyNode source = nodeRepository.findByCode("BP").orElseThrow();
+        TaxonomyNode target = nodeRepository.findByCode("BR").orElseThrow();
+        relationRepository.deleteAll(
+                relationRepository.findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "BP", "BR", RelationType.CONTAINS));
+        relationRepository.flush();
 
-        TaxonomyRelation duplicate = relation(node, "schema-contract-duplicate");
-        assertThatThrownBy(() -> relationRepository.saveAndFlush(duplicate))
+        relationRepository.saveAndFlush(relation(source, target, "schema-contract-first"));
+
+        assertThatThrownBy(() -> relationRepository.saveAndFlush(
+                relation(source, target, "schema-contract-duplicate")))
                 .isInstanceOf(DataIntegrityViolationException.class);
     }
 
-    private static TaxonomyRelation relation(TaxonomyNode node, String description) {
+    private static TaxonomyRelation relation(TaxonomyNode source,
+                                              TaxonomyNode target,
+                                              String description) {
         TaxonomyRelation relation = new TaxonomyRelation();
-        relation.setSourceNode(node);
-        relation.setTargetNode(node);
+        relation.setSourceNode(source);
+        relation.setTargetNode(target);
         relation.setRelationType(RelationType.CONTAINS);
         relation.setDescription(description);
         relation.setProvenance("schema-contract-test");

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/SchemaContractMigrationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/SchemaContractMigrationTest.java
@@ -1,0 +1,135 @@
+package com.taxonomy.shared.config;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.model.TaxonomyRelation;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.model.RelationType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class SchemaContractMigrationTest {
+
+    private static final Set<String> EXPECTED_SCOPE_COLUMNS = Set.of(
+            "source_node_id", "target_node_id", "relation_type", "workspace_scope_key");
+
+    @Autowired private SchemaContractMigration migration;
+    @Autowired private DataSource dataSource;
+    @Autowired private TaxonomyNodeRepository nodeRepository;
+    @Autowired private TaxonomyRelationRepository relationRepository;
+
+    @Test
+    void migrationIsIdempotentAndRequiredColumnsExist() throws Exception {
+        migration.migrate();
+        migration.migrate();
+
+        try (Connection connection = dataSource.getConnection()) {
+            assertThat(columnExists(connection, "relation_proposal", "workspace_scope_key")).isTrue();
+            assertThat(columnExists(connection, "taxonomy_relation", "workspace_scope_key")).isTrue();
+            assertThat(columnExists(connection, "app_user", "must_change_password")).isTrue();
+            assertThat(uniqueColumnSets(connection, "relation_proposal"))
+                    .contains(EXPECTED_SCOPE_COLUMNS);
+            assertThat(uniqueColumnSets(connection, "taxonomy_relation"))
+                    .contains(EXPECTED_SCOPE_COLUMNS);
+        }
+    }
+
+    @Test
+    void sharedRelationDuplicatesAreRejectedByDatabaseConstraint() {
+        TaxonomyNode node = nodeRepository.findByCode("BP").orElseThrow();
+        TaxonomyRelation first = relation(node, "schema-contract-first");
+        relationRepository.saveAndFlush(first);
+
+        TaxonomyRelation duplicate = relation(node, "schema-contract-duplicate");
+        assertThatThrownBy(() -> relationRepository.saveAndFlush(duplicate))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private static TaxonomyRelation relation(TaxonomyNode node, String description) {
+        TaxonomyRelation relation = new TaxonomyRelation();
+        relation.setSourceNode(node);
+        relation.setTargetNode(node);
+        relation.setRelationType(RelationType.CONTAINS);
+        relation.setDescription(description);
+        relation.setProvenance("schema-contract-test");
+        relation.setWorkspaceId(null);
+        return relation;
+    }
+
+    private static boolean columnExists(Connection connection,
+                                        String tableName,
+                                        String columnName) throws Exception {
+        DatabaseMetaData metadata = connection.getMetaData();
+        try (ResultSet tables = metadata.getTables(
+                connection.getCatalog(), null, "%", new String[]{"TABLE"})) {
+            while (tables.next()) {
+                String actualTable = tables.getString("TABLE_NAME");
+                if (!tableName.equalsIgnoreCase(actualTable)) continue;
+                try (ResultSet columns = metadata.getColumns(
+                        tables.getString("TABLE_CAT"), tables.getString("TABLE_SCHEM"),
+                        actualTable, "%")) {
+                    while (columns.next()) {
+                        if (columnName.equalsIgnoreCase(columns.getString("COLUMN_NAME"))) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Set<Set<String>> uniqueColumnSets(Connection connection,
+                                                      String tableName) throws Exception {
+        DatabaseMetaData metadata = connection.getMetaData();
+        String actualTable = null;
+        String catalog = null;
+        String schema = null;
+        try (ResultSet tables = metadata.getTables(
+                connection.getCatalog(), null, "%", new String[]{"TABLE"})) {
+            while (tables.next()) {
+                if (tableName.equalsIgnoreCase(tables.getString("TABLE_NAME"))) {
+                    actualTable = tables.getString("TABLE_NAME");
+                    catalog = tables.getString("TABLE_CAT");
+                    schema = tables.getString("TABLE_SCHEM");
+                    break;
+                }
+            }
+        }
+        assertThat(actualTable).isNotNull();
+
+        Map<String, Map<Short, String>> indexes = new LinkedHashMap<>();
+        try (ResultSet result = metadata.getIndexInfo(catalog, schema, actualTable, true, false)) {
+            while (result.next()) {
+                String indexName = result.getString("INDEX_NAME");
+                String columnName = result.getString("COLUMN_NAME");
+                if (indexName == null || columnName == null) continue;
+                indexes.computeIfAbsent(indexName, ignored -> new TreeMap<>())
+                        .put(result.getShort("ORDINAL_POSITION"),
+                                columnName.toLowerCase(Locale.ROOT));
+            }
+        }
+
+        Set<Set<String>> result = new LinkedHashSet<>();
+        indexes.values().forEach(columns ->
+                result.add(new LinkedHashSet<>(columns.values())));
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #429 as a stacked QA PR on top of #428.

### Checked acceptance matrix

Adds a machine-readable role × workflow × state matrix covering:

- USER, ARCHITECT, and ADMIN;
- keyboard authentication and role-specific navigation;
- analysis loading, success, stale, and deterministic provider-error states;
- proposal mutation denial for USER and review actions for ARCHITECT/ADMIN;
- accessible dialog focus entry, close, and focus restoration;
- mobile layout, WebKit, Firefox, Chromium, reduced motion, Forced Colors, and 200%/400% reflow equivalents.

### Dynamic accessibility evidence

The Playwright runner executes axe after populated/error/dialog states rather than only after top-level tab navigation. Critical, serious, and moderate violations fail. Browser console errors and external browser requests also fail.

Every state archives:

- full-page screenshot;
- serialized DOM;
- ARIA snapshot where supported;
- machine-readable checks and axe findings.

### Stacking

Base branch: `fix/proposal-workspace-authorization`, because the USER proposal-mutation test intentionally verifies the 403 contract introduced by #428. Retarget to `main` after #428 merges.

## Verification

Opened as draft until all six browser/profile jobs and the stacked base checks pass.

Addresses #429.