### PR TITLE
QA: expand UI and accessibility across roles and dynamic states

### DIFF
--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -1,0 +1,272 @@
+import { chromium, firefox, webkit, request } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
+const adminUsername = process.env.TAXONOMY_UI_ADMIN_USERNAME || 'admin';
+const adminPassword = process.env.TAXONOMY_UI_ADMIN_PASSWORD || 'ui-state-admin-password';
+const profileId = process.env.TAXONOMY_UI_PROFILE || 'desktop-user-chromium';
+const browserName = process.env.TAXONOMY_BROWSER || 'chromium';
+const role = process.env.TAXONOMY_ROLE || 'USER';
+const physicalWidth = Number.parseInt(process.env.TAXONOMY_VIEWPORT_WIDTH || '1440', 10);
+const physicalHeight = Number.parseInt(process.env.TAXONOMY_VIEWPORT_HEIGHT || '1000', 10);
+const zoom = Number.parseFloat(process.env.TAXONOMY_ZOOM || '1');
+const forcedColors = process.env.TAXONOMY_FORCED_COLORS === 'true';
+const outputDir = process.env.TAXONOMY_UI_OUTPUT_DIR || `/tmp/taxonomy-ui-state-${profileId}`;
+const matrixPath = process.env.TAXONOMY_UI_MATRIX || '.github/ui-acceptance-matrix.json';
+
+const browserType = { chromium, firefox, webkit }[browserName];
+if (!browserType) throw new Error(`Unsupported browser: ${browserName}`);
+if (!['USER', 'ARCHITECT', 'ADMIN'].includes(role)) throw new Error(`Unsupported role: ${role}`);
+if (!Number.isFinite(zoom) || zoom < 1) throw new Error(`Invalid zoom factor: ${zoom}`);
+
+const matrix = JSON.parse(await readFile(matrixPath, 'utf8'));
+if (matrix.schemaVersion !== 1) throw new Error(`Unsupported UI matrix schema: ${matrix.schemaVersion}`);
+const declaredProfile = matrix.profiles.find(profile => profile.id === profileId);
+if (!declaredProfile) throw new Error(`Profile ${profileId} is missing from ${matrixPath}`);
+if (declaredProfile.browser !== browserName || declaredProfile.role !== role
+    || declaredProfile.zoom !== zoom || Boolean(declaredProfile.forcedColors) !== forcedColors) {
+  throw new Error(`Workflow/profile drift for ${profileId}`);
+}
+
+const effectiveViewport = {
+  width: Math.max(320, Math.floor(physicalWidth / zoom)),
+  height: Math.max(240, Math.floor(physicalHeight / zoom))
+};
+const credentials = {
+  USER: { username: 'qa-ui-user', password: 'qa-ui-user-password-2026', roles: ['USER'] },
+  ARCHITECT: {
+    username: 'qa-ui-architect', password: 'qa-ui-architect-password-2026',
+    roles: ['USER', 'ARCHITECT']
+  },
+  ADMIN: { username: adminUsername, password: adminPassword, roles: ['USER', 'ARCHITECT', 'ADMIN'] }
+};
+const account = credentials[role];
+const checks = [];
+const findings = [];
+const consoleErrors = [];
+const externalRequests = [];
+let auditError = null;
+
+function passed(name) {
+  checks.push(name);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function ensureRoleAccounts() {
+  const api = await request.newContext({
+    baseURL: baseUrl,
+    httpCredentials: { username: adminUsername, password: adminPassword }
+  });
+  try {
+    for (const value of [credentials.USER, credentials.ARCHITECT]) {
+      const response = await api.post('/api/admin/users', {
+        data: {
+          username: value.username,
+          password: value.password,
+          displayName: `QA ${value.roles.at(-1)}`,
+          email: `${value.username}@example.invalid`,
+          roles: value.roles
+        }
+      });
+      if (![200, 201, 409].includes(response.status())) {
+        throw new Error(`Unable to provision ${value.username}: ${response.status()} ${await response.text()}`);
+      }
+    }
+  } finally {
+    await api.dispose();
+  }
+}
+
+async function saveState(page, state) {
+  const prefix = path.join(outputDir, state);
+  await page.screenshot({ path: `${prefix}.png`, fullPage: true });
+  await writeFile(`${prefix}.html`, await page.content(), 'utf8');
+  const body = page.locator('body');
+  const aria = typeof body.ariaSnapshot === 'function'
+    ? await body.ariaSnapshot().catch(error => `ARIA snapshot unavailable: ${error}`)
+    : 'ARIA snapshot API unavailable';
+  await writeFile(`${prefix}.aria.txt`, `${aria}\n`, 'utf8');
+}
+
+async function runAxe(page, state) {
+  const result = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  const blocking = result.violations.filter(violation =>
+    ['critical', 'serious', 'moderate'].includes(violation.impact));
+  findings.push({ state, violations: result.violations, blocking });
+  if (blocking.length) {
+    const summary = blocking.map(item => `${item.impact}:${item.id}`).join(', ');
+    throw new Error(`Blocking axe findings in ${state}: ${summary}`);
+  }
+  passed(`axe ${state}`);
+}
+
+async function csrfPost(page, endpoint, body) {
+  return page.evaluate(async ({ endpoint, body }) => {
+    const token = document.querySelector('meta[name="_csrf"]')?.content;
+    const header = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+    const headers = { 'Content-Type': 'application/json' };
+    if (token) headers[header] = token;
+    const response = await fetch(endpoint, {
+      method: 'POST', headers, body: JSON.stringify(body)
+    });
+    const text = await response.text();
+    let json = null;
+    try { json = text ? JSON.parse(text) : null; } catch { /* stable status remains authoritative */ }
+    return { status: response.status, json, text };
+  }, { endpoint, body });
+}
+
+await mkdir(outputDir, { recursive: true });
+await ensureRoleAccounts();
+
+const browser = await browserType.launch({ headless: true });
+const context = await browser.newContext({
+  viewport: effectiveViewport,
+  reducedMotion: 'reduce',
+  forcedColors: forcedColors ? 'active' : 'none'
+});
+const page = await context.newPage();
+const baseOrigin = new URL(baseUrl).origin;
+page.on('request', requestEvent => {
+  const url = requestEvent.url();
+  if (url.startsWith('data:') || url.startsWith('blob:')) return;
+  if (new URL(url).origin !== baseOrigin) externalRequests.push(url);
+});
+page.on('console', message => {
+  if (message.type() === 'error') consoleErrors.push(message.text());
+});
+page.on('pageerror', error => consoleErrors.push(error.message));
+
+try {
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'networkidle' });
+  await page.locator('input[name="username"]').fill(account.username);
+  await page.locator('input[name="password"]').fill(account.password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.endsWith('/login'), { timeout: 30_000 }),
+    page.keyboard.press('Enter')
+  ]);
+  await page.locator('#mainContent').waitFor({ state: 'visible', timeout: 60_000 });
+  const onboardingDismiss = page.locator('#onboardingDismiss');
+  if (await onboardingDismiss.isVisible().catch(() => false)) {
+    await onboardingDismiss.focus();
+    await page.keyboard.press('Enter');
+  }
+  passed('keyboard authentication');
+
+  const adminTab = page.locator('#adminNavTab');
+  const adminVisible = await adminTab.isVisible().catch(() => false);
+  assert(role === 'ADMIN' ? adminVisible : !adminVisible,
+    `${role} admin navigation visibility is incorrect`);
+  passed('role-specific navigation');
+
+  await page.locator('#mainNavTabs [data-page="analyze"]').click();
+  await page.locator('#businessText').fill(
+    'Provide resilient hospital communications with traceable architecture decisions.');
+  await page.locator('#analyzeBtn').focus();
+  await page.keyboard.press('Enter');
+  await page.locator('#statusArea').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForFunction(() => {
+    const text = document.querySelector('#statusArea')?.textContent?.toLowerCase() || '';
+    return text.includes('complete') || text.includes('completed');
+  }, null, { timeout: 120_000 });
+  assert(await page.locator('.tax-pct').count() > 0, 'Analysis produced no scored nodes');
+  passed('analysis loading and success');
+  await runAxe(page, 'analysis-success');
+  await saveState(page, 'analysis-success');
+
+  await page.locator('#businessText').fill(
+    'Provide resilient hospital communications with an emergency notification capability.');
+  await page.locator('#businessText.stale-results').waitFor({ state: 'visible', timeout: 10_000 });
+  passed('stale-result indication');
+
+  await page.route('**/api/analyze', async route => {
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'QA_PROVIDER_UNAVAILABLE', message: 'Deterministic QA failure' })
+    });
+  }, { times: 1 });
+  await page.locator('#analyzeBtn').click();
+  await page.waitForFunction(() => {
+    const text = document.querySelector('#statusArea')?.textContent?.toLowerCase() || '';
+    return text.includes('error') || text.includes('failed') || text.includes('503')
+      || text.includes('unavailable');
+  }, null, { timeout: 30_000 });
+  passed('analysis provider error state');
+  await runAxe(page, 'analysis-error');
+  await saveState(page, 'analysis-error');
+
+  const proposal = await csrfPost(page, '/api/proposals/from-hypothesis', {
+    sourceCode: 'BP', targetCode: 'BR', relationType: 'RELATED_TO',
+    confidence: 0.72, rationale: 'Role acceptance test'
+  });
+  if (role === 'USER') {
+    assert(proposal.status === 403, `USER proposal mutation returned ${proposal.status}, expected 403`);
+    passed('user proposal mutation forbidden');
+  } else {
+    assert([200, 409].includes(proposal.status),
+      `${role} proposal creation returned ${proposal.status}`);
+    if (proposal.status === 200 && proposal.json?.id) {
+      const accepted = await csrfPost(page, `/api/proposals/${proposal.json.id}/accept`, {});
+      assert(accepted.status === 200, `Proposal acceptance returned ${accepted.status}`);
+    }
+    passed('architectural proposal review');
+  }
+  await runAxe(page, 'role-operation-feedback');
+  await saveState(page, 'role-operation-feedback');
+
+  const businessText = page.locator('#businessText');
+  await businessText.focus();
+  await page.evaluate(() => window.TaxonomyUtils.showMessage('Accessible QA dialog', 'QA notice'));
+  const dialog = page.locator('#taxonomyAccessibleDialog');
+  await dialog.waitFor({ state: 'visible' });
+  assert(await page.evaluate(() => document.activeElement?.id === 'taxonomyAccessibleDialogConfirm'),
+    'Dialog did not move focus to its confirmation control');
+  await runAxe(page, 'dialog-open');
+  await saveState(page, 'dialog-open');
+  await page.keyboard.press('Enter');
+  await dialog.waitFor({ state: 'hidden' });
+  assert(await page.evaluate(() => document.activeElement?.id === 'businessText'),
+    'Dialog did not restore focus to its invoker');
+  passed('dialog focus entry and restoration');
+
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    forcedColors: matchMedia('(forced-colors: active)').matches,
+    reducedMotion: matchMedia('(prefers-reduced-motion: reduce)').matches
+  }));
+  assert(overflow.scrollWidth <= overflow.clientWidth + 2,
+    `Viewport reflow failed at ${zoom}x: ${overflow.scrollWidth} > ${overflow.clientWidth}`);
+  assert(overflow.reducedMotion, 'Reduced motion preference was not active');
+  assert(forcedColors ? overflow.forcedColors : true, 'Forced-colors profile was not active');
+  passed(`reflow at ${zoom}x`);
+  if (forcedColors) passed('forced-colors media state');
+
+  assert(externalRequests.length === 0,
+    `External browser requests detected: ${externalRequests.join(', ')}`);
+  assert(consoleErrors.length === 0,
+    `Browser console errors: ${consoleErrors.join(' | ')}`);
+  passed('local assets and clean console');
+} catch (error) {
+  auditError = error?.stack || String(error);
+  process.exitCode = 1;
+} finally {
+  await writeFile(path.join(outputDir, 'report.json'), JSON.stringify({
+    profileId, browserName, role, physicalViewport: { width: physicalWidth, height: physicalHeight },
+    effectiveViewport, zoom, forcedColors, checks, findings,
+    externalRequests, consoleErrors, auditError
+  }, null, 2) + '\n', 'utf8');
+  await context.close();
+  await browser.close();
+}
+
+if (auditError) throw new Error(auditError);
+console.log(`UI role/state acceptance passed for ${profileId}: ${checks.join(', ')}`);

--- a/.github/ui-acceptance-matrix.json
+++ b/.github/ui-acceptance-matrix.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "roles": ["USER", "ARCHITECT", "ADMIN"],
+  "workflows": [
+    {
+      "id": "authentication-and-navigation",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["success", "keyboard-only", "role-specific-surface"]
+    },
+    {
+      "id": "requirement-analysis",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["loading", "success", "stale", "provider-error"]
+    },
+    {
+      "id": "proposal-review",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["forbidden", "created", "accepted-or-rejected"]
+    },
+    {
+      "id": "accessible-dialog",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["opened", "focus-contained", "closed", "focus-restored"]
+    },
+    {
+      "id": "responsive-reflow",
+      "roles": ["USER", "ARCHITECT", "ADMIN"],
+      "states": ["mobile", "zoom-200", "zoom-400", "forced-colors"]
+    }
+  ],
+  "profiles": [
+    {"id": "desktop-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 1, "forcedColors": false},
+    {"id": "desktop-architect-firefox", "browser": "firefox", "role": "ARCHITECT", "width": 1440, "height": 1000, "zoom": 1, "forcedColors": false},
+    {"id": "mobile-admin-webkit", "browser": "webkit", "role": "ADMIN", "width": 390, "height": 844, "zoom": 1, "forcedColors": false},
+    {"id": "zoom-200-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 2, "forcedColors": false},
+    {"id": "zoom-400-user-chromium", "browser": "chromium", "role": "USER", "width": 1440, "height": 1000, "zoom": 4, "forcedColors": false},
+    {"id": "forced-colors-architect-chromium", "browser": "chromium", "role": "ARCHITECT", "width": 1024, "height": 768, "zoom": 1, "forcedColors": true}
+  ]
+}

--- a/.github/workflows/ui-role-state-acceptance.yml
+++ b/.github/workflows/ui-role-state-acceptance.yml
@@ -1,0 +1,142 @@
+name: UI Role and State Acceptance
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'taxonomy-app/src/main/**'
+      - 'taxonomy-app/src/test/**'
+      - '.github/ui-acceptance-matrix.json'
+      - '.github/scripts/ui-role-state-acceptance.mjs'
+      - '.github/workflows/ui-role-state-acceptance.yml'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  role-state-flow:
+    name: ${{ matrix.profile }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: desktop-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 1
+            forced_colors: false
+          - profile: desktop-architect-firefox
+            browser: firefox
+            role: ARCHITECT
+            width: 1440
+            height: 1000
+            zoom: 1
+            forced_colors: false
+          - profile: mobile-admin-webkit
+            browser: webkit
+            role: ADMIN
+            width: 390
+            height: 844
+            zoom: 1
+            forced_colors: false
+          - profile: zoom-200-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 2
+            forced_colors: false
+          - profile: zoom-400-user-chromium
+            browser: chromium
+            role: USER
+            width: 1440
+            height: 1000
+            zoom: 4
+            forced_colors: false
+          - profile: forced-colors-architect-chromium
+            browser: chromium
+            role: ARCHITECT
+            width: 1024
+            height: 768
+            zoom: 1
+            forced_colors: true
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 21
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
+      - name: Build application
+        run: mvn -q -pl taxonomy-app -am package -DskipTests
+
+      - name: Start deterministic application
+        env:
+          TAXONOMY_ADMIN_PASSWORD: ui-state-admin-password
+          TAXONOMY_REQUIRE_PASSWORD_CHANGE: 'false'
+          TAXONOMY_EMBEDDING_ENABLED: 'false'
+          TAXONOMY_INIT_ASYNC: 'true'
+          TAXONOMY_THYMELEAF_CACHE: 'false'
+          LLM_MOCK: 'true'
+        run: |
+          JAR=$(find taxonomy-app/target -maxdepth 1 -name 'taxonomy-app-*.jar' ! -name 'original-*' | head -n 1)
+          test -n "$JAR"
+          java -jar "$JAR" > /tmp/taxonomy-ui-state.log 2>&1 &
+          echo $! > /tmp/taxonomy-ui-state.pid
+          for i in $(seq 1 90); do
+            if curl -fsS http://127.0.0.1:8080/login >/dev/null; then exit 0; fi
+            sleep 2
+          done
+          cat /tmp/taxonomy-ui-state.log
+          exit 1
+
+      - name: Install pinned browser tools
+        run: |
+          npm install --no-save --no-audit --no-fund \
+            @playwright/test@1.61.1 \
+            @axe-core/playwright@4.12.1
+          npx playwright install --with-deps "${{ matrix.browser }}"
+
+      - name: Run role and state acceptance
+        env:
+          TAXONOMY_BASE_URL: http://127.0.0.1:8080
+          TAXONOMY_UI_ADMIN_USERNAME: admin
+          TAXONOMY_UI_ADMIN_PASSWORD: ui-state-admin-password
+          TAXONOMY_UI_PROFILE: ${{ matrix.profile }}
+          TAXONOMY_BROWSER: ${{ matrix.browser }}
+          TAXONOMY_ROLE: ${{ matrix.role }}
+          TAXONOMY_VIEWPORT_WIDTH: ${{ matrix.width }}
+          TAXONOMY_VIEWPORT_HEIGHT: ${{ matrix.height }}
+          TAXONOMY_ZOOM: ${{ matrix.zoom }}
+          TAXONOMY_FORCED_COLORS: ${{ matrix.forced_colors }}
+          TAXONOMY_UI_OUTPUT_DIR: /tmp/taxonomy-ui-state-${{ matrix.profile }}
+        run: node .github/scripts/ui-role-state-acceptance.mjs
+
+      - name: Upload per-state evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ui-state-${{ matrix.profile }}
+          path: |
+            /tmp/taxonomy-ui-state-${{ matrix.profile }}/**
+            /tmp/taxonomy-ui-state.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/dev/UI_ACCEPTANCE_MATRIX.md
+++ b/docs/dev/UI_ACCEPTANCE_MATRIX.md
@@ -1,0 +1,46 @@
+# UI, role, state, and accessibility acceptance matrix
+
+The checked matrix lives in `.github/ui-acceptance-matrix.json`. The workflow and browser script reject profile drift rather than silently running an undeclared combination.
+
+## Roles
+
+- **USER** — read, analyse, search, and export; architecture mutations must return 403 and mutation controls must not imply availability.
+- **ARCHITECT** — architecture and proposal mutations are available; administrator navigation remains hidden.
+- **ADMIN** — administrator navigation and all architecture workflows are available.
+
+Each run provisions deterministic local USER and ARCHITECT accounts through the real admin API. Browser authentication remains form-based and keyboard-only; API setup uses explicit HTTP Basic credentials, preserving CSRF protection for browser sessions.
+
+## Dynamic states
+
+The browser test captures DOM, screenshot, ARIA snapshot, and axe evidence after:
+
+1. successful scored analysis;
+2. stale results after requirement editing;
+3. deterministic provider failure;
+4. role-appropriate proposal mutation feedback;
+5. an open application dialog with focus inside it;
+6. dialog close and focus restoration.
+
+Critical, serious, and moderate axe findings fail the run. Browser console errors and any external browser request also fail.
+
+## Browser and visual profiles
+
+- desktop Chromium / USER;
+- desktop Firefox / ARCHITECT;
+- mobile WebKit / ADMIN;
+- Chromium reflow equivalent to 200% zoom;
+- Chromium reflow equivalent to 400% zoom;
+- Chromium Forced Colors / ARCHITECT.
+
+Browser zoom reduces the CSS layout viewport. The tests use the equivalent effective viewport and assert that document-level horizontal scrolling is not introduced. Reduced Motion is active in every profile.
+
+## Evidence retention
+
+Every state produces:
+
+- full-page PNG;
+- serialized DOM HTML;
+- ARIA snapshot when supported by Playwright;
+- one machine-readable report containing checks, axe findings, viewport data, console errors, external requests, and any failure stack.
+
+Artifacts are retained for 30 days to make UI regressions reviewable rather than relying only on a green check name. The workflow itself uses immutable GitHub Action references and is covered by the repository supply-chain gate.

--- a/docs/dev/UI_ACCEPTANCE_MATRIX.md
+++ b/docs/dev/UI_ACCEPTANCE_MATRIX.md
@@ -43,4 +43,4 @@ Every state produces:
 - ARIA snapshot when supported by Playwright;
 - one machine-readable report containing checks, axe findings, viewport data, console errors, external requests, and any failure stack.
 
-Artifacts are retained for 30 days to make UI regressions reviewable rather than relying only on a green check name. The workflow itself uses immutable GitHub Action references and is covered by the repository supply-chain gate.
+Artifacts are retained for 30 days to make UI regressions reviewable rather than relying only on a green check name. The workflow itself uses immutable GitHub Action references and is covered by the repository supply-chain gate. Normal CI additionally verifies reactor-wide coverage, CodeQL, Trivy, database/container compatibility, and the strict bounded-context architecture gate.


### PR DESCRIPTION
## Summary

Clean implementation of #429 on the current `main`.

### Checked acceptance matrix

- USER, ARCHITECT, and ADMIN;
- keyboard authentication and role-specific navigation;
- analysis loading, success, stale, and deterministic provider-error states;
- proposal mutation denial for USER and review actions for ARCHITECT/ADMIN;
- accessible dialog focus entry, close, and focus restoration;
- mobile layout, WebKit, Firefox, Chromium, Reduced Motion, Forced Colors, and 200%/400% reflow equivalents.

### Dynamic accessibility evidence

The runner executes axe after populated, error, role-feedback, and dialog states rather than only after top-level navigation. Critical, serious, and moderate findings fail. Browser console errors, external requests, and horizontal reflow also fail.

Every state archives a full-page screenshot, serialized DOM, ARIA snapshot where supported, and a machine-readable report. All workflow actions are commit-SHA pinned and covered by the repository supply-chain gate.

Opened as draft until all six browser/profile jobs and normal CI, Security, CodeQL, documentation, and frontend checks pass.

Addresses #429.