### PR TITLE
Use integrity-verifiable JGit storage release metadata

### DIFF
--- a/.github/scripts/ui-primary-relation-workflows.mjs
+++ b/.github/scripts/ui-primary-relation-workflows.mjs
@@ -1,30 +1,81 @@
 import { navigateArchitectureSubtab } from './ui-role-fixtures.mjs';
 
+const MANUAL_RELATION = {
+  sourceCode: 'CP',
+  targetCode: 'IP',
+  relationType: 'CONSUMES'
+};
+
 export async function runRelationWorkflows({ page, evidence }) {
-  const { passed, axeState, saveState, waitForText } = evidence;
+  const { passed, axeState, saveState } = evidence;
   await navigateArchitectureSubtab(page, 'relations');
   const panel = page.locator('#relationsBrowser');
   if (!(await panel.getAttribute('open'))) await panel.locator('summary').click();
   await page.locator('#relationsTableContainer').waitFor({ state: 'visible' });
 
+  async function waitForRelation(present) {
+    await page.waitForFunction(({ relation, present }) => {
+      const matches = Array.from(document.querySelectorAll('#relationsTableContainer tbody tr'))
+        .filter(row => {
+          const cells = row.querySelectorAll('td');
+          return cells.length >= 3
+            && cells[0].textContent.trim() === relation.sourceCode
+            && cells[1].textContent.trim() === relation.targetCode
+            && cells[2].textContent.trim() === relation.relationType;
+        });
+      return present ? matches.length === 1 : matches.length === 0;
+    }, { relation: MANUAL_RELATION, present }, { timeout: 15_000 });
+  }
+
+  async function exactRelationRow() {
+    const rows = page.locator('#relationsTableContainer tbody tr');
+    const matching = rows.filter({
+      has: page.locator('td:nth-child(1)', { hasText: /^CP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(2)', { hasText: /^IP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(3)', { hasText: /^CONSUMES$/ })
+    });
+    if (await matching.count() !== 1) {
+      throw new Error(`Expected exactly one CP -> IP CONSUMES row, found ${await matching.count()}`);
+    }
+    return matching.first();
+  }
+
+  async function assertBackendRelationCount(expected) {
+    const count = await page.evaluate(async relation => {
+      const response = await fetch('/api/relations', { headers: { Accept: 'application/json' } });
+      if (!response.ok) throw new Error(`Relation list returned ${response.status}`);
+      const relations = await response.json();
+      return relations.filter(item => item.sourceCode === relation.sourceCode
+        && item.targetCode === relation.targetCode
+        && item.relationType === relation.relationType).length;
+    }, MANUAL_RELATION);
+    if (count !== expected) {
+      throw new Error(`Expected ${expected} persisted CP -> IP CONSUMES relation(s), found ${count}`);
+    }
+  }
+
   async function openCreate() {
     await page.locator('#createRelationBtn').click();
     await page.locator('#createRelationModal').waitFor({ state: 'visible', timeout: 10_000 });
-    await page.locator('#newRelSource').fill('CP');
-    await page.locator('#newRelTarget').fill('IP');
-    await page.locator('#newRelType').selectOption('CONSUMES');
+    await page.locator('#newRelSource').fill(MANUAL_RELATION.sourceCode);
+    await page.locator('#newRelTarget').fill(MANUAL_RELATION.targetCode);
+    await page.locator('#newRelType').selectOption(MANUAL_RELATION.relationType);
     await page.locator('#newRelDescription').fill('Primary workflow relation');
   }
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
-  await waitForText('#relationsTableContainer', text => text.includes('CP') && text.includes('IP'));
+  await waitForRelation(true);
+  await assertBackendRelationCount(1);
   passed('relation create');
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationError').waitFor({ state: 'visible', timeout: 15_000 });
+  await assertBackendRelationCount(1);
   await axeState('relation-duplicate-error', '#createRelationModal');
   await saveState('relation-duplicate-error', '#createRelationModal');
   const modal = page.locator('#createRelationModal');
@@ -32,13 +83,10 @@ export async function runRelationWorkflows({ page, evidence }) {
   await modal.waitFor({ state: 'hidden' });
   passed('relation duplicate conflict feedback');
 
-  const row = page.locator('#relationsTableContainer tr', { hasText: 'CP' })
-    .filter({ hasText: 'IP' }).first();
+  const row = await exactRelationRow();
   page.once('dialog', dialog => dialog.accept());
   await row.locator('.relation-delete-btn').click();
-  await page.waitForFunction(() => !Array.from(
-    document.querySelectorAll('#relationsTableContainer tr'))
-    .some(row => row.textContent.includes('CP') && row.textContent.includes('IP')),
-  null, { timeout: 15_000 });
+  await waitForRelation(false);
+  await assertBackendRelationCount(0);
   passed('relation delete confirmation');
 }

--- a/docs/dev/DEPENDENCY_HYGIENE.md
+++ b/docs/dev/DEPENDENCY_HYGIENE.md
@@ -16,6 +16,29 @@ Test-scoped fixtures are not matched by the compile/runtime Maven bans. They mus
 still be justified in the test that introduces them and must never enter the
 packaged application.
 
+## Distribution integrity
+
+Taxonomy consumes `jgit-storage-hibernate` from its anonymous, immutable release
+repository. A version is eligible for use only when the upstream release contains:
+
+- Maven POM and binary/source/Javadoc artifacts for every public module;
+- SHA-1 sidecars required by Maven Resolver compatibility;
+- canonical SHA-256 and SHA-512 sidecars;
+- a `releases/<version>.json` manifest recording every file, size and digest;
+- successful anonymous local and remote resolution in the upstream release state
+  machine before the tag is created.
+
+Do not republish or mutate an already consumed version to repair missing metadata.
+Publish a new release and update the centrally managed
+`jgit-storage-hibernate.version` property instead. Taxonomy CI resolves the release
+on a clean hosted runner, so missing POMs, binaries or checksum metadata are visible
+in the canonical Maven evidence rather than hidden by a developer cache.
+
+Generated WebJar metadata is managed explicitly when an aggregate package points to
+an incomplete artifact version. The root `dependencyManagement` section must pin a
+compatible release with complete metadata and explain the mediation; application
+code must not add duplicate JavaScript packages to work around a Maven warning.
+
 ## Verification and diagnostics
 
 ```bash
@@ -30,6 +53,9 @@ python3 .github/scripts/check-dependency-hygiene.py \
 ./mvnw -pl taxonomy-app dependency:tree \
   -Dscope=runtime \
   -Dincludes='org.apache.pdfbox:*,com.vladsch.flexmark:flexmark-pdf-converter,com.openhtmltopdf:*'
+
+./mvnw -pl taxonomy-app dependency:tree \
+  -Dincludes='io.github.carstenartur:*,org.webjars.npm:d3-hierarchy'
 ```
 
 The CI build archives both the focused dependency tree and the SBOM validation

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,8 @@
         <hibernate-search.version>8.4.0.Final</hibernate-search.version>
         <hibernate-search-backend.version>${hibernate-search.version}</hibernate-search-backend.version>
         <jgit.version>7.7.0.202606012155-r</jgit.version>
-        <jgit-storage-hibernate.version>0.1.13</jgit-storage-hibernate.version>
+        <jgit-storage-hibernate.version>0.1.14</jgit-storage-hibernate.version>
+        <d3-hierarchy.version>3.1.2</d3-hierarchy.version>
         <springdoc.version>3.0.3</springdoc.version>
         <postgresql.version>42.7.12</postgresql.version>
         <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
@@ -128,6 +129,15 @@
                 <version>${jackson-2-bom.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- The aggregate D3 WebJar references 3.0.1, whose generated Maven
+                 metadata is incomplete. Manage the compatible 3.1.2 release so
+                 clean builds resolve complete dependency metadata without a
+                 warning while retaining D3's supported 3.x range. -->
+            <dependency>
+                <groupId>org.webjars.npm</groupId>
+                <artifactId>d3-hierarchy</artifactId>
+                <version>${d3-hierarchy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.search</groupId>

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageHibernateSchemaFilterProvider.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageHibernateSchemaFilterProvider.java
@@ -10,14 +10,21 @@ import org.hibernate.tool.schema.spi.SchemaFilter;
 import org.hibernate.tool.schema.spi.SchemaFilterProvider;
 
 /**
- * Keeps the Flyway-owned JGit Core tables outside Hibernate schema mutation.
+ * Keeps every Flyway-owned JGit Core table outside Hibernate schema mutation.
  *
  * <p>The entities remain mapped and are still included in schema validation. Only
- * create, migrate, truncate and drop operations exclude the two Core tables.</p>
+ * create, migrate, truncate and drop operations exclude the complete released Core
+ * schema. This is deliberately a table allow-list rather than a {@code git_*}
+ * wildcard so an unrelated application table cannot silently escape Hibernate's
+ * lifecycle.</p>
  */
 public final class JgitStorageHibernateSchemaFilterProvider implements SchemaFilterProvider {
 
-    private static final Set<String> FLYWAY_OWNED_TABLES = Set.of("git_packs", "git_reflog");
+    private static final Set<String> FLYWAY_OWNED_TABLES = Set.of(
+            "git_packs",
+            "git_reflog",
+            "git_repository_lock",
+            "git_pack_chunks");
 
     private static final SchemaFilter MUTATION_FILTER = new SchemaFilter() {
         @Override

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -49,6 +49,9 @@ public class JgitStorageSchemaMigrationConfig {
     private static final int LEGACY_TAXONOMY_PACK_EXTENSION_LENGTH = 255;
     private static final int REQUIRED_REF_NAME_LENGTH = 1024;
     private static final int LEGACY_TAXONOMY_REF_NAME_LENGTH = 255;
+    private static final String LATEST_CORE_SCHEMA_VERSION = "0.1.14.2";
+    private static final String LATEST_CORE_BASELINE_DESCRIPTION =
+            "jgit-storage-hibernate-core 0.1.14";
 
     private static final Set<String> LEGACY_PACK_COLUMNS = Set.of(
             "ID",
@@ -59,7 +62,8 @@ public class JgitStorageSchemaMigrationConfig {
             "FILE_SIZE",
             "CREATED_AT");
 
-    private static final Set<String> CURRENT_PACK_COLUMNS = Set.of(
+    /** Exact physical pack shape released from 0.1.4 through 0.1.14.1. */
+    private static final Set<String> PRE_WRITE_LEASE_PACK_COLUMNS = Set.of(
             "ID",
             "REPOSITORY_NAME",
             "PACK_NAME",
@@ -69,6 +73,20 @@ public class JgitStorageSchemaMigrationConfig {
             "COMMITTED",
             "CREATED_AT",
             "COMMITTED_AT");
+
+    /** Exact physical pack shape released by jgit-storage-hibernate 0.1.14. */
+    private static final Set<String> CURRENT_PACK_COLUMNS = Set.of(
+            "ID",
+            "REPOSITORY_NAME",
+            "PACK_NAME",
+            "PACK_EXTENSION",
+            "DATA",
+            "FILE_SIZE",
+            "COMMITTED",
+            "CREATED_AT",
+            "COMMITTED_AT",
+            "WRITE_TOKEN",
+            "WRITE_LEASE_UNTIL");
 
     private static final Set<String> REFLOG_COLUMNS = Set.of(
             "ID",
@@ -124,7 +142,7 @@ public class JgitStorageSchemaMigrationConfig {
                 schema = SchemaSnapshot.inspect(dataSource);
             }
 
-            requireCurrentCoreShape(schema);
+            requireMigratableCoreShape(schema);
             log.info("Migrating managed JGit Core schema for {}", family.displayName());
             flyway.migrate();
             requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
@@ -174,26 +192,55 @@ public class JgitStorageSchemaMigrationConfig {
             return;
         }
 
-        if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
-            requireSafePackRows(dataSource, false);
-            requireCurrentCoreColumnLengths(schema);
-            requireCurrentCoreIndexes(schema);
-            log.info(
-                    "Establishing Flyway history for an exact unversioned JGit Core schema on {}",
-                    family.displayName());
-            migrateNormalWithBaseline(
-                    configuration,
-                    family,
-                    CoreSchemaMigrations.LEGACY_SCHEMA_VERSION,
-                    CoreSchemaMigrations.LEGACY_BASELINE_DESCRIPTION);
-            flyway.migrate();
-            requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
+        if (schema.packColumns().equals(PRE_WRITE_LEASE_PACK_COLUMNS)) {
+            establishUnversionedPreWriteLeaseSchema(configuration, family, dataSource, schema);
             return;
         }
 
-        throw unsafeSchema(
-                "git_packs is neither the exact pre-library Taxonomy shape nor the exact released "
-                        + "Core shape. Existing columns: " + schema.packColumns());
+        if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
+            establishUnversionedCurrentSchema(configuration, family, dataSource, schema);
+            return;
+        }
+
+        throw unsupportedPackColumns(schema.packColumns());
+    }
+
+    private static void establishUnversionedPreWriteLeaseSchema(
+            Configuration configuration,
+            DatabaseFamily family,
+            DataSource dataSource,
+            SchemaSnapshot schema) {
+        requireSafePackRows(dataSource, false);
+        requireCurrentCoreColumnLengths(schema);
+        requirePreWriteLeaseCoreIndexes(schema);
+        log.info(
+                "Establishing Flyway history for an exact pre-0.1.14.2 JGit Core schema on {}",
+                family.displayName());
+        migrateNormalWithBaseline(
+                configuration,
+                family,
+                CoreSchemaMigrations.CURRENT_SCHEMA_VERSION,
+                "verified pre-0.1.14.2 JGit Core schema");
+        requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
+    }
+
+    private static void establishUnversionedCurrentSchema(
+            Configuration configuration,
+            DatabaseFamily family,
+            DataSource dataSource,
+            SchemaSnapshot schema) {
+        requireSafePackRows(dataSource, false);
+        requireCurrentCoreColumnLengths(schema);
+        requireCurrentCoreIndexes(schema);
+        log.info(
+                "Establishing Flyway history for an exact unversioned 0.1.14 schema on {}",
+                family.displayName());
+        migrateNormalWithBaseline(
+                configuration,
+                family,
+                LATEST_CORE_SCHEMA_VERSION,
+                LATEST_CORE_BASELINE_DESCRIPTION);
+        requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
     }
 
     private static void migrateLegacyTaxonomySchema(
@@ -232,9 +279,7 @@ public class JgitStorageSchemaMigrationConfig {
             DataSource dataSource,
             SchemaSnapshot schema,
             boolean legacyAdoptionEnabled) {
-        requireExactColumns("git_packs", schema.packColumns(), CURRENT_PACK_COLUMNS);
-        requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
-        requireCurrentCoreIndexes(schema);
+        requireMigratableCoreContract(schema);
 
         boolean currentLengths = hasCurrentCoreColumnLengths(schema);
         if (!currentLengths) {
@@ -259,7 +304,7 @@ public class JgitStorageSchemaMigrationConfig {
         }
 
         migrateExistingAdoptionStream(configuration, family);
-        requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
+        requireMigratableCoreShape(SchemaSnapshot.inspect(dataSource));
     }
 
     private static LegacyCoreSchemaAdoption.LegacySchemaReport requireSafePackRows(
@@ -327,15 +372,39 @@ public class JgitStorageSchemaMigrationConfig {
                 .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
     }
 
-    private static void requireCurrentCoreShape(SchemaSnapshot schema) {
-        if (!schema.hasTable("git_packs") || !schema.hasTable("git_reflog")) {
-            throw unsafeSchema(
-                    "The Core Flyway history exists but one or both owned tables are missing.");
+    /** Accept only exact released shapes that Flyway can safely advance to the pinned release. */
+    private static void requireMigratableCoreShape(SchemaSnapshot schema) {
+        requireMigratableCoreContract(schema);
+        requireCurrentCoreColumnLengths(schema);
+    }
+
+    private static void requireMigratableCoreContract(SchemaSnapshot schema) {
+        requireCoreTables(schema);
+        requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
+        if (schema.packColumns().equals(PRE_WRITE_LEASE_PACK_COLUMNS)) {
+            requirePreWriteLeaseCoreIndexes(schema);
+            return;
         }
+        if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
+            requireCurrentCoreIndexes(schema);
+            return;
+        }
+        throw unsupportedPackColumns(schema.packColumns());
+    }
+
+    private static void requireCurrentCoreShape(SchemaSnapshot schema) {
+        requireCoreTables(schema);
         requireExactColumns("git_packs", schema.packColumns(), CURRENT_PACK_COLUMNS);
         requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
         requireCurrentCoreColumnLengths(schema);
         requireCurrentCoreIndexes(schema);
+    }
+
+    private static void requireCoreTables(SchemaSnapshot schema) {
+        if (!schema.hasTable("git_packs") || !schema.hasTable("git_reflog")) {
+            throw unsafeSchema(
+                    "The Core Flyway history exists but one or both owned tables are missing.");
+        }
     }
 
     private static boolean hasCurrentCoreColumnLengths(SchemaSnapshot schema) {
@@ -397,7 +466,7 @@ public class JgitStorageSchemaMigrationConfig {
                 List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
-    private static void requireCurrentCoreIndexes(SchemaSnapshot schema) {
+    private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
         requireLegacyCoreIndexes(schema);
         requireIndex(
                 "git_packs",
@@ -409,6 +478,15 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 true,
                 List.of("REPOSITORY_NAME", "PACK_NAME", "PACK_EXTENSION"));
+    }
+
+    private static void requireCurrentCoreIndexes(SchemaSnapshot schema) {
+        requirePreWriteLeaseCoreIndexes(schema);
+        requireIndex(
+                "git_packs",
+                schema.packIndexes(),
+                false,
+                List.of("REPOSITORY_NAME", "COMMITTED", "WRITE_LEASE_UNTIL"));
     }
 
     private static void requireIndex(
@@ -437,6 +515,18 @@ public class JgitStorageSchemaMigrationConfig {
                     table + " does not match the supported schema; missing=" + missing
                             + ", unexpected=" + unexpected);
         }
+    }
+
+    private static IllegalStateException unsupportedPackColumns(Set<String> actual) {
+        Set<String> missing = new LinkedHashSet<>(CURRENT_PACK_COLUMNS);
+        missing.removeAll(actual);
+        Set<String> unexpected = new LinkedHashSet<>(actual);
+        unexpected.removeAll(CURRENT_PACK_COLUMNS);
+        return unsafeSchema(
+                "git_packs is neither the exact pre-library Taxonomy shape nor an exact released "
+                        + "Core shape; missing from current=" + missing
+                        + ", unexpected=" + unexpected
+                        + ", actual=" + actual);
     }
 
     private static IllegalStateException unsafeSchema(String message) {

--- a/taxonomy-app/src/main/resources/application-hsqldb.properties
+++ b/taxonomy-app/src/main/resources/application-hsqldb.properties
@@ -24,9 +24,10 @@ spring.datasource.hikari.pool-name=taxonomy-hsqldb
 # Explicit dialect keeps startup deterministic for both in-memory and file URLs.
 spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
 
-# jgit-storage-hibernate owns git_packs and git_reflog through its released
-# Flyway migration stream. Hibernate still validates these mapped entities but
-# does not create, update, truncate, or drop the two library-owned tables.
+# jgit-storage-hibernate owns git_packs, git_reflog, git_repository_lock and
+# git_pack_chunks through its released Flyway migration stream. Hibernate still
+# validates the mapped entities but must not create, update, truncate or drop any
+# table in that exact ownership boundary.
 spring.flyway.enabled=true
 spring.jpa.properties.hibernate.hbm2ddl.schema_filter_provider=com.taxonomy.dsl.storage.JgitStorageHibernateSchemaFilterProvider
 # One-time, fail-closed adoption of Taxonomy's pre-library pack schema.

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -315,7 +315,26 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        driver.findElement(By.id("searchBtn")).click();
+
+        WebElement searchButton = driver.findElement(By.id("searchBtn"));
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                searchButton);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const button=arguments[0];"
+                                            + "const rect=button.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===button || button.contains(top);",
+                                    searchButton);
+                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
+                            ? searchButton
+                            : null;
+                })
+                .click();
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageHibernateSchemaFilterProviderTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageHibernateSchemaFilterProviderTest.java
@@ -14,7 +14,7 @@ class JgitStorageHibernateSchemaFilterProviderTest {
             new JgitStorageHibernateSchemaFilterProvider();
 
     @Test
-    void excludesOnlyCoreTablesFromEveryMutationFilter() {
+    void excludesEveryReleasedCoreTableFromEveryMutationFilter() {
         assertMutationBoundary(provider.getCreateFilter());
         assertMutationBoundary(provider.getDropFilter());
         assertMutationBoundary(provider.getTruncatorFilter());
@@ -22,15 +22,22 @@ class JgitStorageHibernateSchemaFilterProviderTest {
     }
 
     @Test
-    void keepsCoreTablesInSchemaValidation() {
+    void keepsEveryCoreTableInSchemaValidation() {
         assertThat(provider.getValidateFilter().includeTable(table("git_packs"))).isTrue();
         assertThat(provider.getValidateFilter().includeTable(table("git_reflog"))).isTrue();
+        assertThat(provider.getValidateFilter().includeTable(table("git_repository_lock")))
+                .isTrue();
+        assertThat(provider.getValidateFilter().includeTable(table("git_pack_chunks")))
+                .isTrue();
         assertThat(provider.getValidateFilter().includeTable(table("taxonomy_node"))).isTrue();
     }
 
     private static void assertMutationBoundary(SchemaFilter filter) {
         assertThat(filter.includeTable(table("git_packs"))).isFalse();
         assertThat(filter.includeTable(table("GIT_REFLOG"))).isFalse();
+        assertThat(filter.includeTable(table("git_repository_lock"))).isFalse();
+        assertThat(filter.includeTable(table("GIT_PACK_CHUNKS"))).isFalse();
+        assertThat(filter.includeTable(table("git_unrelated_application_table"))).isTrue();
         assertThat(filter.includeTable(table("taxonomy_node"))).isTrue();
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
@@ -63,7 +63,7 @@ class JgitStoragePostgresMigrationIT {
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
         assertEquals(
-                List.of(CoreSchemaMigrations.CURRENT_SCHEMA_VERSION),
+                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
         SQLException duplicate = assertThrows(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
@@ -36,6 +36,11 @@ import org.junit.jupiter.api.Test;
 
 class JgitStorageSchemaMigrationConfigTest {
 
+    private static final List<String> FULL_CORE_HISTORY = List.of(
+            "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2");
+    private static final List<String> ADOPTED_CORE_HISTORY = List.of(
+            "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2");
+
     @Test
     void installsCoreSchemaIntoEmptyDatabase() throws Exception {
         DataSource dataSource = dataSource("fresh");
@@ -44,10 +49,14 @@ class JgitStorageSchemaMigrationConfigTest {
 
         assertTrue(tableExists(dataSource, "git_packs"));
         assertTrue(tableExists(dataSource, "git_reflog"));
+        assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_pack_chunks"));
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_TOKEN"));
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
         assertEquals(
-                List.of("0.1.4", "0.1.5"),
+                FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
 
@@ -61,7 +70,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(tableExists(dataSource, "application_marker"));
         assertTrue(tableExists(dataSource, "git_packs"));
         assertEquals(
-                List.of("0", "0.1.4", "0.1.5"),
+                List.of("0", "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
 
@@ -86,7 +95,7 @@ class JgitStorageSchemaMigrationConfigTest {
     }
 
     @Test
-    void adoptsActualTaxonomySchemaThroughReleasedV1AndV2WithoutRewritingData()
+    void adoptsActualTaxonomySchemaThroughReleasedStreamsWithoutRewritingData()
             throws Exception {
         DataSource dataSource = dataSource("legacy-adoption");
         installLegacySchema(dataSource);
@@ -100,6 +109,10 @@ class JgitStorageSchemaMigrationConfigTest {
         Set<String> packColumns = columns(dataSource, "git_packs");
         assertTrue(packColumns.contains("COMMITTED"));
         assertTrue(packColumns.contains("COMMITTED_AT"));
+        assertTrue(packColumns.contains("WRITE_TOKEN"));
+        assertTrue(packColumns.contains("WRITE_LEASE_UNTIL"));
+        assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_pack_chunks"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
         assertArrayEquals(original, packData(dataSource, "legacy", "pack-a", "reftable"));
@@ -123,7 +136,7 @@ class JgitStorageSchemaMigrationConfigTest {
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
         assertEquals(
-                List.of(CoreSchemaMigrations.CURRENT_SCHEMA_VERSION),
+                ADOPTED_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
         assertThrows(
@@ -164,12 +177,38 @@ class JgitStorageSchemaMigrationConfigTest {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
+        assertEquals(
+                ADOPTED_CORE_HISTORY,
+                successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
         assertArrayEquals(original, packData(dataSource, "legacy", "pack-v1", "reftable"));
         assertEquals(refName, reflogRefName(dataSource));
 
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+    }
+
+    @Test
+    void upgradesManagedPreWriteLeaseSchemaAndPreservesPackPayload() throws Exception {
+        DataSource dataSource = dataSource("managed-015");
+        flyway(dataSource, CoreSchemaMigrations.CURRENT_SCHEMA_VERSION).migrate();
+        byte[] original = new byte[] {11, 12, 13, 14};
+        insertVersionedPack(dataSource, "managed", "pack-existing", "pack", original);
+        assertFalse(columns(dataSource, "git_packs").contains("WRITE_TOKEN"));
+
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_TOKEN"));
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
+        assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_pack_chunks"));
+        assertArrayEquals(
+                original,
+                packData(dataSource, "managed", "pack-existing", "pack"));
+        assertEquals(
+                FULL_CORE_HISTORY,
+                successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
 
     @Test
@@ -242,7 +281,7 @@ class JgitStorageSchemaMigrationConfigTest {
     }
 
     @Test
-    void establishesHistoryForExactUnversionedCoreSchema() throws Exception {
+    void establishesHistoryForExactUnversionedCurrentCoreSchema() throws Exception {
         DataSource dataSource = dataSource("unversioned-current");
         flyway(dataSource).migrate();
         dropTable(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
@@ -250,8 +289,9 @@ class JgitStorageSchemaMigrationConfigTest {
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
 
         assertEquals(
-                List.of("0.1.4", "0.1.5"),
+                List.of("0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+        assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
     }
 
     private static DataSource dataSource(String purpose) {
@@ -268,6 +308,15 @@ class JgitStorageSchemaMigrationConfigTest {
                 .dataSource(dataSource)
                 .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
                 .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+    }
+
+    private static Flyway flyway(DataSource dataSource, String target) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .target(MigrationVersion.fromVersion(target))
                 .load();
     }
 
@@ -290,6 +339,7 @@ class JgitStorageSchemaMigrationConfigTest {
                 .baselineOnMigrate(true)
                 .baselineVersion(CoreSchemaMigrations.CURRENT_SCHEMA_VERSION)
                 .baselineDescription("adopted pre-library core schema")
+                .target(MigrationVersion.fromVersion(CoreSchemaMigrations.CURRENT_SCHEMA_VERSION))
                 .load()
                 .migrate();
     }
@@ -348,6 +398,31 @@ class JgitStorageSchemaMigrationConfigTest {
             statement.setBytes(4, data);
             statement.setLong(5, data.length);
             statement.setTimestamp(6, Timestamp.from(Instant.now()));
+            statement.executeUpdate();
+        }
+    }
+
+    private static void insertVersionedPack(
+            DataSource dataSource,
+            String repositoryName,
+            String packName,
+            String extension,
+            byte[] data) throws SQLException {
+        Timestamp now = Timestamp.from(Instant.now());
+        try (Connection connection = dataSource.getConnection();
+             var statement = connection.prepareStatement("""
+                     insert into git_packs
+                         (repository_name, pack_name, pack_extension, data, file_size,
+                          committed, created_at, committed_at)
+                     values (?, ?, ?, ?, ?, true, ?, ?)
+                     """)) {
+            statement.setString(1, repositoryName);
+            statement.setString(2, packName);
+            statement.setString(3, extension);
+            statement.setBytes(4, data);
+            statement.setLong(5, data.length);
+            statement.setTimestamp(6, now);
+            statement.setTimestamp(7, now);
             statement.executeUpdate();
         }
     }


### PR DESCRIPTION
## Summary

Completes the Taxonomy-side dependency remediation from #475.

### jgit-storage-hibernate

- update `jgit-storage-hibernate.version` from 0.1.13 to the guarded 0.1.14 release
- consume the newly published immutable Maven layout with SHA-1 compatibility sidecars, canonical SHA-256/SHA-512 sidecars and `releases/0.1.14.json`
- document the distribution-integrity requirements and the rule that published versions are never mutated to repair metadata

The upstream release was produced by its self-checking release state machine: full Maven/Docker verification, local anonymous resolution, remote anonymous resolution, publication, tag/release creation and request-branch cleanup.

### D3 metadata

- manage `org.webjars.npm:d3-hierarchy` at 3.1.2
- avoid the incomplete generated Maven metadata of the aggregate WebJar's 3.0.1 reference
- stay within the supported D3 3.x dependency range without introducing duplicate frontend packages

### Shared CI stabilization

The current hosted Chrome 150 image exposed an existing `ElementClickInterceptedException` in `OnnxSeleniumIT`. The branch includes the same narrowly scoped fix as #487/#488: scroll the real `#searchBtn` to the viewport centre, confirm its centre is unobscured with `elementFromPoint`, then perform the normal Selenium click. This is required for the canonical dependency verification to reach the dependency-policy and SBOM stages; it does not bypass the UI with JavaScript.

## Verification

- anonymous upstream 0.1.14 JAR, POM and checksum sidecars verified
- upstream release manifest verified
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Closes #475 once canonical Maven, CodeQL and Security Scan are green.