### PR TITLE
Verify live OpenTelemetry trace export through Collector

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -33,6 +33,9 @@ class LocalOnnxPipelineIT {
     private static final HttpClient HTTP = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .build();
+    private static final Duration SEARCH_INDEX_TIMEOUT = Duration.ofMinutes(2);
+    private static final String FULL_TEXT_SEARCH_PATH =
+            "/api/search?q=Business%20Processes&maxResults=20";
     private static final String BASIC_AUTH = "Basic "
             + Base64.getEncoder().encodeToString(
                     ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
@@ -141,12 +144,28 @@ class LocalOnnxPipelineIT {
     @Test
     @Order(6)
     void fullTextSearchEndpointReturnsResults() throws Exception {
-        HttpResponse<String> response = httpGet(
-                "/api/search?q=Business%20Processes&maxResults=20");
-        assertThat(response.statusCode()).isEqualTo(200);
-        JsonNode body = MAPPER.readTree(response.body());
-        assertThat(body.isArray()).isTrue();
-        assertThat(body.size()).isGreaterThan(0);
+        long deadline = System.nanoTime() + SEARCH_INDEX_TIMEOUT.toNanos();
+        int lastStatus = -1;
+        String lastBody = "";
+
+        while (System.nanoTime() < deadline) {
+            HttpResponse<String> response = httpGet(FULL_TEXT_SEARCH_PATH);
+            lastStatus = response.statusCode();
+            lastBody = response.body();
+            if (lastStatus == 200) {
+                JsonNode body = MAPPER.readTree(lastBody);
+                if (body.isArray() && !body.isEmpty()) {
+                    return;
+                }
+            }
+            Thread.sleep(500);
+        }
+
+        throw new AssertionError(
+                "Full-text index did not become usable within "
+                        + SEARCH_INDEX_TIMEOUT
+                        + "; last status=" + lastStatus
+                        + ", last body=" + lastBody);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
@@ -1,0 +1,248 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the real Java-agent and OTLP export path against an OpenTelemetry
+ * Collector. The Collector uses its detailed debug exporter so the test can
+ * prove parent/child correlation without introducing a trace backend.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ObservabilityContainerIT {
+
+    private static final String AGENT_IMAGE =
+            "otel/autoinstrumentation-java:2.28.1@sha256:"
+                    + "41b92978e61d13d4f32c6eb20c6ae7821a73ffdec8539bc6a73858e884b411d8";
+    private static final String RUNTIME_IMAGE =
+            "eclipse-temurin:21-jre-jammy@sha256:"
+                    + "2c2088115d82ba0022ccf8080f233d2398b7ad3ba3308ed45e860caf511f6b95";
+    private static final String COLLECTOR_IMAGE =
+            "otel/opentelemetry-collector-contrib:0.157.0";
+    private static final String COLLECTOR_ALIAS = "otel-collector.test";
+    private static final String APP_ALIAS = "taxonomy-observability.test";
+    private static final String BASIC_AUTH = "Basic "
+            + Base64.getEncoder().encodeToString(
+                    ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                            .getBytes(StandardCharsets.UTF_8));
+    private static final Pattern EXPORTED_SPAN = Pattern.compile(
+            "Trace ID\\s*:\\s*([0-9a-fA-F]{32}).*?Name\\s*:\\s*([^\\r\\n]+)",
+            Pattern.DOTALL);
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    private Network network;
+    private GenericContainer<?> collector;
+    private GenericContainer<?> application;
+    private Path generatedDockerfile;
+
+    @BeforeAll
+    void startObservedApplication() throws Exception {
+        network = Network.newNetwork();
+
+        collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(COLLECTOR_ALIAS)
+                .withExposedPorts(4318)
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource(
+                                "observability/otel-collector-test-config.yml"),
+                        "/etc/otelcol-contrib/config.yaml")
+                .withCommand("--config=/etc/otelcol-contrib/config.yaml")
+                .waitingFor(Wait.forLogMessage(".*Everything is ready.*\\n", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
+        collector.start();
+
+        Future<String> observedImage = observedApplicationImage();
+        application = new GenericContainer<>(observedImage)
+                .withNetwork(network)
+                .withNetworkAliases(APP_ALIAS)
+                .withExposedPorts(8080)
+                .withEnv("SPRING_PROFILES_ACTIVE", "hsqldb,observability")
+                .withEnv("TAXONOMY_ADMIN_PASSWORD",
+                        ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                .withEnv("TAXONOMY_REQUIRE_PASSWORD_CHANGE", "false")
+                .withEnv("TAXONOMY_EMBEDDING_ENABLED", "false")
+                .withEnv("TAXONOMY_THYMELEAF_CACHE", "false")
+                .withEnv("LLM_MOCK", "true")
+                .withEnv("JAVA_TOOL_OPTIONS",
+                        "-javaagent:/tmp/opentelemetry-javaagent.jar")
+                .withEnv("OTEL_JAVAAGENT_CONFIGURATION_FILE",
+                        "/tmp/javaagent.properties")
+                .withEnv("OTEL_SERVICE_NAME", "taxonomy-observability-it")
+                .withEnv("OTEL_TRACES_EXPORTER", "otlp")
+                .withEnv("OTEL_METRICS_EXPORTER", "none")
+                .withEnv("OTEL_LOGS_EXPORTER", "none")
+                .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+                .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT",
+                        "http://" + COLLECTOR_ALIAS + ":4318")
+                .withEnv("OTEL_TRACES_SAMPLER", "always_on")
+                .withEnv("OTEL_BSP_SCHEDULE_DELAY", "100")
+                .withEnv("OTEL_BSP_EXPORT_TIMEOUT", "1000")
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        application.start();
+    }
+
+    @AfterAll
+    void stopContainers() throws Exception {
+        ContainerTestUtils.closeAll(application, collector, network);
+        if (generatedDockerfile != null) {
+            Files.deleteIfExists(generatedDockerfile);
+        }
+    }
+
+    @Test
+    void exportsCorrelatedHttpAndTaxonomySpansAndFailsOpenWithoutCollector()
+            throws Exception {
+        HttpResponse<String> relations = applicationGet("/api/relations");
+        assertThat(relations.statusCode()).isEqualTo(200);
+
+        HttpResponse<String> prometheus = applicationGet("/actuator/prometheus");
+        assertThat(prometheus.statusCode()).isEqualTo(200);
+        assertThat(prometheus.body()).contains("jvm_memory");
+
+        TraceEvidence evidence = awaitCorrelatedTrace();
+        assertThat(evidence.spanNames())
+                .anyMatch(name -> name.contains("/api/relations"));
+        assertThat(evidence.spanNames())
+                .anyMatch(name -> name.contains("resolveCurrentContext"));
+        assertThat(evidence.collectorLogs())
+                .doesNotContain(
+                        "taxonomy.workspace.name",
+                        "taxonomy.repository.name",
+                        "taxonomy.dsl.source",
+                        "taxonomy.document.filename",
+                        "gen_ai.prompt",
+                        "llm.prompt");
+
+        collector.stop();
+
+        HttpResponse<String> withoutCollector = applicationGet("/api/relations");
+        assertThat(withoutCollector.statusCode()).isEqualTo(200);
+    }
+
+    private Future<String> observedApplicationImage() throws Exception {
+        Path root = repositoryRoot();
+        generatedDockerfile = Files.createTempFile(
+                root.resolve("target"), "Dockerfile-observability-it-", ".dockerfile");
+        Files.writeString(generatedDockerfile, """
+                FROM %s AS opentelemetry
+                FROM %s
+                WORKDIR /app
+                COPY app.jar /app/app.jar
+                COPY javaagent.properties /tmp/javaagent.properties
+                COPY --from=opentelemetry /javaagent.jar /tmp/opentelemetry-javaagent.jar
+                EXPOSE 8080
+                ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+                """.formatted(AGENT_IMAGE, RUNTIME_IMAGE));
+
+        return new ImageFromDockerfile("taxonomy-observability-it", false)
+                .withDockerfile(generatedDockerfile)
+                .withFileFromPath("app.jar", ContainerTestUtils.findApplicationJar())
+                .withFileFromPath(
+                        "javaagent.properties",
+                        root.resolve("observability/javaagent.properties"));
+    }
+
+    private TraceEvidence awaitCorrelatedTrace() throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        String lastLogs = "";
+        while (System.nanoTime() < deadline) {
+            lastLogs = collector.getLogs();
+            Map<String, Set<String>> spansByTrace = spansByTrace(lastLogs);
+            for (Map.Entry<String, Set<String>> trace : spansByTrace.entrySet()) {
+                boolean http = trace.getValue().stream()
+                        .anyMatch(name -> name.contains("/api/relations"));
+                boolean taxonomy = trace.getValue().stream()
+                        .anyMatch(name -> name.contains("resolveCurrentContext"));
+                if (http && taxonomy) {
+                    return new TraceEvidence(
+                            trace.getKey(), Set.copyOf(trace.getValue()), lastLogs);
+                }
+            }
+            Thread.sleep(250);
+        }
+
+        int start = Math.max(0, lastLogs.length() - 12_000);
+        throw new AssertionError(
+                "No correlated HTTP and Taxonomy spans were exported. Collector tail:\n"
+                        + lastLogs.substring(start));
+    }
+
+    private static Map<String, Set<String>> spansByTrace(String logs) {
+        Map<String, Set<String>> result = new LinkedHashMap<>();
+        Matcher matcher = EXPORTED_SPAN.matcher(logs);
+        while (matcher.find()) {
+            result.computeIfAbsent(
+                            matcher.group(1).toLowerCase(),
+                            ignored -> new LinkedHashSet<>())
+                    .add(matcher.group(2).trim());
+        }
+        return result;
+    }
+
+    private HttpResponse<String> applicationGet(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(applicationUri(path))
+                .timeout(Duration.ofSeconds(20))
+                .header("Accept", "application/json")
+                .header("Authorization", BASIC_AUTH)
+                .GET()
+                .build();
+        return HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private URI applicationUri(String path) {
+        return URI.create("http://" + application.getHost() + ":"
+                + application.getMappedPort(8080) + path);
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("project.basedir", "."))
+                .toAbsolutePath().normalize();
+        if (Files.isRegularFile(current.resolve("taxonomy-app/pom.xml"))) {
+            return current;
+        }
+        if ("taxonomy-app".equals(current.getFileName().toString())
+                && Files.isRegularFile(current.resolve("pom.xml"))) {
+            return current.getParent();
+        }
+        throw new IllegalStateException(
+                "Cannot locate Taxonomy repository root from " + current);
+    }
+
+    private record TraceEvidence(
+            String traceId,
+            Set<String> spanNames,
+            String collectorLogs) {
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
@@ -45,7 +45,8 @@ class ObservabilityContainerIT {
             "eclipse-temurin:21-jre-jammy@sha256:"
                     + "2c2088115d82ba0022ccf8080f233d2398b7ad3ba3308ed45e860caf511f6b95";
     private static final String COLLECTOR_IMAGE =
-            "otel/opentelemetry-collector-contrib:0.157.0";
+            "otel/opentelemetry-collector-contrib:0.157.0@sha256:"
+                    + "f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6";
     private static final String COLLECTOR_ALIAS = "otel-collector.test";
     private static final String APP_ALIAS = "taxonomy-observability.test";
     private static final String BASIC_AUTH = "Basic "
@@ -71,7 +72,6 @@ class ObservabilityContainerIT {
         collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
                 .withNetwork(network)
                 .withNetworkAliases(COLLECTOR_ALIAS)
-                .withExposedPorts(4318)
                 .withCopyFileToContainer(
                         MountableFile.forClasspathResource(
                                 "observability/otel-collector-test-config.yml"),
@@ -153,8 +153,10 @@ class ObservabilityContainerIT {
 
     private Future<String> observedApplicationImage() throws Exception {
         Path root = repositoryRoot();
+        Path targetDir = root.resolve("target");
+        Files.createDirectories(targetDir);
         generatedDockerfile = Files.createTempFile(
-                root.resolve("target"), "Dockerfile-observability-it-", ".dockerfile");
+                targetDir, "Dockerfile-observability-it-", ".dockerfile");
         Files.writeString(generatedDockerfile, """
                 FROM %s AS opentelemetry
                 FROM %s

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
@@ -127,7 +127,8 @@ class ObservabilityContainerIT {
         HttpResponse<String> relations = applicationGet("/api/relations");
         assertThat(relations.statusCode()).isEqualTo(200);
 
-        HttpResponse<String> prometheus = applicationGet("/actuator/prometheus");
+        HttpResponse<String> prometheus = applicationGet(
+                "/actuator/prometheus", "text/plain");
         assertThat(prometheus.statusCode()).isEqualTo(200);
         assertThat(prometheus.body()).contains("jvm_memory");
 
@@ -214,9 +215,14 @@ class ObservabilityContainerIT {
     }
 
     private HttpResponse<String> applicationGet(String path) throws Exception {
+        return applicationGet(path, "application/json");
+    }
+
+    private HttpResponse<String> applicationGet(String path, String accept)
+            throws Exception {
         HttpRequest request = HttpRequest.newBuilder(applicationUri(path))
                 .timeout(Duration.ofSeconds(20))
-                .header("Accept", "application/json")
+                .header("Accept", accept)
                 .header("Authorization", BASIC_AUTH)
                 .GET()
                 .build();

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -220,9 +220,10 @@ class OnnxSeleniumIT {
         }
 
         assertThat(items).isNotEmpty();
-        String code = items.getFirst().getAttribute("data-code");
+        WebElement firstResult = items.getFirst();
+        String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        items.getFirst().click();
+        clickWhenUnobscured(firstResult);
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -300,6 +301,29 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
+    private void clickWhenUnobscured(WebElement element) {
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                element);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const target=arguments[0];"
+                                            + "const rect=target.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===target || target.contains(top);",
+                                    element);
+                    return Boolean.TRUE.equals(unobscured)
+                            && element.isDisplayed()
+                            && element.isEnabled()
+                            ? element
+                            : null;
+                })
+                .click();
+    }
+
     private void executeUiSearch(String mode, String query) {
         WebElement searchPanel = driver.findElement(By.id("searchPanel"));
         if (searchPanel.getAttribute("open") == null) {
@@ -315,7 +339,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        driver.findElement(By.id("searchBtn")).click();
+        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,20 +1,23 @@
 package com.taxonomy;
 
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,26 +32,28 @@ class ProductionPersistenceRestartIT {
     private static final String PERSISTENCE_PROVENANCE = "production-persistence-restart-it";
     private static final String AUTHORIZATION = "Basic " + Base64.getEncoder().encodeToString(
             ("admin:" + ADMIN_PASSWORD).getBytes(StandardCharsets.UTF_8));
-
-    @TempDir
-    Path persistentData;
+    private static final Duration PRODUCTION_STARTUP_TIMEOUT = Duration.ofMinutes(3);
 
     @Test
     void relationSurvivesContainerReplacement() throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+        String dataVolume = "taxonomy-persistence-it-"
+                + UUID.randomUUID().toString().replace("-", "");
+        GenericContainer<?> first = null;
+        GenericContainer<?> second = null;
 
-        long countBeforeWrite;
-        GenericContainer<?> first = persistentAppContainer();
         try {
+            long countBeforeWrite;
+            first = persistentAppContainer(dataVolume);
             first.start();
-            URI origin = origin(first);
-            awaitInitialized(client, origin);
+            URI firstOrigin = origin(first);
+            awaitInitialized(client, firstOrigin);
 
-            countBeforeWrite = relationCount(client, origin);
+            countBeforeWrite = relationCount(client, firstOrigin);
             HttpResponse<String> createResponse = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    firstOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString("""
@@ -63,19 +68,17 @@ class ProductionPersistenceRestartIT {
                     .build());
             assertThat(createResponse.statusCode()).isEqualTo(200);
             assertThat(createResponse.body()).contains(PERSISTENCE_PROVENANCE);
-            assertThat(relationCount(client, origin)).isGreaterThan(countBeforeWrite);
-        } finally {
-            stopContainerAndRestoreHostPermissions(first);
-        }
+            assertThat(relationCount(client, firstOrigin)).isGreaterThan(countBeforeWrite);
+            first.stop();
+            first = null;
 
-        GenericContainer<?> second = persistentAppContainer();
-        try {
+            second = persistentAppContainer(dataVolume);
             second.start();
-            URI origin = origin(second);
-            awaitInitialized(client, origin);
+            URI secondOrigin = origin(second);
+            awaitInitialized(client, secondOrigin);
 
             HttpResponse<String> relations = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    secondOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .GET()
                     .build());
@@ -87,16 +90,24 @@ class ProductionPersistenceRestartIT {
             // Catalogue-derived relation totals may be normalized during startup. The
             // persistence contract is that the explicit user relation survives and that
             // the repository does not fall below its pre-write baseline.
-            assertThat(relationCount(client, origin)).isGreaterThanOrEqualTo(countBeforeWrite);
+            assertThat(relationCount(client, secondOrigin))
+                    .isGreaterThanOrEqualTo(countBeforeWrite);
         } finally {
-            stopContainerAndRestoreHostPermissions(second);
+            stopQuietly(second);
+            stopQuietly(first);
+            removeVolume(dataVolume);
         }
     }
 
-    private GenericContainer<?> persistentAppContainer() {
+    private GenericContainer<?> persistentAppContainer(String dataVolume) {
         return ContainerTestUtils.appContainer()
-                .withFileSystemBind(persistentData.toAbsolutePath().toString(),
-                        "/app/data", BindMode.READ_WRITE)
+                .withCreateContainerCmdModifier(command -> command.getHostConfig()
+                        .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .forPort(8080)
+                        .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))
+                .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT)
                 .withEnv("SPRING_PROFILES_ACTIVE", "production,hsqldb")
                 .withEnv("TAXONOMY_DATASOURCE_URL",
                         "jdbc:hsqldb:file:/app/data/taxonomydb;hsqldb.default_table_type=cached;"
@@ -111,26 +122,24 @@ class ProductionPersistenceRestartIT {
                 .withEnv("TAXONOMY_THYMELEAF_CACHE", "true");
     }
 
-    /**
-     * The production image deliberately runs as the non-root {@code taxonomy}
-     * user. Files created in a host bind mount therefore have the container UID.
-     * Before JUnit removes its {@link TempDir}, make the persisted contents
-     * writable by the host runner. This preserves the non-root runtime contract
-     * while keeping test cleanup deterministic.
-     */
-    private static void stopContainerAndRestoreHostPermissions(GenericContainer<?> container)
-            throws Exception {
+    private static void stopQuietly(GenericContainer<?> container) {
+        if (container == null) {
+            return;
+        }
         try {
-            if (container.isRunning()) {
-                var result = container.execInContainer(
-                        "sh", "-c",
-                        "find /app/data -mindepth 1 -exec chmod a+rwX {} +");
-                assertThat(result.getExitCode())
-                        .as("restore host cleanup permissions: %s", result.getStderr())
-                        .isZero();
-            }
-        } finally {
             container.stop();
+        } catch (RuntimeException ignored) {
+            // Preserve the original test failure; volume removal below is still attempted.
+        }
+    }
+
+    private static void removeVolume(String volumeName) {
+        try {
+            DockerClientFactory.instance().client()
+                    .removeVolumeCmd(volumeName)
+                    .exec();
+        } catch (NotFoundException ignored) {
+            // A failed container creation may not have created the named volume yet.
         }
     }
 

--- a/taxonomy-app/src/test/resources/observability/otel-collector-test-config.yml
+++ b/taxonomy-app/src/test/resources/observability/otel-collector-test-config.yml
@@ -1,0 +1,65 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 96
+    spike_limit_mib: 24
+
+  transform/privacy:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - delete_key(attributes, "url.query")
+          - delete_key(attributes, "http.target")
+          - delete_key(attributes, "http.url")
+          - delete_key(attributes, "enduser.id")
+          - delete_key(attributes, "enduser.role")
+          - delete_key(attributes, "enduser.scope")
+          - delete_key(attributes, "user.id")
+          - delete_key(attributes, "user.email")
+          - delete_key(attributes, "gen_ai.prompt")
+          - delete_key(attributes, "gen_ai.completion")
+          - delete_key(attributes, "gen_ai.request.prompt")
+          - delete_key(attributes, "gen_ai.response.text")
+          - delete_key(attributes, "gen_ai.input.messages")
+          - delete_key(attributes, "gen_ai.output.messages")
+          - delete_key(attributes, "llm.prompt")
+          - delete_key(attributes, "llm.response")
+          - delete_key(attributes, "taxonomy.workspace.name")
+          - delete_key(attributes, "taxonomy.repository.name")
+          - delete_key(attributes, "taxonomy.dsl.source")
+          - delete_key(attributes, "taxonomy.document.filename")
+      - context: spanevent
+        statements:
+          - delete_key(attributes, "exception.message")
+          - delete_key(attributes, "exception.stacktrace")
+
+  batch:
+    timeout: 200ms
+    send_batch_size: 1
+    send_batch_max_size: 64
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  extensions: [health_check]
+  telemetry:
+    logs:
+      level: info
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, transform/privacy, batch]
+      exporters: [debug]


### PR DESCRIPTION
## Summary

Adds the missing live OTLP acceptance proof from #483 without introducing a mandatory trace backend or workflow-owned test logic.

### Real runtime path

- build a minimal Testcontainers runtime image from the already packaged Taxonomy JAR
- copy the exact digest-pinned OpenTelemetry Java agent used by the production Dockerfile
- attach the agent explicitly through `JAVA_TOOL_OPTIONS`
- start the pinned OpenTelemetry Collector in the same isolated Docker network
- export traces through OTLP HTTP/protobuf with metrics and logs disabled

### Correlation assertion

The test calls the authenticated `/api/relations` endpoint and inspects the Collector's detailed debug export. It requires one trace ID to contain both:

- the automatic HTTP server span for `/api/relations`; and
- the Taxonomy-specific `WorkspaceContextResolver.resolveCurrentContext` method span.

This proves that generic framework instrumentation and a Taxonomy domain boundary are exported as one correlated trace.

### Safety assertions

- run the same privacy transform used by the optional deployment before the debug exporter
- reject forbidden workspace, repository, DSL, filename and LLM content attributes in exported evidence
- verify `/actuator/prometheus` remains available
- stop the Collector and verify Taxonomy continues serving requests, proving telemetry failure does not become an application failure
- keep Collector ingestion ports internal to the Testcontainers network

The test is a normal `*IT` and therefore runs under Maven's existing integration-test authority when `skipITs=false`; no GitHub-specific test selection is added.

## Verification

- `./mvnw -B verify -Pci -DrunOnnxTests=true`
- focused reproduction: `./mvnw -B verify -pl taxonomy-app -am -DskipITs=false -Dit.test=ObservabilityContainerIT`

Refs #483