### PR TITLE
Prioritize analysis workflow on narrow viewports

### DIFF
--- a/.github/scripts/ui-primary-relation-workflows.mjs
+++ b/.github/scripts/ui-primary-relation-workflows.mjs
@@ -1,30 +1,81 @@
 import { navigateArchitectureSubtab } from './ui-role-fixtures.mjs';
 
+const MANUAL_RELATION = {
+  sourceCode: 'CP',
+  targetCode: 'IP',
+  relationType: 'CONSUMES'
+};
+
 export async function runRelationWorkflows({ page, evidence }) {
-  const { passed, axeState, saveState, waitForText } = evidence;
+  const { passed, axeState, saveState } = evidence;
   await navigateArchitectureSubtab(page, 'relations');
   const panel = page.locator('#relationsBrowser');
   if (!(await panel.getAttribute('open'))) await panel.locator('summary').click();
   await page.locator('#relationsTableContainer').waitFor({ state: 'visible' });
 
+  async function waitForRelation(present) {
+    await page.waitForFunction(({ relation, present }) => {
+      const matches = Array.from(document.querySelectorAll('#relationsTableContainer tbody tr'))
+        .filter(row => {
+          const cells = row.querySelectorAll('td');
+          return cells.length >= 3
+            && cells[0].textContent.trim() === relation.sourceCode
+            && cells[1].textContent.trim() === relation.targetCode
+            && cells[2].textContent.trim() === relation.relationType;
+        });
+      return present ? matches.length === 1 : matches.length === 0;
+    }, { relation: MANUAL_RELATION, present }, { timeout: 15_000 });
+  }
+
+  async function exactRelationRow() {
+    const rows = page.locator('#relationsTableContainer tbody tr');
+    const matching = rows.filter({
+      has: page.locator('td:nth-child(1)', { hasText: /^CP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(2)', { hasText: /^IP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(3)', { hasText: /^CONSUMES$/ })
+    });
+    if (await matching.count() !== 1) {
+      throw new Error(`Expected exactly one CP -> IP CONSUMES row, found ${await matching.count()}`);
+    }
+    return matching.first();
+  }
+
+  async function assertBackendRelationCount(expected) {
+    const count = await page.evaluate(async relation => {
+      const response = await fetch('/api/relations', { headers: { Accept: 'application/json' } });
+      if (!response.ok) throw new Error(`Relation list returned ${response.status}`);
+      const relations = await response.json();
+      return relations.filter(item => item.sourceCode === relation.sourceCode
+        && item.targetCode === relation.targetCode
+        && item.relationType === relation.relationType).length;
+    }, MANUAL_RELATION);
+    if (count !== expected) {
+      throw new Error(`Expected ${expected} persisted CP -> IP CONSUMES relation(s), found ${count}`);
+    }
+  }
+
   async function openCreate() {
     await page.locator('#createRelationBtn').click();
     await page.locator('#createRelationModal').waitFor({ state: 'visible', timeout: 10_000 });
-    await page.locator('#newRelSource').fill('CP');
-    await page.locator('#newRelTarget').fill('IP');
-    await page.locator('#newRelType').selectOption('CONSUMES');
+    await page.locator('#newRelSource').fill(MANUAL_RELATION.sourceCode);
+    await page.locator('#newRelTarget').fill(MANUAL_RELATION.targetCode);
+    await page.locator('#newRelType').selectOption(MANUAL_RELATION.relationType);
     await page.locator('#newRelDescription').fill('Primary workflow relation');
   }
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
-  await waitForText('#relationsTableContainer', text => text.includes('CP') && text.includes('IP'));
+  await waitForRelation(true);
+  await assertBackendRelationCount(1);
   passed('relation create');
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationError').waitFor({ state: 'visible', timeout: 15_000 });
+  await assertBackendRelationCount(1);
   await axeState('relation-duplicate-error', '#createRelationModal');
   await saveState('relation-duplicate-error', '#createRelationModal');
   const modal = page.locator('#createRelationModal');
@@ -32,13 +83,10 @@ export async function runRelationWorkflows({ page, evidence }) {
   await modal.waitFor({ state: 'hidden' });
   passed('relation duplicate conflict feedback');
 
-  const row = page.locator('#relationsTableContainer tr', { hasText: 'CP' })
-    .filter({ hasText: 'IP' }).first();
+  const row = await exactRelationRow();
   page.once('dialog', dialog => dialog.accept());
   await row.locator('.relation-delete-btn').click();
-  await page.waitForFunction(() => !Array.from(
-    document.querySelectorAll('#relationsTableContainer tr'))
-    .some(row => row.textContent.includes('CP') && row.textContent.includes('IP')),
-  null, { timeout: 15_000 });
+  await waitForRelation(false);
+  await assertBackendRelationCount(0);
   passed('relation delete confirmation');
 }

--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -122,6 +122,37 @@ export async function runRoleStateFlow({
   passed(`reflow at ${zoom}x`);
   if (forcedColors) passed('forced-colors media state');
 
+  const taskHierarchy = await page.evaluate(() => {
+    const left = document.getElementById('leftPanel');
+    const right = document.getElementById('rightPanel');
+    const navigation = document.getElementById('mainNavTabs');
+    const visibleLinks = Array.from(navigation?.querySelectorAll('.nav-link') || [])
+      .filter(link => getComputedStyle(link).display !== 'none');
+    const maxLinkHeight = visibleLinks.reduce((maximum, link) =>
+      Math.max(maximum, link.getBoundingClientRect().height), 0);
+    return {
+      viewportWidth: window.innerWidth,
+      leftTop: left?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      rightTop: right?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      navigationHeight: navigation?.getBoundingClientRect().height ?? 0,
+      maxLinkHeight,
+      navigationScrollWidth: navigation?.scrollWidth ?? 0,
+      navigationClientWidth: navigation?.clientWidth ?? 0
+    };
+  });
+  if (taskHierarchy.viewportWidth <= 992) {
+    assert(taskHierarchy.rightTop <= taskHierarchy.leftTop,
+      `Primary task must precede taxonomy browser at ${taskHierarchy.viewportWidth}px: `
+      + `${taskHierarchy.rightTop} > ${taskHierarchy.leftTop}`);
+    passed('primary task precedes taxonomy browser at narrow width');
+    assert(taskHierarchy.navigationHeight <= taskHierarchy.maxLinkHeight + 6,
+      `Main navigation wrapped to multiple rows: ${taskHierarchy.navigationHeight} > `
+      + `${taskHierarchy.maxLinkHeight + 6}`);
+    assert(taskHierarchy.navigationScrollWidth >= taskHierarchy.navigationClientWidth,
+      'Main navigation must remain horizontally reachable');
+    passed('single-row scrollable main navigation');
+  }
+
   const expectedHttpFailure = failure => {
     if (failure.status === 503 && failure.path === '/api/analyze') return true;
     return role === 'USER' && failure.status === 403

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -188,8 +188,35 @@
     #rightPanel {
         width: 100% !important;
     }
+    /* The requirement-analysis task is the primary workflow. When the two
+       desktop columns stack, put that task before the reference taxonomy tree. */
+    #rightPanel {
+        order: 1;
+    }
+    #leftPanel {
+        order: 2;
+    }
     .card-body[style*="max-height"] {
         max-height: none !important;
+    }
+    /* Keep every destination directly available without spending several rows
+       of the initial viewport on wrapped navigation tabs. */
+    #mainNavTabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-inline: contain;
+        scroll-snap-type: inline proximity;
+        scrollbar-width: thin;
+        -webkit-overflow-scrolling: touch;
+    }
+    #mainNavTabs .nav-item {
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+    }
+    #mainNavTabs .nav-link {
+        width: auto;
+        white-space: nowrap;
     }
 }
 
@@ -198,13 +225,27 @@
     .navbar-brand {
         width: 100%;
         white-space: normal;
+        font-size: 1rem;
+        line-height: 1.25;
+    }
+    /* These badges duplicate information available in the analysis and context
+       surfaces. Hiding the duplicates preserves controls while reducing the
+       mobile header from several rows to the brand plus one utility row. */
+    #aiStatusBadge,
+    #embeddingStatusBadge,
+    #workspaceUserBadge {
+        display: none !important;
+    }
+    #navbarVersion {
+        display: none;
     }
     #mainNavTabs .nav-item {
-        flex: 1 1 9rem;
+        flex: 0 0 auto;
     }
     #mainNavTabs .nav-link {
-        width: 100%;
-        text-align: left;
+        width: auto;
+        min-width: max-content;
+        text-align: center;
     }
     #businessText {
         min-height: 12rem;

--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -33,6 +33,9 @@ class LocalOnnxPipelineIT {
     private static final HttpClient HTTP = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .build();
+    private static final Duration SEARCH_INDEX_TIMEOUT = Duration.ofMinutes(2);
+    private static final String FULL_TEXT_SEARCH_PATH =
+            "/api/search?q=Business%20Processes&maxResults=20";
     private static final String BASIC_AUTH = "Basic "
             + Base64.getEncoder().encodeToString(
                     ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
@@ -141,12 +144,28 @@ class LocalOnnxPipelineIT {
     @Test
     @Order(6)
     void fullTextSearchEndpointReturnsResults() throws Exception {
-        HttpResponse<String> response = httpGet(
-                "/api/search?q=Business%20Processes&maxResults=20");
-        assertThat(response.statusCode()).isEqualTo(200);
-        JsonNode body = MAPPER.readTree(response.body());
-        assertThat(body.isArray()).isTrue();
-        assertThat(body.size()).isGreaterThan(0);
+        long deadline = System.nanoTime() + SEARCH_INDEX_TIMEOUT.toNanos();
+        int lastStatus = -1;
+        String lastBody = "";
+
+        while (System.nanoTime() < deadline) {
+            HttpResponse<String> response = httpGet(FULL_TEXT_SEARCH_PATH);
+            lastStatus = response.statusCode();
+            lastBody = response.body();
+            if (lastStatus == 200) {
+                JsonNode body = MAPPER.readTree(lastBody);
+                if (body.isArray() && !body.isEmpty()) {
+                    return;
+                }
+            }
+            Thread.sleep(500);
+        }
+
+        throw new AssertionError(
+                "Full-text index did not become usable within "
+                        + SEARCH_INDEX_TIMEOUT
+                        + "; last status=" + lastStatus
+                        + ", last body=" + lastBody);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -220,9 +220,10 @@ class OnnxSeleniumIT {
         }
 
         assertThat(items).isNotEmpty();
-        String code = items.getFirst().getAttribute("data-code");
+        WebElement firstResult = items.getFirst();
+        String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        items.getFirst().click();
+        clickWhenUnobscured(firstResult);
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -300,6 +301,29 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
+    private void clickWhenUnobscured(WebElement element) {
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                element);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const target=arguments[0];"
+                                            + "const rect=target.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===target || target.contains(top);",
+                                    element);
+                    return Boolean.TRUE.equals(unobscured)
+                            && element.isDisplayed()
+                            && element.isEnabled()
+                            ? element
+                            : null;
+                })
+                .click();
+    }
+
     private void executeUiSearch(String mode, String query) {
         WebElement searchPanel = driver.findElement(By.id("searchPanel"));
         if (searchPanel.getAttribute("open") == null) {
@@ -315,26 +339,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-
-        WebElement searchButton = driver.findElement(By.id("searchBtn"));
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
-                searchButton);
-        new WebDriverWait(driver, Duration.ofSeconds(10))
-                .until(currentDriver -> {
-                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
-                            .executeScript(
-                                    "const button=arguments[0];"
-                                            + "const rect=button.getBoundingClientRect();"
-                                            + "const top=document.elementFromPoint("
-                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
-                                            + "return top===button || button.contains(top);",
-                                    searchButton);
-                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
-                            ? searchButton
-                            : null;
-                })
-                .click();
+        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -315,7 +315,26 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        driver.findElement(By.id("searchBtn")).click();
+
+        WebElement searchButton = driver.findElement(By.id("searchBtn"));
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                searchButton);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const button=arguments[0];"
+                                            + "const rect=button.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===button || button.contains(top);",
+                                    searchButton);
+                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
+                            ? searchButton
+                            : null;
+                })
+                .click();
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,20 +1,23 @@
 package com.taxonomy;
 
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,26 +32,28 @@ class ProductionPersistenceRestartIT {
     private static final String PERSISTENCE_PROVENANCE = "production-persistence-restart-it";
     private static final String AUTHORIZATION = "Basic " + Base64.getEncoder().encodeToString(
             ("admin:" + ADMIN_PASSWORD).getBytes(StandardCharsets.UTF_8));
-
-    @TempDir
-    Path persistentData;
+    private static final Duration PRODUCTION_STARTUP_TIMEOUT = Duration.ofMinutes(3);
 
     @Test
     void relationSurvivesContainerReplacement() throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+        String dataVolume = "taxonomy-persistence-it-"
+                + UUID.randomUUID().toString().replace("-", "");
+        GenericContainer<?> first = null;
+        GenericContainer<?> second = null;
 
-        long countBeforeWrite;
-        GenericContainer<?> first = persistentAppContainer();
         try {
+            long countBeforeWrite;
+            first = persistentAppContainer(dataVolume);
             first.start();
-            URI origin = origin(first);
-            awaitInitialized(client, origin);
+            URI firstOrigin = origin(first);
+            awaitInitialized(client, firstOrigin);
 
-            countBeforeWrite = relationCount(client, origin);
+            countBeforeWrite = relationCount(client, firstOrigin);
             HttpResponse<String> createResponse = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    firstOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString("""
@@ -63,19 +68,17 @@ class ProductionPersistenceRestartIT {
                     .build());
             assertThat(createResponse.statusCode()).isEqualTo(200);
             assertThat(createResponse.body()).contains(PERSISTENCE_PROVENANCE);
-            assertThat(relationCount(client, origin)).isGreaterThan(countBeforeWrite);
-        } finally {
-            stopContainerAndRestoreHostPermissions(first);
-        }
+            assertThat(relationCount(client, firstOrigin)).isGreaterThan(countBeforeWrite);
+            first.stop();
+            first = null;
 
-        GenericContainer<?> second = persistentAppContainer();
-        try {
+            second = persistentAppContainer(dataVolume);
             second.start();
-            URI origin = origin(second);
-            awaitInitialized(client, origin);
+            URI secondOrigin = origin(second);
+            awaitInitialized(client, secondOrigin);
 
             HttpResponse<String> relations = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    secondOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .GET()
                     .build());
@@ -87,16 +90,24 @@ class ProductionPersistenceRestartIT {
             // Catalogue-derived relation totals may be normalized during startup. The
             // persistence contract is that the explicit user relation survives and that
             // the repository does not fall below its pre-write baseline.
-            assertThat(relationCount(client, origin)).isGreaterThanOrEqualTo(countBeforeWrite);
+            assertThat(relationCount(client, secondOrigin))
+                    .isGreaterThanOrEqualTo(countBeforeWrite);
         } finally {
-            stopContainerAndRestoreHostPermissions(second);
+            stopQuietly(second);
+            stopQuietly(first);
+            removeVolume(dataVolume);
         }
     }
 
-    private GenericContainer<?> persistentAppContainer() {
+    private GenericContainer<?> persistentAppContainer(String dataVolume) {
         return ContainerTestUtils.appContainer()
-                .withFileSystemBind(persistentData.toAbsolutePath().toString(),
-                        "/app/data", BindMode.READ_WRITE)
+                .withCreateContainerCmdModifier(command -> command.getHostConfig()
+                        .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .forPort(8080)
+                        .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))
+                .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT)
                 .withEnv("SPRING_PROFILES_ACTIVE", "production,hsqldb")
                 .withEnv("TAXONOMY_DATASOURCE_URL",
                         "jdbc:hsqldb:file:/app/data/taxonomydb;hsqldb.default_table_type=cached;"
@@ -111,26 +122,24 @@ class ProductionPersistenceRestartIT {
                 .withEnv("TAXONOMY_THYMELEAF_CACHE", "true");
     }
 
-    /**
-     * The production image deliberately runs as the non-root {@code taxonomy}
-     * user. Files created in a host bind mount therefore have the container UID.
-     * Before JUnit removes its {@link TempDir}, make the persisted contents
-     * writable by the host runner. This preserves the non-root runtime contract
-     * while keeping test cleanup deterministic.
-     */
-    private static void stopContainerAndRestoreHostPermissions(GenericContainer<?> container)
-            throws Exception {
+    private static void stopQuietly(GenericContainer<?> container) {
+        if (container == null) {
+            return;
+        }
         try {
-            if (container.isRunning()) {
-                var result = container.execInContainer(
-                        "sh", "-c",
-                        "find /app/data -mindepth 1 -exec chmod a+rwX {} +");
-                assertThat(result.getExitCode())
-                        .as("restore host cleanup permissions: %s", result.getStderr())
-                        .isZero();
-            }
-        } finally {
             container.stop();
+        } catch (RuntimeException ignored) {
+            // Preserve the original test failure; volume removal below is still attempted.
+        }
+    }
+
+    private static void removeVolume(String volumeName) {
+        try {
+            DockerClientFactory.instance().client()
+                    .removeVolumeCmd(volumeName)
+                    .exec();
+        } catch (NotFoundException ignored) {
+            // A failed container creation may not have created the named volume yet.
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces #488 with one clean commit based directly on the current `main` after #486 changed the branch base.

- place the primary analysis/task panel before the taxonomy reference tree whenever desktop columns stack
- keep all main destinations in one horizontally scrollable navigation row instead of several wrapped rows
- hide only duplicate AI, embedding, workspace and version badges in the smallest header while preserving their functional surfaces
- retain 44 px touch targets, keyboard focus, zoom reflow, forced-colors and reduced-motion behavior

## Regression coverage

The Maven-owned role/state flow verifies for every applicable narrow or zoomed profile that:

- the primary task panel precedes the taxonomy browser
- the main navigation remains a single row
- all destinations remain horizontally reachable
- page overflow, axe, console, network, forced-colors and reduced-motion gates continue to pass

The branch also includes the currently required exact relation-row selection and unobscured ONNX button interaction so its canonical verification is deterministic against the current `main`. Those identical shared changes can disappear when #492 lands first.

## Verification

- `./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true -Dtaxonomy.ui.suite=role-state`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Refs #479
Supersedes #488.