### PR TITLE
Reduce successful UI evidence volume

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -6,7 +6,8 @@
     "node": "24.x"
   },
   "scripts": {
-    "verify:ui": "node scripts/run-ui-suite.mjs"
+    "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/scripts/ui-evidence-policy.mjs
+++ b/.github/scripts/ui-evidence-policy.mjs
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const VALID_MODES = new Set(['compact', 'full']);
+const DEFAULT_CURATED_STATES = 'analysis-success';
+
+function normalizeStates(value) {
+  const candidates = Array.isArray(value) ? value : String(value || '').split(',');
+  return [...new Set(candidates.map(item => String(item).trim()).filter(Boolean))];
+}
+
+export function createEvidencePolicy({
+  mode = process.env.TAXONOMY_UI_EVIDENCE_MODE || 'compact',
+  curatedStates = process.env.TAXONOMY_UI_CURATED_STATES || DEFAULT_CURATED_STATES
+} = {}) {
+  const normalizedMode = String(mode).trim().toLowerCase();
+  if (!VALID_MODES.has(normalizedMode)) {
+    throw new Error(`Unsupported TAXONOMY_UI_EVIDENCE_MODE=${mode}; expected compact or full`);
+  }
+  const normalizedStates = normalizeStates(curatedStates);
+  const curated = new Set(normalizedStates);
+  return {
+    mode: normalizedMode,
+    curatedStates: normalizedStates,
+    shouldCapture: state => normalizedMode === 'full' || curated.has(state)
+  };
+}
+
+export async function captureFailureEvidence({
+  page,
+  outputDir,
+  prefix = 'failure',
+  selector = 'body'
+}) {
+  await mkdir(outputDir, { recursive: true });
+  const target = page.locator(selector);
+  await target.waitFor({ state: 'visible', timeout: 5_000 });
+
+  const screenshot = path.join(outputDir, `${prefix}.png`);
+  const html = path.join(outputDir, `${prefix}.html`);
+  const aria = path.join(outputDir, `${prefix}.aria.txt`);
+
+  // A single viewport image is sufficient to locate the failing state while
+  // avoiding the unbounded full-page screenshots that made successful CI
+  // evidence hundreds of megabytes large.
+  await page.screenshot({ path: screenshot, fullPage: false, animations: 'disabled' });
+  await writeFile(html, await target.evaluate(node => node.outerHTML), 'utf8');
+  const ariaSnapshot = typeof target.ariaSnapshot === 'function'
+    ? await target.ariaSnapshot().catch(error => `ARIA snapshot unavailable: ${error}`)
+    : 'ARIA snapshot API unavailable';
+  await writeFile(aria, `${ariaSnapshot}\n`, 'utf8');
+
+  return {
+    selector,
+    files: [path.basename(screenshot), path.basename(html), path.basename(aria)]
+  };
+}

--- a/.github/scripts/ui-evidence-policy.test.mjs
+++ b/.github/scripts/ui-evidence-policy.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
+
+test('compact mode retains only curated successful states', () => {
+  const policy = createEvidencePolicy({ mode: 'compact', curatedStates: 'analysis-success' });
+  assert.equal(policy.mode, 'compact');
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('analysis-error'), false);
+});
+
+test('full mode retains every successful state', () => {
+  const policy = createEvidencePolicy({ mode: 'full', curatedStates: [] });
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('dialog-open'), true);
+});
+
+test('curated state parsing trims and removes duplicates', () => {
+  const policy = createEvidencePolicy({
+    mode: 'compact',
+    curatedStates: ' analysis-success,dialog-open,analysis-success '
+  });
+  assert.deepEqual(policy.curatedStates, ['analysis-success', 'dialog-open']);
+});
+
+test('unsupported evidence mode fails before browser execution', () => {
+  assert.throws(
+    () => createEvidencePolicy({ mode: 'everything' }),
+    /expected compact or full/
+  );
+});

--- a/.github/scripts/ui-primary-evidence.mjs
+++ b/.github/scripts/ui-primary-evidence.mjs
@@ -1,11 +1,14 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createEvidence(page, outputDir) {
   const checks = [];
   const axeFindings = [];
   const screenshots = [];
+  const states = [];
+  const policy = createEvidencePolicy();
 
   function assert(condition, message) {
     if (!condition) throw new Error(message);
@@ -18,6 +21,10 @@ export function createEvidence(page, outputDir) {
   async function saveState(state, selector = '#mainContent') {
     const target = page.locator(selector);
     await target.waitFor({ state: 'visible', timeout: 20_000 });
+    const captured = policy.shouldCapture(state);
+    states.push({ state, selector, captured });
+    if (!captured) return;
+
     const file = path.join(outputDir, `${state}.png`);
     await target.screenshot({ path: file, animations: 'disabled' });
     screenshots.push(path.basename(file));
@@ -59,6 +66,14 @@ export function createEvidence(page, outputDir) {
     saveState,
     axeState,
     waitForText,
-    report: auditError => ({ checks, axeFindings, screenshots, auditError })
+    report: auditError => ({
+      evidenceMode: policy.mode,
+      curatedStates: policy.curatedStates,
+      checks,
+      axeFindings,
+      states,
+      screenshots,
+      auditError
+    })
   };
 }

--- a/.github/scripts/ui-primary-workflow-acceptance.mjs
+++ b/.github/scripts/ui-primary-workflow-acceptance.mjs
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { ROLE_ACCOUNTS, openRoleSession } from './ui-role-fixtures.mjs';
 import { createEvidence } from './ui-primary-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runBasicWorkflows } from './ui-primary-basic-workflows.mjs';
 import { runProposalWorkflows } from './ui-primary-proposal-workflows.mjs';
 import { runRelationWorkflows } from './ui-primary-relation-workflows.mjs';
@@ -23,6 +24,7 @@ let context;
 let page;
 let account;
 let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -46,9 +48,18 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({
+        page, outputDir, prefix: 'failure', selector: '#mainContent'
+      });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const details = evidence ? evidence.report(auditError)
-    : { checks: [], axeFindings: [], screenshots: [], auditError };
-  const report = { role, browserName, ...details };
+    : { checks: [], axeFindings: [], states: [], screenshots: [], auditError };
+  const report = { role, browserName, ...details, failureEvidence };
   await writeFile(path.join(outputDir, 'report.json'),
     `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) console.error(`Primary workflow acceptance failed for ${role}:\n${auditError}`);

--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -1,7 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { openRoleSession, ROLE_ACCOUNTS } from './ui-role-fixtures.mjs';
+import { openRoleSession } from './ui-role-fixtures.mjs';
 import { createRoleStateEvidence } from './ui-role-state-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runRoleStateFlow } from './ui-role-state-flow.mjs';
 
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
@@ -40,6 +41,8 @@ let auditError = null;
 let browser;
 let context;
 let page;
+let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -69,7 +72,7 @@ try {
   });
   page.on('pageerror', error => consoleErrors.push(error.message));
 
-  const evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
+  evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
   await runRoleStateFlow({
     page, role, zoom, forcedColors, checks, httpFailures,
     externalRequests, consoleErrors, evidence
@@ -78,11 +81,22 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({ page, outputDir, prefix: 'failure' });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const report = {
     profileId, browserName, role,
     physicalViewport: { width: physicalWidth, height: physicalHeight },
-    effectiveViewport, zoom, forcedColors, checks, findings,
-    externalRequests, httpFailures, consoleErrors, auditError
+    effectiveViewport, zoom, forcedColors,
+    evidenceMode: evidence?.evidenceMode || null,
+    curatedStates: evidence?.curatedStates || [],
+    states: evidence?.states || [],
+    checks, findings, externalRequests, httpFailures, consoleErrors,
+    auditError, failureEvidence
   };
   await writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) {

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -1,8 +1,12 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
+  const policy = createEvidencePolicy();
+  const states = [];
+
   async function saveState(state) {
     const prefix = path.join(outputDir, state);
     const dimensions = await page.evaluate(() => ({
@@ -13,14 +17,16 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       width: Math.min(dimensions.width, 1440),
       height: Math.min(dimensions.height, 1000)
     };
+    const captured = policy.shouldCapture(state);
     const screenshotFiles = [];
     const segments = [];
-    if (dimensions.width <= 30000 && dimensions.height <= 30000) {
+
+    if (captured && dimensions.width <= 30000 && dimensions.height <= 30000) {
       const file = `${prefix}.png`;
       await page.screenshot({ path: file, fullPage: true, animations: 'disabled' });
       screenshotFiles.push(path.basename(file));
       segments.push({ file: path.basename(file), scrollY: 0, fullPage: true });
-    } else {
+    } else if (captured) {
       const maxScrollY = Math.max(0, dimensions.height - viewport.height);
       const targets = [];
       for (let y = 0; y < maxScrollY; y += viewport.height) targets.push(y);
@@ -40,9 +46,20 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       }
       await page.evaluate(() => window.scrollTo(0, 0));
     }
-    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify({
-      dimensions, viewport, screenshotFiles, segments
-    }, null, 2)}\n`, 'utf8');
+
+    const stateSummary = {
+      state,
+      evidenceMode: policy.mode,
+      captured,
+      dimensions,
+      viewport,
+      screenshotFiles,
+      segments
+    };
+    states.push(stateSummary);
+    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify(stateSummary, null, 2)}\n`, 'utf8');
+
+    if (!captured) return;
     await writeFile(`${prefix}.html`, await page.content(), 'utf8');
     const body = page.locator('body');
     const aria = typeof body.ariaSnapshot === 'function'
@@ -65,5 +82,11 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
     checks.push(`axe ${state}`);
   }
 
-  return { saveState, runAxe };
+  return {
+    saveState,
+    runAxe,
+    evidenceMode: policy.mode,
+    curatedStates: policy.curatedStates,
+    states
+  };
 }

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,33 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI evidence policy
+
+Browser assertions, axe analysis, console checks, network checks and JSON summaries
+run for every selected state. Successful verification uses compact evidence by
+default: it retains the machine-readable reports and a small curated screenshot
+baseline instead of storing screenshots, HTML and ARIA snapshots for every passing
+state. A failing primary or role/state scenario always captures a viewport
+screenshot, DOM snapshot and ARIA snapshot before the browser closes.
+
+Full successful evidence remains locally reproducible when it is needed for a
+manual audit:
+
+```bash
+TAXONOMY_UI_EVIDENCE_MODE=full \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+The curated compact baseline can be changed without changing test selection:
+
+```bash
+TAXONOMY_UI_CURATED_STATES=analysis-success,dialog-open \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+`TAXONOMY_UI_EVIDENCE_MODE` accepts only `compact` or `full`; invalid values fail
+before browser scenarios execute.
+
 ## Workflow responsibilities
 
 Only eight workflows remain:


### PR DESCRIPTION
## Summary

Replaces #492 after #489 and the Taxonomy 1.2.7 release advanced `main` while its long verification was still running.

This PR is one clean commit directly on the current post-release `main` and contains only the remaining UI-evidence work from #476:

- add a tested `compact`/`full` evidence policy;
- keep every browser assertion, axe check, console check, network check and JSON finding active;
- retain only curated successful screenshots by default;
- retain compact machine-readable state manifests for all role/state checks;
- automatically capture viewport screenshot, DOM and ARIA evidence when a primary or role/state scenario fails;
- allow full successful evidence with `TAXONOMY_UI_EVIDENCE_MODE=full`;
- allow the compact screenshot baseline to be selected with `TAXONOMY_UI_CURATED_STATES`;
- reject invalid evidence modes before browser execution;
- document both compact and full Maven-owned reproduction.

The relation-row assertions and ONNX search-button stabilization from the former branch are deliberately absent because they are already byte-identical in `main` through merged PR #489. The `.dockerignore` work remains in merged PR #486.

## Verification

- `node --test .github/scripts/ui-evidence-policy.test.mjs`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Refs #476
Supersedes #492.