### PR TITLE
Wait for unobscured ONNX search result before clicking

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -220,9 +220,10 @@ class OnnxSeleniumIT {
         }
 
         assertThat(items).isNotEmpty();
-        String code = items.getFirst().getAttribute("data-code");
+        WebElement firstResult = items.getFirst();
+        String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        items.getFirst().click();
+        clickWhenUnobscured(firstResult);
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -298,6 +299,29 @@ class OnnxSeleniumIT {
                 .until(currentDriver -> currentDriver.findElement(
                         By.cssSelector("#searchModeSelect option[value='semantic']"))
                         .isEnabled());
+    }
+
+    private void clickWhenUnobscured(WebElement element) {
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                element);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const target=arguments[0];"
+                                            + "const rect=target.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===target || target.contains(top);",
+                                    element);
+                    return Boolean.TRUE.equals(unobscured)
+                            && element.isDisplayed()
+                            && element.isEnabled()
+                            ? element
+                            : null;
+                })
+                .click();
     }
 
     private void executeUiSearch(String mode, String query) {


### PR DESCRIPTION
## Summary

Stabilizes the remaining real Selenium click in `OnnxSeleniumIT` without bypassing product behavior.

A hosted Chrome 150 run completed the production restart test and semantic search successfully, but the first search-result card was positioned at the bottom of the viewport and another element intercepted the normal WebDriver click.

The test now:

- keeps the actual result element and its `data-code` assertion;
- scrolls that element to the viewport centre;
- verifies its centre point resolves to the element or one of its descendants using `document.elementFromPoint`;
- requires the element to remain displayed and enabled;
- performs the normal Selenium click only after those conditions hold;
- retains the exact-node highlight assertion after the click.

No JavaScript click is used and no application code or search assertion is changed.

## Verification

- `./mvnw -B verify -Ponnx`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`