### PR TITLE
Import: make ArchiMate materialization atomic and workspace-scoped

### DIFF
--- a/.github/workflows/archimate-import-evidence.yml
+++ b/.github/workflows/archimate-import-evidence.yml
@@ -1,0 +1,51 @@
+name: QA ArchiMate Import Evidence
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'taxonomy-domain/src/main/java/com/taxonomy/dto/ArchiMateImportResult.java'
+      - 'taxonomy-app/src/main/java/com/taxonomy/catalog/**/ArchiMate*'
+      - 'taxonomy-app/src/main/java/com/taxonomy/catalog/service/CatalogFacade.java'
+      - 'taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java'
+      - 'taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java'
+      - 'taxonomy-app/src/test/java/com/taxonomy/catalog/service/CatalogFacadeTest.java'
+      - '.github/workflows/archimate-import-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  focused-archimate-import:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - name: Install reactor dependencies
+        run: mvn -B -q -pl taxonomy-app -am install -DskipTests
+      - name: Run focused import tests
+        id: tests
+        continue-on-error: true
+        run: >-
+          mvn -B -pl taxonomy-app test
+          -Dtest=ArchiMateWorkspaceImportTests,CatalogFacadeTest
+          -DfailIfNoTests=false
+      - name: Upload raw reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: qa-archimate-import-reports
+          path: taxonomy-app/target/surefire-reports/**
+          if-no-files-found: error
+          retention-days: 14
+      - name: Propagate focused result
+        if: steps.tests.outcome != 'success'
+        run: exit 1

--- a/docs/dev/ARCHIMATE_IMPORT_SAFETY.md
+++ b/docs/dev/ARCHIMATE_IMPORT_SAFETY.md
@@ -38,4 +38,4 @@ DTD support and external entity resolution are disabled on the StAX factory. Mal
 
 ## Verification
 
-Focused tests cover preview non-mutation, two-workspace isolation, same-workspace duplicate handling, malformed XML, endpoint 422 behavior, XXE rejection, and explicit facade context. Full CI additionally runs reactor coverage, CodeQL, Trivy, immutable supply-chain validation, database compatibility, container restart, UI, accessibility, frontend architecture, and documentation checks.
+Focused tests cover preview non-mutation, two-workspace isolation, same-workspace duplicate handling, malformed XML, endpoint 422 behavior, XXE rejection, and explicit facade context. Full CI additionally runs reactor coverage, CodeQL, Trivy, immutable supply-chain validation, database compatibility, container restart, UI, accessibility, frontend architecture, documentation checks, and the strict bounded-context architecture gate.

--- a/docs/dev/ARCHIMATE_IMPORT_SAFETY.md
+++ b/docs/dev/ARCHIMATE_IMPORT_SAFETY.md
@@ -1,0 +1,41 @@
+# ArchiMate import safety and workspace contract
+
+ArchiMate 3.x Model Exchange XML is parsed and matched before any relation is materialized. The HTTP boundary resolves one explicit `WorkspaceContext`, and the importer receives that context as an argument rather than consulting global state.
+
+## Endpoints
+
+- `POST /api/import/preview/archimate` — available to authenticated users; parses, matches, and evaluates visible duplicates without writing.
+- `POST /api/import/archimate` — restricted to ARCHITECT or ADMIN; atomically creates eligible relations in the exact active workspace.
+
+## Transaction contract
+
+The materializing import is one Spring transaction. Relations are created through `TaxonomyRelationService`, not by direct repository writes. Unexpected persistence failures are wrapped in `ArchiMateImportException` and escape the transactional boundary, rolling back all relations created by that request.
+
+A concurrent equivalent relation is treated as a duplicate only when it is visible after the failed insert. Other failures are not converted into a partial-success response.
+
+## Workspace visibility
+
+A personal workspace sees its own relations plus the shared baseline. Therefore an equivalent shared relation is reported as a duplicate and is not copied into the personal workspace. Equivalent relations may still exist independently in two distinct personal workspaces.
+
+A null workspace means shared scope only; it never means an unrestricted query across all users.
+
+## Preview and counters
+
+The result distinguishes:
+
+- parsed elements and relationships;
+- matched and unmatched elements;
+- created relations;
+- visible duplicates skipped;
+- relationships rejected because one or both endpoints were unmatched;
+- preview versus materializing mode.
+
+Preview executes the same parsing, matching, relation mapping, and duplicate policy as import but performs no mutation.
+
+## XML security
+
+DTD support and external entity resolution are disabled on the StAX factory. Malformed XML, DTD declarations, and unresolved entity input produce HTTP `422` with error code `INVALID_ARCHIMATE_XML`. Internal stack traces and parser implementation details are not returned.
+
+## Verification
+
+Focused tests cover preview non-mutation, two-workspace isolation, same-workspace duplicate handling, malformed XML, endpoint 422 behavior, XXE rejection, and explicit facade context. Full CI additionally runs reactor coverage, CodeQL, Trivy, immutable supply-chain validation, database compatibility, container restart, UI, accessibility, frontend architecture, and documentation checks.

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/controller/ArchiMateImportController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/controller/ArchiMateImportController.java
@@ -1,24 +1,25 @@
 package com.taxonomy.catalog.controller;
 
-import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.catalog.service.ArchiMateImportException;
 import com.taxonomy.catalog.service.ArchiMateXmlImporter;
+import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-/**
- * REST API for ArchiMate XML import.
- *
- * <p>Endpoints:
- * <ul>
- *   <li>{@code POST /api/import/archimate} — Import ArchiMate XML file</li>
- * </ul>
- */
+import java.util.Map;
+
+/** REST API for previewing and importing ArchiMate 3.x XML models. */
 @RestController
 @RequestMapping("/api/import")
 @Tag(name = "ArchiMate Import")
@@ -27,30 +28,55 @@ public class ArchiMateImportController {
     private static final Logger log = LoggerFactory.getLogger(ArchiMateImportController.class);
 
     private final ArchiMateXmlImporter importer;
+    private final WorkspaceContextResolver contextResolver;
 
-    public ArchiMateImportController(ArchiMateXmlImporter importer) {
+    public ArchiMateImportController(ArchiMateXmlImporter importer,
+                                     WorkspaceContextResolver contextResolver) {
         this.importer = importer;
+        this.contextResolver = contextResolver;
     }
 
-    /**
-     * Imports an ArchiMate 3.x Model Exchange Format XML file.
-     */
+    @Operation(summary = "Preview ArchiMate XML import",
+            description = "Parses, matches, and checks duplicates for the active workspace without writing relations")
+    @PostMapping(value = "/preview/archimate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> previewArchiMate(@RequestParam("file") MultipartFile file) {
+        return process(file, true);
+    }
+
     @Operation(summary = "Import ArchiMate XML",
-               description = "Parses an ArchiMate 3.x XML file and creates taxonomy relations from matched elements")
+            description = "Atomically creates matched taxonomy relations in the active workspace")
     @PostMapping(value = "/archimate", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ArchiMateImportResult> importArchiMate(
-            @RequestParam("file") MultipartFile file) {
+    public ResponseEntity<?> importArchiMate(@RequestParam("file") MultipartFile file) {
+        return process(file, false);
+    }
+
+    private ResponseEntity<?> process(MultipartFile file, boolean preview) {
         if (file.isEmpty()) {
-            return ResponseEntity.badRequest().build();
+            return ResponseEntity.badRequest().body(Map.of(
+                    "error", "EMPTY_FILE",
+                    "message", "The uploaded ArchiMate XML file is empty"));
         }
+
+        WorkspaceContext context = contextResolver.resolveCurrentContext();
         try {
-            ArchiMateImportResult result = importer.importXml(file.getInputStream());
+            ArchiMateImportResult result = preview
+                    ? importer.previewXml(file.getInputStream(), context)
+                    : importer.importXml(file.getInputStream(), context);
             return ResponseEntity.ok(result);
-        } catch (Exception e) {
-            log.error("ArchiMate import failed for file: {}", file.getOriginalFilename(), e);
-            ArchiMateImportResult error = new ArchiMateImportResult();
-            error.getNotes().add("Import failed: unable to process the uploaded file");
-            return ResponseEntity.badRequest().body(error);
+        } catch (ArchiMateImportException error) {
+            log.warn("ArchiMate {} rejected for file '{}' in workspace '{}': {}",
+                    preview ? "preview" : "import", file.getOriginalFilename(),
+                    context.workspaceId(), error.getMessage());
+            return ResponseEntity.status(422).body(Map.of(
+                    "error", "INVALID_ARCHIMATE_XML",
+                    "message", error.getMessage()));
+        } catch (Exception error) {
+            log.error("ArchiMate {} failed for file '{}' in workspace '{}'",
+                    preview ? "preview" : "import", file.getOriginalFilename(),
+                    context.workspaceId(), error);
+            return ResponseEntity.internalServerError().body(Map.of(
+                    "error", "ARCHIMATE_IMPORT_FAILED",
+                    "message", "The ArchiMate model could not be processed"));
         }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateImportException.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateImportException.java
@@ -1,0 +1,20 @@
+package com.taxonomy.catalog.service;
+
+/**
+ * Stable failure type for ArchiMate parsing or materialization errors.
+ *
+ * <p>Throwing a runtime exception from the transactional importer guarantees
+ * that partially created relations are rolled back. Controllers can map this
+ * exception to a deterministic non-2xx response without exposing stack traces
+ * or provider-specific parser messages.</p>
+ */
+public class ArchiMateImportException extends RuntimeException {
+
+    public ArchiMateImportException(String message) {
+        super(message);
+    }
+
+    public ArchiMateImportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateXmlImporter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/ArchiMateXmlImporter.java
@@ -1,12 +1,11 @@
 package com.taxonomy.catalog.service;
 
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.dto.ArchiMateImportResult;
 import com.taxonomy.dsl.mapping.profiles.ArchiMateMappingProfile;
 import com.taxonomy.model.RelationType;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.catalog.model.TaxonomyRelation;
-import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.workspace.service.WorkspaceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -14,120 +13,197 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
-import java.util.*;
-import com.taxonomy.export.ArchiMateDiagramService;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Imports an ArchiMate 3.x Model Exchange Format XML file and maps its
- * elements and relationships to taxonomy nodes and relations.
+ * Parses ArchiMate 3.x Model Exchange XML and materializes matched relations in
+ * an explicit workspace.
  *
- * <p>The importer performs the following steps:
- * <ol>
- *   <li>Parse elements from the XML and extract id, type, and label.</li>
- *   <li>Parse relationships from the XML and extract source, target, and type.</li>
- *   <li>Map each ArchiMate element type to a taxonomy root code using the
- *       reverse of {@link ArchiMateDiagramService#toArchiMateType(String)}.</li>
- *   <li>Match elements to existing taxonomy nodes by name similarity.</li>
- *   <li>Create new relations for matched elements.</li>
- * </ol>
+ * <p>Parsing/matching and persistence are deliberately separated. Preview uses
+ * the same parser and duplicate policy but performs no writes. Import runs in a
+ * single transaction; a fatal materialization error therefore rolls back every
+ * relation created by that request.</p>
  */
 @Service
 public class ArchiMateXmlImporter {
 
     private static final Logger log = LoggerFactory.getLogger(ArchiMateXmlImporter.class);
-
-    private final TaxonomyNodeRepository nodeRepository;
-    private final TaxonomyRelationRepository relationRepository;
-
-    /** Shared mapping profile for ArchiMate types. */
     private static final ArchiMateMappingProfile PROFILE = new ArchiMateMappingProfile();
 
+    private final TaxonomyNodeRepository nodeRepository;
+    private final TaxonomyRelationService relationService;
+
     public ArchiMateXmlImporter(TaxonomyNodeRepository nodeRepository,
-                                 TaxonomyRelationRepository relationRepository) {
+                                TaxonomyRelationService relationService) {
         this.nodeRepository = nodeRepository;
-        this.relationRepository = relationRepository;
+        this.relationService = relationService;
+    }
+
+    /** Parses and validates the model without mutating architecture state. */
+    @Transactional(readOnly = true)
+    public ArchiMateImportResult previewXml(InputStream inputStream, WorkspaceContext context) {
+        return execute(inputStream, requireContext(context), false);
     }
 
     /**
-     * Imports an ArchiMate XML file and creates taxonomy relations.
-     *
-     * @param inputStream the XML input stream
-     * @return the import result with statistics
+     * Parses, validates, and atomically creates relations in the exact active
+     * workspace. Shared baseline relations are visible to personal workspaces
+     * and therefore count as duplicates rather than being copied locally.
      */
     @Transactional
+    public ArchiMateImportResult importXml(InputStream inputStream, WorkspaceContext context) {
+        return execute(inputStream, requireContext(context), true);
+    }
+
+    /** Backward-compatible shared-scope overload for non-request callers. */
+    @Transactional
     public ArchiMateImportResult importXml(InputStream inputStream) {
-        ArchiMateImportResult result = new ArchiMateImportResult();
+        return importXml(inputStream, WorkspaceContext.SHARED);
+    }
+
+    private ArchiMateImportResult execute(InputStream inputStream,
+                                          WorkspaceContext context,
+                                          boolean materialize) {
+        ParsedModel model = parseModel(inputStream);
         List<String> notes = new ArrayList<>();
+        notes.add("Parsed " + model.elements().size() + " elements and "
+                + model.relationships().size() + " relationships from XML");
 
-        try {
-            // Parse XML
-            Map<String, ParsedElement> elements = new LinkedHashMap<>();
-            List<ParsedRelationship> relationships = new ArrayList<>();
-            parseXml(inputStream, elements, relationships);
+        Map<String, TaxonomyNode> matchedNodes = matchElements(model.elements(), notes);
 
-            notes.add("Parsed " + elements.size() + " elements and " + relationships.size() + " relationships from XML");
+        ArchiMateImportResult result = new ArchiMateImportResult();
+        result.setPreview(!materialize);
+        result.setElementsImported(model.elements().size());
+        result.setElementsMatched(matchedNodes.size());
+        result.setElementsUnmatched(model.elements().size() - matchedNodes.size());
+        result.setRelationsParsed(model.relationships().size());
 
-            // Match elements to taxonomy nodes
-            Map<String, TaxonomyNode> matchedNodes = matchElements(elements, notes);
-            result.setElementsMatched(matchedNodes.size());
-            result.setElementsUnmatched(elements.size() - matchedNodes.size());
-            result.setElementsImported(elements.size());
+        int created = 0;
+        int skipped = 0;
+        int rejected = 0;
 
-            // Create relations for matched element pairs
-            int relationsCreated = createRelations(relationships, elements, matchedNodes, notes);
-            result.setRelationsImported(relationsCreated);
+        for (ParsedRelationship relation : model.relationships()) {
+            TaxonomyNode sourceNode = matchedNodes.get(relation.sourceId());
+            TaxonomyNode targetNode = matchedNodes.get(relation.targetId());
+            if (sourceNode == null || targetNode == null) {
+                rejected++;
+                continue;
+            }
 
-        } catch (Exception e) {
-            log.error("ArchiMate import failed", e);
-            notes.add("Import error: " + e.getMessage());
+            String mappedType = PROFILE.mapRelationType(relation.type());
+            RelationType relationType = mappedType != null
+                    ? RelationType.valueOf(mappedType)
+                    : RelationType.RELATED_TO;
+
+            boolean exists = relationService.relationExistsVisible(
+                    sourceNode.getCode(), targetNode.getCode(), relationType, context.workspaceId());
+            if (exists) {
+                skipped++;
+                continue;
+            }
+
+            if (!materialize) {
+                continue;
+            }
+
+            try {
+                relationService.createRelation(
+                        sourceNode.getCode(), targetNode.getCode(), relationType,
+                        "Imported from ArchiMate XML", "ARCHIMATE_IMPORT",
+                        context.workspaceId(), context.username());
+                created++;
+            } catch (IllegalArgumentException error) {
+                // Treat only a concurrent duplicate as a skip. Any other failure
+                // is fatal and must roll the complete import transaction back.
+                if (relationService.relationExistsVisible(
+                        sourceNode.getCode(), targetNode.getCode(), relationType, context.workspaceId())) {
+                    skipped++;
+                } else {
+                    throw new ArchiMateImportException(
+                            "Unable to materialize ArchiMate relation", error);
+                }
+            } catch (RuntimeException error) {
+                throw new ArchiMateImportException(
+                        "Unable to materialize ArchiMate relation", error);
+            }
         }
 
+        result.setRelationsImported(created);
+        result.setRelationsSkipped(skipped);
+        result.setRelationsRejected(rejected);
         result.setNotes(notes);
+
+        int eligible = model.relationships().size() - skipped - rejected;
+        notes.add(materialize
+                ? "Created " + created + " relation(s) in workspace " + scopeName(context)
+                        + "; skipped " + skipped + " duplicate(s); rejected " + rejected
+                        + " relation(s) with unmatched endpoints"
+                : "Preview found " + eligible + " relation(s) eligible for workspace "
+                        + scopeName(context) + "; " + skipped + " duplicate(s); "
+                        + rejected + " relation(s) with unmatched endpoints");
+
+        log.info("ArchiMate {} complete: elements={}, matched={}, relations={}, created={}, skipped={}, rejected={}, workspace={}",
+                materialize ? "import" : "preview", model.elements().size(), matchedNodes.size(),
+                model.relationships().size(), created, skipped, rejected, context.workspaceId());
         return result;
     }
 
-    private void parseXml(InputStream inputStream,
-                          Map<String, ParsedElement> elements,
-                          List<ParsedRelationship> relationships) throws Exception {
+    private ParsedModel parseModel(InputStream inputStream) {
+        if (inputStream == null) {
+            throw new ArchiMateImportException("No ArchiMate XML input was provided");
+        }
+
+        Map<String, ParsedElement> elements = new LinkedHashMap<>();
+        List<ParsedRelationship> relationships = new ArrayList<>();
 
         XMLInputFactory factory = XMLInputFactory.newInstance();
-        // Security: disable external entities
+        // XXE hardening: never resolve DTDs or external entities.
         factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
 
-        XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
-
-        while (reader.hasNext()) {
-            int event = reader.next();
-            if (event == XMLStreamConstants.START_ELEMENT) {
-                String localName = reader.getLocalName();
-
-                if ("element".equals(localName)) {
-                    parseElement(reader, elements);
-                } else if ("relationship".equals(localName)) {
-                    parseRelationship(reader, relationships);
+        try {
+            XMLStreamReader reader = factory.createXMLStreamReader(inputStream);
+            try {
+                while (reader.hasNext()) {
+                    int event = reader.next();
+                    if (event != XMLStreamConstants.START_ELEMENT) {
+                        continue;
+                    }
+                    if ("element".equals(reader.getLocalName())) {
+                        parseElement(reader, elements);
+                    } else if ("relationship".equals(reader.getLocalName())) {
+                        parseRelationship(reader, relationships);
+                    }
                 }
+            } finally {
+                reader.close();
             }
+        } catch (XMLStreamException error) {
+            throw new ArchiMateImportException("Malformed ArchiMate XML", error);
         }
-        reader.close();
+
+        return new ParsedModel(elements, relationships);
     }
 
-    private void parseElement(XMLStreamReader reader, Map<String, ParsedElement> elements) throws Exception {
+    private void parseElement(XMLStreamReader reader,
+                              Map<String, ParsedElement> elements) throws XMLStreamException {
         String identifier = reader.getAttributeValue(null, "identifier");
         String xsiType = reader.getAttributeValue(
                 "http://www.w3.org/2001/XMLSchema-instance", "type");
+        if (identifier == null || xsiType == null) {
+            return;
+        }
 
-        if (identifier == null || xsiType == null) return;
-
-        // Strip "id-" prefix if present
-        String id = identifier.startsWith("id-") ? identifier.substring(3) : identifier;
-
+        String id = stripIdentifierPrefix(identifier);
         String label = null;
         String documentation = null;
-
-        // Read child elements for name and documentation
         int depth = 1;
         while (reader.hasNext() && depth > 0) {
             int event = reader.next();
@@ -135,7 +211,7 @@ public class ArchiMateXmlImporter {
                 depth++;
                 if ("name".equals(reader.getLocalName())) {
                     label = reader.getElementText();
-                    depth--; // getElementText consumes the end element
+                    depth--;
                 } else if ("documentation".equals(reader.getLocalName())) {
                     documentation = reader.getElementText();
                     depth--;
@@ -144,126 +220,97 @@ public class ArchiMateXmlImporter {
                 depth--;
             }
         }
-
         elements.put(id, new ParsedElement(id, xsiType, label, documentation));
     }
 
-    private void parseRelationship(XMLStreamReader reader, List<ParsedRelationship> relationships) throws Exception {
+    private void parseRelationship(XMLStreamReader reader,
+                                   List<ParsedRelationship> relationships) {
         String identifier = reader.getAttributeValue(null, "identifier");
         String xsiType = reader.getAttributeValue(
                 "http://www.w3.org/2001/XMLSchema-instance", "type");
         String source = reader.getAttributeValue(null, "source");
         String target = reader.getAttributeValue(null, "target");
+        if (identifier == null || source == null || target == null) {
+            return;
+        }
 
-        if (identifier == null || source == null || target == null) return;
-
-        // Strip "id-" prefix variants
-        String sourceId = source.startsWith("id-") ? source.substring(3) : source;
-        String targetId = target.startsWith("id-") ? target.substring(3) : target;
-        String type = xsiType != null ? xsiType : "Association";
-
-        relationships.add(new ParsedRelationship(identifier, sourceId, targetId, type));
+        relationships.add(new ParsedRelationship(
+                identifier,
+                stripIdentifierPrefix(source),
+                stripIdentifierPrefix(target),
+                xsiType != null ? xsiType : "Association"));
     }
 
     private Map<String, TaxonomyNode> matchElements(Map<String, ParsedElement> elements,
-                                                      List<String> notes) {
+                                                     List<String> notes) {
         Map<String, TaxonomyNode> matched = new LinkedHashMap<>();
-
-        for (ParsedElement el : elements.values()) {
-            String taxonomyRoot = PROFILE.mapElementType(el.type);
+        for (ParsedElement element : elements.values()) {
+            String taxonomyRoot = PROFILE.mapElementType(element.type());
             if (taxonomyRoot == null) {
-                notes.add("Unknown ArchiMate type: " + el.type + " for element " + el.label);
+                notes.add("Unknown ArchiMate type: " + element.type() + " for element " + element.label());
+                continue;
+            }
+            if (element.label() == null || element.label().isBlank()) {
                 continue;
             }
 
-            // Try to find a matching taxonomy node by name in the expected root
-            if (el.label != null && !el.label.isBlank()) {
-                List<TaxonomyNode> candidates = nodeRepository
-                        .findByTaxonomyRootOrderByLevelAscNameEnAsc(taxonomyRoot);
-
-                TaxonomyNode bestMatch = findBestMatch(el.label, candidates);
-                if (bestMatch != null) {
-                    matched.put(el.id, bestMatch);
-                }
+            List<TaxonomyNode> candidates = nodeRepository
+                    .findByTaxonomyRootOrderByLevelAscNameEnAsc(taxonomyRoot);
+            TaxonomyNode bestMatch = findBestMatch(element.label(), candidates);
+            if (bestMatch != null) {
+                matched.put(element.id(), bestMatch);
             }
         }
-
-        notes.add("Matched " + matched.size() + " of " + elements.size() + " elements to taxonomy nodes");
+        notes.add("Matched " + matched.size() + " of " + elements.size()
+                + " elements to taxonomy nodes");
         return matched;
     }
 
     private TaxonomyNode findBestMatch(String label, List<TaxonomyNode> candidates) {
-        if (candidates.isEmpty()) return null;
-
+        if (candidates.isEmpty()) {
+            return null;
+        }
         String normalizedLabel = label.toLowerCase(Locale.ROOT).trim();
-
-        // First: exact name match
         for (TaxonomyNode node : candidates) {
-            if (node.getNameEn() != null &&
-                    node.getNameEn().toLowerCase(Locale.ROOT).trim().equals(normalizedLabel)) {
+            if (node.getNameEn() != null
+                    && node.getNameEn().toLowerCase(Locale.ROOT).trim().equals(normalizedLabel)) {
                 return node;
             }
         }
-
-        // Second: contains match
         for (TaxonomyNode node : candidates) {
-            if (node.getNameEn() != null) {
-                String nodeName = node.getNameEn().toLowerCase(Locale.ROOT).trim();
-                if (nodeName.contains(normalizedLabel) || normalizedLabel.contains(nodeName)) {
-                    return node;
-                }
+            if (node.getNameEn() == null) {
+                continue;
+            }
+            String nodeName = node.getNameEn().toLowerCase(Locale.ROOT).trim();
+            if (nodeName.contains(normalizedLabel) || normalizedLabel.contains(nodeName)) {
+                return node;
             }
         }
-
         return null;
     }
 
-    private int createRelations(List<ParsedRelationship> relationships,
-                                 Map<String, ParsedElement> elements,
-                                 Map<String, TaxonomyNode> matchedNodes,
-                                 List<String> notes) {
-        int created = 0;
-
-        for (ParsedRelationship rel : relationships) {
-            TaxonomyNode sourceNode = matchedNodes.get(rel.sourceId);
-            TaxonomyNode targetNode = matchedNodes.get(rel.targetId);
-
-            if (sourceNode == null || targetNode == null) continue;
-
-            String relTypeName = PROFILE.mapRelationType(rel.type);
-            RelationType relationType = relTypeName != null
-                    ? RelationType.valueOf(relTypeName)
-                    : RelationType.RELATED_TO;
-
-            // Check if relation already exists
-            List<TaxonomyRelation> existing = relationRepository
-                    .findBySourceNodeCode(sourceNode.getCode());
-            boolean alreadyExists = existing.stream()
-                    .anyMatch(r -> r.getTargetNode().getCode().equals(targetNode.getCode()) &&
-                            r.getRelationType() == relationType);
-
-            if (!alreadyExists) {
-                TaxonomyRelation newRel = new TaxonomyRelation();
-                newRel.setSourceNode(sourceNode);
-                newRel.setTargetNode(targetNode);
-                newRel.setRelationType(relationType);
-                newRel.setDescription("Imported from ArchiMate XML");
-                newRel.setProvenance("ARCHIMATE_IMPORT");
-                relationRepository.save(newRel);
-                created++;
-            }
+    private static WorkspaceContext requireContext(WorkspaceContext context) {
+        if (context == null) {
+            throw new ArchiMateImportException("An explicit workspace context is required");
         }
-
-        notes.add("Created " + created + " new relations (" +
-                (relationships.size() - created) + " already existed or had unmatched endpoints)");
-        return created;
+        return context;
     }
 
-    // ── Internal record types ─────────────────────────────────────────────────
+    private static String stripIdentifierPrefix(String value) {
+        return value.startsWith("id-") ? value.substring(3) : value;
+    }
 
-    /** Represents a parsed ArchiMate element with its id, ArchiMate type, display label, and optional documentation text. */
-    private record ParsedElement(String id, String type, String label, String documentation) {}
+    private static String scopeName(WorkspaceContext context) {
+        return context.workspaceId() != null ? context.workspaceId() : "shared";
+    }
 
-    /** Represents a parsed ArchiMate relationship linking a source element to a target element via a specific relationship type. */
-    private record ParsedRelationship(String id, String sourceId, String targetId, String type) {}
+    private record ParsedModel(Map<String, ParsedElement> elements,
+                               List<ParsedRelationship> relationships) {
+    }
+
+    private record ParsedElement(String id, String type, String label, String documentation) {
+    }
+
+    private record ParsedRelationship(String id, String sourceId, String targetId, String type) {
+    }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/CatalogFacade.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/CatalogFacade.java
@@ -47,9 +47,14 @@ public class CatalogFacade {
         return dto;
     }
 
-    public ArchiMateImportResult importAndValidate(InputStream xmlStream) {
-        log.info("Starting ArchiMate XML import via facade");
-        ArchiMateImportResult result = archiMateXmlImporter.importXml(xmlStream);
+    public ArchiMateImportResult importAndValidate(InputStream xmlStream,
+                                                    WorkspaceContext workspaceContext) {
+        if (workspaceContext == null) {
+            throw new IllegalArgumentException("Workspace context is required for ArchiMate import");
+        }
+        log.info("Starting ArchiMate XML import via facade for workspace {}",
+                workspaceContext.workspaceId());
+        ArchiMateImportResult result = archiMateXmlImporter.importXml(xmlStream, workspaceContext);
         log.info("ArchiMate import complete – {} elements matched, {} relations created",
                 result.getElementsMatched(), result.getRelationsImported());
         return result;
@@ -57,8 +62,8 @@ public class CatalogFacade {
 
     @Transactional(readOnly = true)
     public List<TaxonomyNodeDto> searchWithContext(String query,
-                                                    int maxResults,
-                                                    WorkspaceContext workspaceContext) {
+                                                   int maxResults,
+                                                   WorkspaceContext workspaceContext) {
         List<TaxonomyNodeDto> results = searchService.search(query, maxResults);
         results.forEach(dto -> attachRelations(dto, workspaceContext));
         return results;

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java
@@ -55,6 +55,22 @@ public class TaxonomyRelationService {
         return toDtos(relations);
     }
 
+    /**
+     * Returns whether an equivalent relation is already visible in the target
+     * workspace. Personal workspaces inherit shared baseline relations, while a
+     * null workspace checks shared rows only and never scans personal data.
+     */
+    @Transactional(readOnly = true)
+    public boolean relationExistsVisible(String sourceCode, String targetCode,
+                                         RelationType type,
+                                         @Nullable String workspaceId) {
+        List<TaxonomyRelation> existing = workspaceId != null
+                ? relationRepository.findVisibleByWorkspaceAndSourceTargetType(
+                        workspaceId, sourceCode, targetCode, type)
+                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
+        return !existing.isEmpty();
+    }
+
     // ── Legacy delegating read methods (shared scope) ───────────────
 
     @Transactional(readOnly = true)
@@ -85,14 +101,7 @@ public class TaxonomyRelationService {
         TaxonomyNode target = nodeRepository.findByCode(targetCode)
                 .orElseThrow(() -> new IllegalArgumentException("Target node not found: " + targetCode));
 
-        // Workspace overlays inherit shared relations, so an equivalent shared
-        // relation remains a duplicate for creation. Shared mode checks shared
-        // rows only and never scans personal workspaces.
-        List<TaxonomyRelation> existing = workspaceId != null
-                ? relationRepository.findByWorkspaceAndSourceTargetType(
-                        workspaceId, sourceCode, targetCode, type)
-                : relationRepository.findSharedBySourceTargetType(sourceCode, targetCode, type);
-        if (!existing.isEmpty()) {
+        if (relationExistsVisible(sourceCode, targetCode, type, workspaceId)) {
             throw new IllegalArgumentException(String.format(
                     "Relation already exists: %s --[%s]--> %s (workspace=%s)",
                     sourceCode, type, targetCode, workspaceId));

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
@@ -1,0 +1,154 @@
+package com.taxonomy;
+
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.catalog.service.ArchiMateImportException;
+import com.taxonomy.catalog.service.ArchiMateXmlImporter;
+import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@WithMockUser(username = "qa-architect", roles = {"USER", "ARCHITECT"})
+class ArchiMateWorkspaceImportTests {
+
+    @Autowired
+    private ArchiMateXmlImporter importer;
+
+    @Autowired
+    private TaxonomyRelationRepository relationRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void previewReportsEligibleRelationWithoutWriting() {
+        WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        long before = relationRepository.count();
+
+        ArchiMateImportResult result = importer.previewXml(stream(validModel()), context);
+
+        assertThat(result.isPreview()).isTrue();
+        assertThat(result.getElementsMatched()).isEqualTo(2);
+        assertThat(result.getRelationsParsed()).isEqualTo(1);
+        assertThat(result.getRelationsImported()).isZero();
+        assertThat(result.getRelationsSkipped()).isZero();
+        assertThat(result.getRelationsRejected()).isZero();
+        assertThat(relationRepository.count()).isEqualTo(before);
+    }
+
+    @Test
+    void equivalentModelsCanBeImportedIntoSeparateWorkspaces() {
+        WorkspaceContext firstContext = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        WorkspaceContext secondContext = new WorkspaceContext("bob", "qa-archimate-b", "draft");
+        long sharedBefore = relationRepository.countByWorkspaceIdIsNull();
+
+        ArchiMateImportResult first = importer.importXml(stream(validModel()), firstContext);
+        ArchiMateImportResult second = importer.importXml(stream(validModel()), secondContext);
+
+        assertThat(first.getRelationsImported()).isEqualTo(1);
+        assertThat(second.getRelationsImported()).isEqualTo(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-b")).hasSize(1);
+        assertThat(relationRepository.countByWorkspaceIdIsNull()).isEqualTo(sharedBefore);
+    }
+
+    @Test
+    void repeatedImportInSameWorkspaceIsReportedAsDuplicate() {
+        WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+        importer.importXml(stream(validModel()), context);
+
+        ArchiMateImportResult duplicate = importer.importXml(stream(validModel()), context);
+
+        assertThat(duplicate.getRelationsImported()).isZero();
+        assertThat(duplicate.getRelationsSkipped()).isEqualTo(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
+    }
+
+    @Test
+    void malformedXmlFailsInsteadOfReturningSuccessfulResult() {
+        assertThatThrownBy(() -> importer.importXml(
+                stream("<model><elements>"), WorkspaceContext.SHARED))
+                .isInstanceOf(ArchiMateImportException.class)
+                .hasMessageContaining("Malformed");
+    }
+
+    @Test
+    void endpointReturns422ForMalformedXmlAndDoesNotMutateRelations() throws Exception {
+        long before = relationRepository.count();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "broken.xml", MediaType.APPLICATION_XML_VALUE,
+                "<model><elements>".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/api/import/archimate").file(file))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error").value("INVALID_ARCHIMATE_XML"));
+
+        assertThat(relationRepository.count()).isEqualTo(before);
+    }
+
+    @Test
+    void endpointRejectsDoctypeAndExternalEntityInput() throws Exception {
+        String xml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE model [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                  <elements>
+                    <element identifier="id-e1" xsi:type="Capability"><name>&xxe;</name></element>
+                  </elements>
+                </model>
+                """;
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "xxe.xml", MediaType.APPLICATION_XML_VALUE,
+                xml.getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(multipart("/api/import/preview/archimate").file(file))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error").value("INVALID_ARCHIMATE_XML"));
+    }
+
+    private static ByteArrayInputStream stream(String xml) {
+        return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String validModel() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       identifier="id-model-1">
+                  <elements>
+                    <element identifier="id-e1" xsi:type="Capability">
+                      <name xml:lang="en">Capabilities</name>
+                    </element>
+                    <element identifier="id-e2" xsi:type="ApplicationService">
+                      <name xml:lang="en">Core Services</name>
+                    </element>
+                  </elements>
+                  <relationships>
+                    <relationship identifier="id-r1" xsi:type="Realization"
+                                  source="id-e1" target="id-e2"/>
+                  </relationships>
+                </model>
+                """;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ArchiMateWorkspaceImportTests.java
@@ -4,7 +4,9 @@ import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.catalog.service.ArchiMateImportException;
 import com.taxonomy.catalog.service.ArchiMateXmlImporter;
 import com.taxonomy.dto.ArchiMateImportResult;
+import com.taxonomy.model.RelationType;
 import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,12 +41,24 @@ class ArchiMateWorkspaceImportTests {
     @Autowired
     private MockMvc mockMvc;
 
+    @BeforeEach
+    void removeEligibleFixtureRelationFromAllScopes() {
+        // The tests intentionally exercise creation of a Flow/COMMUNICATES_WITH
+        // relation between the matched CP and CR root nodes. Remove any fixture
+        // residue or future catalogue addition transactionally so eligibility is
+        // deterministic; the test transaction restores the catalogue afterwards.
+        relationRepository.deleteAll(
+                relationRepository.findBySourceNodeCodeAndTargetNodeCodeAndRelationType(
+                        "CP", "CR", RelationType.COMMUNICATES_WITH));
+        relationRepository.flush();
+    }
+
     @Test
     void previewReportsEligibleRelationWithoutWriting() {
         WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
         long before = relationRepository.count();
 
-        ArchiMateImportResult result = importer.previewXml(stream(validModel()), context);
+        ArchiMateImportResult result = importer.previewXml(stream(eligibleModel()), context);
 
         assertThat(result.isPreview()).isTrue();
         assertThat(result.getElementsMatched()).isEqualTo(2);
@@ -61,8 +75,8 @@ class ArchiMateWorkspaceImportTests {
         WorkspaceContext secondContext = new WorkspaceContext("bob", "qa-archimate-b", "draft");
         long sharedBefore = relationRepository.countByWorkspaceIdIsNull();
 
-        ArchiMateImportResult first = importer.importXml(stream(validModel()), firstContext);
-        ArchiMateImportResult second = importer.importXml(stream(validModel()), secondContext);
+        ArchiMateImportResult first = importer.importXml(stream(eligibleModel()), firstContext);
+        ArchiMateImportResult second = importer.importXml(stream(eligibleModel()), secondContext);
 
         assertThat(first.getRelationsImported()).isEqualTo(1);
         assertThat(second.getRelationsImported()).isEqualTo(1);
@@ -74,13 +88,24 @@ class ArchiMateWorkspaceImportTests {
     @Test
     void repeatedImportInSameWorkspaceIsReportedAsDuplicate() {
         WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
-        importer.importXml(stream(validModel()), context);
+        importer.importXml(stream(eligibleModel()), context);
 
-        ArchiMateImportResult duplicate = importer.importXml(stream(validModel()), context);
+        ArchiMateImportResult duplicate = importer.importXml(stream(eligibleModel()), context);
 
         assertThat(duplicate.getRelationsImported()).isZero();
         assertThat(duplicate.getRelationsSkipped()).isEqualTo(1);
         assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).hasSize(1);
+    }
+
+    @Test
+    void sharedBaselineRelationIsVisibleAsDuplicateInPersonalWorkspace() {
+        WorkspaceContext context = new WorkspaceContext("alice", "qa-archimate-a", "draft");
+
+        ArchiMateImportResult result = importer.previewXml(stream(sharedDuplicateModel()), context);
+
+        assertThat(result.getRelationsImported()).isZero();
+        assertThat(result.getRelationsSkipped()).isEqualTo(1);
+        assertThat(relationRepository.findByWorkspaceId("qa-archimate-a")).isEmpty();
     }
 
     @Test
@@ -130,7 +155,15 @@ class ArchiMateWorkspaceImportTests {
         return new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
     }
 
-    private static String validModel() {
+    private static String eligibleModel() {
+        return modelWithRelationshipType("Flow");
+    }
+
+    private static String sharedDuplicateModel() {
+        return modelWithRelationshipType("Realization");
+    }
+
+    private static String modelWithRelationshipType(String relationshipType) {
         return """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
@@ -145,10 +178,10 @@ class ArchiMateWorkspaceImportTests {
                     </element>
                   </elements>
                   <relationships>
-                    <relationship identifier="id-r1" xsi:type="Realization"
+                    <relationship identifier="id-r1" xsi:type="%s"
                                   source="id-e1" target="id-e2"/>
                   </relationships>
                 </model>
-                """;
+                """.formatted(relationshipType);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/catalog/service/CatalogFacadeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/catalog/service/CatalogFacadeTest.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -83,12 +84,23 @@ class CatalogFacadeTest {
     }
 
     @Test
-    void importDelegatesAndReturnsImportResult() {
+    void importDelegatesWithExplicitWorkspaceAndReturnsResult() {
         ByteArrayInputStream stream = new ByteArrayInputStream("<model/>".getBytes());
+        WorkspaceContext context = new WorkspaceContext("alice", "ws-1", "draft");
         ArchiMateImportResult expected = new ArchiMateImportResult();
-        when(archiMateXmlImporter.importXml(stream)).thenReturn(expected);
+        when(archiMateXmlImporter.importXml(stream, context)).thenReturn(expected);
 
-        assertThat(facade.importAndValidate(stream)).isSameAs(expected);
+        assertThat(facade.importAndValidate(stream, context)).isSameAs(expected);
+    }
+
+    @Test
+    void importRejectsMissingWorkspaceContext() {
+        ByteArrayInputStream stream = new ByteArrayInputStream("<model/>".getBytes());
+
+        assertThatThrownBy(() -> facade.importAndValidate(stream, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Workspace context");
+        verify(archiMateXmlImporter, never()).importXml(stream, WorkspaceContext.SHARED);
     }
 
     private static TaxonomyNodeDto dto(String code) {

--- a/taxonomy-domain/src/main/java/com/taxonomy/dto/ArchiMateImportResult.java
+++ b/taxonomy-domain/src/main/java/com/taxonomy/dto/ArchiMateImportResult.java
@@ -4,30 +4,50 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Result of an ArchiMate XML import operation.
- * Describes how many elements and relations were imported or matched.
+ * Result of an ArchiMate XML preview or import operation.
+ *
+ * <p>The counters deliberately distinguish parsing/matching from mutation so
+ * clients can tell whether a model was understood, skipped as a duplicate, or
+ * materialized into the active workspace.</p>
  */
 public class ArchiMateImportResult {
 
     private int elementsImported;
-    private int relationsImported;
     private int elementsMatched;
     private int elementsUnmatched;
+    private int relationsParsed;
+    private int relationsImported;
+    private int relationsSkipped;
+    private int relationsRejected;
+    private boolean preview;
     private List<String> notes = new ArrayList<>();
 
-    public ArchiMateImportResult() {}
+    public ArchiMateImportResult() {
+    }
 
     public int getElementsImported() { return elementsImported; }
     public void setElementsImported(int elementsImported) { this.elementsImported = elementsImported; }
-
-    public int getRelationsImported() { return relationsImported; }
-    public void setRelationsImported(int relationsImported) { this.relationsImported = relationsImported; }
 
     public int getElementsMatched() { return elementsMatched; }
     public void setElementsMatched(int elementsMatched) { this.elementsMatched = elementsMatched; }
 
     public int getElementsUnmatched() { return elementsUnmatched; }
     public void setElementsUnmatched(int elementsUnmatched) { this.elementsUnmatched = elementsUnmatched; }
+
+    public int getRelationsParsed() { return relationsParsed; }
+    public void setRelationsParsed(int relationsParsed) { this.relationsParsed = relationsParsed; }
+
+    public int getRelationsImported() { return relationsImported; }
+    public void setRelationsImported(int relationsImported) { this.relationsImported = relationsImported; }
+
+    public int getRelationsSkipped() { return relationsSkipped; }
+    public void setRelationsSkipped(int relationsSkipped) { this.relationsSkipped = relationsSkipped; }
+
+    public int getRelationsRejected() { return relationsRejected; }
+    public void setRelationsRejected(int relationsRejected) { this.relationsRejected = relationsRejected; }
+
+    public boolean isPreview() { return preview; }
+    public void setPreview(boolean preview) { this.preview = preview; }
 
     public List<String> getNotes() { return notes; }
     public void setNotes(List<String> notes) { this.notes = notes; }


### PR DESCRIPTION
## Summary

Implements #422.

- resolves `WorkspaceContext` once at the ArchiMate HTTP boundary;
- adds read-only preview with identischer Parser-, Mapping- und Duplikatlogik;
- materializes exclusively through `TaxonomyRelationService` in the exact workspace;
- treats shared baseline relations as visible duplicates;
- propagates materialization failures for complete transaction rollback;
- rejects malformed XML, DTDs, and external entities with stable HTTP 422 responses;
- exposes parsed, matched, created, skipped, rejected, and preview counters;
- requires explicit workspace context in `CatalogFacade`;
- covers preview non-mutation, separate-workspace imports, shared/same-workspace duplicates, malformed XML, and XXE rejection.

### Verified gates

- QA ArchiMate Import Evidence — success
- CI / CD and reactor coverage — success
- Security Scan and immutable pin gate — success
- CodeQL Source Analysis — success
- QA Architecture Evidence — success
- Core Integration — success
- UI Acceptance — success
- Accessibility — success
- Documentation Links — success

Closes #422.