### PR TITLE
Architecture: enforce bounded-context cycles with expiring exceptions

### DIFF
--- a/.github/architecture-exceptions.json
+++ b/.github/architecture-exceptions.json
@@ -1,0 +1,135 @@
+{
+  "schemaVersion": 1,
+  "exceptions": [
+    {
+      "id": "cycle-architecture-to-export",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.architecture..",
+      "toPackage": "com.taxonomy.export..",
+      "owner": "architecture-maintainers",
+      "rationale": "The application adapter layer still invokes export services directly from architecture orchestration.",
+      "removalCondition": "Introduce an export port in taxonomy-extension-api and inject the adapter from taxonomy-app.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-export-to-architecture",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.export..",
+      "toPackage": "com.taxonomy.architecture..",
+      "owner": "architecture-maintainers",
+      "rationale": "Diagram generation currently consumes application architecture view models.",
+      "removalCondition": "Move canonical export input contracts into taxonomy-export or taxonomy-extension-api.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-catalog-to-relations",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.catalog..",
+      "toPackage": "com.taxonomy.relations..",
+      "owner": "catalog-maintainers",
+      "rationale": "Catalog facades expose relation-enriched node representations.",
+      "removalCondition": "Replace direct relation package dependencies with a read port owned by the catalog boundary.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-relations-to-catalog",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.relations..",
+      "toPackage": "com.taxonomy.catalog..",
+      "owner": "relations-maintainers",
+      "rationale": "Relation persistence references canonical taxonomy nodes and catalog-owned relation entities.",
+      "removalCondition": "Move shared node/relation identities to a framework-free domain contract module.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-versioning-to-workspace",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.versioning..",
+      "toPackage": "com.taxonomy.workspace..",
+      "owner": "versioning-maintainers",
+      "rationale": "Version operations require explicit workspace context and repository routing.",
+      "removalCondition": "Introduce a versioning-owned repository-context port implemented by the workspace adapter.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-workspace-to-versioning",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.workspace..",
+      "toPackage": "com.taxonomy.versioning..",
+      "owner": "workspace-maintainers",
+      "rationale": "Workspace synchronization currently invokes versioning and repository-state services.",
+      "removalCondition": "Move synchronization orchestration to an application service above both bounded contexts.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-dsl-adapter-outbound",
+      "kind": "adapter-boundary",
+      "fromPackage": "com.taxonomy.dsl.storage..|com.taxonomy.dsl.export..",
+      "toPackage": "*",
+      "owner": "dsl-maintainers",
+      "rationale": "Spring/JGit persistence and export adapters still reside below the com.taxonomy.dsl package root in taxonomy-app.",
+      "removalCondition": "Move these adapters to a dedicated taxonomy-adapters module and leave taxonomy-dsl framework-free.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-dsl-adapter-inbound",
+      "kind": "adapter-boundary",
+      "fromPackage": "*",
+      "toPackage": "com.taxonomy.dsl.storage..|com.taxonomy.dsl.export..",
+      "owner": "dsl-maintainers",
+      "rationale": "Application services still address DSL persistence/export adapters through their historical package names.",
+      "removalCondition": "Move these adapters to a dedicated taxonomy-adapters module and expose narrow ports.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-analysis-usecase-to-export-metadata",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.analysis.usecase..",
+      "toPackage": "com.taxonomy.export..",
+      "owner": "analysis-maintainers",
+      "rationale": "AnalyzeRequirementUseCase reads a policy metadata record that is currently declared in the export module.",
+      "removalCondition": "Move the policy metadata contract to taxonomy-domain and retain export-only construction in taxonomy-export.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-catalog-model-to-search-binder",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.catalog.model..",
+      "toPackage": "com.taxonomy.search..",
+      "owner": "search-maintainers",
+      "rationale": "Hibernate Search entity annotations reference application-level embedding binder implementations.",
+      "removalCondition": "Move binder adapters next to the catalog persistence adapter or introduce an annotation-free mapping contributor.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-search-binder-to-catalog-model",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.search..",
+      "toPackage": "com.taxonomy.catalog.model..",
+      "owner": "search-maintainers",
+      "rationale": "Embedding type bridges necessarily bind the indexed catalog entity types while the annotations still point back to the bridges.",
+      "removalCondition": "Relocate the binder implementation into a catalog-owned persistence adapter package together with the mapping definition.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-architecture-controller-to-versioning-state",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.architecture.controller..",
+      "toPackage": "com.taxonomy.versioning.service..",
+      "owner": "architecture-maintainers",
+      "rationale": "Report endpoints combine architecture rendering with repository snapshot resolution at the HTTP application boundary.",
+      "removalCondition": "Move cross-context HTTP orchestration into a dedicated application-controller package above both bounded contexts.",
+      "expiresOn": "2027-06-30"
+    },
+    {
+      "id": "cycle-catalog-controller-to-versioning-state",
+      "kind": "cycle-edge",
+      "fromPackage": "com.taxonomy.catalog.controller..",
+      "toPackage": "com.taxonomy.versioning.service..",
+      "owner": "catalog-maintainers",
+      "rationale": "Framework import endpoints combine catalog import with repository view-context resolution.",
+      "removalCondition": "Move cross-context import orchestration into a dedicated application-controller package above catalog and versioning.",
+      "expiresOn": "2027-06-30"
+    }
+  ]
+}

--- a/.github/workflows/qa-architecture-evidence.yml
+++ b/.github/workflows/qa-architecture-evidence.yml
@@ -1,0 +1,46 @@
+name: QA Architecture Evidence
+
+on:
+  pull_request:
+    branches: [ security/source-sast-and-pinning-v2, main ]
+    paths:
+      - 'taxonomy-app/src/**'
+      - '.github/architecture-exceptions.json'
+      - '.github/workflows/qa-architecture-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  architecture-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - name: Install dependencies without tests
+        run: mvn -B -q -pl taxonomy-app -am install -DskipTests
+      - name: Run architecture tests
+        id: tests
+        continue-on-error: true
+        run: >-
+          mvn -B -pl taxonomy-app test
+          -Dtest=ArchitectureTest,ArchitectureCycleBoundaryTest,ArchitectureExceptionLedgerTest,ArchitectureCycleRuleRegressionTest
+      - name: Upload raw reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: qa-architecture-reports
+          path: taxonomy-app/target/surefire-reports/**
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate result
+        if: steps.tests.outcome != 'success'
+        run: exit 1

--- a/docs/dev/ARCHITECTURE_EXCEPTION_LEDGER.md
+++ b/docs/dev/ARCHITECTURE_EXCEPTION_LEDGER.md
@@ -34,4 +34,4 @@ Before extending an exception:
 
 The shared DTO, model, and shared-infrastructure packages are structural contracts rather than bounded contexts. They are excluded separately and must not be used as a route for domain-service dependencies.
 
-The five additional edges recorded in the initial strict-rule adoption are narrower than a bounded context: one analysis use-case dependency, two Hibernate Search binder directions, and two HTTP-controller orchestration dependencies. The reverse service dependencies remain governed by the cycle rule.
+The strict-rule adoption exposed seven cycles hidden by the former broad exclusions. Five additional directed edges are sufficient to explain them: one analysis use-case dependency, two Hibernate Search binder directions, and two HTTP-controller orchestration dependencies. Reverse service dependencies remain governed by the cycle rule, and all five adoption entries expire on 30 June 2027.

--- a/docs/dev/ARCHITECTURE_EXCEPTION_LEDGER.md
+++ b/docs/dev/ARCHITECTURE_EXCEPTION_LEDGER.md
@@ -1,0 +1,37 @@
+# Architecture exception ledger
+
+`.github/architecture-exceptions.json` is the machine-readable inventory of temporary dependency edges excluded from the strict ArchUnit cycle rule.
+
+Every entry requires:
+
+- a stable identifier;
+- exception kind;
+- exact origin and target package patterns;
+- accountable owner;
+- concrete rationale;
+- objectively testable removal condition;
+- expiry date.
+
+The test suite fails when:
+
+- the JSON is malformed or a required field is blank;
+- identifiers are duplicated;
+- an entry has expired;
+- the ledger and the exceptions compiled into `ArchitectureCycleBoundaryTest` differ;
+- a new cycle is introduced outside the documented package edges.
+
+A synthetic alpha/beta cycle is included in the test sources and must be rejected by ArchUnit. This protects the test itself against accidental weakening.
+
+## Exception review
+
+Before extending an exception:
+
+1. demonstrate the actual dependency path;
+2. explain why a port or shared contract cannot be extracted in the same change;
+3. assign an owner and a removal condition;
+4. use the shortest practical expiry;
+5. update both the ledger and the ArchUnit rule in one reviewed pull request.
+
+The shared DTO, model, and shared-infrastructure packages are structural contracts rather than bounded contexts. They are excluded separately and must not be used as a route for domain-service dependencies.
+
+The five additional edges recorded in the initial strict-rule adoption are narrower than a bounded context: one analysis use-case dependency, two Hibernate Search binder directions, and two HTTP-controller orchestration dependencies. The reverse service dependencies remain governed by the cycle rule.

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchitectureCycleBoundaryTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchitectureCycleBoundaryTest.java
@@ -1,0 +1,94 @@
+package com.taxonomy;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import java.util.Set;
+
+import static com.tngtech.archunit.base.DescribedPredicate.alwaysTrue;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+/**
+ * Enforces cycle freedom for core bounded contexts while allowing only the
+ * narrow, temporary edges recorded in .github/architecture-exceptions.json.
+ */
+@AnalyzeClasses(packages = "com.taxonomy", importOptions = ImportOption.DoNotIncludeTests.class)
+class ArchitectureCycleBoundaryTest {
+
+    static final Set<String> DOCUMENTED_EXCEPTION_IDS = Set.of(
+            "cycle-architecture-to-export",
+            "cycle-export-to-architecture",
+            "cycle-catalog-to-relations",
+            "cycle-relations-to-catalog",
+            "cycle-versioning-to-workspace",
+            "cycle-workspace-to-versioning",
+            "cycle-dsl-adapter-outbound",
+            "cycle-dsl-adapter-inbound",
+            "cycle-analysis-usecase-to-export-metadata",
+            "cycle-catalog-model-to-search-binder",
+            "cycle-search-binder-to-catalog-model",
+            "cycle-architecture-controller-to-versioning-state",
+            "cycle-catalog-controller-to-versioning-state"
+    );
+
+    private static final String[] STRUCTURAL_SHARED_PACKAGES = {
+            "com.taxonomy.dto..",
+            "com.taxonomy.model..",
+            "com.taxonomy.shared.."
+    };
+
+    private static final String[] DSL_ADAPTER_PACKAGES = {
+            "com.taxonomy.dsl.storage..",
+            "com.taxonomy.dsl.export.."
+    };
+
+    @ArchTest
+    static final ArchRule coreDomainSlicesShouldBeFreeOfUndocumentedCycles = slices()
+            .matching("com.taxonomy.(*)..")
+            .should().beFreeOfCycles()
+            // Structural contracts are intentionally shared and are not bounded contexts.
+            .ignoreDependency(resideInAnyPackage(STRUCTURAL_SHARED_PACKAGES), alwaysTrue())
+            .ignoreDependency(alwaysTrue(), resideInAnyPackage(STRUCTURAL_SHARED_PACKAGES))
+            // Known bidirectional edges, each represented in the checked ledger.
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.architecture.."),
+                    resideInAnyPackage("com.taxonomy.export.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.export.."),
+                    resideInAnyPackage("com.taxonomy.architecture.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.catalog.."),
+                    resideInAnyPackage("com.taxonomy.relations.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.relations.."),
+                    resideInAnyPackage("com.taxonomy.catalog.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.versioning.."),
+                    resideInAnyPackage("com.taxonomy.workspace.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.workspace.."),
+                    resideInAnyPackage("com.taxonomy.versioning.."))
+            // Precisely scoped pre-existing edges exposed by replacing the old no-op rule.
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.analysis.usecase.."),
+                    resideInAnyPackage("com.taxonomy.export.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.catalog.model.."),
+                    resideInAnyPackage("com.taxonomy.search.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.search.."),
+                    resideInAnyPackage("com.taxonomy.catalog.model.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.architecture.controller.."),
+                    resideInAnyPackage("com.taxonomy.versioning.service.."))
+            .ignoreDependency(
+                    resideInAnyPackage("com.taxonomy.catalog.controller.."),
+                    resideInAnyPackage("com.taxonomy.versioning.service.."))
+            // Spring/JGit DSL adapters still live below the otherwise pure DSL root.
+            .ignoreDependency(resideInAnyPackage(DSL_ADAPTER_PACKAGES), alwaysTrue())
+            .ignoreDependency(alwaysTrue(), resideInAnyPackage(DSL_ADAPTER_PACKAGES))
+            .because("new core-domain cycles require a reviewed, expiring ledger entry");
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchitectureCycleRuleRegressionTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchitectureCycleRuleRegressionTest.java
@@ -1,0 +1,25 @@
+package com.taxonomy;
+
+import com.taxonomy.architecturefixture.alpha.AlphaCycleFixture;
+import com.taxonomy.architecturefixture.beta.BetaCycleFixture;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ArchitectureCycleRuleRegressionTest {
+
+    @Test
+    void deliberatelyIntroducedUndocumentedCycleFails() {
+        var classes = new ClassFileImporter().importClasses(
+                AlphaCycleFixture.class, BetaCycleFixture.class);
+        var rule = slices()
+                .matching("com.taxonomy.architecturefixture.(*)..")
+                .should().beFreeOfCycles();
+
+        assertThatThrownBy(() -> rule.check(classes))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Cycle detected");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchitectureExceptionLedgerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchitectureExceptionLedgerTest.java
@@ -1,0 +1,70 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArchitectureExceptionLedgerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void checkedLedgerMatchesExactlyTheExceptionsUsedByArchUnit() throws Exception {
+        Path ledgerPath = findRepositoryRoot().resolve(".github/architecture-exceptions.json");
+        JsonNode root = objectMapper.readTree(Files.readString(ledgerPath));
+
+        assertThat(root.path("schemaVersion").asInt()).isEqualTo(1);
+        JsonNode exceptions = root.path("exceptions");
+        assertThat(exceptions.isArray()).isTrue();
+
+        Set<String> ids = new LinkedHashSet<>();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        for (JsonNode entry : exceptions) {
+            String id = requiredText(entry, "id");
+            assertThat(ids.add(id)).as("duplicate exception id %s", id).isTrue();
+            requiredText(entry, "kind");
+            requiredText(entry, "fromPackage");
+            requiredText(entry, "toPackage");
+            requiredText(entry, "owner");
+            requiredText(entry, "rationale");
+            requiredText(entry, "removalCondition");
+            LocalDate expiry = LocalDate.parse(requiredText(entry, "expiresOn"));
+            assertThat(expiry)
+                    .as("architecture exception %s must not be expired", id)
+                    .isAfterOrEqualTo(today);
+        }
+
+        assertThat(ids)
+                .as("ledger entries and hard-coded ArchUnit exceptions must match exactly")
+                .containsExactlyInAnyOrderElementsOf(
+                        ArchitectureCycleBoundaryTest.DOCUMENTED_EXCEPTION_IDS);
+    }
+
+    private static String requiredText(JsonNode entry, String field) {
+        String value = entry.path(field).asText();
+        assertThat(value)
+                .as("ledger field %s must be present and non-blank", field)
+                .isNotBlank();
+        return value;
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir")).toAbsolutePath();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve(".github/architecture-exceptions.json"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate repository root");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/architecturefixture/alpha/AlphaCycleFixture.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/architecturefixture/alpha/AlphaCycleFixture.java
@@ -1,0 +1,12 @@
+package com.taxonomy.architecturefixture.alpha;
+
+import com.taxonomy.architecturefixture.beta.BetaCycleFixture;
+
+/** Test-only fixture proving that the cycle rule rejects a new domain cycle. */
+public class AlphaCycleFixture {
+    private BetaCycleFixture beta;
+
+    public BetaCycleFixture getBeta() {
+        return beta;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/architecturefixture/beta/BetaCycleFixture.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/architecturefixture/beta/BetaCycleFixture.java
@@ -1,0 +1,12 @@
+package com.taxonomy.architecturefixture.beta;
+
+import com.taxonomy.architecturefixture.alpha.AlphaCycleFixture;
+
+/** Test-only fixture proving that the cycle rule rejects a new domain cycle. */
+public class BetaCycleFixture {
+    private AlphaCycleFixture alpha;
+
+    public AlphaCycleFixture getAlpha() {
+        return alpha;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #426 on the merged Security/CI basis.

- replaces the former nearly-vacuous cycle rule with top-level bounded-context slices;
- excludes only structural DTO/model/shared contracts and two known DSL adapter groups;
- records every tolerated directed edge with owner, rationale, removal condition, and expiry;
- represents the seven exposed legacy cycles through five narrowly scoped adoption edges rather than broad reverse-domain exemptions;
- rejects malformed, duplicate, expired, missing, or silently added ledger entries;
- includes a deliberately cyclic fixture proving that a new undocumented cycle fails;
- archives raw focused ArchUnit reports.

### Verified gates

- QA Architecture Evidence — success
- CodeQL Source Analysis — success
- Security Scan and immutable pin gate — success
- CI / CD and reactor coverage — success
- Core Integration — success
- Documentation Links — success

Closes #426.