### PR TITLE
Add optional OpenTelemetry observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,10 @@ RUN --mount=type=cache,target=/root/.m2/repository \
     ./mvnw -q -DskipTests package
 
 # ---- optional OpenTelemetry Java agent stage ----
-# This exact version is copied into the runtime image but is never attached by
-# default. Operators opt in explicitly through JAVA_TOOL_OPTIONS.
-FROM otel/autoinstrumentation-java:2.30.0 AS opentelemetry
+# Tag retained for automated update discovery; the multi-platform index digest is
+# authoritative. The agent is copied into the runtime image but is never attached
+# by default. Operators opt in explicitly through JAVA_TOOL_OPTIONS.
+FROM otel/autoinstrumentation-java:2.28.1@sha256:41b92978e61d13d4f32c6eb20c6ae7821a73ffdec8539bc6a73858e884b411d8 AS opentelemetry
 
 # ---- runtime stage ----
 # Tag retained for readability; digest prevents mutable-tag supply-chain drift.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ COPY LICENSE NOTICE THIRD-PARTY-NOTICES.md ./
 RUN --mount=type=cache,target=/root/.m2/repository \
     ./mvnw -q -DskipTests package
 
+# ---- optional OpenTelemetry Java agent stage ----
+# This exact version is copied into the runtime image but is never attached by
+# default. Operators opt in explicitly through JAVA_TOOL_OPTIONS.
+FROM otel/autoinstrumentation-java:2.30.0 AS opentelemetry
+
 # ---- runtime stage ----
 # Tag retained for readability; digest prevents mutable-tag supply-chain drift.
 FROM eclipse-temurin:21-jre-jammy@sha256:2c2088115d82ba0022ccf8080f233d2398b7ad3ba3308ed45e860caf511f6b95
@@ -72,8 +77,11 @@ RUN apt-get update \
     && useradd --system --gid taxonomy --home-dir /app --shell /usr/sbin/nologin taxonomy
 
 WORKDIR /app
-RUN mkdir -p /app/data && chown -R taxonomy:taxonomy /app
+RUN mkdir -p /app/data /opt/opentelemetry \
+    && chown -R taxonomy:taxonomy /app /opt/opentelemetry
 COPY --from=build --chown=taxonomy:taxonomy /workspace/taxonomy-app/target/taxonomy-app-*.jar app.jar
+COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar /opt/opentelemetry/opentelemetry-javaagent.jar
+COPY --chown=taxonomy:taxonomy observability/javaagent.properties /opt/opentelemetry/javaagent.properties
 
 # Port 8080 is for INTERNAL communication only (e.g. Caddy reverse proxy inside Docker network).
 # NEVER publish this port to the internet. Use docker-compose.prod.yml for HTTPS on port 443.
@@ -95,4 +103,6 @@ STOPSIGNAL SIGTERM
 # exec replaces the shell with the JVM so Java becomes PID 1 and receives
 # Docker's SIGTERM directly. This allows Spring, HikariCP, HSQLDB and Lucene to
 # close cleanly before a replacement container opens the persisted data again.
+# The OpenTelemetry agent is deliberately absent from this command. It is only
+# attached when an operator sets JAVA_TOOL_OPTIONS=-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar.
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -5,6 +5,11 @@ Taxonomy Architecture Analyzer incorporates components from the following third-
 > **SBOM:** A machine-readable Software Bill of Materials (CycloneDX format) is generated
 > at build time via `mvn package`. The SBOM files are located at
 > `target/taxonomy-sbom.json` and `target/taxonomy-sbom.xml`.
+>
+> The optional OpenTelemetry Java agent is copied into the container image rather
+> than added as a Maven runtime dependency. The optional Collector and Jaeger run
+> as separate containers. Include all three in container-level SBOM generation and
+> vulnerability scanning in addition to the Maven SBOM.
 
 ---
 
@@ -12,7 +17,7 @@ Taxonomy Architecture Analyzer incorporates components from the following third-
 
 | License | Components | Government Use |
 |---|---|---|
-| Apache License 2.0 | Spring Boot, Apache POI, Apache PDFBox, Lucene, Hibernate, springdoc, DJL, Micrometer, JaCoCo | ✅ Permissive, no restrictions |
+| Apache License 2.0 | Spring Boot, Apache POI, Apache PDFBox, Lucene, Hibernate, springdoc, DJL, Micrometer, OpenTelemetry, Jaeger, JaCoCo | ✅ Permissive, no restrictions |
 | MIT License | Bootstrap, jsPDF, svg2pdf.js, ONNX Runtime, CodeMirror | ✅ Permissive, no restrictions |
 | ISC License | D3.js | ✅ Permissive, no restrictions |
 | BSD Licenses | HSQLDB, PostgreSQL JDBC, XStream, Flexmark-java | ✅ Permissive, no restrictions |
@@ -60,6 +65,20 @@ https://djl.ai/
 ### Micrometer
 Copyright © VMware, Inc.
 https://micrometer.io/
+
+### OpenTelemetry Java instrumentation and Collector
+Copyright © OpenTelemetry Authors
+https://opentelemetry.io/
+
+> **Note:** The Java agent is present in the container image but disabled by
+> default. The Collector is used only by the optional observability deployment.
+
+### Jaeger
+Copyright © The Jaeger Authors
+https://www.jaegertracing.io/
+
+> **Note:** Jaeger is an optional trace backend and is not included in the
+> Taxonomy application runtime classpath.
 
 ### Spring Security
 Copyright © Pivotal Software, Inc. / VMware, Inc.
@@ -199,13 +218,19 @@ Output files:
 - `target/taxonomy-sbom.json` — JSON format (machine-readable)
 - `target/taxonomy-sbom.xml` — XML format (CycloneDX standard)
 
-The SBOM includes:
-- All direct and transitive dependencies
+The Maven SBOM includes:
+- All direct and transitive Maven dependencies
 - Package names, versions, and checksums
 - License information per dependency
 - Dependency tree structure
 
-Use the SBOM for:
+Additionally generate or inspect a container-level SBOM for:
+- the Java runtime base image;
+- the bundled OpenTelemetry Java agent;
+- the optional OpenTelemetry Collector image;
+- the optional Jaeger image.
+
+Use the SBOMs for:
 - **BSI IT-Grundschutz** software supply chain requirements
 - **Vulnerability scanning** (import into tools like Dependency-Track)
 - **License compliance** audits for government procurement

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,78 @@
+services:
+  taxonomy:
+    build:
+      context: .
+      args:
+        VERSION: ${TAXONOMY_VERSION:-dev}
+    image: taxonomy-observability:local
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    environment:
+      JAVA_OPTS: >-
+        -XX:+UseSerialGC
+        -Xss512k
+        -XX:MaxRAMPercentage=60.0
+        -Xmx512m
+      JAVA_TOOL_OPTIONS: >-
+        -javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar
+      OTEL_JAVAAGENT_CONFIGURATION_FILE: /opt/opentelemetry/javaagent.properties
+      OTEL_SERVICE_NAME: taxonomy
+      OTEL_RESOURCE_ATTRIBUTES: >-
+        service.namespace=taxonomy,
+        service.version=${TAXONOMY_VERSION:-dev},
+        deployment.environment=local
+      OTEL_TRACES_EXPORTER: otlp
+      OTEL_METRICS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: none
+      OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+      OTEL_PROPAGATORS: tracecontext,baggage
+      OTEL_TRACES_SAMPLER: always_on
+      OTEL_BSP_MAX_QUEUE_SIZE: "2048"
+      OTEL_BSP_MAX_EXPORT_BATCH_SIZE: "512"
+      OTEL_BSP_SCHEDULE_DELAY: "5000"
+      OTEL_BSP_EXPORT_TIMEOUT: "10000"
+      TAXONOMY_EMBEDDING_ENABLED: "false"
+      TAXONOMY_DATASOURCE_URL: >-
+        jdbc:hsqldb:file:/app/data/taxonomydb;
+        hsqldb.default_table_type=cached;
+        hsqldb.write_delay_millis=0;
+        shutdown=true
+      TAXONOMY_DDL_AUTO: update
+      TAXONOMY_REQUIRE_PASSWORD_CHANGE: "false"
+    volumes:
+      - taxonomy-observability-data:/app/data
+    depends_on:
+      otel-collector:
+        condition: service_started
+    mem_limit: 1g
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.157.0
+    restart: unless-stopped
+    command:
+      - --config=/etc/otelcol-contrib/config.yaml
+    volumes:
+      - ./observability/otel-collector-config.yml:/etc/otelcol-contrib/config.yaml:ro
+    expose:
+      - "4317"
+      - "4318"
+      - "13133"
+    depends_on:
+      jaeger:
+        condition: service_started
+    mem_limit: 256m
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:16686:16686"
+    expose:
+      - "4317"
+      - "4318"
+    mem_limit: 512m
+
+volumes:
+  taxonomy-observability-data:

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
+      SPRING_PROFILES_ACTIVE: hsqldb,observability
       JAVA_OPTS: >-
         -XX:+UseSerialGC
         -Xss512k
@@ -18,10 +19,7 @@ services:
         -javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar
       OTEL_JAVAAGENT_CONFIGURATION_FILE: /opt/opentelemetry/javaagent.properties
       OTEL_SERVICE_NAME: taxonomy
-      OTEL_RESOURCE_ATTRIBUTES: >-
-        service.namespace=taxonomy,
-        service.version=${TAXONOMY_VERSION:-dev},
-        deployment.environment=local
+      OTEL_RESOURCE_ATTRIBUTES: "service.namespace=taxonomy,service.version=${TAXONOMY_VERSION:-dev},deployment.environment=local"
       OTEL_TRACES_EXPORTER: otlp
       OTEL_METRICS_EXPORTER: none
       OTEL_LOGS_EXPORTER: none
@@ -34,11 +32,7 @@ services:
       OTEL_BSP_SCHEDULE_DELAY: "5000"
       OTEL_BSP_EXPORT_TIMEOUT: "10000"
       TAXONOMY_EMBEDDING_ENABLED: "false"
-      TAXONOMY_DATASOURCE_URL: >-
-        jdbc:hsqldb:file:/app/data/taxonomydb;
-        hsqldb.default_table_type=cached;
-        hsqldb.write_delay_millis=0;
-        shutdown=true
+      TAXONOMY_DATASOURCE_URL: "jdbc:hsqldb:file:/app/data/taxonomydb;hsqldb.default_table_type=cached;hsqldb.write_delay_millis=0;shutdown=true"
       TAXONOMY_DDL_AUTO: update
       TAXONOMY_REQUIRE_PASSWORD_CHANGE: "false"
     volumes:

--- a/docs/de/OBSERVABILITY.md
+++ b/docs/de/OBSERVABILITY.md
@@ -1,0 +1,214 @@
+# Observability mit OpenTelemetry
+
+Taxonomy unterstützt eine **optionale, herstellerneutrale Tracing-Schicht** auf Basis des OpenTelemetry-Java-Agents und OTLP. Der normale JVM- und Docker-Start bleibt unverändert: Der Agent ist im Runtime-Image vorhanden, wird aber nur angehängt, wenn dies ein Betreiber ausdrücklich aktiviert.
+
+Die erste Implementierung lässt den bestehenden Metrikpfad bewusst unverändert:
+
+```text
+Taxonomy-Anwendung
+  ├─ Spring Boot Actuator und Micrometer → /actuator/prometheus
+  ├─ optionaler OpenTelemetry-Java-Agent
+  │    ├─ HTTP-, Spring-, Hibernate-, JDBC-, HikariCP- und HTTP-Client-Spans
+  │    └─ ausgewählte fachliche Taxonomy-Methoden-Spans
+  └─ OTLP-Traces
+       ↓
+OpenTelemetry Collector
+  ├─ Speicherbegrenzung und Batching
+  ├─ Datenschutz- und Inhaltsfilter
+  └─ Jaeger als lokales Beispiel-Backend
+```
+
+OpenTelemetry ist kein erforderlicher Laufzeitdienst. Taxonomy wird nicht von Jaeger, Grafana, Tempo oder einem kommerziellen Monitoringanbieter abhängig.
+
+## Was instrumentiert wird
+
+Der Java-Agent deckt unterstützte technische Grenzen automatisch ab, insbesondere:
+
+- eingehende Spring-MVC-Anfragen;
+- ausgehende HTTP-Anfragen einschließlich unterstützter LLM-HTTP-Clients;
+- Hibernate-ORM- und JDBC-Operationen;
+- HikariCP sowie Kontextweitergabe über Executors;
+- Ausnahmen und Request-Ergebnisse.
+
+`observability/javaagent.properties` ergänzt grobe interne Spans für Grenzen, die eine generische Framework-Instrumentierung nicht fachlich erkennen kann:
+
+- Workspace-Auflösung und Routing logischer Repositories;
+- JGit-Lesen, Commits, Diffs, Branches und Merges;
+- DSL-Parsing und Materialisierung;
+- Hibernate-Search-Abfragen;
+- Anforderungs- und Kindknotenanalysen;
+- LLM-Orchestrierungsaufrufe;
+- Framework-Vorschau und -Import;
+- Visio-, ArchiMate-, Mermaid- und Structurizr-Exporte.
+
+Die Methodeninstrumentierung erfasst Laufzeit und Ausnahmen. Sie zeichnet **keine** Aufrufargumente oder Rückgabewerte auf.
+
+## Lokaler Trace-Stack
+
+Anwendung, Collector und Jaeger werden gemeinsam gestartet mit:
+
+```bash
+docker compose -f docker-compose.observability.yml up --build
+```
+
+Danach sind erreichbar:
+
+- Taxonomy: `http://localhost:8080`
+- Jaeger: `http://localhost:16686`
+
+In Jaeger den Service `taxonomy` auswählen und anschließend in Taxonomy eine Suche, Analyse, einen Import, Export oder eine DSL-Operation ausführen. Ein Trace sollte einen HTTP-Root-Span, gegebenenfalls Framework- und Datenbank-Child-Spans sowie ausgewählte Taxonomy-Methoden-Spans enthalten.
+
+Der lokale Stack veröffentlicht nur die Anwendung und die Jaeger-Oberfläche auf dem Loopback-Interface. Die OTLP-Ports 4317 und 4318 bleiben im Compose-Netzwerk.
+
+Stoppen:
+
+```bash
+docker compose -f docker-compose.observability.yml down
+```
+
+Lokale Taxonomy-Datenbank zusätzlich löschen:
+
+```bash
+docker compose -f docker-compose.observability.yml down --volumes
+```
+
+## Der normale Start bleibt unverändert
+
+Diese Aufrufe hängen den Agent nicht an:
+
+```bash
+./mvnw -pl taxonomy-app -am spring-boot:run
+docker build -t taxonomy .
+docker run --rm taxonomy
+```
+
+Der Docker-Entrypoint enthält absichtlich keine `-javaagent`-Option. Das bloße Bauen oder Starten des Images benötigt keinen Collector und erzeugt keinen OTLP-Verkehr.
+
+## Externen Collector verwenden
+
+Der mitgelieferte Agent wird ausdrücklich aktiviert und erhält einen OTLP-Endpunkt:
+
+```bash
+docker run --rm \
+  -e JAVA_TOOL_OPTIONS=-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar \
+  -e OTEL_JAVAAGENT_CONFIGURATION_FILE=/opt/opentelemetry/javaagent.properties \
+  -e SPRING_PROFILES_ACTIVE=hsqldb,observability \
+  -e OTEL_SERVICE_NAME=taxonomy \
+  -e OTEL_TRACES_EXPORTER=otlp \
+  -e OTEL_METRICS_EXPORTER=none \
+  -e OTEL_LOGS_EXPORTER=none \
+  -e OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.invalid:4318 \
+  taxonomy
+```
+
+OTLP-Zugangsdaten oder Client-Zertifikate gehören in den Secret-Speicher der Zielumgebung. Sie dürfen nicht in Compose-Dateien oder Repository-Konfigurationen eingecheckt werden.
+
+Für einen entfernten Collector müssen TLS und Authentifizierung eingerichtet werden. Die lokale Beispielkonfiguration verwendet eine unverschlüsselte Verbindung ausschließlich innerhalb des privaten Compose-Netzwerks.
+
+## Sampling
+
+Das lokale Beispiel zeichnet alle Traces auf, damit jeder getestete Ablauf sichtbar ist. Für Produktion sollte ein konfigurierbares parent-basiertes Ratio-Sampling verwendet werden, beispielsweise:
+
+```text
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.10
+```
+
+`0.10` zeichnet ungefähr zehn Prozent neu beginnender Root-Traces auf und respektiert eine vorgelagerte Sampling-Entscheidung. Sampling reduziert Trace-Datenmenge und Overhead, verändert aber nicht die Aggregation der Prometheus-Metriken.
+
+## Metriken
+
+Taxonomy stellt Micrometer-Metriken weiterhin bereit unter:
+
+```text
+/actuator/prometheus
+```
+
+Das Java-Agent-Beispiel setzt:
+
+```text
+OTEL_METRICS_EXPORTER=none
+```
+
+Dadurch entsteht kein zweiter Metrikpfad und es werden Spring-Boot-, JVM-, Hibernate- und Connection-Pool-Metriken nicht doppelt exportiert. Hibernate-Statistiken sind in der Anwendung bereits aktiviert und über den vorhandenen Micrometer-/Prometheus-Pfad verfügbar.
+
+## Log-Korrelation
+
+Das Spring-Profil `observability` formatiert die OpenTelemetry-MDC-Felder so:
+
+```text
+[trace_id=<32 hexadezimale Zeichen> span_id=<16 hexadezimale Zeichen>]
+```
+
+Mit diesen Kennungen kann der zugehörige Trace beziehungsweise Span gefunden werden. Wenn kein Span aktiv ist, erscheint `none`. Logs bleiben in dieser ersten Implementierung bei der Anwendung; der OTLP-Logexport ist deaktiviert.
+
+## Datenminimierung
+
+Telemetrie darf keine Architektur- oder Benutzerinhalte enthalten. Anwendung und Agent erfassen keine Methodenargumente. Der Collector filtert die Daten vor dem Export ein zweites Mal.
+
+Unzulässig sind insbesondere:
+
+- Prompts und LLM-Antworten;
+- DSL-Quelltext und erzeugte Architekturinhalte;
+- Taxonomie-Titel, Beschreibungen und importierte Zellwerte;
+- Workspace- und Repository-Namen;
+- Benutzernamen, E-Mail-Adressen, Tokens, Rollen und Berechtigungen;
+- Dateinamen und absolute Pfade hochgeladener Dateien;
+- Query-Strings und beliebige HTTP-Header;
+- SQL-Bindewerte.
+
+Der Collector entfernt bekannte Generative-AI-Inhaltsattribute, Identitätsfelder, URL-Query-Felder, Taxonomy-Inhaltsfelder, Exception-Meldungen und Stacktraces. Zusätzlich begrenzt er Anzahl und Länge der Attribute. Exception-Typ und Fehlerstatus eines Spans bleiben für die Betriebsdiagnose erhalten.
+
+`@SpanAttribute`, Request-/Response-Header-Erfassung, Request-Parameter-Erfassung und frei formulierte Identifikatoren dürfen nur nach einer gesonderten Datenschutz- und Kardinalitätsprüfung ergänzt werden.
+
+## Ressourcen- und Fehlergrenzen
+
+Die mitgelieferte Collector-Konfiguration verwendet:
+
+- einen Memory-Limiter von 128 MiB;
+- begrenzte Batches;
+- eine begrenzte Exporter-Queue mit 512 Einträgen;
+- eine begrenzte Retry-Dauer;
+- keine persistente Queue;
+- keinen öffentlich erreichbaren Ingestion-Port.
+
+Ein nicht erreichbarer Collector darf den Start von Taxonomy nicht verhindern. Der Java-Agent puffert nur innerhalb begrenzter Grenzen und meldet Exportfehler in seinen eigenen Logs. Wiederholte Exportfehler sollten behoben und nicht durch unbegrenzte Queues verborgen werden.
+
+## Performance-Prüfung
+
+Vor der Aktivierung in Produktion muss derselbe repräsentative Workload mit und ohne Agent verglichen werden. Mindestens zu erfassen sind:
+
+- Startdauer;
+- Speicher- und CPU-Verbrauch im stabilen Betrieb;
+- p50- und p95-Latenz für Suche, Analyse und Repository-Operationen;
+- exportierte Spans pro Request;
+- Wirkung der vorgesehenen Sampling-Rate.
+
+Mehr als zehn Prozent p95-Latenz-Overhead im repräsentativen Test müssen untersucht werden. Zunächst sollten Span-Menge oder Sampling reduziert werden, bevor Collector-Queues oder Speicher vergrößert werden.
+
+## Fehlerbehebung
+
+### Keine Traces sichtbar
+
+Prüfen, ob:
+
+1. `JAVA_TOOL_OPTIONS` den Pfad des mitgelieferten Agents enthält;
+2. `OTEL_TRACES_EXPORTER` auf `otlp` steht;
+3. Endpunkt, Collector-Port und Protokoll zusammenpassen;
+4. die Collector-Konfiguration fehlerfrei geladen wurde;
+5. Jaeger nach einem ausgeführten Request den Service `taxonomy` anzeigt.
+
+Nur zur vorübergehenden Diagnose kann `OTEL_JAVAAGENT_DEBUG=true` gesetzt werden. Die Agent-Debugausgabe ist sehr umfangreich und sollte im Normalbetrieb deaktiviert bleiben.
+
+### Doppelte Spans oder Metriken
+
+Neben dem Java-Agent darf kein separat konfiguriertes OpenTelemetry-SDK beziehungsweise kein zusätzlicher Starter parallel laufen, sofern die Überschneidung nicht ausdrücklich entworfen wurde. Solange Prometheus die Metrikautorität bleibt, müssen Micrometer-Bridge und OTLP-Metrikexport des Agents deaktiviert bleiben.
+
+### Fachlicher Span fehlt nach einem Refactoring
+
+`ObservabilityConfigurationTest` prüft, dass jede in `observability/javaagent.properties` genannte Methode weiterhin existiert. Bei Umbenennungen müssen Konfiguration und Dokumentation gemeinsam aktualisiert werden.
+
+## Versions- und Supply-Chain-Regel
+
+Das Runtime-Image verwendet eine versionierte OpenTelemetry-Java-Agent-Image-Stufe. Auch Collector und Jaeger sind auf konkrete Versionen festgelegt. Aktualisierungen erfolgen als geprüfte Abhängigkeitsänderung mit erneuter Konfigurations-, Container- und Performance-Prüfung. Da der kopierte Agent keine Maven-Runtime-Abhängigkeit ist, muss er zusätzlich beim Container-SBOM und beim Vulnerability-Scanning berücksichtigt werden.

--- a/docs/en/OBSERVABILITY.md
+++ b/docs/en/OBSERVABILITY.md
@@ -1,0 +1,214 @@
+# Observability with OpenTelemetry
+
+Taxonomy supports an **optional, vendor-neutral tracing layer** based on the OpenTelemetry Java agent and OTLP. The normal JVM and Docker startup remain unchanged: the agent is present in the runtime image but is not attached unless an operator explicitly enables it.
+
+The first implementation deliberately keeps the existing metrics path intact:
+
+```text
+Taxonomy application
+  ├─ Spring Boot Actuator and Micrometer → /actuator/prometheus
+  ├─ optional OpenTelemetry Java agent
+  │    ├─ HTTP, Spring, Hibernate, JDBC, HikariCP and HTTP-client spans
+  │    └─ selected Taxonomy method spans
+  └─ OTLP traces
+       ↓
+OpenTelemetry Collector
+  ├─ memory limiting and batching
+  ├─ privacy/content filtering
+  └─ Jaeger (local example)
+```
+
+OpenTelemetry is not a required runtime service and Taxonomy does not depend on Jaeger, Grafana, Tempo or a commercial monitoring vendor.
+
+## What is instrumented
+
+The Java agent automatically covers supported technical boundaries such as:
+
+- incoming Spring MVC requests;
+- outgoing HTTP requests, including calls made by supported LLM HTTP clients;
+- Hibernate ORM and JDBC operations;
+- HikariCP and executor/context propagation;
+- exceptions and request outcomes.
+
+`observability/javaagent.properties` also adds coarse internal spans for boundaries that generic framework instrumentation cannot identify reliably:
+
+- workspace resolution and logical repository routing;
+- JGit repository reads, commits, diffs, branches and merges;
+- DSL parsing and materialisation;
+- Hibernate Search queries;
+- requirement and child-node analysis;
+- LLM orchestration calls;
+- framework preview/import;
+- Visio, ArchiMate, Mermaid and Structurizr exports.
+
+Method instrumentation records method duration and exceptions. It does **not** capture invocation arguments or return values.
+
+## Local trace stack
+
+Start the application, Collector and Jaeger with:
+
+```bash
+docker compose -f docker-compose.observability.yml up --build
+```
+
+Then open:
+
+- Taxonomy: `http://localhost:8080`
+- Jaeger: `http://localhost:16686`
+
+Select the `taxonomy` service in Jaeger and execute a search, analysis, import, export or DSL operation in Taxonomy. A trace should contain an HTTP root span, framework/database child spans where applicable, and selected Taxonomy method spans.
+
+The local stack publishes only the application and Jaeger UI on loopback. OTLP ports 4317 and 4318 remain inside the Compose network.
+
+Stop the stack with:
+
+```bash
+docker compose -f docker-compose.observability.yml down
+```
+
+To remove the local Taxonomy database as well:
+
+```bash
+docker compose -f docker-compose.observability.yml down --volumes
+```
+
+## Normal startup remains unchanged
+
+These commands do not attach the agent:
+
+```bash
+./mvnw -pl taxonomy-app -am spring-boot:run
+docker build -t taxonomy .
+docker run --rm taxonomy
+```
+
+The Docker entrypoint intentionally contains no `-javaagent` option. Merely building or running the image does not require a Collector and produces no OTLP traffic.
+
+## Using an external Collector
+
+Attach the bundled agent explicitly and provide an OTLP endpoint:
+
+```bash
+docker run --rm \
+  -e JAVA_TOOL_OPTIONS=-javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar \
+  -e OTEL_JAVAAGENT_CONFIGURATION_FILE=/opt/opentelemetry/javaagent.properties \
+  -e SPRING_PROFILES_ACTIVE=hsqldb,observability \
+  -e OTEL_SERVICE_NAME=taxonomy \
+  -e OTEL_TRACES_EXPORTER=otlp \
+  -e OTEL_METRICS_EXPORTER=none \
+  -e OTEL_LOGS_EXPORTER=none \
+  -e OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.invalid:4318 \
+  taxonomy
+```
+
+Use deployment secret storage for OTLP authentication headers or client certificates. Do not commit credentials to Compose files or repository configuration.
+
+For a remote Collector, configure TLS and authentication. The included local Collector deliberately uses an unencrypted connection only inside the private Compose network.
+
+## Sampling
+
+The local example uses full sampling so every exercised workflow is visible. Production deployments should use configurable parent-based ratio sampling, for example:
+
+```text
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.10
+```
+
+A value of `0.10` samples approximately ten percent of new root traces while respecting an upstream sampling decision. Sampling reduces trace volume and overhead; it does not change Prometheus metric aggregation.
+
+## Metrics
+
+Taxonomy continues to expose Micrometer metrics at:
+
+```text
+/actuator/prometheus
+```
+
+The Java-agent example sets:
+
+```text
+OTEL_METRICS_EXPORTER=none
+```
+
+This avoids creating a second metric pipeline or duplicating Spring Boot, JVM, Hibernate and database-pool metrics. Hibernate statistics are already enabled in the application and available through the existing Micrometer/Prometheus path.
+
+## Log correlation
+
+The `observability` Spring profile formats the OpenTelemetry MDC fields as:
+
+```text
+[trace_id=<32 hexadecimal characters> span_id=<16 hexadecimal characters>]
+```
+
+Use those identifiers to locate the corresponding trace and span. When no span is active, the fields show `none`. Logs remain local/application-managed in this first implementation; OTLP log export is disabled.
+
+## Data minimisation
+
+Telemetry must not contain architecture or user content. The application/agent configuration avoids method argument capture, and the Collector applies a second privacy filter before export.
+
+Forbidden telemetry includes:
+
+- prompts and LLM responses;
+- DSL source and generated architecture content;
+- taxonomy titles, descriptions or imported cell values;
+- workspace and repository names;
+- usernames, email addresses, access tokens or roles;
+- uploaded filenames and absolute paths;
+- request query strings and arbitrary headers;
+- SQL bind values.
+
+The Collector removes known generative-AI content attributes, identity fields, URL query fields, Taxonomy content fields, exception messages and exception stack traces. It also limits attribute counts and lengths. Exception type and span error status remain available for operational diagnosis.
+
+Do not add `@SpanAttribute`, request/response-header capture, request-parameter capture or free-form identifiers without a separate privacy and cardinality review.
+
+## Resource and failure controls
+
+The included Collector configuration uses:
+
+- a 128 MiB memory limiter;
+- bounded batches;
+- a bounded 512-item exporter queue;
+- bounded retry duration;
+- no persistent queue;
+- no publicly exposed ingestion port.
+
+An unreachable Collector must not prevent Taxonomy from starting. The Java agent buffers within bounded limits and reports exporter failures in its own logs. Repeated exporter failures should be fixed rather than hidden by unbounded queues.
+
+## Performance verification
+
+Before enabling tracing for a production environment, compare the same representative workload with and without the agent. Record at least:
+
+- startup duration;
+- steady-state memory and CPU;
+- p50 and p95 latency for search, analysis and repository operations;
+- exported spans per request;
+- impact of the intended sampling ratio.
+
+Investigate more than ten percent p95 latency overhead under the representative workload. Reduce span volume or sampling before increasing Collector queues or memory.
+
+## Troubleshooting
+
+### No traces appear
+
+Check that:
+
+1. `JAVA_TOOL_OPTIONS` contains the bundled agent path;
+2. `OTEL_TRACES_EXPORTER` is `otlp`;
+3. the endpoint uses the correct Collector port and protocol;
+4. the Collector configuration loaded without errors;
+5. Jaeger lists the `taxonomy` service after a request has been executed.
+
+For temporary diagnostics only, set `OTEL_JAVAAGENT_DEBUG=true`. Agent debug output is verbose and should not remain enabled in normal operation.
+
+### Duplicate spans or metrics
+
+Do not run a separately configured OpenTelemetry SDK/starter alongside the Java agent unless the overlap has been designed explicitly. Keep the agent Micrometer metric bridge and OTLP metric exporter disabled while Prometheus remains the metrics authority.
+
+### Missing domain span after a refactoring
+
+`ObservabilityConfigurationTest` verifies that every method named in `observability/javaagent.properties` still exists. Update the configuration and the documentation when a relevant class or method is renamed.
+
+## Version and supply-chain policy
+
+The runtime image uses a version-pinned OpenTelemetry Java-agent image stage. Collector and Jaeger images also use explicit versions. Upgrade them through a reviewed dependency update and rerun the configuration, container and performance checks. The copied agent is not a Maven runtime dependency, so it must also be considered during container SBOM and vulnerability scanning.

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,40 @@
+# Taxonomy observability deployment files
+
+This directory contains the configuration used by the optional OpenTelemetry deployment:
+
+- `javaagent.properties` — privacy-preserving Java-agent and Taxonomy method instrumentation;
+- `otel-collector-config.yml` — bounded OTLP receiver, privacy filter and Jaeger exporter.
+
+The runtime image bundles the OpenTelemetry Java agent but does not attach it by default. The normal Taxonomy runtime therefore remains independent of a Collector or trace backend.
+
+Use the repository-root `docker-compose.observability.yml` to start the local stack.
+
+Full operational documentation:
+
+- [English](../docs/en/OBSERVABILITY.md)
+- [Deutsch](../docs/de/OBSERVABILITY.md)
+
+## Domain metrics
+
+Taxonomy-owned service boundaries also create Micrometer observations with only fixed, low-cardinality tags. They remain on the existing `/actuator/prometheus` path and use these observation names:
+
+```text
+taxonomy.workspace.resolve
+taxonomy.repository.route
+taxonomy.repository.operation
+taxonomy.search
+taxonomy.analysis
+taxonomy.llm
+taxonomy.import
+taxonomy.export
+```
+
+Every observation uses only:
+
+```text
+taxonomy.component=<fixed component>
+taxonomy.operation=<fixed method name>
+outcome=success|error
+```
+
+Do not add arguments, return values, user or workspace identifiers, filenames, taxonomy content, DSL text, prompts, responses or free-form query values as tags or span attributes.

--- a/observability/javaagent.properties
+++ b/observability/javaagent.properties
@@ -1,0 +1,30 @@
+# Taxonomy OpenTelemetry Java-agent configuration
+#
+# This file is inert unless the Java agent is explicitly attached. It deliberately
+# creates spans only around coarse application boundaries and never captures method
+# arguments, return values, prompts, responses, DSL text, workspace names or files.
+
+# Hibernate/JDBC instrumentation keeps statement structure while replacing bind values.
+otel.instrumentation.common.db-statement-sanitizer.enabled=true
+
+# Identity telemetry remains disabled. Authentication and authorisation are visible
+# through status/error outcomes without exporting usernames, roles or scopes.
+otel.instrumentation.common.enduser.id.enabled=false
+otel.instrumentation.common.enduser.role.enabled=false
+otel.instrumentation.common.enduser.scope.enabled=false
+
+# Add internal spans for boundaries that generic Spring/Hibernate instrumentation
+# cannot identify. The methods instrumentation records duration and exceptions, but
+# does not add invocation arguments as span attributes.
+otel.instrumentation.methods.include=\
+com.taxonomy.workspace.service.WorkspaceContextResolver[resolveCurrentContext,resolveForUser];\
+com.taxonomy.dsl.storage.DslGitRepositoryFactory[resolveRepository,getSystemRepository,getWorkspaceRepository];\
+com.taxonomy.dsl.storage.DslGitRepository[commitDsl,getDslAtHead,getDslAtCommit,getDslHistory,createBranch,diffBetween,diffBranches,textDiff,cherryPick,merge,revert,undoLast,restore];\
+com.taxonomy.versioning.service.DslOperationsFacade[materialize,materializeIncremental,commitDsl,getDslHistory,diffBetween,textDiff,listBranches,createBranch,cherryPick,merge,revert,undoLast,restore,getDslAtHead,getDslAtCommit,getHeadCommit,indexBranch,searchHistory];\
+com.taxonomy.dsl.parser.TaxDslParser[parse];\
+com.taxonomy.catalog.service.SearchService[search];\
+com.taxonomy.analysis.usecase.AnalyzeRequirementUseCase[analyze];\
+com.taxonomy.analysis.usecase.AnalyzeNodeChildrenUseCase[analyze];\
+com.taxonomy.analysis.service.LlmService[analyzeWithBudget,analyzeSingleBatchDetailed,generateLeafJustification,callLlmRaw];\
+com.taxonomy.catalog.service.importer.FrameworkImportService[preview,importFile];\
+com.taxonomy.export.service.ExportFacade[exportAsVisio,exportAsArchiMate,exportAsMermaid,exportAsStructurizrDsl,buildDiagram,importFromJson]

--- a/observability/javaagent.properties
+++ b/observability/javaagent.properties
@@ -7,6 +7,10 @@
 # Hibernate/JDBC instrumentation keeps statement structure while replacing bind values.
 otel.instrumentation.common.db-statement-sanitizer.enabled=true
 
+# Micrometer/Prometheus remains the metric authority. Do not bridge the application's
+# Micrometer meters into the Java agent, which would create a second metric pipeline.
+otel.instrumentation.micrometer.enabled=false
+
 # Identity telemetry remains disabled. Authentication and authorisation are visible
 # through status/error outcomes without exporting usernames, roles or scopes.
 otel.instrumentation.common.enduser.id.enabled=false

--- a/observability/otel-collector-config.yml
+++ b/observability/otel-collector-config.yml
@@ -18,36 +18,41 @@ processors:
 
   # Defence in depth: the application and Java agent are configured not to
   # capture content, and the Collector removes sensitive/unbounded fields again
-  # before a backend can persist them.
+  # before a backend can persist them. Span and event contexts are separated
+  # explicitly so OTTL parsing does not depend on context inference.
   transform/privacy:
     error_mode: ignore
     trace_statements:
-      - delete_key(span.attributes, "url.query")
-      - delete_key(span.attributes, "http.target")
-      - delete_key(span.attributes, "http.url")
-      - delete_key(span.attributes, "enduser.id")
-      - delete_key(span.attributes, "enduser.role")
-      - delete_key(span.attributes, "enduser.scope")
-      - delete_key(span.attributes, "user.id")
-      - delete_key(span.attributes, "user.email")
-      - delete_key(span.attributes, "gen_ai.prompt")
-      - delete_key(span.attributes, "gen_ai.completion")
-      - delete_key(span.attributes, "gen_ai.request.prompt")
-      - delete_key(span.attributes, "gen_ai.response.text")
-      - delete_key(span.attributes, "gen_ai.input.messages")
-      - delete_key(span.attributes, "gen_ai.output.messages")
-      - delete_key(span.attributes, "llm.prompt")
-      - delete_key(span.attributes, "llm.response")
-      - delete_key(span.attributes, "taxonomy.workspace.name")
-      - delete_key(span.attributes, "taxonomy.repository.name")
-      - delete_key(span.attributes, "taxonomy.dsl.source")
-      - delete_key(span.attributes, "taxonomy.document.filename")
-      - delete_key(spanevent.attributes, "exception.message")
-      - delete_key(spanevent.attributes, "exception.stacktrace")
-      - limit(span.attributes, 64, [])
-      - truncate_all(span.attributes, 2048)
-      - limit(spanevent.attributes, 32, [])
-      - truncate_all(spanevent.attributes, 2048)
+      - context: span
+        statements:
+          - delete_key(attributes, "url.query")
+          - delete_key(attributes, "http.target")
+          - delete_key(attributes, "http.url")
+          - delete_key(attributes, "enduser.id")
+          - delete_key(attributes, "enduser.role")
+          - delete_key(attributes, "enduser.scope")
+          - delete_key(attributes, "user.id")
+          - delete_key(attributes, "user.email")
+          - delete_key(attributes, "gen_ai.prompt")
+          - delete_key(attributes, "gen_ai.completion")
+          - delete_key(attributes, "gen_ai.request.prompt")
+          - delete_key(attributes, "gen_ai.response.text")
+          - delete_key(attributes, "gen_ai.input.messages")
+          - delete_key(attributes, "gen_ai.output.messages")
+          - delete_key(attributes, "llm.prompt")
+          - delete_key(attributes, "llm.response")
+          - delete_key(attributes, "taxonomy.workspace.name")
+          - delete_key(attributes, "taxonomy.repository.name")
+          - delete_key(attributes, "taxonomy.dsl.source")
+          - delete_key(attributes, "taxonomy.document.filename")
+          - limit(attributes, 64, [])
+          - truncate_all(attributes, 2048)
+      - context: spanevent
+        statements:
+          - delete_key(attributes, "exception.message")
+          - delete_key(attributes, "exception.stacktrace")
+          - limit(attributes, 32, [])
+          - truncate_all(attributes, 2048)
 
   batch:
     timeout: 5s

--- a/observability/otel-collector-config.yml
+++ b/observability/otel-collector-config.yml
@@ -1,0 +1,80 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 128
+    spike_limit_mib: 32
+
+  # Defence in depth: the application and Java agent are configured not to
+  # capture content, and the Collector removes sensitive/unbounded fields again
+  # before a backend can persist them.
+  transform/privacy:
+    error_mode: ignore
+    trace_statements:
+      - delete_key(span.attributes, "url.query")
+      - delete_key(span.attributes, "http.target")
+      - delete_key(span.attributes, "http.url")
+      - delete_key(span.attributes, "enduser.id")
+      - delete_key(span.attributes, "enduser.role")
+      - delete_key(span.attributes, "enduser.scope")
+      - delete_key(span.attributes, "user.id")
+      - delete_key(span.attributes, "user.email")
+      - delete_key(span.attributes, "gen_ai.prompt")
+      - delete_key(span.attributes, "gen_ai.completion")
+      - delete_key(span.attributes, "gen_ai.request.prompt")
+      - delete_key(span.attributes, "gen_ai.response.text")
+      - delete_key(span.attributes, "gen_ai.input.messages")
+      - delete_key(span.attributes, "gen_ai.output.messages")
+      - delete_key(span.attributes, "llm.prompt")
+      - delete_key(span.attributes, "llm.response")
+      - delete_key(span.attributes, "taxonomy.workspace.name")
+      - delete_key(span.attributes, "taxonomy.repository.name")
+      - delete_key(span.attributes, "taxonomy.dsl.source")
+      - delete_key(span.attributes, "taxonomy.document.filename")
+      - delete_key(spanevent.attributes, "exception.message")
+      - delete_key(spanevent.attributes, "exception.stacktrace")
+      - limit(span.attributes, 64, [])
+      - truncate_all(span.attributes, 2048)
+      - limit(spanevent.attributes, 32, [])
+      - truncate_all(spanevent.attributes, 2048)
+
+  batch:
+    timeout: 5s
+    send_batch_size: 512
+    send_batch_max_size: 1024
+
+exporters:
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+    sending_queue:
+      enabled: true
+      queue_size: 512
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 5s
+      max_elapsed_time: 30s
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, transform/privacy, batch]
+      exporters: [otlp/jaeger]

--- a/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
@@ -1,0 +1,159 @@
+package com.taxonomy.observability;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.util.ClassUtils;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Adds low-cardinality Micrometer observations to Taxonomy-owned service boundaries.
+ *
+ * <p>The OpenTelemetry Java agent remains responsible for automatic technical spans
+ * and selected method spans. These observations intentionally provide the existing
+ * Micrometer/Prometheus path with stable domain timings and outcomes. No invocation
+ * argument, return value, user, workspace, repository, query, prompt, response or
+ * document content is inspected or attached to an observation.</p>
+ */
+@Configuration(proxyBeanMethods = false)
+public class TaxonomyObservationConfiguration {
+
+    @Bean
+    static BeanPostProcessor taxonomyObservationBeanPostProcessor(
+            ObjectProvider<ObservationRegistry> registryProvider) {
+        ObservationRegistry registry = registryProvider.getIfAvailable(
+                () -> ObservationRegistry.NOOP);
+        return new TaxonomyObservationBeanPostProcessor(registry);
+    }
+
+    record TargetDescriptor(String observationName, String component,
+                            Set<String> methods) {
+        TargetDescriptor {
+            methods = Set.copyOf(methods);
+        }
+    }
+
+    static final class TaxonomyObservationBeanPostProcessor
+            implements BeanPostProcessor, Ordered {
+
+        private static final Map<String, TargetDescriptor> TARGETS = Map.ofEntries(
+                Map.entry("com.taxonomy.workspace.service.WorkspaceContextResolver",
+                        new TargetDescriptor("taxonomy.workspace.resolve", "workspace",
+                                Set.of("resolveCurrentContext", "resolveForUser"))),
+                Map.entry("com.taxonomy.dsl.storage.DslGitRepositoryFactory",
+                        new TargetDescriptor("taxonomy.repository.route", "repository",
+                                Set.of("resolveRepository", "getSystemRepository",
+                                        "getWorkspaceRepository"))),
+                Map.entry("com.taxonomy.versioning.service.DslOperationsFacade",
+                        new TargetDescriptor("taxonomy.repository.operation", "repository",
+                                Set.of("materialize", "materializeIncremental", "commitDsl",
+                                        "getDslHistory", "diffBetween", "textDiff",
+                                        "listBranches", "createBranch", "cherryPick", "merge",
+                                        "revert", "undoLast", "restore", "getDslAtHead",
+                                        "getDslAtCommit", "getHeadCommit", "indexBranch",
+                                        "searchHistory"))),
+                Map.entry("com.taxonomy.catalog.service.SearchService",
+                        new TargetDescriptor("taxonomy.search", "search", Set.of("search"))),
+                Map.entry("com.taxonomy.analysis.usecase.AnalyzeRequirementUseCase",
+                        new TargetDescriptor("taxonomy.analysis", "analysis", Set.of("analyze"))),
+                Map.entry("com.taxonomy.analysis.usecase.AnalyzeNodeChildrenUseCase",
+                        new TargetDescriptor("taxonomy.analysis", "analysis", Set.of("analyze"))),
+                Map.entry("com.taxonomy.analysis.service.LlmService",
+                        new TargetDescriptor("taxonomy.llm", "llm",
+                                Set.of("analyzeWithBudget", "analyzeSingleBatchDetailed",
+                                        "generateLeafJustification", "callLlmRaw"))),
+                Map.entry("com.taxonomy.catalog.service.importer.FrameworkImportService",
+                        new TargetDescriptor("taxonomy.import", "import",
+                                Set.of("preview", "importFile"))),
+                Map.entry("com.taxonomy.export.service.ExportFacade",
+                        new TargetDescriptor("taxonomy.export", "export",
+                                Set.of("exportAsVisio", "exportAsArchiMate", "exportAsMermaid",
+                                        "exportAsStructurizrDsl", "buildDiagram",
+                                        "importFromJson")))
+        );
+
+        private final ObservationRegistry observationRegistry;
+
+        TaxonomyObservationBeanPostProcessor(ObservationRegistry observationRegistry) {
+            this.observationRegistry = observationRegistry;
+        }
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName)
+                throws BeansException {
+            Class<?> targetClass = ClassUtils.getUserClass(AopUtils.getTargetClass(bean));
+            TargetDescriptor descriptor = TARGETS.get(targetClass.getName());
+            if (descriptor == null) {
+                return bean;
+            }
+
+            MethodInterceptor interceptor =
+                    new TaxonomyObservationInterceptor(observationRegistry, descriptor);
+            if (bean instanceof Advised advised) {
+                advised.addAdvice(interceptor);
+                return bean;
+            }
+
+            ProxyFactory proxyFactory = new ProxyFactory(bean);
+            proxyFactory.setProxyTargetClass(true);
+            proxyFactory.addAdvice(interceptor);
+            return proxyFactory.getProxy(bean.getClass().getClassLoader());
+        }
+
+        @Override
+        public int getOrder() {
+            return Ordered.LOWEST_PRECEDENCE;
+        }
+    }
+
+    static final class TaxonomyObservationInterceptor implements MethodInterceptor {
+
+        private final ObservationRegistry observationRegistry;
+        private final TargetDescriptor descriptor;
+
+        TaxonomyObservationInterceptor(ObservationRegistry observationRegistry,
+                                       TargetDescriptor descriptor) {
+            this.observationRegistry = observationRegistry;
+            this.descriptor = descriptor;
+        }
+
+        @Override
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            String operation = invocation.getMethod().getName();
+            if (!descriptor.methods().contains(operation)) {
+                return invocation.proceed();
+            }
+
+            Observation observation = Observation.createNotStarted(
+                            descriptor.observationName(), observationRegistry)
+                    .lowCardinalityKeyValue("taxonomy.component", descriptor.component())
+                    .lowCardinalityKeyValue("taxonomy.operation", operation)
+                    .start();
+            try (Observation.Scope ignored = observation.openScope()) {
+                Object result = invocation.proceed();
+                observation.lowCardinalityKeyValue("outcome", "success");
+                return result;
+            } catch (Throwable failure) {
+                // The exception is deliberately not attached to the Observation because its
+                // message may contain imported, DSL or LLM content. Agent method spans retain
+                // exception type and error status independently.
+                observation.lowCardinalityKeyValue("outcome", "error");
+                throw failure;
+            } finally {
+                observation.stop();
+            }
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/I18nConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/I18nConfig.java
@@ -18,7 +18,8 @@ public class I18nConfig {
         ms.setBasenames(
                 "classpath:i18n/messages",
                 "classpath:i18n/messages_document_import",
-                "classpath:i18n/messages_jgit_storage");
+                "classpath:i18n/messages_jgit_storage",
+                "classpath:i18n/messages_observability");
         ms.setDefaultEncoding("UTF-8");
         ms.setFallbackToSystemLocale(false);
         return ms;

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
@@ -74,6 +74,7 @@ public class HelpController {
         new String[]{"FEATURE_MATRIX",             "📋", "help.toc.FEATURE_MATRIX",                "help.audience.developers"},
         new String[]{"DEPLOYMENT_GUIDE",          "🚀", "help.toc.DEPLOYMENT_GUIDE",              "help.audience.devops"},
         new String[]{"CONTAINER_IMAGE",           "🐳", "help.toc.CONTAINER_IMAGE",               "help.audience.devops"},
+        new String[]{"OBSERVABILITY",             "📈", "help.toc.OBSERVABILITY",                 "help.audience.devops"},
         new String[]{"SECURITY",                  "🔒", "help.toc.SECURITY",                      "help.audience.admins"},
         new String[]{"DATABASE_SETUP",            "🗄️", "help.toc.DATABASE_SETUP",                "help.audience.devops"},
         new String[]{"DEPLOYMENT_CHECKLIST",      "✅", "help.toc.DEPLOYMENT_CHECKLIST",           "help.audience.devops"},
@@ -196,8 +197,8 @@ public class HelpController {
     private String parseResource(ClassPathResource resource, String docName) {
         try (InputStream in = resource.getInputStream()) {
             String markdown = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-            markdown = markdown.replaceAll("\\(\\.\\./images/([^)]++)\\)", "(/help/images/$1)");
-            markdown = markdown.replaceAll("src=\"\\.\\./images/([^\"]++)\"", "src=\"/help/images/$1\"");
+            markdown = markdown.replaceAll("\(\.\./images/([^)]++)\)", "(/help/images/$1)");
+            markdown = markdown.replaceAll("src=\"\.\./images/([^\"]++)\"", "src=\"/help/images/$1\"");
             markdown = rewriteRepositoryDocLinks(markdown);
             Node document = parser.parse(markdown);
             String body = renderer.render(document);
@@ -210,8 +211,8 @@ public class HelpController {
 
     static String rewriteRepositoryDocLinks(String markdown) {
         return markdown
-                .replaceAll("\\(\\.\\./dev/([^)]++)\\)", "(" + REPOSITORY_DOCS_URL + "dev/$1)")
-                .replaceAll("\\(\\.\\./internal/([^)]++)\\)", "(" + REPOSITORY_DOCS_URL + "internal/$1)");
+                .replaceAll("\(\.\./dev/([^)]++)\)", "(" + REPOSITORY_DOCS_URL + "dev/$1)")
+                .replaceAll("\(\.\./internal/([^)]++)\)", "(" + REPOSITORY_DOCS_URL + "internal/$1)");
     }
 
     private MediaType guessMediaType(String imageName) {

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
@@ -197,8 +197,8 @@ public class HelpController {
     private String parseResource(ClassPathResource resource, String docName) {
         try (InputStream in = resource.getInputStream()) {
             String markdown = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-            markdown = markdown.replaceAll("\(\.\./images/([^)]++)\)", "(/help/images/$1)");
-            markdown = markdown.replaceAll("src=\"\.\./images/([^\"]++)\"", "src=\"/help/images/$1\"");
+            markdown = markdown.replaceAll("[(][.][.]/images/([^)]++)[)]", "(/help/images/$1)");
+            markdown = markdown.replaceAll("src=\"[.][.]/images/([^\"]++)\"", "src=\"/help/images/$1\"");
             markdown = rewriteRepositoryDocLinks(markdown);
             Node document = parser.parse(markdown);
             String body = renderer.render(document);
@@ -211,8 +211,8 @@ public class HelpController {
 
     static String rewriteRepositoryDocLinks(String markdown) {
         return markdown
-                .replaceAll("\(\.\./dev/([^)]++)\)", "(" + REPOSITORY_DOCS_URL + "dev/$1)")
-                .replaceAll("\(\.\./internal/([^)]++)\)", "(" + REPOSITORY_DOCS_URL + "internal/$1)");
+                .replaceAll("[(][.][.]/dev/([^)]++)[)]", "(" + REPOSITORY_DOCS_URL + "dev/$1)")
+                .replaceAll("[(][.][.]/internal/([^)]++)[)]", "(" + REPOSITORY_DOCS_URL + "internal/$1)");
     }
 
     private MediaType guessMediaType(String imageName) {

--- a/taxonomy-app/src/main/resources/application-observability.properties
+++ b/taxonomy-app/src/main/resources/application-observability.properties
@@ -1,0 +1,4 @@
+# Activated explicitly together with the OpenTelemetry Java agent.
+# The agent's Logback MDC instrumentation uses trace_id and span_id. No tracing
+# dependency or exporter is activated by this Spring profile itself.
+logging.pattern.correlation=[trace_id=%X{trace_id:-none} span_id=%X{span_id:-none}] 

--- a/taxonomy-app/src/main/resources/application-observability.properties
+++ b/taxonomy-app/src/main/resources/application-observability.properties
@@ -1,4 +1,4 @@
 # Activated explicitly together with the OpenTelemetry Java agent.
 # The agent's Logback MDC instrumentation uses trace_id and span_id. No tracing
 # dependency or exporter is activated by this Spring profile itself.
-logging.pattern.correlation=[trace_id=%X{trace_id:-none} span_id=%X{span_id:-none}] 
+logging.pattern.correlation=[trace_id=%X{trace_id:-none} span_id=%X{span_id:-none}]\u0020

--- a/taxonomy-app/src/main/resources/i18n/messages_observability.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_observability.properties
@@ -1,0 +1,1 @@
+help.toc.OBSERVABILITY=Observability

--- a/taxonomy-app/src/main/resources/i18n/messages_observability_de.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_observability_de.properties
@@ -1,0 +1,1 @@
+help.toc.OBSERVABILITY=Observability und Telemetrie

--- a/taxonomy-app/src/test/java/com/taxonomy/observability/ObservabilityConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/observability/ObservabilityConfigurationTest.java
@@ -1,0 +1,176 @@
+package com.taxonomy.observability;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Contract tests for the optional OpenTelemetry deployment files. */
+class ObservabilityConfigurationTest {
+
+    private static final String AGENT_PATH =
+            "/opt/opentelemetry/opentelemetry-javaagent.jar";
+
+    @Test
+    void runtimeImageBundlesAgentButDoesNotAttachItByDefault() throws IOException {
+        String dockerfile = readRepositoryFile("Dockerfile");
+
+        assertTrue(dockerfile.contains(
+                "FROM otel/autoinstrumentation-java:2.30.0 AS opentelemetry"));
+        assertTrue(dockerfile.contains(
+                "COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar "
+                        + AGENT_PATH));
+        assertTrue(dockerfile.contains(
+                "COPY --chown=taxonomy:taxonomy observability/javaagent.properties"));
+
+        String entrypoint = dockerfile.lines()
+                .filter(line -> line.startsWith("ENTRYPOINT"))
+                .findFirst()
+                .orElseThrow();
+        assertFalse(entrypoint.contains("-javaagent"),
+                "The normal container entrypoint must remain telemetry-independent");
+    }
+
+    @Test
+    void optionalComposeStackExportsOnlyTracesAndKeepsIngestionPrivate()
+            throws IOException {
+        String compose = readRepositoryFile("docker-compose.observability.yml");
+
+        assertTrue(compose.contains("-javaagent:" + AGENT_PATH));
+        assertTrue(compose.contains(
+                "OTEL_JAVAAGENT_CONFIGURATION_FILE: /opt/opentelemetry/javaagent.properties"));
+        assertTrue(compose.contains("OTEL_TRACES_EXPORTER: otlp"));
+        assertTrue(compose.contains("OTEL_METRICS_EXPORTER: none"));
+        assertTrue(compose.contains("OTEL_LOGS_EXPORTER: none"));
+        assertTrue(compose.contains("127.0.0.1:8080:8080"));
+        assertTrue(compose.contains("127.0.0.1:16686:16686"));
+        assertFalse(compose.contains("4317:4317"),
+                "OTLP gRPC ingestion must not be published to the host");
+        assertFalse(compose.contains("4318:4318"),
+                "OTLP HTTP ingestion must not be published to the host");
+    }
+
+    @Test
+    void collectorAppliesResourceBoundsAndContentRedaction() throws IOException {
+        String collector = readRepositoryFile("observability/otel-collector-config.yml");
+
+        assertTrue(collector.contains("memory_limiter:"));
+        assertTrue(collector.contains("limit_mib: 128"));
+        assertTrue(collector.contains("send_batch_max_size: 1024"));
+        assertTrue(collector.contains("queue_size: 512"));
+        assertTrue(collector.contains("transform/privacy:"));
+        assertTrue(collector.contains("\"gen_ai.prompt\""));
+        assertTrue(collector.contains("\"gen_ai.input.messages\""));
+        assertTrue(collector.contains("\"taxonomy.dsl.source\""));
+        assertTrue(collector.contains("\"taxonomy.document.filename\""));
+        assertTrue(collector.contains("\"exception.message\""));
+        assertTrue(collector.contains("\"url.query\""));
+    }
+
+    @Test
+    void domainInstrumentationNeverReferencesInvocationContent() throws Exception {
+        Properties properties = loadAgentProperties();
+
+        assertTrue(Boolean.parseBoolean(properties.getProperty(
+                "otel.instrumentation.common.db-statement-sanitizer.enabled")));
+        assertFalse(Boolean.parseBoolean(properties.getProperty(
+                "otel.instrumentation.common.enduser.id.enabled")));
+        assertFalse(Boolean.parseBoolean(properties.getProperty(
+                "otel.instrumentation.common.enduser.role.enabled")));
+        assertFalse(Boolean.parseBoolean(properties.getProperty(
+                "otel.instrumentation.common.enduser.scope.enabled")));
+
+        Map<String, Set<String>> targets = parseTargets(properties.getProperty(
+                "otel.instrumentation.methods.include"));
+        assertFalse(targets.isEmpty());
+
+        for (Map.Entry<String, Set<String>> target : targets.entrySet()) {
+            Class<?> type = Class.forName(target.getKey());
+            for (String methodName : target.getValue()) {
+                assertTrue(Arrays.stream(type.getMethods())
+                                .anyMatch(method -> method.getName().equals(methodName)),
+                        () -> "Configured OpenTelemetry method does not exist: "
+                                + target.getKey() + "." + methodName);
+            }
+        }
+
+        String raw = readRepositoryFile("observability/javaagent.properties")
+                .toLowerCase();
+        assertFalse(raw.contains("spanattribute"));
+        assertFalse(raw.contains("capture-request-headers"));
+        assertFalse(raw.contains("capture-response-headers"));
+        assertFalse(raw.contains("capture-request-parameters"));
+    }
+
+    @Test
+    void observabilityProfileUsesAgentMdcKeysForLogCorrelation()
+            throws IOException {
+        String properties = readRepositoryFile(
+                "taxonomy-app/src/main/resources/application-observability.properties");
+
+        assertTrue(properties.contains("%X{trace_id:-none}"));
+        assertTrue(properties.contains("%X{span_id:-none}"));
+    }
+
+    private static Properties loadAgentProperties() throws IOException {
+        Properties properties = new Properties();
+        try (Reader reader = Files.newBufferedReader(
+                repositoryRoot().resolve("observability/javaagent.properties"))) {
+            properties.load(reader);
+        }
+        return properties;
+    }
+
+    private static Map<String, Set<String>> parseTargets(String configuredTargets) {
+        assertNotNull(configuredTargets);
+        Map<String, Set<String>> result = new LinkedHashMap<>();
+        for (String entry : configuredTargets.split(";")) {
+            int openingBracket = entry.indexOf('[');
+            int closingBracket = entry.lastIndexOf(']');
+            assertTrue(openingBracket > 0 && closingBracket > openingBracket,
+                    () -> "Invalid methods instrumentation entry: " + entry);
+
+            String className = entry.substring(0, openingBracket).trim();
+            Set<String> methods = new LinkedHashSet<>();
+            for (String method : entry.substring(openingBracket + 1, closingBracket)
+                    .split(",")) {
+                if (!method.isBlank()) {
+                    methods.add(method.trim());
+                }
+            }
+            assertFalse(methods.isEmpty(),
+                    () -> "No methods configured for " + className);
+            result.put(className, methods);
+        }
+        return result;
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        return Files.readString(repositoryRoot().resolve(relativePath));
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        if (Files.isRegularFile(current.resolve("taxonomy-app/pom.xml"))) {
+            return current;
+        }
+        if ("taxonomy-app".equals(current.getFileName().toString())
+                && Files.isRegularFile(current.resolve("pom.xml"))) {
+            return current.getParent();
+        }
+        throw new IllegalStateException(
+                "Cannot locate Taxonomy repository root from " + current);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/observability/ObservabilityConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/observability/ObservabilityConfigurationTest.java
@@ -22,13 +22,15 @@ class ObservabilityConfigurationTest {
 
     private static final String AGENT_PATH =
             "/opt/opentelemetry/opentelemetry-javaagent.jar";
+    private static final String AGENT_IMAGE =
+            "otel/autoinstrumentation-java:2.28.1@sha256:"
+                    + "41b92978e61d13d4f32c6eb20c6ae7821a73ffdec8539bc6a73858e884b411d8";
 
     @Test
     void runtimeImageBundlesAgentButDoesNotAttachItByDefault() throws IOException {
         String dockerfile = readRepositoryFile("Dockerfile");
 
-        assertTrue(dockerfile.contains(
-                "FROM otel/autoinstrumentation-java:2.30.0 AS opentelemetry"));
+        assertTrue(dockerfile.contains("FROM " + AGENT_IMAGE + " AS opentelemetry"));
         assertTrue(dockerfile.contains(
                 "COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar "
                         + AGENT_PATH));
@@ -96,8 +98,9 @@ class ObservabilityConfigurationTest {
                 "otel.instrumentation.methods.include"));
         assertFalse(targets.isEmpty());
 
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         for (Map.Entry<String, Set<String>> target : targets.entrySet()) {
-            Class<?> type = Class.forName(target.getKey());
+            Class<?> type = Class.forName(target.getKey(), false, classLoader);
             for (String methodName : target.getValue()) {
                 assertTrue(Arrays.stream(type.getMethods())
                                 .anyMatch(method -> method.getName().equals(methodName)),

--- a/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
@@ -1,0 +1,113 @@
+package com.taxonomy.observability;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TaxonomyObservationConfigurationTest {
+
+    @Test
+    void recordsSuccessfulOperationWithBoundedTags() throws Throwable {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(
+                new DefaultMeterObservationHandler(meterRegistry));
+
+        var descriptor = new TaxonomyObservationConfiguration.TargetDescriptor(
+                "taxonomy.test", "test-component", Set.of("work"));
+        var interceptor = new TaxonomyObservationConfiguration.TaxonomyObservationInterceptor(
+                observationRegistry, descriptor);
+
+        Object result = interceptor.invoke(new StubInvocation(false));
+
+        assertEquals("done", result);
+        Timer timer = meterRegistry.get("taxonomy.test")
+                .tag("taxonomy.component", "test-component")
+                .tag("taxonomy.operation", "work")
+                .tag("outcome", "success")
+                .timer();
+        assertEquals(1, timer.count());
+    }
+
+    @Test
+    void recordsNormalizedErrorOutcomeWithoutExceptionContent() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(
+                new DefaultMeterObservationHandler(meterRegistry));
+
+        var descriptor = new TaxonomyObservationConfiguration.TargetDescriptor(
+                "taxonomy.test", "test-component", Set.of("work"));
+        var interceptor = new TaxonomyObservationConfiguration.TaxonomyObservationInterceptor(
+                observationRegistry, descriptor);
+
+        assertThrows(IllegalStateException.class,
+                () -> interceptor.invoke(new StubInvocation(true)));
+
+        Timer timer = meterRegistry.get("taxonomy.test")
+                .tag("taxonomy.component", "test-component")
+                .tag("taxonomy.operation", "work")
+                .tag("outcome", "error")
+                .timer();
+        assertEquals(1, timer.count());
+    }
+
+    private static final class StubInvocation implements MethodInvocation {
+
+        private final boolean fail;
+        private final Method method;
+
+        private StubInvocation(boolean fail) {
+            this.fail = fail;
+            try {
+                method = StubTarget.class.getDeclaredMethod("work");
+            } catch (NoSuchMethodException exception) {
+                throw new IllegalStateException(exception);
+            }
+        }
+
+        @Override
+        public Method getMethod() {
+            return method;
+        }
+
+        @Override
+        public Object[] getArguments() {
+            return new Object[0];
+        }
+
+        @Override
+        public Object proceed() {
+            if (fail) {
+                throw new IllegalStateException("sensitive content must not become a tag");
+            }
+            return "done";
+        }
+
+        @Override
+        public Object getThis() {
+            return new StubTarget();
+        }
+
+        @Override
+        public AccessibleObject getStaticPart() {
+            return method;
+        }
+    }
+
+    private static final class StubTarget {
+        public String work() {
+            return "done";
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the production-oriented core of #483 as an opt-in, vendor-neutral observability layer.

### Runtime and deployment

- bundle a digest-pinned OpenTelemetry Java agent in the runtime image
- keep the normal entrypoint unchanged and telemetry disabled by default
- add an optional Compose stack with Taxonomy, a bounded OpenTelemetry Collector and Jaeger
- keep OTLP ingestion ports internal and publish only loopback-bound Taxonomy/Jaeger ports
- retain Micrometer/Prometheus as the only metrics export path

### Instrumentation

- automatic Spring MVC, Hibernate, JDBC, HikariCP, executor and supported HTTP-client spans through the Java agent
- explicit coarse method spans for workspace routing, JGit/DSL operations, Hibernate Search, analysis, LLM orchestration, import and export
- Micrometer domain observations for workspace, repository, search, analysis, LLM, import and export duration/outcome
- fixed low-cardinality tags only: component, operation and normalized outcome
- trace/span correlation in logs through an explicit `observability` profile

### Privacy and resilience

- no method argument or return-value capture
- no prompt, response, DSL, taxonomy, workspace, repository, filename or identity attributes
- Collector-side defence-in-depth filtering
- bounded Collector memory, batches, retry duration and exporter queue
- metrics and OTLP log export disabled in the agent to prevent duplicate pipelines

### Verification and documentation

- contract tests for disabled-by-default behavior, immutable agent pinning, private OTLP ports and privacy controls
- reflection checks that every configured domain method still exists after refactoring
- tests for successful/error domain observations and bounded tags
- English and German operations guides
- third-party notice and container-SBOM guidance

## Deliberate scope

This PR establishes the implementation and automated contracts. Issue #483 remains open for a measured p50/p95 overhead report and a live end-to-end OTLP container assertion on the supported CI runner; those require executing the built image and comparing representative workloads rather than inventing performance numbers in code.

## Test plan

- `./mvnw verify`
- existing architecture and build-policy checks
- root Dockerfile supply-chain pin check
- root container build/smoke tests
- `docker compose -f docker-compose.observability.yml config`
- `docker compose -f docker-compose.observability.yml up --build`
- execute search/analysis/repository operations and inspect service `taxonomy` in Jaeger

Refs #483