### PR TITLE
Build: align Hibernate Search, ORM, and Lucene through platform BOM

### DIFF
--- a/.github/scripts/check-hibernate-search-alignment.py
+++ b/.github/scripts/check-hibernate-search-alignment.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate the resolved Hibernate Search/ORM/Lucene dependency set."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+COORDINATE = re.compile(
+    r"(?P<group>org\.hibernate\.search|org\.hibernate\.orm|org\.apache\.lucene):"
+    r"(?P<artifact>[A-Za-z0-9_.-]+):(?:[A-Za-z0-9_.-]+:)*(?P<version>[0-9][^:\s]*)"
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tree", required=True, type=Path)
+    parser.add_argument("--search-version", required=True)
+    parser.add_argument("--orm-prefix", default="7.4.")
+    parser.add_argument("--lucene-version", default="9.12.3")
+    args = parser.parse_args()
+
+    text = args.tree.read_text(encoding="utf-8")
+    resolved: dict[tuple[str, str], set[str]] = {}
+    for match in COORDINATE.finditer(text):
+        key = (match.group("group"), match.group("artifact"))
+        resolved.setdefault(key, set()).add(match.group("version"))
+
+    failures: list[str] = []
+    search_entries = {
+        artifact: versions
+        for (group, artifact), versions in resolved.items()
+        if group == "org.hibernate.search"
+    }
+    if not search_entries:
+        failures.append("No org.hibernate.search artifacts were found in the dependency tree")
+    for artifact, versions in sorted(search_entries.items()):
+        if versions != {args.search_version}:
+            failures.append(
+                f"{artifact} resolved to {sorted(versions)}, expected only {args.search_version}"
+            )
+
+    orm_versions = resolved.get(("org.hibernate.orm", "hibernate-core"), set())
+    if len(orm_versions) != 1 or not next(iter(orm_versions), "").startswith(args.orm_prefix):
+        failures.append(
+            f"hibernate-core resolved to {sorted(orm_versions)}, expected one {args.orm_prefix}x version"
+        )
+
+    lucene_versions = resolved.get(("org.apache.lucene", "lucene-core"), set())
+    if lucene_versions != {args.lucene_version}:
+        failures.append(
+            f"lucene-core resolved to {sorted(lucene_versions)}, expected {args.lucene_version}"
+        )
+
+    report = ["Hibernate Search dependency alignment", ""]
+    report.extend(
+        f"- org.hibernate.search:{artifact} = {', '.join(sorted(versions))}"
+        for artifact, versions in sorted(search_entries.items())
+    )
+    report.append(f"- org.hibernate.orm:hibernate-core = {', '.join(sorted(orm_versions)) or 'missing'}")
+    report.append(f"- org.apache.lucene:lucene-core = {', '.join(sorted(lucene_versions)) or 'missing'}")
+    report.append("")
+    report.append("Result: " + ("FAIL" if failures else "PASS"))
+    if failures:
+        report.extend(f"- {failure}" for failure in failures)
+    print("\n".join(report))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/hibernate-search-alignment.yml
+++ b/.github/workflows/hibernate-search-alignment.yml
@@ -1,0 +1,61 @@
+name: Hibernate Search Alignment
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - 'taxonomy-*/pom.xml'
+      - '.github/scripts/check-hibernate-search-alignment.py'
+      - '.github/workflows/hibernate-search-alignment.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'pom.xml'
+      - 'taxonomy-*/pom.xml'
+      - '.github/scripts/check-hibernate-search-alignment.py'
+      - '.github/workflows/hibernate-search-alignment.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  resolved-platform:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Resolve coordinated dependency set
+        run: |
+          mkdir -p target
+          mvn -B -q -pl taxonomy-app -am install -DskipTests
+          mvn -B -q -pl taxonomy-app dependency:tree \
+            -Dincludes='org.hibernate.search:*,org.hibernate.orm:hibernate-core,org.apache.lucene:lucene-core' \
+            -DoutputFile=../target/hibernate-search-dependencies.txt
+          SEARCH_VERSION=$(mvn help:evaluate -Dexpression=hibernate-search.version -q -DforceStdout)
+          python3 .github/scripts/check-hibernate-search-alignment.py \
+            --tree target/hibernate-search-dependencies.txt \
+            --search-version "$SEARCH_VERSION" \
+            | tee target/hibernate-search-alignment.txt
+
+      - name: Upload dependency evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hibernate-search-alignment
+          path: |
+            target/hibernate-search-dependencies.txt
+            target/hibernate-search-alignment.txt
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
+++ b/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
@@ -1,0 +1,35 @@
+# Hibernate Search compatibility contract
+
+The application uses the Hibernate Search **platform BOM**, not independently versioned mapper and backend artifacts.
+
+## Selected release set
+
+| Component | Version line | Source of truth |
+|---|---:|---|
+| Hibernate Search mapper/backend | `8.4.0.Final` | `hibernate-search.version` and `hibernate-search-platform-bom` |
+| Hibernate ORM | `7.4.x` | Hibernate Search platform BOM |
+| Apache Lucene | `9.12.3` | Hibernate Search platform BOM and `lucene.version` |
+
+Hibernate Search 8.4 targets Hibernate ORM 7.4 and its normal Lucene backend uses Lucene 9.12.3. The platform BOM coordinates these dependencies and prevents mapper/backend minor-version skew.
+
+## Local verification
+
+```bash
+mvn -B -q -pl taxonomy-app -am install -DskipTests
+mvn -B -q -pl taxonomy-app dependency:tree \
+  -Dincludes='org.hibernate.search:*,org.hibernate.orm:hibernate-core,org.apache.lucene:lucene-core' \
+  -DoutputFile=../target/hibernate-search-dependencies.txt
+python3 .github/scripts/check-hibernate-search-alignment.py \
+  --tree target/hibernate-search-dependencies.txt \
+  --search-version 8.4.0.Final
+```
+
+The same check runs in `Hibernate Search Alignment` and archives the resolved tree for each POM change.
+
+## Upgrade procedure
+
+1. Read the Hibernate Search compatibility and migration documentation.
+2. Update only `hibernate-search.version`.
+3. Keep `hibernate-search-backend.version` as an alias or remove it together with all remaining child-POM references.
+4. Run the full Maven reactor, persistent-index restart tests, database compatibility matrix, and mass-index/search tests.
+5. Confirm whether a reindex is required before release and document that decision.

--- a/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
+++ b/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
@@ -10,7 +10,7 @@ The application uses the Hibernate Search **platform BOM**, not independently ve
 | Hibernate ORM | `7.4.x` | Hibernate Search platform BOM |
 | Apache Lucene | `9.12.3` | Hibernate Search platform BOM and `lucene.version` |
 
-Hibernate Search 8.4 targets Hibernate ORM 7.4 and its normal Lucene backend uses Lucene 9.12.3. The platform BOM coordinates these dependencies and prevents mapper/backend minor-version skew.
+Hibernate Search 8.4 targets Hibernate ORM 7.4 and its Lucene backend uses Lucene 9.12.3. The platform BOM coordinates these dependencies and prevents mapper/backend minor-version skew.
 
 ## Local verification
 

--- a/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
+++ b/docs/dev/HIBERNATE_SEARCH_COMPATIBILITY.md
@@ -33,3 +33,5 @@ The same check runs in `Hibernate Search Alignment` and archives the resolved tr
 3. Keep `hibernate-search-backend.version` as an alias or remove it together with all remaining child-POM references.
 4. Run the full Maven reactor, persistent-index restart tests, database compatibility matrix, and mass-index/search tests.
 5. Confirm whether a reindex is required before release and document that decision.
+
+A release is incomplete until the resolved dependency evidence and persistent-index restart test are both green.

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,10 @@
         <poi.version>5.5.1</poi.version>
         <pdfbox.version>3.0.8</pdfbox.version>
         <lucene.version>9.12.3</lucene.version>
-        <hibernate-search.version>8.3.1.Final</hibernate-search.version>
-        <hibernate-search-backend.version>8.4.0.Final</hibernate-search-backend.version>
+        <!-- Hibernate Search 8.4 targets Hibernate ORM 7.4 and Lucene 9.12.3.
+             The platform BOM below coordinates the complete dependency family. -->
+        <hibernate-search.version>8.4.0.Final</hibernate-search.version>
+        <hibernate-search-backend.version>${hibernate-search.version}</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <springdoc.version>3.0.3</springdoc.version>
         <!-- Spring Boot-managed patch overrides for currently fixed security releases. -->
@@ -102,6 +104,13 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.hibernate.search</groupId>
+                <artifactId>hibernate-search-platform-bom</artifactId>
+                <version>${hibernate-search.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>


### PR DESCRIPTION
## Summary

Clean rebuild of #434 on the current `main`, implementing #424 without inherited squash-merge conflicts.

- imports `org.hibernate.search:hibernate-search-platform-bom:8.4.0.Final`;
- aligns mapper and Lucene backend through one release property;
- prevents the previous 8.3.1 mapper / 8.4.0 backend skew;
- coordinates Hibernate ORM 7.4 and Lucene 9.12.3 with the supported release set;
- adds a reusable resolved-dependency validator;
- adds a pinned, least-privilege CI gate with archived dependency evidence;
- documents local verification, persistent-index testing, and the upgrade procedure.

The prior alignment workflow passed on the original implementation. This clean branch must now pass the full current-main Maven, security, database, and persistent-index gates before leaving draft.

Addresses #424.