### PR TITLE
Stabilize asynchronous container acceptance tests

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -33,6 +33,9 @@ class LocalOnnxPipelineIT {
     private static final HttpClient HTTP = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
             .build();
+    private static final Duration SEARCH_INDEX_TIMEOUT = Duration.ofMinutes(2);
+    private static final String FULL_TEXT_SEARCH_PATH =
+            "/api/search?q=Business%20Processes&maxResults=20";
     private static final String BASIC_AUTH = "Basic "
             + Base64.getEncoder().encodeToString(
                     ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
@@ -141,12 +144,28 @@ class LocalOnnxPipelineIT {
     @Test
     @Order(6)
     void fullTextSearchEndpointReturnsResults() throws Exception {
-        HttpResponse<String> response = httpGet(
-                "/api/search?q=Business%20Processes&maxResults=20");
-        assertThat(response.statusCode()).isEqualTo(200);
-        JsonNode body = MAPPER.readTree(response.body());
-        assertThat(body.isArray()).isTrue();
-        assertThat(body.size()).isGreaterThan(0);
+        long deadline = System.nanoTime() + SEARCH_INDEX_TIMEOUT.toNanos();
+        int lastStatus = -1;
+        String lastBody = "";
+
+        while (System.nanoTime() < deadline) {
+            HttpResponse<String> response = httpGet(FULL_TEXT_SEARCH_PATH);
+            lastStatus = response.statusCode();
+            lastBody = response.body();
+            if (lastStatus == 200) {
+                JsonNode body = MAPPER.readTree(lastBody);
+                if (body.isArray() && !body.isEmpty()) {
+                    return;
+                }
+            }
+            Thread.sleep(500);
+        }
+
+        throw new AssertionError(
+                "Full-text index did not become usable within "
+                        + SEARCH_INDEX_TIMEOUT
+                        + "; last status=" + lastStatus
+                        + ", last body=" + lastBody);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -220,9 +220,10 @@ class OnnxSeleniumIT {
         }
 
         assertThat(items).isNotEmpty();
-        String code = items.getFirst().getAttribute("data-code");
+        WebElement firstResult = items.getFirst();
+        String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        items.getFirst().click();
+        clickWhenUnobscured(firstResult);
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -300,6 +301,29 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
+    private void clickWhenUnobscured(WebElement element) {
+        ((JavascriptExecutor) driver).executeScript(
+                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                element);
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> {
+                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
+                            .executeScript(
+                                    "const target=arguments[0];"
+                                            + "const rect=target.getBoundingClientRect();"
+                                            + "const top=document.elementFromPoint("
+                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
+                                            + "return top===target || target.contains(top);",
+                                    element);
+                    return Boolean.TRUE.equals(unobscured)
+                            && element.isDisplayed()
+                            && element.isEnabled()
+                            ? element
+                            : null;
+                })
+                .click();
+    }
+
     private void executeUiSearch(String mode, String query) {
         WebElement searchPanel = driver.findElement(By.id("searchPanel"));
         if (searchPanel.getAttribute("open") == null) {
@@ -315,26 +339,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-
-        WebElement searchButton = driver.findElement(By.id("searchBtn"));
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
-                searchButton);
-        new WebDriverWait(driver, Duration.ofSeconds(10))
-                .until(currentDriver -> {
-                    Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
-                            .executeScript(
-                                    "const button=arguments[0];"
-                                            + "const rect=button.getBoundingClientRect();"
-                                            + "const top=document.elementFromPoint("
-                                            + "rect.left+rect.width/2,rect.top+rect.height/2);"
-                                            + "return top===button || button.contains(top);",
-                                    searchButton);
-                    return Boolean.TRUE.equals(unobscured) && searchButton.isEnabled()
-                            ? searchButton
-                            : null;
-                })
-                .click();
+        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,20 +1,23 @@
 package com.taxonomy;
 
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.containers.BindMode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,26 +32,28 @@ class ProductionPersistenceRestartIT {
     private static final String PERSISTENCE_PROVENANCE = "production-persistence-restart-it";
     private static final String AUTHORIZATION = "Basic " + Base64.getEncoder().encodeToString(
             ("admin:" + ADMIN_PASSWORD).getBytes(StandardCharsets.UTF_8));
-
-    @TempDir
-    Path persistentData;
+    private static final Duration PRODUCTION_STARTUP_TIMEOUT = Duration.ofMinutes(3);
 
     @Test
     void relationSurvivesContainerReplacement() throws Exception {
         HttpClient client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+        String dataVolume = "taxonomy-persistence-it-"
+                + UUID.randomUUID().toString().replace("-", "");
+        GenericContainer<?> first = null;
+        GenericContainer<?> second = null;
 
-        long countBeforeWrite;
-        GenericContainer<?> first = persistentAppContainer();
         try {
+            long countBeforeWrite;
+            first = persistentAppContainer(dataVolume);
             first.start();
-            URI origin = origin(first);
-            awaitInitialized(client, origin);
+            URI firstOrigin = origin(first);
+            awaitInitialized(client, firstOrigin);
 
-            countBeforeWrite = relationCount(client, origin);
+            countBeforeWrite = relationCount(client, firstOrigin);
             HttpResponse<String> createResponse = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    firstOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString("""
@@ -63,19 +68,17 @@ class ProductionPersistenceRestartIT {
                     .build());
             assertThat(createResponse.statusCode()).isEqualTo(200);
             assertThat(createResponse.body()).contains(PERSISTENCE_PROVENANCE);
-            assertThat(relationCount(client, origin)).isGreaterThan(countBeforeWrite);
-        } finally {
-            stopContainerAndRestoreHostPermissions(first);
-        }
+            assertThat(relationCount(client, firstOrigin)).isGreaterThan(countBeforeWrite);
+            first.stop();
+            first = null;
 
-        GenericContainer<?> second = persistentAppContainer();
-        try {
+            second = persistentAppContainer(dataVolume);
             second.start();
-            URI origin = origin(second);
-            awaitInitialized(client, origin);
+            URI secondOrigin = origin(second);
+            awaitInitialized(client, secondOrigin);
 
             HttpResponse<String> relations = send(client, HttpRequest.newBuilder(
-                    origin.resolve("/api/relations"))
+                    secondOrigin.resolve("/api/relations"))
                     .header("Authorization", AUTHORIZATION)
                     .GET()
                     .build());
@@ -87,16 +90,24 @@ class ProductionPersistenceRestartIT {
             // Catalogue-derived relation totals may be normalized during startup. The
             // persistence contract is that the explicit user relation survives and that
             // the repository does not fall below its pre-write baseline.
-            assertThat(relationCount(client, origin)).isGreaterThanOrEqualTo(countBeforeWrite);
+            assertThat(relationCount(client, secondOrigin))
+                    .isGreaterThanOrEqualTo(countBeforeWrite);
         } finally {
-            stopContainerAndRestoreHostPermissions(second);
+            stopQuietly(second);
+            stopQuietly(first);
+            removeVolume(dataVolume);
         }
     }
 
-    private GenericContainer<?> persistentAppContainer() {
+    private GenericContainer<?> persistentAppContainer(String dataVolume) {
         return ContainerTestUtils.appContainer()
-                .withFileSystemBind(persistentData.toAbsolutePath().toString(),
-                        "/app/data", BindMode.READ_WRITE)
+                .withCreateContainerCmdModifier(command -> command.getHostConfig()
+                        .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .forPort(8080)
+                        .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))
+                .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT)
                 .withEnv("SPRING_PROFILES_ACTIVE", "production,hsqldb")
                 .withEnv("TAXONOMY_DATASOURCE_URL",
                         "jdbc:hsqldb:file:/app/data/taxonomydb;hsqldb.default_table_type=cached;"
@@ -111,26 +122,24 @@ class ProductionPersistenceRestartIT {
                 .withEnv("TAXONOMY_THYMELEAF_CACHE", "true");
     }
 
-    /**
-     * The production image deliberately runs as the non-root {@code taxonomy}
-     * user. Files created in a host bind mount therefore have the container UID.
-     * Before JUnit removes its {@link TempDir}, make the persisted contents
-     * writable by the host runner. This preserves the non-root runtime contract
-     * while keeping test cleanup deterministic.
-     */
-    private static void stopContainerAndRestoreHostPermissions(GenericContainer<?> container)
-            throws Exception {
+    private static void stopQuietly(GenericContainer<?> container) {
+        if (container == null) {
+            return;
+        }
         try {
-            if (container.isRunning()) {
-                var result = container.execInContainer(
-                        "sh", "-c",
-                        "find /app/data -mindepth 1 -exec chmod a+rwX {} +");
-                assertThat(result.getExitCode())
-                        .as("restore host cleanup permissions: %s", result.getStderr())
-                        .isZero();
-            }
-        } finally {
             container.stop();
+        } catch (RuntimeException ignored) {
+            // Preserve the original test failure; volume removal below is still attempted.
+        }
+    }
+
+    private static void removeVolume(String volumeName) {
+        try {
+            DockerClientFactory.instance().client()
+                    .removeVolumeCmd(volumeName)
+                    .exec();
+        } catch (NotFoundException ignored) {
+            // A failed container creation may not have created the named volume yet.
         }
     }
 


### PR DESCRIPTION
## Summary

Consolidates and supersedes #495, #496 and #497 as one clean commit directly on the current post-1.2.7 `main`.

The three failures were independent readiness/interaction races in otherwise successful acceptance paths:

### Full-text readiness

`LocalOnnxPipelineIT` previously treated HTTP process health as proof that the full-text index was already queryable. It now polls the unchanged search endpoint for up to two minutes and retains the final status/body when readiness is not reached.

### Real Selenium interactions

`OnnxSeleniumIT` keeps normal WebDriver clicks for both the search button and the first result card. A shared helper:

- scrolls the real element to the viewport centre;
- checks the centre point with `document.elementFromPoint`;
- requires the element to remain displayed and enabled;
- performs the normal Selenium click only after it is unobscured.

No JavaScript click or application bypass is used.

### Production restart persistence

`ProductionPersistenceRestartIT` now mirrors the documented deployment more closely:

- use one uniquely named Docker volume for `/app/data` across both production-profile containers;
- allow an explicit three-minute production startup budget;
- prove the relation, database/JGit state and filesystem-backed search state survive container replacement;
- remove the volume in `finally` without depending on host bind-mount UID cleanup.

## Evidence already obtained on the former branches

- the volume-backed production restart contract completed successfully, including both container starts and persisted relation;
- the combined persistence plus unobscured-click branch passed the canonical Maven suite, Security Scan and CodeQL;
- all changes are now re-run together against the current `main` to avoid merging evidence from stale release bases.

## Verification

- `./mvnw -B verify -Pcore-integration -Dit.test=ProductionPersistenceRestartIT`
- `./mvnw -B verify -Ponnx`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Supersedes #495, #496 and #497.