### PR TITLE
Prioritize analysis workflow on narrow viewports

### DIFF
--- a/.github/scripts/ui-primary-relation-workflows.mjs
+++ b/.github/scripts/ui-primary-relation-workflows.mjs
@@ -1,30 +1,81 @@
 import { navigateArchitectureSubtab } from './ui-role-fixtures.mjs';
 
+const MANUAL_RELATION = {
+  sourceCode: 'CP',
+  targetCode: 'IP',
+  relationType: 'CONSUMES'
+};
+
 export async function runRelationWorkflows({ page, evidence }) {
-  const { passed, axeState, saveState, waitForText } = evidence;
+  const { passed, axeState, saveState } = evidence;
   await navigateArchitectureSubtab(page, 'relations');
   const panel = page.locator('#relationsBrowser');
   if (!(await panel.getAttribute('open'))) await panel.locator('summary').click();
   await page.locator('#relationsTableContainer').waitFor({ state: 'visible' });
 
+  async function waitForRelation(present) {
+    await page.waitForFunction(({ relation, present }) => {
+      const matches = Array.from(document.querySelectorAll('#relationsTableContainer tbody tr'))
+        .filter(row => {
+          const cells = row.querySelectorAll('td');
+          return cells.length >= 3
+            && cells[0].textContent.trim() === relation.sourceCode
+            && cells[1].textContent.trim() === relation.targetCode
+            && cells[2].textContent.trim() === relation.relationType;
+        });
+      return present ? matches.length === 1 : matches.length === 0;
+    }, { relation: MANUAL_RELATION, present }, { timeout: 15_000 });
+  }
+
+  async function exactRelationRow() {
+    const rows = page.locator('#relationsTableContainer tbody tr');
+    const matching = rows.filter({
+      has: page.locator('td:nth-child(1)', { hasText: /^CP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(2)', { hasText: /^IP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(3)', { hasText: /^CONSUMES$/ })
+    });
+    if (await matching.count() !== 1) {
+      throw new Error(`Expected exactly one CP -> IP CONSUMES row, found ${await matching.count()}`);
+    }
+    return matching.first();
+  }
+
+  async function assertBackendRelationCount(expected) {
+    const count = await page.evaluate(async relation => {
+      const response = await fetch('/api/relations', { headers: { Accept: 'application/json' } });
+      if (!response.ok) throw new Error(`Relation list returned ${response.status}`);
+      const relations = await response.json();
+      return relations.filter(item => item.sourceCode === relation.sourceCode
+        && item.targetCode === relation.targetCode
+        && item.relationType === relation.relationType).length;
+    }, MANUAL_RELATION);
+    if (count !== expected) {
+      throw new Error(`Expected ${expected} persisted CP -> IP CONSUMES relation(s), found ${count}`);
+    }
+  }
+
   async function openCreate() {
     await page.locator('#createRelationBtn').click();
     await page.locator('#createRelationModal').waitFor({ state: 'visible', timeout: 10_000 });
-    await page.locator('#newRelSource').fill('CP');
-    await page.locator('#newRelTarget').fill('IP');
-    await page.locator('#newRelType').selectOption('CONSUMES');
+    await page.locator('#newRelSource').fill(MANUAL_RELATION.sourceCode);
+    await page.locator('#newRelTarget').fill(MANUAL_RELATION.targetCode);
+    await page.locator('#newRelType').selectOption(MANUAL_RELATION.relationType);
     await page.locator('#newRelDescription').fill('Primary workflow relation');
   }
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
-  await waitForText('#relationsTableContainer', text => text.includes('CP') && text.includes('IP'));
+  await waitForRelation(true);
+  await assertBackendRelationCount(1);
   passed('relation create');
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationError').waitFor({ state: 'visible', timeout: 15_000 });
+  await assertBackendRelationCount(1);
   await axeState('relation-duplicate-error', '#createRelationModal');
   await saveState('relation-duplicate-error', '#createRelationModal');
   const modal = page.locator('#createRelationModal');
@@ -32,13 +83,10 @@ export async function runRelationWorkflows({ page, evidence }) {
   await modal.waitFor({ state: 'hidden' });
   passed('relation duplicate conflict feedback');
 
-  const row = page.locator('#relationsTableContainer tr', { hasText: 'CP' })
-    .filter({ hasText: 'IP' }).first();
+  const row = await exactRelationRow();
   page.once('dialog', dialog => dialog.accept());
   await row.locator('.relation-delete-btn').click();
-  await page.waitForFunction(() => !Array.from(
-    document.querySelectorAll('#relationsTableContainer tr'))
-    .some(row => row.textContent.includes('CP') && row.textContent.includes('IP')),
-  null, { timeout: 15_000 });
+  await waitForRelation(false);
+  await assertBackendRelationCount(0);
   passed('relation delete confirmation');
 }

--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -122,6 +122,37 @@ export async function runRoleStateFlow({
   passed(`reflow at ${zoom}x`);
   if (forcedColors) passed('forced-colors media state');
 
+  const taskHierarchy = await page.evaluate(() => {
+    const left = document.getElementById('leftPanel');
+    const right = document.getElementById('rightPanel');
+    const navigation = document.getElementById('mainNavTabs');
+    const visibleLinks = Array.from(navigation?.querySelectorAll('.nav-link') || [])
+      .filter(link => getComputedStyle(link).display !== 'none');
+    const maxLinkHeight = visibleLinks.reduce((maximum, link) =>
+      Math.max(maximum, link.getBoundingClientRect().height), 0);
+    return {
+      viewportWidth: window.innerWidth,
+      leftTop: left?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      rightTop: right?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      navigationHeight: navigation?.getBoundingClientRect().height ?? 0,
+      maxLinkHeight,
+      navigationScrollWidth: navigation?.scrollWidth ?? 0,
+      navigationClientWidth: navigation?.clientWidth ?? 0
+    };
+  });
+  if (taskHierarchy.viewportWidth <= 992) {
+    assert(taskHierarchy.rightTop <= taskHierarchy.leftTop,
+      `Primary task must precede taxonomy browser at ${taskHierarchy.viewportWidth}px: `
+      + `${taskHierarchy.rightTop} > ${taskHierarchy.leftTop}`);
+    passed('primary task precedes taxonomy browser at narrow width');
+    assert(taskHierarchy.navigationHeight <= taskHierarchy.maxLinkHeight + 6,
+      `Main navigation wrapped to multiple rows: ${taskHierarchy.navigationHeight} > `
+      + `${taskHierarchy.maxLinkHeight + 6}`);
+    assert(taskHierarchy.navigationScrollWidth >= taskHierarchy.navigationClientWidth,
+      'Main navigation must remain horizontally reachable');
+    passed('single-row scrollable main navigation');
+  }
+
   const expectedHttpFailure = failure => {
     if (failure.status === 503 && failure.path === '/api/analyze') return true;
     return role === 'USER' && failure.status === 403

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -188,8 +188,35 @@
     #rightPanel {
         width: 100% !important;
     }
+    /* The requirement-analysis task is the primary workflow. When the two
+       desktop columns stack, put that task before the reference taxonomy tree. */
+    #rightPanel {
+        order: 1;
+    }
+    #leftPanel {
+        order: 2;
+    }
     .card-body[style*="max-height"] {
         max-height: none !important;
+    }
+    /* Keep every destination directly available without spending several rows
+       of the initial viewport on wrapped navigation tabs. */
+    #mainNavTabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-inline: contain;
+        scroll-snap-type: inline proximity;
+        scrollbar-width: thin;
+        -webkit-overflow-scrolling: touch;
+    }
+    #mainNavTabs .nav-item {
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+    }
+    #mainNavTabs .nav-link {
+        width: auto;
+        white-space: nowrap;
     }
 }
 
@@ -198,13 +225,27 @@
     .navbar-brand {
         width: 100%;
         white-space: normal;
+        font-size: 1rem;
+        line-height: 1.25;
+    }
+    /* These badges duplicate information available in the analysis and context
+       surfaces. Hiding the duplicates preserves controls while reducing the
+       mobile header from several rows to the brand plus one utility row. */
+    #aiStatusBadge,
+    #embeddingStatusBadge,
+    #workspaceUserBadge {
+        display: none !important;
+    }
+    #navbarVersion {
+        display: none;
     }
     #mainNavTabs .nav-item {
-        flex: 1 1 9rem;
+        flex: 0 0 auto;
     }
     #mainNavTabs .nav-link {
-        width: 100%;
-        text-align: left;
+        width: auto;
+        min-width: max-content;
+        text-align: center;
     }
     #businessText {
         min-height: 12rem;

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -315,7 +315,26 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        driver.findElement(By.id("searchBtn")).click();
+
+        WebElement searchButton = driver.findElement(By.id("searchBtn"));
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                searchButton);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const button=arguments[0];"
+                                            + "const rect=button.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===button || button.contains(top);",
+                                    searchButton);
+                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
+                            ? searchButton
+                            : null;
+                })
+                .click();
     }
 
     private void waitForSearchResults() {


### PR DESCRIPTION
## Summary

Implements a focused first slice of #479 using the existing responsive shell and browser acceptance matrix.

- place the primary analysis/task panel before the taxonomy reference tree whenever the desktop columns stack
- keep all main destinations available in one horizontally scrollable tab row instead of consuming several rows of the initial viewport
- remove duplicate AI/embedding/workspace badges from the smallest header while preserving the equivalent analysis/context surfaces and all utility controls
- retain 44 px touch targets, keyboard focus, zoom reflow and forced-colors behavior

## Regression coverage

The Maven-owned role/state flow now verifies for every applicable narrow/zoom profile that:

- the right/primary task panel precedes the taxonomy browser;
- the main navigation remains a single row;
- the row remains horizontally reachable;
- the existing no-page-overflow, reduced-motion, forced-colors, axe, console and network gates still apply.

## Deliberate scope

This does not claim all information-architecture work in #479 is complete. It addresses the most visible first-viewport problem without hiding navigation or introducing an untested mobile-only menu. Later work can progressively disclose repository/model diagnostics and simplify task stages.

## Verification

- `./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true -Dtaxonomy.ui.suite=role-state`

Refs #479