### PR TITLE
Reuse UI application across isolated scenario groups

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -6,7 +6,8 @@
     "node": "24.x"
   },
   "scripts": {
-    "verify:ui": "node scripts/run-ui-suite.mjs"
+    "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/package.json
+++ b/.github/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
-    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
+    "test:ui-suite-plan": "node --test scripts/ui-suite-plan.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && npm run test:ui-suite-plan && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/scripts/run-ui-suite.mjs
+++ b/.github/scripts/run-ui-suite.mjs
@@ -1,17 +1,23 @@
+import { closeSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { mkdir, readdir, readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { groupScenarios } from './ui-suite-plan.mjs';
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
-const matrix = JSON.parse(await readFile(path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
+const matrix = JSON.parse(await readFile(
+  path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
 const requestedSuite = process.env.TAXONOMY_UI_SUITE || 'all';
 const requestedProfile = process.env.TAXONOMY_UI_PROFILE_FILTER || '';
 const adminPassword = process.env.TAXONOMY_ADMIN_PASSWORD || 'ui-primary-admin-password';
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
-const outputRoot = path.resolve(repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
+const outputRoot = path.resolve(
+  repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
 
 const uiProfiles = [
   { id: 'desktop-chromium', browser: 'chromium', width: 1440, height: 1000, mode: 'full' },
@@ -37,7 +43,8 @@ async function findApplicationJar() {
     .filter(name => /^taxonomy-app-.*\.jar$/.test(name) && !name.startsWith('original-'))
     .sort();
   if (candidates.length !== 1) {
-    throw new Error(`Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
+    throw new Error(
+      `Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
   }
   return path.join(target, candidates[0]);
 }
@@ -48,7 +55,8 @@ function runProcess(executable, args, options = {}) {
     child.once('error', reject);
     child.once('exit', (code, signal) => {
       if (code === 0) resolve();
-      else reject(new Error(`${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
+      else reject(new Error(
+        `${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
     });
   });
 }
@@ -57,7 +65,8 @@ async function waitForApplication(application, logPath) {
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
     if (application.exitCode !== null) {
-      throw new Error(`Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
+      throw new Error(
+        `Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
     }
     try {
       const response = await fetch(`${baseUrl}/login`, { redirect: 'manual' });
@@ -67,7 +76,8 @@ async function waitForApplication(application, logPath) {
     }
     await new Promise(resolve => setTimeout(resolve, 2_000));
   }
-  throw new Error(`Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
+  throw new Error(
+    `Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
 }
 
 async function stopApplication(application) {
@@ -80,13 +90,8 @@ async function stopApplication(application) {
   if (application.exitCode === null) application.kill('SIGKILL');
 }
 
-async function runScenario({ suite, id, script, env = {} }) {
-  const outputDir = path.join(outputRoot, suite, id);
-  await mkdir(outputDir, { recursive: true });
-  const logPath = path.join(outputDir, 'application.log');
-  const jar = await findApplicationJar();
-  const logHandle = await import('node:fs').then(({ openSync }) => openSync(logPath, 'a'));
-  const applicationEnv = {
+function applicationEnvironment() {
+  return {
     ...process.env,
     TAXONOMY_ADMIN_PASSWORD: adminPassword,
     TAXONOMY_REQUIRE_PASSWORD_CHANGE: 'false',
@@ -95,32 +100,104 @@ async function runScenario({ suite, id, script, env = {} }) {
     TAXONOMY_THYMELEAF_CACHE: 'false',
     LLM_MOCK: 'true'
   };
+}
+
+function scenarioEnvironment(scenario) {
+  return {
+    ...process.env,
+    TAXONOMY_BASE_URL: baseUrl,
+    TAXONOMY_UI_USERNAME: 'admin',
+    TAXONOMY_UI_PASSWORD: adminPassword,
+    TAXONOMY_A11Y_USERNAME: 'admin',
+    TAXONOMY_A11Y_PASSWORD: adminPassword,
+    TAXONOMY_UI_ADMIN_USERNAME: 'admin',
+    TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
+    ...scenario.env
+  };
+}
+
+function safeFileName(value) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+async function runScenario(application, scenario, applicationLog, groupTiming) {
+  if (application.exitCode !== null) {
+    throw new Error(
+      `Taxonomy application exited before ${scenario.suite}/${scenario.id}; see ${applicationLog}`);
+  }
+
+  const outputDir = path.join(outputRoot, scenario.suite, scenario.id);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, 'application-log.txt'),
+    `${path.relative(outputDir, applicationLog)}\n`,
+    'utf8');
+
+  console.log(`\n=== Maven-owned UI scenario: ${scenario.suite}/${scenario.id} ===`);
+  const started = performance.now();
+  const timing = {
+    suite: scenario.suite,
+    id: scenario.id,
+    startedAt: new Date().toISOString(),
+    outcome: 'running'
+  };
+  groupTiming.scenarios.push(timing);
+  try {
+    await runProcess(process.execPath, [path.join(scriptDir, scenario.script)], {
+      cwd: repoRoot,
+      env: scenarioEnvironment(scenario)
+    });
+    timing.outcome = 'passed';
+  } catch (error) {
+    timing.outcome = 'failed';
+    timing.error = error?.message || String(error);
+    throw error;
+  } finally {
+    timing.durationMs = Math.round(performance.now() - started);
+  }
+}
+
+async function runGroup(group, jar, report) {
+  const applicationDirectory = path.join(outputRoot, '_applications');
+  await mkdir(applicationDirectory, { recursive: true });
+  const logPath = path.join(applicationDirectory, `${safeFileName(group.id)}.log`);
+  const logHandle = openSync(logPath, 'a');
+  const groupStarted = performance.now();
+  const groupTiming = {
+    id: group.id,
+    applicationLog: path.relative(outputRoot, logPath),
+    scenarioCount: group.scenarios.length,
+    startedAt: new Date().toISOString(),
+    outcome: 'running',
+    scenarios: []
+  };
+  report.groups.push(groupTiming);
+
   const application = spawn('java', ['-jar', jar], {
     cwd: repoRoot,
-    env: applicationEnv,
+    env: applicationEnvironment(),
     stdio: ['ignore', logHandle, logHandle]
   });
+
   try {
+    const startupStarted = performance.now();
     await waitForApplication(application, logPath);
-    const childEnv = {
-      ...process.env,
-      TAXONOMY_BASE_URL: baseUrl,
-      TAXONOMY_UI_USERNAME: 'admin',
-      TAXONOMY_UI_PASSWORD: adminPassword,
-      TAXONOMY_A11Y_USERNAME: 'admin',
-      TAXONOMY_A11Y_PASSWORD: adminPassword,
-      TAXONOMY_UI_ADMIN_USERNAME: 'admin',
-      TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
-      ...env
-    };
-    console.log(`\n=== Maven-owned UI scenario: ${suite}/${id} ===`);
-    await runProcess(process.execPath, [path.join(scriptDir, script)], {
-      cwd: repoRoot,
-      env: childEnv
-    });
+    groupTiming.startupMs = Math.round(performance.now() - startupStarted);
+    console.log(
+      `\n=== UI application group ${group.id}: ${group.scenarios.length} scenario(s), `
+      + `startup ${groupTiming.startupMs} ms ===`);
+    for (const scenario of group.scenarios) {
+      await runScenario(application, scenario, logPath, groupTiming);
+    }
+    groupTiming.outcome = 'passed';
+  } catch (error) {
+    groupTiming.outcome = 'failed';
+    groupTiming.error = error?.message || String(error);
+    throw error;
   } finally {
     await stopApplication(application);
-    await import('node:fs').then(({ closeSync }) => closeSync(logHandle));
+    closeSync(logHandle);
+    groupTiming.durationMs = Math.round(performance.now() - groupStarted);
   }
 }
 
@@ -175,13 +252,51 @@ for (const profile of matrix.profiles.filter(item => !item.textSpacing)) {
   });
 }
 if (selected('special-modes', 'text-spacing-and-offline')) scenarios.push({
-  suite: 'special-modes', id: 'text-spacing-and-offline', script: 'ui-special-modes-acceptance.mjs', env: {
-    TAXONOMY_UI_OUTPUT_DIR: path.join(outputRoot, 'special-modes', 'text-spacing-and-offline')
+  suite: 'special-modes',
+  id: 'text-spacing-and-offline',
+  script: 'ui-special-modes-acceptance.mjs',
+  env: {
+    TAXONOMY_UI_OUTPUT_DIR: path.join(
+      outputRoot, 'special-modes', 'text-spacing-and-offline')
   }
 });
 
 if (scenarios.length === 0) {
-  throw new Error(`No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
+  throw new Error(
+    `No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
 }
-for (const scenario of scenarios) await runScenario(scenario);
-console.log(`\nMaven-owned UI verification passed: ${scenarios.length} scenario(s).`);
+
+const groups = groupScenarios(scenarios);
+const report = {
+  schemaVersion: 1,
+  requestedSuite,
+  requestedProfile: requestedProfile || null,
+  startedAt: new Date().toISOString(),
+  scenarioCount: scenarios.length,
+  applicationStartCount: groups.length,
+  groups: []
+};
+const overallStarted = performance.now();
+let failure = null;
+try {
+  const jar = await findApplicationJar();
+  for (const group of groups) await runGroup(group, jar, report);
+} catch (error) {
+  failure = error;
+  report.outcome = 'failed';
+  report.error = error?.message || String(error);
+} finally {
+  report.finishedAt = new Date().toISOString();
+  report.durationMs = Math.round(performance.now() - overallStarted);
+  if (!report.outcome) report.outcome = 'passed';
+  await mkdir(outputRoot, { recursive: true });
+  await writeFile(
+    path.join(outputRoot, 'timings.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+    'utf8');
+}
+
+if (failure) throw failure;
+console.log(
+  `\nMaven-owned UI verification passed: ${scenarios.length} scenario(s) `
+  + `in ${groups.length} application start(s), ${report.durationMs} ms total.`);

--- a/.github/scripts/ui-evidence-policy.mjs
+++ b/.github/scripts/ui-evidence-policy.mjs
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const VALID_MODES = new Set(['compact', 'full']);
+const DEFAULT_CURATED_STATES = 'analysis-success';
+
+function normalizeStates(value) {
+  const candidates = Array.isArray(value) ? value : String(value || '').split(',');
+  return [...new Set(candidates.map(item => String(item).trim()).filter(Boolean))];
+}
+
+export function createEvidencePolicy({
+  mode = process.env.TAXONOMY_UI_EVIDENCE_MODE || 'compact',
+  curatedStates = process.env.TAXONOMY_UI_CURATED_STATES || DEFAULT_CURATED_STATES
+} = {}) {
+  const normalizedMode = String(mode).trim().toLowerCase();
+  if (!VALID_MODES.has(normalizedMode)) {
+    throw new Error(`Unsupported TAXONOMY_UI_EVIDENCE_MODE=${mode}; expected compact or full`);
+  }
+  const normalizedStates = normalizeStates(curatedStates);
+  const curated = new Set(normalizedStates);
+  return {
+    mode: normalizedMode,
+    curatedStates: normalizedStates,
+    shouldCapture: state => normalizedMode === 'full' || curated.has(state)
+  };
+}
+
+export async function captureFailureEvidence({
+  page,
+  outputDir,
+  prefix = 'failure',
+  selector = 'body'
+}) {
+  await mkdir(outputDir, { recursive: true });
+  const target = page.locator(selector);
+  await target.waitFor({ state: 'visible', timeout: 5_000 });
+
+  const screenshot = path.join(outputDir, `${prefix}.png`);
+  const html = path.join(outputDir, `${prefix}.html`);
+  const aria = path.join(outputDir, `${prefix}.aria.txt`);
+
+  // A single viewport image is sufficient to locate the failing state while
+  // avoiding the unbounded full-page screenshots that made successful CI
+  // evidence hundreds of megabytes large.
+  await page.screenshot({ path: screenshot, fullPage: false, animations: 'disabled' });
+  await writeFile(html, await target.evaluate(node => node.outerHTML), 'utf8');
+  const ariaSnapshot = typeof target.ariaSnapshot === 'function'
+    ? await target.ariaSnapshot().catch(error => `ARIA snapshot unavailable: ${error}`)
+    : 'ARIA snapshot API unavailable';
+  await writeFile(aria, `${ariaSnapshot}\n`, 'utf8');
+
+  return {
+    selector,
+    files: [path.basename(screenshot), path.basename(html), path.basename(aria)]
+  };
+}

--- a/.github/scripts/ui-evidence-policy.test.mjs
+++ b/.github/scripts/ui-evidence-policy.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
+
+test('compact mode retains only curated successful states', () => {
+  const policy = createEvidencePolicy({ mode: 'compact', curatedStates: 'analysis-success' });
+  assert.equal(policy.mode, 'compact');
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('analysis-error'), false);
+});
+
+test('full mode retains every successful state', () => {
+  const policy = createEvidencePolicy({ mode: 'full', curatedStates: [] });
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('dialog-open'), true);
+});
+
+test('curated state parsing trims and removes duplicates', () => {
+  const policy = createEvidencePolicy({
+    mode: 'compact',
+    curatedStates: ' analysis-success,dialog-open,analysis-success '
+  });
+  assert.deepEqual(policy.curatedStates, ['analysis-success', 'dialog-open']);
+});
+
+test('unsupported evidence mode fails before browser execution', () => {
+  assert.throws(
+    () => createEvidencePolicy({ mode: 'everything' }),
+    /expected compact or full/
+  );
+});

--- a/.github/scripts/ui-primary-evidence.mjs
+++ b/.github/scripts/ui-primary-evidence.mjs
@@ -1,11 +1,14 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createEvidence(page, outputDir) {
   const checks = [];
   const axeFindings = [];
   const screenshots = [];
+  const states = [];
+  const policy = createEvidencePolicy();
 
   function assert(condition, message) {
     if (!condition) throw new Error(message);
@@ -18,6 +21,10 @@ export function createEvidence(page, outputDir) {
   async function saveState(state, selector = '#mainContent') {
     const target = page.locator(selector);
     await target.waitFor({ state: 'visible', timeout: 20_000 });
+    const captured = policy.shouldCapture(state);
+    states.push({ state, selector, captured });
+    if (!captured) return;
+
     const file = path.join(outputDir, `${state}.png`);
     await target.screenshot({ path: file, animations: 'disabled' });
     screenshots.push(path.basename(file));
@@ -59,6 +66,14 @@ export function createEvidence(page, outputDir) {
     saveState,
     axeState,
     waitForText,
-    report: auditError => ({ checks, axeFindings, screenshots, auditError })
+    report: auditError => ({
+      evidenceMode: policy.mode,
+      curatedStates: policy.curatedStates,
+      checks,
+      axeFindings,
+      states,
+      screenshots,
+      auditError
+    })
   };
 }

--- a/.github/scripts/ui-primary-relation-workflows.mjs
+++ b/.github/scripts/ui-primary-relation-workflows.mjs
@@ -1,30 +1,81 @@
 import { navigateArchitectureSubtab } from './ui-role-fixtures.mjs';
 
+const MANUAL_RELATION = {
+  sourceCode: 'CP',
+  targetCode: 'IP',
+  relationType: 'CONSUMES'
+};
+
 export async function runRelationWorkflows({ page, evidence }) {
-  const { passed, axeState, saveState, waitForText } = evidence;
+  const { passed, axeState, saveState } = evidence;
   await navigateArchitectureSubtab(page, 'relations');
   const panel = page.locator('#relationsBrowser');
   if (!(await panel.getAttribute('open'))) await panel.locator('summary').click();
   await page.locator('#relationsTableContainer').waitFor({ state: 'visible' });
 
+  async function waitForRelation(present) {
+    await page.waitForFunction(({ relation, present }) => {
+      const matches = Array.from(document.querySelectorAll('#relationsTableContainer tbody tr'))
+        .filter(row => {
+          const cells = row.querySelectorAll('td');
+          return cells.length >= 3
+            && cells[0].textContent.trim() === relation.sourceCode
+            && cells[1].textContent.trim() === relation.targetCode
+            && cells[2].textContent.trim() === relation.relationType;
+        });
+      return present ? matches.length === 1 : matches.length === 0;
+    }, { relation: MANUAL_RELATION, present }, { timeout: 15_000 });
+  }
+
+  async function exactRelationRow() {
+    const rows = page.locator('#relationsTableContainer tbody tr');
+    const matching = rows.filter({
+      has: page.locator('td:nth-child(1)', { hasText: /^CP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(2)', { hasText: /^IP$/ })
+    }).filter({
+      has: page.locator('td:nth-child(3)', { hasText: /^CONSUMES$/ })
+    });
+    if (await matching.count() !== 1) {
+      throw new Error(`Expected exactly one CP -> IP CONSUMES row, found ${await matching.count()}`);
+    }
+    return matching.first();
+  }
+
+  async function assertBackendRelationCount(expected) {
+    const count = await page.evaluate(async relation => {
+      const response = await fetch('/api/relations', { headers: { Accept: 'application/json' } });
+      if (!response.ok) throw new Error(`Relation list returned ${response.status}`);
+      const relations = await response.json();
+      return relations.filter(item => item.sourceCode === relation.sourceCode
+        && item.targetCode === relation.targetCode
+        && item.relationType === relation.relationType).length;
+    }, MANUAL_RELATION);
+    if (count !== expected) {
+      throw new Error(`Expected ${expected} persisted CP -> IP CONSUMES relation(s), found ${count}`);
+    }
+  }
+
   async function openCreate() {
     await page.locator('#createRelationBtn').click();
     await page.locator('#createRelationModal').waitFor({ state: 'visible', timeout: 10_000 });
-    await page.locator('#newRelSource').fill('CP');
-    await page.locator('#newRelTarget').fill('IP');
-    await page.locator('#newRelType').selectOption('CONSUMES');
+    await page.locator('#newRelSource').fill(MANUAL_RELATION.sourceCode);
+    await page.locator('#newRelTarget').fill(MANUAL_RELATION.targetCode);
+    await page.locator('#newRelType').selectOption(MANUAL_RELATION.relationType);
     await page.locator('#newRelDescription').fill('Primary workflow relation');
   }
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
-  await waitForText('#relationsTableContainer', text => text.includes('CP') && text.includes('IP'));
+  await waitForRelation(true);
+  await assertBackendRelationCount(1);
   passed('relation create');
 
   await openCreate();
   await page.locator('#createRelationSubmit').click();
   await page.locator('#createRelationError').waitFor({ state: 'visible', timeout: 15_000 });
+  await assertBackendRelationCount(1);
   await axeState('relation-duplicate-error', '#createRelationModal');
   await saveState('relation-duplicate-error', '#createRelationModal');
   const modal = page.locator('#createRelationModal');
@@ -32,13 +83,10 @@ export async function runRelationWorkflows({ page, evidence }) {
   await modal.waitFor({ state: 'hidden' });
   passed('relation duplicate conflict feedback');
 
-  const row = page.locator('#relationsTableContainer tr', { hasText: 'CP' })
-    .filter({ hasText: 'IP' }).first();
+  const row = await exactRelationRow();
   page.once('dialog', dialog => dialog.accept());
   await row.locator('.relation-delete-btn').click();
-  await page.waitForFunction(() => !Array.from(
-    document.querySelectorAll('#relationsTableContainer tr'))
-    .some(row => row.textContent.includes('CP') && row.textContent.includes('IP')),
-  null, { timeout: 15_000 });
+  await waitForRelation(false);
+  await assertBackendRelationCount(0);
   passed('relation delete confirmation');
 }

--- a/.github/scripts/ui-primary-workflow-acceptance.mjs
+++ b/.github/scripts/ui-primary-workflow-acceptance.mjs
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { ROLE_ACCOUNTS, openRoleSession } from './ui-role-fixtures.mjs';
 import { createEvidence } from './ui-primary-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runBasicWorkflows } from './ui-primary-basic-workflows.mjs';
 import { runProposalWorkflows } from './ui-primary-proposal-workflows.mjs';
 import { runRelationWorkflows } from './ui-primary-relation-workflows.mjs';
@@ -23,6 +24,7 @@ let context;
 let page;
 let account;
 let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -46,9 +48,18 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({
+        page, outputDir, prefix: 'failure', selector: '#mainContent'
+      });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const details = evidence ? evidence.report(auditError)
-    : { checks: [], axeFindings: [], screenshots: [], auditError };
-  const report = { role, browserName, ...details };
+    : { checks: [], axeFindings: [], states: [], screenshots: [], auditError };
+  const report = { role, browserName, ...details, failureEvidence };
   await writeFile(path.join(outputDir, 'report.json'),
     `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) console.error(`Primary workflow acceptance failed for ${role}:\n${auditError}`);

--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -1,7 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { openRoleSession, ROLE_ACCOUNTS } from './ui-role-fixtures.mjs';
+import { openRoleSession } from './ui-role-fixtures.mjs';
 import { createRoleStateEvidence } from './ui-role-state-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runRoleStateFlow } from './ui-role-state-flow.mjs';
 
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
@@ -40,6 +41,8 @@ let auditError = null;
 let browser;
 let context;
 let page;
+let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -69,7 +72,7 @@ try {
   });
   page.on('pageerror', error => consoleErrors.push(error.message));
 
-  const evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
+  evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
   await runRoleStateFlow({
     page, role, zoom, forcedColors, checks, httpFailures,
     externalRequests, consoleErrors, evidence
@@ -78,11 +81,22 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({ page, outputDir, prefix: 'failure' });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const report = {
     profileId, browserName, role,
     physicalViewport: { width: physicalWidth, height: physicalHeight },
-    effectiveViewport, zoom, forcedColors, checks, findings,
-    externalRequests, httpFailures, consoleErrors, auditError
+    effectiveViewport, zoom, forcedColors,
+    evidenceMode: evidence?.evidenceMode || null,
+    curatedStates: evidence?.curatedStates || [],
+    states: evidence?.states || [],
+    checks, findings, externalRequests, httpFailures, consoleErrors,
+    auditError, failureEvidence
   };
   await writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) {

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -1,8 +1,12 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
+  const policy = createEvidencePolicy();
+  const states = [];
+
   async function saveState(state) {
     const prefix = path.join(outputDir, state);
     const dimensions = await page.evaluate(() => ({
@@ -13,14 +17,16 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       width: Math.min(dimensions.width, 1440),
       height: Math.min(dimensions.height, 1000)
     };
+    const captured = policy.shouldCapture(state);
     const screenshotFiles = [];
     const segments = [];
-    if (dimensions.width <= 30000 && dimensions.height <= 30000) {
+
+    if (captured && dimensions.width <= 30000 && dimensions.height <= 30000) {
       const file = `${prefix}.png`;
       await page.screenshot({ path: file, fullPage: true, animations: 'disabled' });
       screenshotFiles.push(path.basename(file));
       segments.push({ file: path.basename(file), scrollY: 0, fullPage: true });
-    } else {
+    } else if (captured) {
       const maxScrollY = Math.max(0, dimensions.height - viewport.height);
       const targets = [];
       for (let y = 0; y < maxScrollY; y += viewport.height) targets.push(y);
@@ -40,9 +46,20 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       }
       await page.evaluate(() => window.scrollTo(0, 0));
     }
-    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify({
-      dimensions, viewport, screenshotFiles, segments
-    }, null, 2)}\n`, 'utf8');
+
+    const stateSummary = {
+      state,
+      evidenceMode: policy.mode,
+      captured,
+      dimensions,
+      viewport,
+      screenshotFiles,
+      segments
+    };
+    states.push(stateSummary);
+    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify(stateSummary, null, 2)}\n`, 'utf8');
+
+    if (!captured) return;
     await writeFile(`${prefix}.html`, await page.content(), 'utf8');
     const body = page.locator('body');
     const aria = typeof body.ariaSnapshot === 'function'
@@ -65,5 +82,11 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
     checks.push(`axe ${state}`);
   }
 
-  return { saveState, runAxe };
+  return {
+    saveState,
+    runAxe,
+    evidenceMode: policy.mode,
+    curatedStates: policy.curatedStates,
+    states
+  };
 }

--- a/.github/scripts/ui-suite-plan.mjs
+++ b/.github/scripts/ui-suite-plan.mjs
@@ -1,0 +1,25 @@
+function roleName(scenario) {
+  return String(scenario.env?.TAXONOMY_ROLE || '').trim().toLowerCase();
+}
+
+export function isolationGroupId(scenario) {
+  if (['ui', 'accessibility', 'special-modes'].includes(scenario.suite)) {
+    return 'shared-browser-nonmutating';
+  }
+  if (scenario.suite === 'role-state') {
+    const role = roleName(scenario);
+    if (!role) throw new Error(`Role-state scenario ${scenario.id} has no TAXONOMY_ROLE`);
+    return `role-state-${role}`;
+  }
+  return `${scenario.suite}-${scenario.id}`;
+}
+
+export function groupScenarios(scenarios) {
+  const groups = new Map();
+  for (const scenario of scenarios) {
+    const id = isolationGroupId(scenario);
+    if (!groups.has(id)) groups.set(id, { id, scenarios: [] });
+    groups.get(id).scenarios.push(scenario);
+  }
+  return [...groups.values()];
+}

--- a/.github/scripts/ui-suite-plan.test.mjs
+++ b/.github/scripts/ui-suite-plan.test.mjs
@@ -61,6 +61,43 @@ test('keeps every primary mutation workflow isolated', () => {
   ]);
 });
 
+test('maps the complete current matrix from eighteen scenarios to seven starts', () => {
+  const scenarios = [
+    scenario('ui', 'desktop-chromium'),
+    scenario('ui', 'desktop-firefox'),
+    scenario('ui', 'tablet-chromium'),
+    scenario('ui', 'mobile-chromium'),
+    scenario('accessibility', 'desktop'),
+    scenario('accessibility', 'tablet'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline'),
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN'),
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN'),
+    scenario('role-state', 'landscape-user-firefox', 'USER'),
+    scenario('role-state', 'zoom-200-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT')
+  ];
+
+  const groups = groupScenarios(scenarios);
+
+  assert.equal(scenarios.length, 18);
+  assert.equal(groups.length, 7);
+  assert.deepEqual(groups.map(group => group.id), [
+    'shared-browser-nonmutating',
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium',
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+});
+
 test('rejects role-state scenarios without an explicit role', () => {
   assert.throws(
     () => isolationGroupId(scenario('role-state', 'broken-profile')),

--- a/.github/scripts/ui-suite-plan.test.mjs
+++ b/.github/scripts/ui-suite-plan.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { groupScenarios, isolationGroupId } from './ui-suite-plan.mjs';
+
+function scenario(suite, id, role) {
+  return {
+    suite,
+    id,
+    env: role ? { TAXONOMY_ROLE: role } : {}
+  };
+}
+
+test('groups browser-only suites into one shared application', () => {
+  const groups = groupScenarios([
+    scenario('ui', 'desktop-chromium'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline')
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].id, 'shared-browser-nonmutating');
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-chromium',
+    'mobile',
+    'text-spacing-and-offline'
+  ]);
+});
+
+test('shares role-state applications only inside the same role', () => {
+  const groups = groupScenarios([
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-user-chromium',
+    'zoom-400-user-chromium'
+  ]);
+});
+
+test('keeps every primary mutation workflow isolated', () => {
+  const groups = groupScenarios([
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium'
+  ]);
+});
+
+test('rejects role-state scenarios without an explicit role', () => {
+  assert.throws(
+    () => isolationGroupId(scenario('role-state', 'broken-profile')),
+    /has no TAXONOMY_ROLE/
+  );
+});

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,33 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI evidence policy
+
+Browser assertions, axe analysis, console checks, network checks and JSON summaries
+run for every selected state. Successful verification uses compact evidence by
+default: it retains the machine-readable reports and a small curated screenshot
+baseline instead of storing screenshots, HTML and ARIA snapshots for every passing
+state. A failing primary or role/state scenario always captures a viewport
+screenshot, DOM snapshot and ARIA snapshot before the browser closes.
+
+Full successful evidence remains locally reproducible when it is needed for a
+manual audit:
+
+```bash
+TAXONOMY_UI_EVIDENCE_MODE=full \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+The curated compact baseline can be changed without changing test selection:
+
+```bash
+TAXONOMY_UI_CURATED_STATES=analysis-success,dialog-open \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+`TAXONOMY_UI_EVIDENCE_MODE` accepts only `compact` or `full`; invalid values fail
+before browser scenarios execute.
+
 ## Workflow responsibilities
 
 Only eight workflows remain:

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,28 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI process isolation and timings
+
+The Maven-owned launcher executes every selected browser scenario but does not
+restart the packaged application when scenarios have the same isolation needs:
+
+- `ui`, `accessibility`, text-spacing and offline checks share one application;
+- role/state profiles share one application only with profiles for the same role;
+- each primary mutation workflow keeps its own fresh application.
+
+The complete default matrix therefore retains all 18 scenarios while reducing
+application starts from 18 to 7. Execution remains sequential. Primary mutation
+workflows are not allowed to share state, and a role/state scenario can never
+share an application with another role. These rules are executable contracts in
+`.github/scripts/ui-suite-plan.test.mjs` rather than implicit CI behavior.
+
+Each scenario contains `application-log.txt`, which points to the log of its
+isolation group. The launcher also writes `target/ui-verification/timings.json`
+with application startup duration, scenario duration, group duration, total
+duration and pass/fail outcome. This report is produced even when a scenario
+fails, so performance and startup regressions can be compared without reading
+the full Maven log.
+
 ## UI evidence policy
 
 Browser assertions, axe analysis, console checks, network checks and JSON summaries

--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -33,6 +33,9 @@ class LocalOnnxPipelineIT {
     private static final HttpClient HTTP = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .build();
+    private static final Duration SEARCH_INDEX_TIMEOUT = Duration.ofMinutes(2);
+    private static final String FULL_TEXT_SEARCH_PATH =
+            "/api/search?q=Business%20Processes&maxResults=20";
     private static final String BASIC_AUTH = "Basic "
             + Base64.getEncoder().encodeToString(
                     ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
@@ -141,12 +144,28 @@ class LocalOnnxPipelineIT {
     @Test
     @Order(6)
     void fullTextSearchEndpointReturnsResults() throws Exception {
-        HttpResponse<String> response = httpGet(
-                "/api/search?q=Business%20Processes&maxResults=20");
-        assertThat(response.statusCode()).isEqualTo(200);
-        JsonNode body = MAPPER.readTree(response.body());
-        assertThat(body.isArray()).isTrue();
-        assertThat(body.size()).isGreaterThan(0);
+        long deadline = System.nanoTime() + SEARCH_INDEX_TIMEOUT.toNanos();
+        int lastStatus = -1;
+        String lastBody = "";
+
+        while (System.nanoTime() < deadline) {
+            HttpResponse<String> response = httpGet(FULL_TEXT_SEARCH_PATH);
+            lastStatus = response.statusCode();
+            lastBody = response.body();
+            if (lastStatus == 200) {
+                JsonNode body = MAPPER.readTree(lastBody);
+                if (body.isArray() && !body.isEmpty()) {
+                    return;
+                }
+            }
+            Thread.sleep(500);
+        }
+
+        throw new AssertionError(
+                "Full-text index did not become usable within "
+                        + SEARCH_INDEX_TIMEOUT
+                        + "; last status=" + lastStatus
+                        + ", last body=" + lastBody);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -220,9 +220,10 @@ class OnnxSeleniumIT {
         }
 
         assertThat(items).isNotEmpty();
-        String code = items.getFirst().getAttribute("data-code");
+        WebElement firstResult = items.getFirst();
+        String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        items.getFirst().click();
+        clickWhenUnobscured(firstResult);
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -300,6 +301,29 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
+    private void clickWhenUnobscured(WebElement element) {
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                element);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const target=arguments[0];"
+                                            + "const rect=target.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===target || target.contains(top);",
+                                    element);
+                    return Boolean.TRUE.equals(unobscured)
+                            && element.isDisplayed()
+                            && element.isEnabled()
+                            ? element
+                            : null;
+                })
+                .click();
+    }
+
     private void executeUiSearch(String mode, String query) {
         WebElement searchPanel = driver.findElement(By.id("searchPanel"));
         if (searchPanel.getAttribute("open") == null) {
@@ -315,26 +339,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-
-        WebElement searchButton = driver.findElement(By.id("searchBtn"));
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
-                searchButton);
-        new WebDriverWait(driver, Duration.ofSeconds(10))
-                .until(currentDriver -> {
-                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
-                            .executeScript(
-                                    "const button=arguments[0];"
-                                            + "const rect=button.getBoundingClientRect();"
-                                            + "const top=document.elementFromPoint("
-                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
-                                            + "return top===button || button.contains(top);",
-                                    searchButton);
-                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
-                            ? searchButton
-                            : null;
-                })
-                .click();
+        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -315,7 +315,26 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        driver.findElement(By.id("searchBtn")).click();
+
+        WebElement searchButton = driver.findElement(By.id("searchBtn"));
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                searchButton);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const button=arguments[0];"
+                                            + "const rect=button.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===button || button.contains(top);",
+                                    searchButton);
+                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
+                            ? searchButton
+                            : null;
+                })
+                .click();
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,20 +1,23 @@
 package com.taxonomy;
 
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,26 +32,28 @@ class ProductionPersistenceRestartIT {
     private static final String PERSISTENCE_PROVENANCE = "production-persistence-restart-it";
     private static final String AUTHORIZATION = "Basic " + Base64.getEncoder().encodeToString(
             ("admin:" + ADMIN_PASSWORD).getBytes(StandardCharsets.UTF_8));
-
-    @TempDir
-    Path persistentData;
+    private static final Duration PRODUCTION_STARTUP_TIMEOUT = Duration.ofMinutes(3);
 
     @Test
     void relationSurvivesContainerReplacement() throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+        String dataVolume = "taxonomy-persistence-it-"
+                + UUID.randomUUID().toString().replace("-", "");
+        GenericContainer<?> first = null;
+        GenericContainer<?> second = null;
 
-        long countBeforeWrite;
-        GenericContainer<?> first = persistentAppContainer();
         try {
+            long countBeforeWrite;
+            first = persistentAppContainer(dataVolume);
             first.start();
-            URI origin = origin(first);
-            awaitInitialized(client, origin);
+            URI firstOrigin = origin(first);
+            awaitInitialized(client, firstOrigin);
 
-            countBeforeWrite = relationCount(client, origin);
+            countBeforeWrite = relationCount(client, firstOrigin);
             HttpResponse<String> createResponse = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    firstOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString("""
@@ -63,19 +68,17 @@ class ProductionPersistenceRestartIT {
                     .build());
             assertThat(createResponse.statusCode()).isEqualTo(200);
             assertThat(createResponse.body()).contains(PERSISTENCE_PROVENANCE);
-            assertThat(relationCount(client, origin)).isGreaterThan(countBeforeWrite);
-        } finally {
-            stopContainerAndRestoreHostPermissions(first);
-        }
+            assertThat(relationCount(client, firstOrigin)).isGreaterThan(countBeforeWrite);
+            first.stop();
+            first = null;
 
-        GenericContainer<?> second = persistentAppContainer();
-        try {
+            second = persistentAppContainer(dataVolume);
             second.start();
-            URI origin = origin(second);
-            awaitInitialized(client, origin);
+            URI secondOrigin = origin(second);
+            awaitInitialized(client, secondOrigin);
 
             HttpResponse<String> relations = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    secondOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .GET()
                     .build());
@@ -87,16 +90,24 @@ class ProductionPersistenceRestartIT {
             // Catalogue-derived relation totals may be normalized during startup. The
             // persistence contract is that the explicit user relation survives and that
             // the repository does not fall below its pre-write baseline.
-            assertThat(relationCount(client, origin)).isGreaterThanOrEqualTo(countBeforeWrite);
+            assertThat(relationCount(client, secondOrigin))
+                    .isGreaterThanOrEqualTo(countBeforeWrite);
         } finally {
-            stopContainerAndRestoreHostPermissions(second);
+            stopQuietly(second);
+            stopQuietly(first);
+            removeVolume(dataVolume);
         }
     }
 
-    private GenericContainer<?> persistentAppContainer() {
+    private GenericContainer<?> persistentAppContainer(String dataVolume) {
         return ContainerTestUtils.appContainer()
-                .withFileSystemBind(persistentData.toAbsolutePath().toString(),
-                        "/app/data", BindMode.READ_WRITE)
+                .withCreateContainerCmdModifier(command -> command.getHostConfig()
+                        .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .forPort(8080)
+                        .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))
+                .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT)
                 .withEnv("SPRING_PROFILES_ACTIVE", "production,hsqldb")
                 .withEnv("TAXONOMY_DATASOURCE_URL",
                         "jdbc:hsqldb:file:/app/data/taxonomydb;hsqldb.default_table_type=cached;"
@@ -111,26 +122,24 @@ class ProductionPersistenceRestartIT {
                 .withEnv("TAXONOMY_THYMELEAF_CACHE", "true");
     }
 
-    /**
-     * The production image deliberately runs as the non-root {@code taxonomy}
-     * user. Files created in a host bind mount therefore have the container UID.
-     * Before JUnit removes its {@link TempDir}, make the persisted contents
-     * writable by the host runner. This preserves the non-root runtime contract
-     * while keeping test cleanup deterministic.
-     */
-    private static void stopContainerAndRestoreHostPermissions(GenericContainer<?> container)
-            throws Exception {
+    private static void stopQuietly(GenericContainer<?> container) {
+        if (container == null) {
+            return;
+        }
         try {
-            if (container.isRunning()) {
-                var result = container.execInContainer(
-                        "sh", "-c",
-                        "find /app/data -mindepth 1 -exec chmod a+rwX {} +");
-                assertThat(result.getExitCode())
-                        .as("restore host cleanup permissions: %s", result.getStderr())
-                        .isZero();
-            }
-        } finally {
             container.stop();
+        } catch (RuntimeException ignored) {
+            // Preserve the original test failure; volume removal below is still attempted.
+        }
+    }
+
+    private static void removeVolume(String volumeName) {
+        try {
+            DockerClientFactory.instance().client()
+                    .removeVolumeCmd(volumeName)
+                    .exec();
+        } catch (NotFoundException ignored) {
+            // A failed container creation may not have created the named volume yet.
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the remaining dominant runtime reduction from #476 while preserving the complete Maven-owned browser matrix.

This branch is intentionally based on #492 and is opened as a draft. After #492 merges, the diff reduces to the process-reuse and timing work described below.

### Explicit isolation model

All 18 existing scenarios still run, sequentially, with the same browsers, roles, viewports, zoom levels, forced-colors, text-spacing, offline and axe assertions. The launcher now reuses the packaged application only where state isolation permits it:

- one application for `ui`, `accessibility` and browser-only special modes;
- one application per role for role/state profiles;
- one fresh application for every primary mutation workflow.

This reduces application starts from 18 to 7 without removing a scenario or weakening a guardrail. The grouping rules are executable contracts in `ui-suite-plan.test.mjs`.

### Timing and diagnostics

- emit `target/ui-verification/timings.json` on success and failure;
- record application startup, scenario, group and total durations;
- retain one application log per isolation group below `_applications/`;
- write an `application-log.txt` pointer into every scenario directory;
- fail immediately if a shared application exits before the next scenario.

### Maven authority

The existing Maven browser profile still owns installation and execution. No browser selection, role selection or orchestration is added to workflow YAML.

## Expected measurable effect

The previous launcher restarted Spring Boot for every scenario. The new launcher retains all 18 scenarios but reduces the number of JVM/application initialisations to seven. The actual runner timings will be taken from the generated manifest rather than estimated.

## Verification

- `node --test .github/scripts/ui-suite-plan.test.mjs`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Depends on #492
Refs #476