### PR TITLE
Reuse UI application across isolated scenario groups

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -6,7 +6,8 @@
     "node": "24.x"
   },
   "scripts": {
-    "verify:ui": "node scripts/run-ui-suite.mjs"
+    "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/package.json
+++ b/.github/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
-    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
+    "test:ui-suite-plan": "node --test scripts/ui-suite-plan.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && npm run test:ui-suite-plan && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/scripts/run-ui-suite.mjs
+++ b/.github/scripts/run-ui-suite.mjs
@@ -1,17 +1,23 @@
+import { closeSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { mkdir, readdir, readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { groupScenarios } from './ui-suite-plan.mjs';
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
-const matrix = JSON.parse(await readFile(path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
+const matrix = JSON.parse(await readFile(
+  path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
 const requestedSuite = process.env.TAXONOMY_UI_SUITE || 'all';
 const requestedProfile = process.env.TAXONOMY_UI_PROFILE_FILTER || '';
 const adminPassword = process.env.TAXONOMY_ADMIN_PASSWORD || 'ui-primary-admin-password';
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
-const outputRoot = path.resolve(repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
+const outputRoot = path.resolve(
+  repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
 
 const uiProfiles = [
   { id: 'desktop-chromium', browser: 'chromium', width: 1440, height: 1000, mode: 'full' },
@@ -37,7 +43,8 @@ async function findApplicationJar() {
     .filter(name => /^taxonomy-app-.*\.jar$/.test(name) && !name.startsWith('original-'))
     .sort();
   if (candidates.length !== 1) {
-    throw new Error(`Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
+    throw new Error(
+      `Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
   }
   return path.join(target, candidates[0]);
 }
@@ -48,7 +55,8 @@ function runProcess(executable, args, options = {}) {
     child.once('error', reject);
     child.once('exit', (code, signal) => {
       if (code === 0) resolve();
-      else reject(new Error(`${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
+      else reject(new Error(
+        `${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
     });
   });
 }
@@ -57,7 +65,8 @@ async function waitForApplication(application, logPath) {
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
     if (application.exitCode !== null) {
-      throw new Error(`Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
+      throw new Error(
+        `Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
     }
     try {
       const response = await fetch(`${baseUrl}/login`, { redirect: 'manual' });
@@ -67,7 +76,8 @@ async function waitForApplication(application, logPath) {
     }
     await new Promise(resolve => setTimeout(resolve, 2_000));
   }
-  throw new Error(`Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
+  throw new Error(
+    `Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
 }
 
 async function stopApplication(application) {
@@ -80,13 +90,8 @@ async function stopApplication(application) {
   if (application.exitCode === null) application.kill('SIGKILL');
 }
 
-async function runScenario({ suite, id, script, env = {} }) {
-  const outputDir = path.join(outputRoot, suite, id);
-  await mkdir(outputDir, { recursive: true });
-  const logPath = path.join(outputDir, 'application.log');
-  const jar = await findApplicationJar();
-  const logHandle = await import('node:fs').then(({ openSync }) => openSync(logPath, 'a'));
-  const applicationEnv = {
+function applicationEnvironment() {
+  return {
     ...process.env,
     TAXONOMY_ADMIN_PASSWORD: adminPassword,
     TAXONOMY_REQUIRE_PASSWORD_CHANGE: 'false',
@@ -95,32 +100,104 @@ async function runScenario({ suite, id, script, env = {} }) {
     TAXONOMY_THYMELEAF_CACHE: 'false',
     LLM_MOCK: 'true'
   };
+}
+
+function scenarioEnvironment(scenario) {
+  return {
+    ...process.env,
+    TAXONOMY_BASE_URL: baseUrl,
+    TAXONOMY_UI_USERNAME: 'admin',
+    TAXONOMY_UI_PASSWORD: adminPassword,
+    TAXONOMY_A11Y_USERNAME: 'admin',
+    TAXONOMY_A11Y_PASSWORD: adminPassword,
+    TAXONOMY_UI_ADMIN_USERNAME: 'admin',
+    TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
+    ...scenario.env
+  };
+}
+
+function safeFileName(value) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+async function runScenario(application, scenario, applicationLog, groupTiming) {
+  if (application.exitCode !== null) {
+    throw new Error(
+      `Taxonomy application exited before ${scenario.suite}/${scenario.id}; see ${applicationLog}`);
+  }
+
+  const outputDir = path.join(outputRoot, scenario.suite, scenario.id);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, 'application-log.txt'),
+    `${path.relative(outputDir, applicationLog)}\n`,
+    'utf8');
+
+  console.log(`\n=== Maven-owned UI scenario: ${scenario.suite}/${scenario.id} ===`);
+  const started = performance.now();
+  const timing = {
+    suite: scenario.suite,
+    id: scenario.id,
+    startedAt: new Date().toISOString(),
+    outcome: 'running'
+  };
+  groupTiming.scenarios.push(timing);
+  try {
+    await runProcess(process.execPath, [path.join(scriptDir, scenario.script)], {
+      cwd: repoRoot,
+      env: scenarioEnvironment(scenario)
+    });
+    timing.outcome = 'passed';
+  } catch (error) {
+    timing.outcome = 'failed';
+    timing.error = error?.message || String(error);
+    throw error;
+  } finally {
+    timing.durationMs = Math.round(performance.now() - started);
+  }
+}
+
+async function runGroup(group, jar, report) {
+  const applicationDirectory = path.join(outputRoot, '_applications');
+  await mkdir(applicationDirectory, { recursive: true });
+  const logPath = path.join(applicationDirectory, `${safeFileName(group.id)}.log`);
+  const logHandle = openSync(logPath, 'a');
+  const groupStarted = performance.now();
+  const groupTiming = {
+    id: group.id,
+    applicationLog: path.relative(outputRoot, logPath),
+    scenarioCount: group.scenarios.length,
+    startedAt: new Date().toISOString(),
+    outcome: 'running',
+    scenarios: []
+  };
+  report.groups.push(groupTiming);
+
   const application = spawn('java', ['-jar', jar], {
     cwd: repoRoot,
-    env: applicationEnv,
+    env: applicationEnvironment(),
     stdio: ['ignore', logHandle, logHandle]
   });
+
   try {
+    const startupStarted = performance.now();
     await waitForApplication(application, logPath);
-    const childEnv = {
-      ...process.env,
-      TAXONOMY_BASE_URL: baseUrl,
-      TAXONOMY_UI_USERNAME: 'admin',
-      TAXONOMY_UI_PASSWORD: adminPassword,
-      TAXONOMY_A11Y_USERNAME: 'admin',
-      TAXONOMY_A11Y_PASSWORD: adminPassword,
-      TAXONOMY_UI_ADMIN_USERNAME: 'admin',
-      TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
-      ...env
-    };
-    console.log(`\n=== Maven-owned UI scenario: ${suite}/${id} ===`);
-    await runProcess(process.execPath, [path.join(scriptDir, script)], {
-      cwd: repoRoot,
-      env: childEnv
-    });
+    groupTiming.startupMs = Math.round(performance.now() - startupStarted);
+    console.log(
+      `\n=== UI application group ${group.id}: ${group.scenarios.length} scenario(s), `
+      + `startup ${groupTiming.startupMs} ms ===`);
+    for (const scenario of group.scenarios) {
+      await runScenario(application, scenario, logPath, groupTiming);
+    }
+    groupTiming.outcome = 'passed';
+  } catch (error) {
+    groupTiming.outcome = 'failed';
+    groupTiming.error = error?.message || String(error);
+    throw error;
   } finally {
     await stopApplication(application);
-    await import('node:fs').then(({ closeSync }) => closeSync(logHandle));
+    closeSync(logHandle);
+    groupTiming.durationMs = Math.round(performance.now() - groupStarted);
   }
 }
 
@@ -175,13 +252,51 @@ for (const profile of matrix.profiles.filter(item => !item.textSpacing)) {
   });
 }
 if (selected('special-modes', 'text-spacing-and-offline')) scenarios.push({
-  suite: 'special-modes', id: 'text-spacing-and-offline', script: 'ui-special-modes-acceptance.mjs', env: {
-    TAXONOMY_UI_OUTPUT_DIR: path.join(outputRoot, 'special-modes', 'text-spacing-and-offline')
+  suite: 'special-modes',
+  id: 'text-spacing-and-offline',
+  script: 'ui-special-modes-acceptance.mjs',
+  env: {
+    TAXONOMY_UI_OUTPUT_DIR: path.join(
+      outputRoot, 'special-modes', 'text-spacing-and-offline')
   }
 });
 
 if (scenarios.length === 0) {
-  throw new Error(`No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
+  throw new Error(
+    `No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
 }
-for (const scenario of scenarios) await runScenario(scenario);
-console.log(`\nMaven-owned UI verification passed: ${scenarios.length} scenario(s).`);
+
+const groups = groupScenarios(scenarios);
+const report = {
+  schemaVersion: 1,
+  requestedSuite,
+  requestedProfile: requestedProfile || null,
+  startedAt: new Date().toISOString(),
+  scenarioCount: scenarios.length,
+  applicationStartCount: groups.length,
+  groups: []
+};
+const overallStarted = performance.now();
+let failure = null;
+try {
+  const jar = await findApplicationJar();
+  for (const group of groups) await runGroup(group, jar, report);
+} catch (error) {
+  failure = error;
+  report.outcome = 'failed';
+  report.error = error?.message || String(error);
+} finally {
+  report.finishedAt = new Date().toISOString();
+  report.durationMs = Math.round(performance.now() - overallStarted);
+  if (!report.outcome) report.outcome = 'passed';
+  await mkdir(outputRoot, { recursive: true });
+  await writeFile(
+    path.join(outputRoot, 'timings.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+    'utf8');
+}
+
+if (failure) throw failure;
+console.log(
+  `\nMaven-owned UI verification passed: ${scenarios.length} scenario(s) `
+  + `in ${groups.length} application start(s), ${report.durationMs} ms total.`);

--- a/.github/scripts/ui-evidence-policy.mjs
+++ b/.github/scripts/ui-evidence-policy.mjs
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const VALID_MODES = new Set(['compact', 'full']);
+const DEFAULT_CURATED_STATES = 'analysis-success';
+
+function normalizeStates(value) {
+  const candidates = Array.isArray(value) ? value : String(value || '').split(',');
+  return [...new Set(candidates.map(item => String(item).trim()).filter(Boolean))];
+}
+
+export function createEvidencePolicy({
+  mode = process.env.TAXONOMY_UI_EVIDENCE_MODE || 'compact',
+  curatedStates = process.env.TAXONOMY_UI_CURATED_STATES || DEFAULT_CURATED_STATES
+} = {}) {
+  const normalizedMode = String(mode).trim().toLowerCase();
+  if (!VALID_MODES.has(normalizedMode)) {
+    throw new Error(`Unsupported TAXONOMY_UI_EVIDENCE_MODE=${mode}; expected compact or full`);
+  }
+  const normalizedStates = normalizeStates(curatedStates);
+  const curated = new Set(normalizedStates);
+  return {
+    mode: normalizedMode,
+    curatedStates: normalizedStates,
+    shouldCapture: state => normalizedMode === 'full' || curated.has(state)
+  };
+}
+
+export async function captureFailureEvidence({
+  page,
+  outputDir,
+  prefix = 'failure',
+  selector = 'body'
+}) {
+  await mkdir(outputDir, { recursive: true });
+  const target = page.locator(selector);
+  await target.waitFor({ state: 'visible', timeout: 5_000 });
+
+  const screenshot = path.join(outputDir, `${prefix}.png`);
+  const html = path.join(outputDir, `${prefix}.html`);
+  const aria = path.join(outputDir, `${prefix}.aria.txt`);
+
+  // A single viewport image is sufficient to locate the failing state while
+  // avoiding the unbounded full-page screenshots that made successful CI
+  // evidence hundreds of megabytes large.
+  await page.screenshot({ path: screenshot, fullPage: false, animations: 'disabled' });
+  await writeFile(html, await target.evaluate(node => node.outerHTML), 'utf8');
+  const ariaSnapshot = typeof target.ariaSnapshot === 'function'
+    ? await target.ariaSnapshot().catch(error => `ARIA snapshot unavailable: ${error}`)
+    : 'ARIA snapshot API unavailable';
+  await writeFile(aria, `${ariaSnapshot}\n`, 'utf8');
+
+  return {
+    selector,
+    files: [path.basename(screenshot), path.basename(html), path.basename(aria)]
+  };
+}

--- a/.github/scripts/ui-evidence-policy.test.mjs
+++ b/.github/scripts/ui-evidence-policy.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
+
+test('compact mode retains only curated successful states', () => {
+  const policy = createEvidencePolicy({ mode: 'compact', curatedStates: 'analysis-success' });
+  assert.equal(policy.mode, 'compact');
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('analysis-error'), false);
+});
+
+test('full mode retains every successful state', () => {
+  const policy = createEvidencePolicy({ mode: 'full', curatedStates: [] });
+  assert.equal(policy.shouldCapture('analysis-success'), true);
+  assert.equal(policy.shouldCapture('dialog-open'), true);
+});
+
+test('curated state parsing trims and removes duplicates', () => {
+  const policy = createEvidencePolicy({
+    mode: 'compact',
+    curatedStates: ' analysis-success,dialog-open,analysis-success '
+  });
+  assert.deepEqual(policy.curatedStates, ['analysis-success', 'dialog-open']);
+});
+
+test('unsupported evidence mode fails before browser execution', () => {
+  assert.throws(
+    () => createEvidencePolicy({ mode: 'everything' }),
+    /expected compact or full/
+  );
+});

--- a/.github/scripts/ui-primary-evidence.mjs
+++ b/.github/scripts/ui-primary-evidence.mjs
@@ -1,11 +1,14 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createEvidence(page, outputDir) {
   const checks = [];
   const axeFindings = [];
   const screenshots = [];
+  const states = [];
+  const policy = createEvidencePolicy();
 
   function assert(condition, message) {
     if (!condition) throw new Error(message);
@@ -18,6 +21,10 @@ export function createEvidence(page, outputDir) {
   async function saveState(state, selector = '#mainContent') {
     const target = page.locator(selector);
     await target.waitFor({ state: 'visible', timeout: 20_000 });
+    const captured = policy.shouldCapture(state);
+    states.push({ state, selector, captured });
+    if (!captured) return;
+
     const file = path.join(outputDir, `${state}.png`);
     await target.screenshot({ path: file, animations: 'disabled' });
     screenshots.push(path.basename(file));
@@ -59,6 +66,14 @@ export function createEvidence(page, outputDir) {
     saveState,
     axeState,
     waitForText,
-    report: auditError => ({ checks, axeFindings, screenshots, auditError })
+    report: auditError => ({
+      evidenceMode: policy.mode,
+      curatedStates: policy.curatedStates,
+      checks,
+      axeFindings,
+      states,
+      screenshots,
+      auditError
+    })
   };
 }

--- a/.github/scripts/ui-primary-workflow-acceptance.mjs
+++ b/.github/scripts/ui-primary-workflow-acceptance.mjs
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { ROLE_ACCOUNTS, openRoleSession } from './ui-role-fixtures.mjs';
 import { createEvidence } from './ui-primary-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runBasicWorkflows } from './ui-primary-basic-workflows.mjs';
 import { runProposalWorkflows } from './ui-primary-proposal-workflows.mjs';
 import { runRelationWorkflows } from './ui-primary-relation-workflows.mjs';
@@ -23,6 +24,7 @@ let context;
 let page;
 let account;
 let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -46,9 +48,18 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({
+        page, outputDir, prefix: 'failure', selector: '#mainContent'
+      });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const details = evidence ? evidence.report(auditError)
-    : { checks: [], axeFindings: [], screenshots: [], auditError };
-  const report = { role, browserName, ...details };
+    : { checks: [], axeFindings: [], states: [], screenshots: [], auditError };
+  const report = { role, browserName, ...details, failureEvidence };
   await writeFile(path.join(outputDir, 'report.json'),
     `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) console.error(`Primary workflow acceptance failed for ${role}:\n${auditError}`);

--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -1,7 +1,8 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { openRoleSession, ROLE_ACCOUNTS } from './ui-role-fixtures.mjs';
+import { openRoleSession } from './ui-role-fixtures.mjs';
 import { createRoleStateEvidence } from './ui-role-state-evidence.mjs';
+import { captureFailureEvidence } from './ui-evidence-policy.mjs';
 import { runRoleStateFlow } from './ui-role-state-flow.mjs';
 
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
@@ -40,6 +41,8 @@ let auditError = null;
 let browser;
 let context;
 let page;
+let evidence;
+let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
 try {
@@ -69,7 +72,7 @@ try {
   });
   page.on('pageerror', error => consoleErrors.push(error.message));
 
-  const evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
+  evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
   await runRoleStateFlow({
     page, role, zoom, forcedColors, checks, httpFailures,
     externalRequests, consoleErrors, evidence
@@ -78,11 +81,22 @@ try {
   auditError = error?.stack || String(error);
   process.exitCode = 1;
 } finally {
+  if (auditError && page) {
+    try {
+      failureEvidence = await captureFailureEvidence({ page, outputDir, prefix: 'failure' });
+    } catch (error) {
+      failureEvidence = { error: error?.stack || String(error), files: [] };
+    }
+  }
   const report = {
     profileId, browserName, role,
     physicalViewport: { width: physicalWidth, height: physicalHeight },
-    effectiveViewport, zoom, forcedColors, checks, findings,
-    externalRequests, httpFailures, consoleErrors, auditError
+    effectiveViewport, zoom, forcedColors,
+    evidenceMode: evidence?.evidenceMode || null,
+    curatedStates: evidence?.curatedStates || [],
+    states: evidence?.states || [],
+    checks, findings, externalRequests, httpFailures, consoleErrors,
+    auditError, failureEvidence
   };
   await writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
   if (auditError) {

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -1,8 +1,12 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createEvidencePolicy } from './ui-evidence-policy.mjs';
 
 export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
+  const policy = createEvidencePolicy();
+  const states = [];
+
   async function saveState(state) {
     const prefix = path.join(outputDir, state);
     const dimensions = await page.evaluate(() => ({
@@ -13,14 +17,16 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       width: Math.min(dimensions.width, 1440),
       height: Math.min(dimensions.height, 1000)
     };
+    const captured = policy.shouldCapture(state);
     const screenshotFiles = [];
     const segments = [];
-    if (dimensions.width <= 30000 && dimensions.height <= 30000) {
+
+    if (captured && dimensions.width <= 30000 && dimensions.height <= 30000) {
       const file = `${prefix}.png`;
       await page.screenshot({ path: file, fullPage: true, animations: 'disabled' });
       screenshotFiles.push(path.basename(file));
       segments.push({ file: path.basename(file), scrollY: 0, fullPage: true });
-    } else {
+    } else if (captured) {
       const maxScrollY = Math.max(0, dimensions.height - viewport.height);
       const targets = [];
       for (let y = 0; y < maxScrollY; y += viewport.height) targets.push(y);
@@ -40,9 +46,20 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       }
       await page.evaluate(() => window.scrollTo(0, 0));
     }
-    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify({
-      dimensions, viewport, screenshotFiles, segments
-    }, null, 2)}\n`, 'utf8');
+
+    const stateSummary = {
+      state,
+      evidenceMode: policy.mode,
+      captured,
+      dimensions,
+      viewport,
+      screenshotFiles,
+      segments
+    };
+    states.push(stateSummary);
+    await writeFile(`${prefix}.screenshots.json`, `${JSON.stringify(stateSummary, null, 2)}\n`, 'utf8');
+
+    if (!captured) return;
     await writeFile(`${prefix}.html`, await page.content(), 'utf8');
     const body = page.locator('body');
     const aria = typeof body.ariaSnapshot === 'function'
@@ -65,5 +82,11 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
     checks.push(`axe ${state}`);
   }
 
-  return { saveState, runAxe };
+  return {
+    saveState,
+    runAxe,
+    evidenceMode: policy.mode,
+    curatedStates: policy.curatedStates,
+    states
+  };
 }

--- a/.github/scripts/ui-suite-plan.mjs
+++ b/.github/scripts/ui-suite-plan.mjs
@@ -1,0 +1,25 @@
+function roleName(scenario) {
+  return String(scenario.env?.TAXONOMY_ROLE || '').trim().toLowerCase();
+}
+
+export function isolationGroupId(scenario) {
+  if (['ui', 'accessibility', 'special-modes'].includes(scenario.suite)) {
+    return 'shared-browser-nonmutating';
+  }
+  if (scenario.suite === 'role-state') {
+    const role = roleName(scenario);
+    if (!role) throw new Error(`Role-state scenario ${scenario.id} has no TAXONOMY_ROLE`);
+    return `role-state-${role}`;
+  }
+  return `${scenario.suite}-${scenario.id}`;
+}
+
+export function groupScenarios(scenarios) {
+  const groups = new Map();
+  for (const scenario of scenarios) {
+    const id = isolationGroupId(scenario);
+    if (!groups.has(id)) groups.set(id, { id, scenarios: [] });
+    groups.get(id).scenarios.push(scenario);
+  }
+  return [...groups.values()];
+}

--- a/.github/scripts/ui-suite-plan.test.mjs
+++ b/.github/scripts/ui-suite-plan.test.mjs
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { groupScenarios, isolationGroupId } from './ui-suite-plan.mjs';
+
+function scenario(suite, id, role) {
+  return {
+    suite,
+    id,
+    env: role ? { TAXONOMY_ROLE: role } : {}
+  };
+}
+
+test('groups browser-only suites into one shared application', () => {
+  const groups = groupScenarios([
+    scenario('ui', 'desktop-chromium'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline')
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].id, 'shared-browser-nonmutating');
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-chromium',
+    'mobile',
+    'text-spacing-and-offline'
+  ]);
+});
+
+test('shares role-state applications only inside the same role', () => {
+  const groups = groupScenarios([
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-user-chromium',
+    'zoom-400-user-chromium'
+  ]);
+});
+
+test('keeps every primary mutation workflow isolated', () => {
+  const groups = groupScenarios([
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium'
+  ]);
+});
+
+test('maps the complete current matrix from eighteen scenarios to seven starts', () => {
+  const scenarios = [
+    scenario('ui', 'desktop-chromium'),
+    scenario('ui', 'desktop-firefox'),
+    scenario('ui', 'tablet-chromium'),
+    scenario('ui', 'mobile-chromium'),
+    scenario('accessibility', 'desktop'),
+    scenario('accessibility', 'tablet'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline'),
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN'),
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN'),
+    scenario('role-state', 'landscape-user-firefox', 'USER'),
+    scenario('role-state', 'zoom-200-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT')
+  ];
+
+  const groups = groupScenarios(scenarios);
+
+  assert.equal(scenarios.length, 18);
+  assert.equal(groups.length, 7);
+  assert.deepEqual(groups.map(group => group.id), [
+    'shared-browser-nonmutating',
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium',
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+});
+
+test('rejects role-state scenarios without an explicit role', () => {
+  assert.throws(
+    () => isolationGroupId(scenario('role-state', 'broken-profile')),
+    /has no TAXONOMY_ROLE/
+  );
+});

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,33 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI evidence policy
+
+Browser assertions, axe analysis, console checks, network checks and JSON summaries
+run for every selected state. Successful verification uses compact evidence by
+default: it retains the machine-readable reports and a small curated screenshot
+baseline instead of storing screenshots, HTML and ARIA snapshots for every passing
+state. A failing primary or role/state scenario always captures a viewport
+screenshot, DOM snapshot and ARIA snapshot before the browser closes.
+
+Full successful evidence remains locally reproducible when it is needed for a
+manual audit:
+
+```bash
+TAXONOMY_UI_EVIDENCE_MODE=full \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+The curated compact baseline can be changed without changing test selection:
+
+```bash
+TAXONOMY_UI_CURATED_STATES=analysis-success,dialog-open \
+  ./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true
+```
+
+`TAXONOMY_UI_EVIDENCE_MODE` accepts only `compact` or `full`; invalid values fail
+before browser scenarios execute.
+
 ## Workflow responsibilities
 
 Only eight workflows remain:

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,28 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI process isolation and timings
+
+The Maven-owned launcher executes every selected browser scenario but does not
+restart the packaged application when scenarios have the same isolation needs:
+
+- `ui`, `accessibility`, text-spacing and offline checks share one application;
+- role/state profiles share one application only with profiles for the same role;
+- each primary mutation workflow keeps its own fresh application.
+
+The complete default matrix therefore retains all 18 scenarios while reducing
+application starts from 18 to 7. Execution remains sequential. Primary mutation
+workflows are not allowed to share state, and a role/state scenario can never
+share an application with another role. These rules are executable contracts in
+`.github/scripts/ui-suite-plan.test.mjs` rather than implicit CI behavior.
+
+Each scenario contains `application-log.txt`, which points to the log of its
+isolation group. The launcher also writes `target/ui-verification/timings.json`
+with application startup duration, scenario duration, group duration, total
+duration and pass/fail outcome. This report is produced even when a scenario
+fails, so performance and startup regressions can be compared without reading
+the full Maven log.
+
 ## UI evidence policy
 
 Browser assertions, axe analysis, console checks, network checks and JSON summaries


### PR DESCRIPTION
## Summary

Replaces draft #494 after #489 and the Taxonomy 1.2.7 release advanced `main`.

This draft is cleanly layered on #499:

1. the first commit is exactly the compact UI-evidence change from #499;
2. the second commit contains only the UI process-reuse and timing implementation.

After #499 merges, the remaining diff will be limited to five files.

### Explicit isolation model

All 18 existing browser scenarios still run sequentially with the same browsers, roles, viewports, zoom levels, forced-colors, text-spacing, offline and axe assertions. The launcher reuses the packaged application only when state isolation permits it:

- one application for `ui`, `accessibility` and browser-only special modes;
- one application per role for role/state profiles;
- one fresh application for every primary mutation workflow.

This reduces application starts from 18 to 7 without removing a scenario or weakening a guardrail. The complete 18-scenario mapping and role boundaries are executable contracts in `ui-suite-plan.test.mjs`.

### Timing and diagnostics

- emit `target/ui-verification/timings.json` on success and failure;
- record application startup, scenario, group and total durations;
- retain one application log per isolation group below `_applications/`;
- write an `application-log.txt` pointer into every scenario directory;
- fail immediately if a shared application exits before the next scenario.

### Maven authority

The existing Maven browser profile still owns installation and execution. No browser selection, role selection or orchestration is added to workflow YAML.

## Verification

- `node --test .github/scripts/ui-suite-plan.test.mjs`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Depends on #499
Refs #476
Supersedes #494.