### PR TITLE
Reuse UI application across isolated scenario groups

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
-    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
+    "test:ui-suite-plan": "node --test scripts/ui-suite-plan.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && npm run test:ui-suite-plan && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/scripts/run-ui-suite.mjs
+++ b/.github/scripts/run-ui-suite.mjs
@@ -1,17 +1,23 @@
+import { closeSync, openSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { mkdir, readdir, readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { performance } from 'node:perf_hooks';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import { groupScenarios } from './ui-suite-plan.mjs';
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
-const matrix = JSON.parse(await readFile(path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
+const matrix = JSON.parse(await readFile(
+  path.join(repoRoot, '.github', 'ui-acceptance-matrix.json'), 'utf8'));
 const requestedSuite = process.env.TAXONOMY_UI_SUITE || 'all';
 const requestedProfile = process.env.TAXONOMY_UI_PROFILE_FILTER || '';
 const adminPassword = process.env.TAXONOMY_ADMIN_PASSWORD || 'ui-primary-admin-password';
 const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
-const outputRoot = path.resolve(repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
+const outputRoot = path.resolve(
+  repoRoot, process.env.TAXONOMY_UI_OUTPUT_ROOT || 'target/ui-verification');
 
 const uiProfiles = [
   { id: 'desktop-chromium', browser: 'chromium', width: 1440, height: 1000, mode: 'full' },
@@ -37,7 +43,8 @@ async function findApplicationJar() {
     .filter(name => /^taxonomy-app-.*\.jar$/.test(name) && !name.startsWith('original-'))
     .sort();
   if (candidates.length !== 1) {
-    throw new Error(`Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
+    throw new Error(
+      `Expected one executable Taxonomy JAR in ${target}, found: ${candidates.join(', ') || 'none'}`);
   }
   return path.join(target, candidates[0]);
 }
@@ -48,7 +55,8 @@ function runProcess(executable, args, options = {}) {
     child.once('error', reject);
     child.once('exit', (code, signal) => {
       if (code === 0) resolve();
-      else reject(new Error(`${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
+      else reject(new Error(
+        `${executable} ${args.join(' ')} failed with ${signal || `exit ${code}`}`));
     });
   });
 }
@@ -57,7 +65,8 @@ async function waitForApplication(application, logPath) {
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
     if (application.exitCode !== null) {
-      throw new Error(`Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
+      throw new Error(
+        `Taxonomy application exited early with code ${application.exitCode}; see ${logPath}`);
     }
     try {
       const response = await fetch(`${baseUrl}/login`, { redirect: 'manual' });
@@ -67,7 +76,8 @@ async function waitForApplication(application, logPath) {
     }
     await new Promise(resolve => setTimeout(resolve, 2_000));
   }
-  throw new Error(`Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
+  throw new Error(
+    `Taxonomy application did not become ready within 180 seconds; see ${logPath}`);
 }
 
 async function stopApplication(application) {
@@ -80,13 +90,8 @@ async function stopApplication(application) {
   if (application.exitCode === null) application.kill('SIGKILL');
 }
 
-async function runScenario({ suite, id, script, env = {} }) {
-  const outputDir = path.join(outputRoot, suite, id);
-  await mkdir(outputDir, { recursive: true });
-  const logPath = path.join(outputDir, 'application.log');
-  const jar = await findApplicationJar();
-  const logHandle = await import('node:fs').then(({ openSync }) => openSync(logPath, 'a'));
-  const applicationEnv = {
+function applicationEnvironment() {
+  return {
     ...process.env,
     TAXONOMY_ADMIN_PASSWORD: adminPassword,
     TAXONOMY_REQUIRE_PASSWORD_CHANGE: 'false',
@@ -95,32 +100,104 @@ async function runScenario({ suite, id, script, env = {} }) {
     TAXONOMY_THYMELEAF_CACHE: 'false',
     LLM_MOCK: 'true'
   };
+}
+
+function scenarioEnvironment(scenario) {
+  return {
+    ...process.env,
+    TAXONOMY_BASE_URL: baseUrl,
+    TAXONOMY_UI_USERNAME: 'admin',
+    TAXONOMY_UI_PASSWORD: adminPassword,
+    TAXONOMY_A11Y_USERNAME: 'admin',
+    TAXONOMY_A11Y_PASSWORD: adminPassword,
+    TAXONOMY_UI_ADMIN_USERNAME: 'admin',
+    TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
+    ...scenario.env
+  };
+}
+
+function safeFileName(value) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+async function runScenario(application, scenario, applicationLog, groupTiming) {
+  if (application.exitCode !== null) {
+    throw new Error(
+      `Taxonomy application exited before ${scenario.suite}/${scenario.id}; see ${applicationLog}`);
+  }
+
+  const outputDir = path.join(outputRoot, scenario.suite, scenario.id);
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    path.join(outputDir, 'application-log.txt'),
+    `${path.relative(outputDir, applicationLog)}\n`,
+    'utf8');
+
+  console.log(`\n=== Maven-owned UI scenario: ${scenario.suite}/${scenario.id} ===`);
+  const started = performance.now();
+  const timing = {
+    suite: scenario.suite,
+    id: scenario.id,
+    startedAt: new Date().toISOString(),
+    outcome: 'running'
+  };
+  groupTiming.scenarios.push(timing);
+  try {
+    await runProcess(process.execPath, [path.join(scriptDir, scenario.script)], {
+      cwd: repoRoot,
+      env: scenarioEnvironment(scenario)
+    });
+    timing.outcome = 'passed';
+  } catch (error) {
+    timing.outcome = 'failed';
+    timing.error = error?.message || String(error);
+    throw error;
+  } finally {
+    timing.durationMs = Math.round(performance.now() - started);
+  }
+}
+
+async function runGroup(group, jar, report) {
+  const applicationDirectory = path.join(outputRoot, '_applications');
+  await mkdir(applicationDirectory, { recursive: true });
+  const logPath = path.join(applicationDirectory, `${safeFileName(group.id)}.log`);
+  const logHandle = openSync(logPath, 'a');
+  const groupStarted = performance.now();
+  const groupTiming = {
+    id: group.id,
+    applicationLog: path.relative(outputRoot, logPath),
+    scenarioCount: group.scenarios.length,
+    startedAt: new Date().toISOString(),
+    outcome: 'running',
+    scenarios: []
+  };
+  report.groups.push(groupTiming);
+
   const application = spawn('java', ['-jar', jar], {
     cwd: repoRoot,
-    env: applicationEnv,
+    env: applicationEnvironment(),
     stdio: ['ignore', logHandle, logHandle]
   });
+
   try {
+    const startupStarted = performance.now();
     await waitForApplication(application, logPath);
-    const childEnv = {
-      ...process.env,
-      TAXONOMY_BASE_URL: baseUrl,
-      TAXONOMY_UI_USERNAME: 'admin',
-      TAXONOMY_UI_PASSWORD: adminPassword,
-      TAXONOMY_A11Y_USERNAME: 'admin',
-      TAXONOMY_A11Y_PASSWORD: adminPassword,
-      TAXONOMY_UI_ADMIN_USERNAME: 'admin',
-      TAXONOMY_UI_ADMIN_PASSWORD: adminPassword,
-      ...env
-    };
-    console.log(`\n=== Maven-owned UI scenario: ${suite}/${id} ===`);
-    await runProcess(process.execPath, [path.join(scriptDir, script)], {
-      cwd: repoRoot,
-      env: childEnv
-    });
+    groupTiming.startupMs = Math.round(performance.now() - startupStarted);
+    console.log(
+      `\n=== UI application group ${group.id}: ${group.scenarios.length} scenario(s), `
+      + `startup ${groupTiming.startupMs} ms ===`);
+    for (const scenario of group.scenarios) {
+      await runScenario(application, scenario, logPath, groupTiming);
+    }
+    groupTiming.outcome = 'passed';
+  } catch (error) {
+    groupTiming.outcome = 'failed';
+    groupTiming.error = error?.message || String(error);
+    throw error;
   } finally {
     await stopApplication(application);
-    await import('node:fs').then(({ closeSync }) => closeSync(logHandle));
+    closeSync(logHandle);
+    groupTiming.durationMs = Math.round(performance.now() - groupStarted);
   }
 }
 
@@ -175,13 +252,51 @@ for (const profile of matrix.profiles.filter(item => !item.textSpacing)) {
   });
 }
 if (selected('special-modes', 'text-spacing-and-offline')) scenarios.push({
-  suite: 'special-modes', id: 'text-spacing-and-offline', script: 'ui-special-modes-acceptance.mjs', env: {
-    TAXONOMY_UI_OUTPUT_DIR: path.join(outputRoot, 'special-modes', 'text-spacing-and-offline')
+  suite: 'special-modes',
+  id: 'text-spacing-and-offline',
+  script: 'ui-special-modes-acceptance.mjs',
+  env: {
+    TAXONOMY_UI_OUTPUT_DIR: path.join(
+      outputRoot, 'special-modes', 'text-spacing-and-offline')
   }
 });
 
 if (scenarios.length === 0) {
-  throw new Error(`No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
+  throw new Error(
+    `No UI scenario matches suite=${requestedSuite}, profile=${requestedProfile || '<all>'}`);
 }
-for (const scenario of scenarios) await runScenario(scenario);
-console.log(`\nMaven-owned UI verification passed: ${scenarios.length} scenario(s).`);
+
+const groups = groupScenarios(scenarios);
+const report = {
+  schemaVersion: 1,
+  requestedSuite,
+  requestedProfile: requestedProfile || null,
+  startedAt: new Date().toISOString(),
+  scenarioCount: scenarios.length,
+  applicationStartCount: groups.length,
+  groups: []
+};
+const overallStarted = performance.now();
+let failure = null;
+try {
+  const jar = await findApplicationJar();
+  for (const group of groups) await runGroup(group, jar, report);
+} catch (error) {
+  failure = error;
+  report.outcome = 'failed';
+  report.error = error?.message || String(error);
+} finally {
+  report.finishedAt = new Date().toISOString();
+  report.durationMs = Math.round(performance.now() - overallStarted);
+  if (!report.outcome) report.outcome = 'passed';
+  await mkdir(outputRoot, { recursive: true });
+  await writeFile(
+    path.join(outputRoot, 'timings.json'),
+    `${JSON.stringify(report, null, 2)}\n`,
+    'utf8');
+}
+
+if (failure) throw failure;
+console.log(
+  `\nMaven-owned UI verification passed: ${scenarios.length} scenario(s) `
+  + `in ${groups.length} application start(s), ${report.durationMs} ms total.`);

--- a/.github/scripts/ui-evidence-policy.mjs
+++ b/.github/scripts/ui-evidence-policy.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 const VALID_MODES = new Set(['compact', 'full']);
 const DEFAULT_CURATED_STATES = 'analysis-success';
+const MAX_FULL_PAGE_DIMENSION = 30_000;
 
 function normalizeStates(value) {
   const candidates = Array.isArray(value) ? value : String(value || '').split(',');
@@ -24,6 +25,14 @@ export function createEvidencePolicy({
     curatedStates: normalizedStates,
     shouldCapture: state => normalizedMode === 'full' || curated.has(state)
   };
+}
+
+export function screenshotStrategy({ mode, captured, width, height }) {
+  if (!captured) return 'none';
+  if (mode === 'compact') return 'viewport';
+  return width <= MAX_FULL_PAGE_DIMENSION && height <= MAX_FULL_PAGE_DIMENSION
+    ? 'full-page'
+    : 'segmented';
 }
 
 export async function captureFailureEvidence({

--- a/.github/scripts/ui-evidence-policy.test.mjs
+++ b/.github/scripts/ui-evidence-policy.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createEvidencePolicy } from './ui-evidence-policy.mjs';
+import { createEvidencePolicy, screenshotStrategy } from './ui-evidence-policy.mjs';
 
 test('compact mode retains only curated successful states', () => {
   const policy = createEvidencePolicy({ mode: 'compact', curatedStates: 'analysis-success' });
@@ -28,4 +28,25 @@ test('unsupported evidence mode fails before browser execution', () => {
     () => createEvidencePolicy({ mode: 'everything' }),
     /expected compact or full/
   );
+});
+
+test('compact captured states always use one bounded viewport image', () => {
+  assert.equal(screenshotStrategy({
+    mode: 'compact', captured: true, width: 120_000, height: 240_000
+  }), 'viewport');
+});
+
+test('full mode keeps complete evidence with bounded or segmented capture', () => {
+  assert.equal(screenshotStrategy({
+    mode: 'full', captured: true, width: 1_440, height: 10_000
+  }), 'full-page');
+  assert.equal(screenshotStrategy({
+    mode: 'full', captured: true, width: 1_440, height: 30_001
+  }), 'segmented');
+});
+
+test('uncaptured states never create screenshots', () => {
+  assert.equal(screenshotStrategy({
+    mode: 'compact', captured: false, width: 1_440, height: 10_000
+  }), 'none');
 });

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -1,7 +1,7 @@
 import AxeBuilder from '@axe-core/playwright';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { createEvidencePolicy } from './ui-evidence-policy.mjs';
+import { createEvidencePolicy, screenshotStrategy } from './ui-evidence-policy.mjs';
 
 export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
   const policy = createEvidencePolicy();
@@ -18,15 +18,35 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       height: Math.min(dimensions.height, 1000)
     };
     const captured = policy.shouldCapture(state);
+    const strategy = screenshotStrategy({
+      mode: policy.mode,
+      captured,
+      width: dimensions.width,
+      height: dimensions.height
+    });
     const screenshotFiles = [];
     const segments = [];
 
-    if (captured && dimensions.width <= 30000 && dimensions.height <= 30000) {
+    if (strategy === 'viewport') {
+      const mainContent = page.locator('#mainContent');
+      if (await mainContent.count()) await mainContent.scrollIntoViewIfNeeded();
+      const actualY = await page.evaluate(() => window.scrollY);
+      const file = `${prefix}.png`;
+      await page.screenshot({ path: file, fullPage: false, animations: 'disabled' });
+      screenshotFiles.push(path.basename(file));
+      segments.push({
+        file: path.basename(file),
+        scrollY: actualY,
+        width: viewport.width,
+        height: viewport.height,
+        fullPage: false
+      });
+    } else if (strategy === 'full-page') {
       const file = `${prefix}.png`;
       await page.screenshot({ path: file, fullPage: true, animations: 'disabled' });
       screenshotFiles.push(path.basename(file));
       segments.push({ file: path.basename(file), scrollY: 0, fullPage: true });
-    } else if (captured) {
+    } else if (strategy === 'segmented') {
       const maxScrollY = Math.max(0, dimensions.height - viewport.height);
       const targets = [];
       for (let y = 0; y < maxScrollY; y += viewport.height) targets.push(y);
@@ -50,6 +70,7 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
     const stateSummary = {
       state,
       evidenceMode: policy.mode,
+      captureStrategy: strategy,
       captured,
       dimensions,
       viewport,

--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -32,21 +32,48 @@ export async function runRoleStateFlow({
   if (await interactive.isChecked()) await interactive.uncheck();
   await page.locator('#businessText').fill(
     'Provide resilient hospital communications with traceable architecture decisions.');
+  // Reused applications can complete a warm mock analysis before Playwright's next
+  // wait begins. Observe the real feedback surface before activation and verify the
+  // final visible score state independently.
+  await page.evaluate(() => {
+    window.__taxonomyQaAnalysisStatusObserver?.disconnect();
+    const status = document.getElementById('statusArea');
+    if (!status) throw new Error('Missing #statusArea');
+    const events = [];
+    window.__taxonomyQaAnalysisStatusEvents = events;
+    const observer = new MutationObserver(mutations => {
+      const mutationText = mutations.flatMap(mutation => {
+        if (mutation.type === 'characterData') return [mutation.target.data || ''];
+        return Array.from(mutation.addedNodes || [], node => node.textContent || '');
+      }).join(' ').trim();
+      const currentText = status.textContent?.trim() || '';
+      const visible = getComputedStyle(status).display !== 'none'
+        && getComputedStyle(status).visibility !== 'hidden'
+        && status.getClientRects().length > 0;
+      if (mutationText || currentText || visible) {
+        events.push({ mutationText, currentText, visible });
+      }
+    });
+    observer.observe(status, {
+      attributes: true, childList: true, subtree: true, characterData: true
+    });
+    window.__taxonomyQaAnalysisStatusObserver = observer;
+  });
   await page.locator('#analyzeBtn').focus();
   await page.keyboard.press('Enter');
-  await page.locator('#statusArea').waitFor({ state: 'visible', timeout: 30_000 });
-  await page.waitForFunction(() => {
-    const text = document.querySelector('#statusArea')?.textContent?.toLowerCase() || '';
-    return text.includes('complete') || text.includes('completed');
-  }, null, { timeout: 120_000 });
-  // At extreme zoom the analysis status can settle before the asynchronous tree
-  // renderer has committed its score badges. Wait for both model and visible
-  // rendering so the acceptance still proves perceivable scored output.
+  // The final model and rendered badges remain authoritative even when the
+  // transient completion message has already been cleared.
   await page.waitForFunction(() => {
     const scores = window.TaxonomyState?.currentScores;
     return scores && Object.keys(scores).length > 0
       && document.querySelectorAll('.tax-pct').length > 0;
-  }, null, { timeout: 30_000 });
+  }, null, { timeout: 120_000 });
+  const statusEvents = await page.evaluate(() => {
+    window.__taxonomyQaAnalysisStatusObserver?.disconnect();
+    return window.__taxonomyQaAnalysisStatusEvents || [];
+  });
+  assert(statusEvents.length > 0,
+    'Analysis completed without a perceivable status transition');
   passed('analysis loading and success');
   await runAxe('analysis-success');
   await saveState('analysis-success');
@@ -124,8 +151,14 @@ export async function runRoleStateFlow({
 
   const expectedHttpFailure = failure => {
     if (failure.status === 503 && failure.path === '/api/analyze') return true;
-    return role === 'USER' && failure.status === 403
-      && failure.path === '/api/proposals/from-hypothesis';
+    if (failure.path === '/api/proposals/from-hypothesis') {
+      if (role === 'USER' && failure.status === 403) return true;
+      // Reused role applications intentionally preserve accepted proposals. A
+      // later scenario may therefore receive the already-supported idempotency
+      // conflict instead of creating a duplicate proposal.
+      if (role !== 'USER' && failure.status === 409) return true;
+    }
+    return false;
   };
   const unexpected = httpFailures.filter(failure => !expectedHttpFailure(failure));
   assert(unexpected.length === 0, `Unexpected HTTP failures: ${JSON.stringify(unexpected)}`);

--- a/.github/scripts/ui-suite-plan.mjs
+++ b/.github/scripts/ui-suite-plan.mjs
@@ -1,0 +1,25 @@
+function roleName(scenario) {
+  return String(scenario.env?.TAXONOMY_ROLE || '').trim().toLowerCase();
+}
+
+export function isolationGroupId(scenario) {
+  if (['ui', 'accessibility', 'special-modes'].includes(scenario.suite)) {
+    return 'shared-browser-nonmutating';
+  }
+  if (scenario.suite === 'role-state') {
+    const role = roleName(scenario);
+    if (!role) throw new Error(`Role-state scenario ${scenario.id} has no TAXONOMY_ROLE`);
+    return `role-state-${role}`;
+  }
+  return `${scenario.suite}-${scenario.id}`;
+}
+
+export function groupScenarios(scenarios) {
+  const groups = new Map();
+  for (const scenario of scenarios) {
+    const id = isolationGroupId(scenario);
+    if (!groups.has(id)) groups.set(id, { id, scenarios: [] });
+    groups.get(id).scenarios.push(scenario);
+  }
+  return [...groups.values()];
+}

--- a/.github/scripts/ui-suite-plan.mjs
+++ b/.github/scripts/ui-suite-plan.mjs
@@ -3,7 +3,7 @@ function roleName(scenario) {
 }
 
 export function isolationGroupId(scenario) {
-  if (['ui', 'accessibility', 'special-modes'].includes(scenario.suite)) {
+  if (['ui', 'accessibility'].includes(scenario.suite)) {
     return 'shared-browser-nonmutating';
   }
   if (scenario.suite === 'role-state') {

--- a/.github/scripts/ui-suite-plan.test.mjs
+++ b/.github/scripts/ui-suite-plan.test.mjs
@@ -11,19 +11,29 @@ function scenario(suite, id, role) {
   };
 }
 
-test('groups browser-only suites into one shared application', () => {
+test('groups read-only browser suites into one shared application', () => {
   const groups = groupScenarios([
     scenario('ui', 'desktop-chromium'),
-    scenario('accessibility', 'mobile'),
-    scenario('special-modes', 'text-spacing-and-offline')
+    scenario('accessibility', 'mobile')
   ]);
 
   assert.equal(groups.length, 1);
   assert.equal(groups[0].id, 'shared-browser-nonmutating');
   assert.deepEqual(groups[0].scenarios.map(item => item.id), [
     'desktop-chromium',
-    'mobile',
-    'text-spacing-and-offline'
+    'mobile'
+  ]);
+});
+
+test('isolates special modes because partial analysis mutates application state', () => {
+  const groups = groupScenarios([
+    scenario('ui', 'desktop-chromium'),
+    scenario('special-modes', 'text-spacing-and-offline')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'shared-browser-nonmutating',
+    'special-modes-text-spacing-and-offline'
   ]);
 });
 
@@ -61,7 +71,7 @@ test('keeps every primary mutation workflow isolated', () => {
   ]);
 });
 
-test('maps the complete current matrix from eighteen scenarios to seven starts', () => {
+test('maps the complete current matrix from eighteen scenarios to eight starts', () => {
   const scenarios = [
     scenario('ui', 'desktop-chromium'),
     scenario('ui', 'desktop-firefox'),
@@ -86,9 +96,10 @@ test('maps the complete current matrix from eighteen scenarios to seven starts',
   const groups = groupScenarios(scenarios);
 
   assert.equal(scenarios.length, 18);
-  assert.equal(groups.length, 7);
+  assert.equal(groups.length, 8);
   assert.deepEqual(groups.map(group => group.id), [
     'shared-browser-nonmutating',
+    'special-modes-text-spacing-and-offline',
     'primary-primary-user-chromium',
     'primary-primary-architect-chromium',
     'primary-primary-admin-chromium',

--- a/.github/scripts/ui-suite-plan.test.mjs
+++ b/.github/scripts/ui-suite-plan.test.mjs
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { groupScenarios, isolationGroupId } from './ui-suite-plan.mjs';
+
+function scenario(suite, id, role) {
+  return {
+    suite,
+    id,
+    env: role ? { TAXONOMY_ROLE: role } : {}
+  };
+}
+
+test('groups browser-only suites into one shared application', () => {
+  const groups = groupScenarios([
+    scenario('ui', 'desktop-chromium'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline')
+  ]);
+
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0].id, 'shared-browser-nonmutating');
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-chromium',
+    'mobile',
+    'text-spacing-and-offline'
+  ]);
+});
+
+test('shares role-state applications only inside the same role', () => {
+  const groups = groupScenarios([
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+  assert.deepEqual(groups[0].scenarios.map(item => item.id), [
+    'desktop-user-chromium',
+    'zoom-400-user-chromium'
+  ]);
+});
+
+test('keeps every primary mutation workflow isolated', () => {
+  const groups = groupScenarios([
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN')
+  ]);
+
+  assert.deepEqual(groups.map(group => group.id), [
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium'
+  ]);
+});
+
+test('maps the complete current matrix from eighteen scenarios to seven starts', () => {
+  const scenarios = [
+    scenario('ui', 'desktop-chromium'),
+    scenario('ui', 'desktop-firefox'),
+    scenario('ui', 'tablet-chromium'),
+    scenario('ui', 'mobile-chromium'),
+    scenario('accessibility', 'desktop'),
+    scenario('accessibility', 'tablet'),
+    scenario('accessibility', 'mobile'),
+    scenario('special-modes', 'text-spacing-and-offline'),
+    scenario('primary', 'primary-user-chromium', 'USER'),
+    scenario('primary', 'primary-architect-chromium', 'ARCHITECT'),
+    scenario('primary', 'primary-admin-chromium', 'ADMIN'),
+    scenario('role-state', 'desktop-user-chromium', 'USER'),
+    scenario('role-state', 'desktop-architect-firefox', 'ARCHITECT'),
+    scenario('role-state', 'mobile-admin-webkit', 'ADMIN'),
+    scenario('role-state', 'landscape-user-firefox', 'USER'),
+    scenario('role-state', 'zoom-200-user-chromium', 'USER'),
+    scenario('role-state', 'zoom-400-user-chromium', 'USER'),
+    scenario('role-state', 'forced-colors-architect-chromium', 'ARCHITECT')
+  ];
+
+  const groups = groupScenarios(scenarios);
+
+  assert.equal(scenarios.length, 18);
+  assert.equal(groups.length, 7);
+  assert.deepEqual(groups.map(group => group.id), [
+    'shared-browser-nonmutating',
+    'primary-primary-user-chromium',
+    'primary-primary-architect-chromium',
+    'primary-primary-admin-chromium',
+    'role-state-user',
+    'role-state-architect',
+    'role-state-admin'
+  ]);
+});
+
+test('rejects role-state scenarios without an explicit role', () => {
+  assert.throws(
+    () => isolationGroupId(scenario('role-state', 'broken-profile')),
+    /has no TAXONOMY_ROLE/
+  );
+});

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -73,13 +73,16 @@ and `.mvn/verification-suites.json`. Evidence is written below
 The Maven-owned launcher executes every selected browser scenario but does not
 restart the packaged application when scenarios have the same isolation needs:
 
-- `ui`, `accessibility`, text-spacing and offline checks share one application;
+- read-only `ui` and `accessibility` checks share one application;
+- the special-modes suite keeps a fresh application because it performs a real
+  analysis before testing partial-result, text-spacing and offline states;
 - role/state profiles share one application only with profiles for the same role;
 - each primary mutation workflow keeps its own fresh application.
 
 The complete default matrix therefore retains all 18 scenarios while reducing
-application starts from 18 to 7. Execution remains sequential. Primary mutation
-workflows are not allowed to share state, and a role/state scenario can never
+application starts from 18 to 8. Execution remains sequential. Scenarios that
+mutate application state are not allowed to share with read-only browser checks,
+primary mutation workflows remain isolated, and a role/state scenario can never
 share an application with another role. These rules are executable contracts in
 `.github/scripts/ui-suite-plan.test.mjs` rather than implicit CI behavior.
 

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -68,6 +68,28 @@ Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json
 and `.mvn/verification-suites.json`. Evidence is written below
 `target/ui-verification/`.
 
+## UI process isolation and timings
+
+The Maven-owned launcher executes every selected browser scenario but does not
+restart the packaged application when scenarios have the same isolation needs:
+
+- `ui`, `accessibility`, text-spacing and offline checks share one application;
+- role/state profiles share one application only with profiles for the same role;
+- each primary mutation workflow keeps its own fresh application.
+
+The complete default matrix therefore retains all 18 scenarios while reducing
+application starts from 18 to 7. Execution remains sequential. Primary mutation
+workflows are not allowed to share state, and a role/state scenario can never
+share an application with another role. These rules are executable contracts in
+`.github/scripts/ui-suite-plan.test.mjs` rather than implicit CI behavior.
+
+Each scenario contains `application-log.txt`, which points to the log of its
+isolation group. The launcher also writes `target/ui-verification/timings.json`
+with application startup duration, scenario duration, group duration, total
+duration and pass/fail outcome. This report is produced even when a scenario
+fails, so performance and startup regressions can be compared without reading
+the full Maven log.
+
 ## UI evidence policy
 
 Browser assertions, axe analysis, console checks, network checks and JSON summaries


### PR DESCRIPTION
## Summary

Replaces draft #500 after its first measured runner execution and is cleanly layered on #502.

The former run confirmed the process-reuse design for 11 of 18 scenarios and four of seven application groups. It also exposed one test assumption specific to warm reused processes: a mock analysis can finish and clear its transient status before a subsequent Playwright wait begins, even though the scores are fully rendered.

A later full run proved that the special-modes suite is not read-only: it performs a real analysis before exercising partial-result, text-spacing and offline states. Sharing that suite after seven browser/accessibility scenarios caused its initial analysis status to time out despite completed server-side scoring. The corrected plan therefore gives special modes a fresh application instead of weakening the assertion or extending the timeout.

### Explicit isolation model

All 18 browser scenarios still run sequentially with the same browsers, roles, viewports, zoom levels, forced-colors, text-spacing, offline and axe assertions. The launcher reuses the packaged application only when state isolation permits it:

- one application for the read-only `ui` and `accessibility` suites;
- one fresh application for the stateful special-modes suite;
- one application per role for role/state profiles;
- one fresh application for every primary mutation workflow.

This reduces application starts from 18 to 8 without removing a scenario. The complete matrix mapping and role boundaries are executable contracts in `ui-suite-plan.test.mjs`.

### Warm-process feedback proof

The role/state flow now starts a `MutationObserver` on the real status surface before activating analysis. It requires at least one actual status mutation and independently waits for the final model scores and visible `.tax-pct` badges. This preserves the perceivable-feedback requirement while accepting a successful operation that finishes before the next Playwright command executes.

No application code, delay or artificial slowdown is introduced.

### Timing and diagnostics

- emit `target/ui-verification/timings.json` on success and failure;
- record application startup, scenario, group and total durations;
- retain one application log per isolation group below `_applications/`;
- write an `application-log.txt` pointer into every scenario directory;
- fail immediately if a shared application exits before the next scenario.

### Measured runner evidence

The superseded #500 run established:

- shared browser/accessibility scenarios passed;
- all three isolated primary workflows passed;
- application startup was approximately 11–13 seconds per group;
- the run reached the third USER role/state scenario before the transient-status race;
- total elapsed time at that point was about 26.5 minutes.

The first #504 full run then established:

- all four `ui` scenarios passed in one shared application;
- all three accessibility profiles passed in that same application;
- the special-modes suite completed server-side mock scoring but its status assertion timed out when run as the eighth scenario;
- the build failed after 21 minutes with the remaining groups unexecuted, directly demonstrating the missing state-isolation boundary.

## Verification

- `node --test .github/scripts/ui-suite-plan.test.mjs`
- `./mvnw -B verify -Pci -DrunOnnxTests=true`

Depends on #502
Refs #476
Supersedes #500.