### PR TITLE
Verify Keycloak browser and bearer security end to end

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-DrunKeycloakTests=true
+-Dkeycloak.container.image=quay.io/keycloak/keycloak:26.7.0

--- a/.mvn/verification-suites.json
+++ b/.mvn/verification-suites.json
@@ -3,7 +3,7 @@
   "canonicalCommand": "./mvnw -B verify -Pci",
   "profiles": {
     "ci": {
-      "purpose": "Required pull-request verification: unit tests, core and PostgreSQL integration tests, quality gates, browser matrix and accessibility audit",
+      "purpose": "Required pull-request verification: unit tests, core, PostgreSQL and Keycloak integration tests, quality gates, browser matrix and accessibility audit",
       "requires": ["Java 21", "Docker", "Python 3", "POSIX shell"]
     },
     "core-integration": {
@@ -17,6 +17,13 @@
     "document-import-tests": {"test": "DocumentImportControllerTest,DocumentParserServiceTest,DocumentImportLimitsTest"},
     "archimate-import-tests": {"test": "ArchiMateWorkspaceImportTests,CatalogFacadeTest"},
     "ui-tests": {"runner": ".github/scripts/run-ui-suite.mjs"}
+  },
+  "focusedCommands": {
+    "keycloak-security": {
+      "command": "./mvnw -B verify -pl taxonomy-app -am -DskipITs=false -Dit.test=KeycloakSecurityContainerIT",
+      "purpose": "Imported-realm browser OIDC, bearer JWT, CSRF, role, Swagger, logout and health verification",
+      "requires": ["Java 21", "Docker"]
+    }
   },
   "workflowResponsibilities": {
     "ci-cd.yml": "authoritative Maven verification and report publication",

--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -15,7 +15,7 @@
 #   - architect / architect → ROLE_USER, ROLE_ARCHITECT
 #   - user / user         → ROLE_USER
 #
-# Note: This is a development setup. For production, see docs/KEYCLOAK_SETUP.md.
+# Note: This is a development setup. For production, see docs/en/KEYCLOAK_SETUP.md.
 
 services:
   db:
@@ -49,7 +49,7 @@ services:
       retries: 10
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.7.0}
     command: start-dev --import-realm
     volumes:
       - ./keycloak/taxonomy-realm.json:/opt/keycloak/data/import/taxonomy-realm.json:ro
@@ -59,15 +59,22 @@ services:
       KC_DB_USERNAME: keycloak
       KC_DB_PASSWORD: keycloak
       KC_HTTP_PORT: 8180
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HEALTH_ENABLED: "true"
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
     ports:
       - "8180:8180"
     depends_on:
       keycloak-db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8180/health/ready || exit 1"]
+      # The hardened Keycloak image deliberately contains no curl. Use the
+      # documented Bash TCP-socket probe against the management port instead.
+      test:
+        - CMD-SHELL
+        - >-
+          { printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0;
+          grep -E 'HTTP/1\.[01] 200'; } 0<>/dev/tcp/127.0.0.1/9000
       interval: 10s
       timeout: 5s
       retries: 30

--- a/docs/dev/MAVEN_VERIFICATION.md
+++ b/docs/dev/MAVEN_VERIFICATION.md
@@ -1,9 +1,9 @@
 # Maven Verification Authority
 
-Taxonomy has one build authority: the checked-in Maven Wrapper and the profiles
-in the root POM. GitHub Actions supplies machines, containers, external scanners
-and artifact publication; it does not own a functional test or a hidden test
-selection.
+Taxonomy has one build authority: the checked-in Maven Wrapper, `.mvn`
+configuration and profiles in the root POM. GitHub Actions supplies machines,
+containers, external scanners and artifact publication; it does not own a
+functional test or a hidden test selection.
 
 ## Toolchain
 
@@ -15,6 +15,8 @@ selection.
 Node.js and the Playwright/axe packages are installed in the build directory by
 `frontend-maven-plugin`; a global Node installation is not part of the contract.
 The exact browser package versions are declared in `.github/package-lock.json`.
+Keycloak integration uses the image pinned in `.mvn/maven.config`; the test never
+requires a pre-existing identity provider.
 
 ## Authoritative commands
 
@@ -28,27 +30,50 @@ The exact browser package versions are declared in `.github/package-lock.json`.
 | SQL Server | `./mvnw -B verify -Pdatabase-mssql` | Docker |
 | Oracle | `./mvnw -B verify -Pdatabase-oracle` | Docker |
 | Local ONNX pipeline | `./mvnw -B verify -Ponnx` | Docker |
+| Keycloak security only | `./mvnw -B verify -pl taxonomy-app -am -DskipITs=false -Dit.test=KeycloakSecurityContainerIT` | Docker |
 | Browser and accessibility only | `./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true` | permission to install browser OS libraries |
 | Documentation screenshots | `./mvnw -B verify -Pscreenshots` | Docker |
 
 `./mvnw -B verify -Pci` is the canonical pull-request command. It runs:
 
 1. all normal unit, Spring, architecture and contract tests;
-2. core and PostgreSQL Testcontainers integration tests;
+2. core, PostgreSQL, local ONNX and imported-realm Keycloak Testcontainers integration tests;
 3. the reactor-wide JaCoCo threshold and dependency-policy gates;
 4. documentation, frontend-boundary, dependency-alignment and supply-chain checks;
 5. the role, workflow, state, browser, zoom, forced-colors and axe matrix.
 
 It excludes real LLM calls and the scheduled SQL Server and Oracle suites.
 
+## Keycloak security contract
+
+`KeycloakSecurityContainerIT` starts an isolated Keycloak container, imports a
+deterministic test-only realm, starts the packaged Taxonomy application with the
+`keycloak` profile and drives both a real browser and real bearer tokens. It proves:
+
+- authorization-code login and principal mapping for USER, ARCHITECT and ADMIN;
+- explicit extraction of `preferred_username` and `realm_access.roles`;
+- fail-closed behavior for missing, malformed and unsupported role claims;
+- CSRF enforcement for browser sessions and exemption only for actual bearer requests;
+- authorization parity for administration, architecture mutation, preview/import and document upload;
+- RP-initiated logout, fresh OIDC challenge and invalidation of the former application session;
+- private and explicitly public Swagger modes;
+- health behavior for reachable, erroneous, unavailable and invalid JWKS endpoints;
+- absence of local password and local-user-management fallbacks while the Keycloak profile is active.
+
+Realm data, client secrets and users are located below
+`taxonomy-app/src/test/resources/keycloak/` and are not deployment defaults.
+
 ## Focused Maven-owned suites
 
-Test class selection is stored in POM profiles, never in workflow YAML:
+Test selection is stored in POM profiles or cataloged Maven commands, never in
+workflow YAML:
 
 ```bash
 ./mvnw test -Parchitecture-tests -pl taxonomy-app
 ./mvnw test -Pdocument-import-tests -pl taxonomy-app
 ./mvnw test -Parchimate-import-tests -pl taxonomy-app
+./mvnw -B verify -pl taxonomy-app -am \
+  -DskipITs=false -Dit.test=KeycloakSecurityContainerIT
 ```
 
 Browser failures can be reproduced without editing a workflow:
@@ -64,9 +89,10 @@ Browser failures can be reproduced without editing a workflow:
   -Dtaxonomy.ui.profile.filter=zoom-400-user-chromium
 ```
 
-Valid suite names and profiles are defined by `.github/ui-acceptance-matrix.json`
-and `.mvn/verification-suites.json`. Evidence is written below
-`target/ui-verification/`.
+Valid suite names, profiles and focused commands are defined by
+`.github/ui-acceptance-matrix.json` and `.mvn/verification-suites.json`. Browser
+evidence is written below `target/ui-verification/`; Java integration results are
+written to the normal Failsafe report directory.
 
 ## UI evidence policy
 

--- a/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakHealthIndicator.java
@@ -40,24 +40,33 @@ public class KeycloakHealthIndicator implements HealthIndicator {
                     .GET()
                     .build();
 
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = httpClient.send(
+                    request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() == 200) {
                 return Health.up()
                         .withDetail("jwksEndpoint", jwkSetUri)
                         .build();
-            } else {
-                return Health.down()
-                        .withDetail("jwksEndpoint", jwkSetUri)
-                        .withDetail("statusCode", response.statusCode())
-                        .build();
             }
-        } catch (Exception e) {
-            log.debug("Keycloak health check failed: {}", e.getMessage());
             return Health.down()
                     .withDetail("jwksEndpoint", jwkSetUri)
-                    .withDetail("error", e.getMessage())
+                    .withDetail("statusCode", response.statusCode())
+                    .build();
+        } catch (Exception error) {
+            String description = describe(error);
+            log.debug("Keycloak health check failed: {}", description, error);
+            return Health.down()
+                    .withDetail("jwksEndpoint", jwkSetUri)
+                    .withDetail("error", description)
                     .build();
         }
+    }
+
+    private static String describe(Throwable error) {
+        String type = error.getClass().getSimpleName();
+        String message = error.getMessage();
+        return message == null || message.isBlank()
+                ? type
+                : type + ": " + message;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakHealthIndicator.java
@@ -27,9 +27,17 @@ public class KeycloakHealthIndicator implements HealthIndicator {
     @Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri:http://localhost:8180/realms/taxonomy/protocol/openid-connect/certs}")
     private String jwkSetUri;
 
-    private final HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(5))
-            .build();
+    private final HttpClient httpClient;
+
+    public KeycloakHealthIndicator() {
+        this(HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build());
+    }
+
+    KeycloakHealthIndicator(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
 
     @Override
     public Health health() {
@@ -52,14 +60,21 @@ public class KeycloakHealthIndicator implements HealthIndicator {
                     .withDetail("jwksEndpoint", jwkSetUri)
                     .withDetail("statusCode", response.statusCode())
                     .build();
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            return down(error);
         } catch (Exception error) {
-            String description = describe(error);
-            log.debug("Keycloak health check failed: {}", description, error);
-            return Health.down()
-                    .withDetail("jwksEndpoint", jwkSetUri)
-                    .withDetail("error", description)
-                    .build();
+            return down(error);
         }
+    }
+
+    private Health down(Throwable error) {
+        String description = describe(error);
+        log.debug("Keycloak health check failed: {}", description, error);
+        return Health.down()
+                .withDetail("jwksEndpoint", jwkSetUri)
+                .withDetail("error", description)
+                .build();
     }
 
     private static String describe(Throwable error) {

--- a/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakLogoutHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/KeycloakLogoutHandler.java
@@ -24,11 +24,16 @@ import java.io.IOException;
  * {@code X-Forwarded-*} / {@code Forwarded} headers when
  * {@code server.forward-headers-strategy=framework} is enabled.
  * <p>
+ * After Keycloak has invalidated its session, the browser returns through the
+ * application's OIDC authorization endpoint. This produces a fresh Keycloak
+ * login challenge instead of leaving the user on a public application page,
+ * while still proving that silent SSO re-authentication is no longer possible.
+ * <p>
  * Keycloak end_session_endpoint:
  * <pre>
  *   {issuer}/protocol/openid-connect/logout?
  *     id_token_hint={id_token}&amp;
- *     post_logout_redirect_uri={app_url}
+ *     post_logout_redirect_uri={app_oidc_entry}
  * </pre>
  */
 @Component
@@ -47,27 +52,20 @@ public class KeycloakLogoutHandler implements LogoutSuccessHandler {
     public void onLogoutSuccess(HttpServletRequest request,
                                 HttpServletResponse response,
                                 Authentication authentication) throws IOException, ServletException {
-        // Invalidate the HTTP session
         if (request.getSession(false) != null) {
             request.getSession().invalidate();
         }
 
-        // Build the Keycloak end_session_endpoint URL
         String logoutUrl = issuerUri + "/protocol/openid-connect/logout";
-
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(logoutUrl);
 
-        // Include id_token_hint for Keycloak to identify the session
         if (authentication != null && authentication.getPrincipal() instanceof OidcUser oidcUser) {
-            String idToken = oidcUser.getIdToken().getTokenValue();
-            builder.queryParam("id_token_hint", idToken);
+            builder.queryParam("id_token_hint", oidcUser.getIdToken().getTokenValue());
         }
 
-        // Derive the post-logout redirect URI from the current request.
-        // ServletUriComponentsBuilder respects X-Forwarded-* headers behind a
-        // reverse proxy (when server.forward-headers-strategy=framework is set).
         String postLogoutRedirectUri = ServletUriComponentsBuilder.fromRequest(request)
-                .replacePath(request.getContextPath() + "/")
+                .replacePath(request.getContextPath()
+                        + "/oauth2/authorization/keycloak")
                 .replaceQuery(null)
                 .fragment(null)
                 .build()

--- a/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/SwaggerKeycloakConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/keycloak/SwaggerKeycloakConfig.java
@@ -1,40 +1,45 @@
 package com.taxonomy.security.keycloak;
 
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 /**
- * Adds an OAuth2 security scheme to the OpenAPI spec when the Keycloak profile
- * is active. Swagger UI will show an "Authorize" button that starts the
- * authorization-code flow against Keycloak.
+ * Adds an OAuth2 security scheme to the shared OpenAPI specification when the
+ * Keycloak profile is active. Swagger UI will show an "Authorize" button that
+ * starts the authorization-code flow against Keycloak.
  */
 @Configuration
 @Profile("keycloak")
 public class SwaggerKeycloakConfig {
 
     @Bean
-    public OpenAPI keycloakOpenAPI(
-            @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:http://localhost:8180/realms/taxonomy}") String issuerUri) {
-        return new OpenAPI()
-                .addSecurityItem(new SecurityRequirement().addList("keycloak"))
-                .components(new Components()
-                        .addSecuritySchemes("keycloak", new SecurityScheme()
-                                .type(SecurityScheme.Type.OAUTH2)
-                                .flows(new OAuthFlows()
-                                        .authorizationCode(new OAuthFlow()
-                                                .authorizationUrl(issuerUri + "/protocol/openid-connect/auth")
-                                                .tokenUrl(issuerUri + "/protocol/openid-connect/token")
-                                        )
-                                )
-                        )
-                );
+    public OpenApiCustomizer keycloakOpenApiCustomizer(
+            @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri:"
+                    + "http://localhost:8180/realms/taxonomy}")
+            String issuerUri) {
+        return openApi -> {
+            openApi.addSecurityItem(new SecurityRequirement().addList("keycloak"));
+            Components components = openApi.getComponents();
+            if (components == null) {
+                components = new Components();
+                openApi.setComponents(components);
+            }
+            components.addSecuritySchemes("keycloak", new SecurityScheme()
+                    .type(SecurityScheme.Type.OAUTH2)
+                    .flows(new OAuthFlows()
+                            .authorizationCode(new OAuthFlow()
+                                    .authorizationUrl(issuerUri
+                                            + "/protocol/openid-connect/auth")
+                                    .tokenUrl(issuerUri
+                                            + "/protocol/openid-connect/token"))));
+        };
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/service/PasswordChangeService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/service/PasswordChangeService.java
@@ -2,12 +2,14 @@ package com.taxonomy.security.service;
 
 import com.taxonomy.security.model.AppUser;
 import com.taxonomy.security.repository.UserRepository;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /** Domain service for validating and applying local-user password changes. */
 @Service
+@Profile("!keycloak")
 public class PasswordChangeService {
 
     public static final int MINIMUM_PASSWORD_LENGTH = 12;

--- a/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
@@ -7,6 +7,8 @@ import com.taxonomy.security.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,9 @@ import java.util.Set;
 
 /** Application service for local user and role administration. */
 @Service
+@Profile("!keycloak")
+@ConditionalOnProperty(name = "taxonomy.security.local-users-enabled",
+        havingValue = "true", matchIfMissing = true)
 @Transactional
 public class UserManagementService {
 

--- a/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
@@ -436,10 +436,14 @@ class KeycloakSecurityContainerIT {
                 "client_secret", clientSecret,
                 "username", username,
                 "password", password,
-                "scope", "openid profile email roles"));
+                "scope", "openid profile"));
         HttpResponse<String> response = hostKeycloakPost(
                 "/realms/" + REALM + "/protocol/openid-connect/token", form);
-        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.statusCode())
+                .withFailMessage(
+                        "Keycloak token request failed for client '%s' and user '%s': HTTP %s: %s",
+                        clientId, username, response.statusCode(), response.body())
+                .isEqualTo(200);
         return MAPPER.readTree(response.body()).get("access_token").asText();
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
@@ -313,7 +313,14 @@ class KeycloakSecurityContainerIT {
             if (health.statusCode() == 503) {
                 break;
             }
-            Thread.sleep(500);
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Interrupted while waiting for Keycloak outage health propagation",
+                        exception);
+            }
         }
 
         assertThat(health).isNotNull();
@@ -344,7 +351,7 @@ class KeycloakSecurityContainerIT {
                         ISSUER + "/protocol/openid-connect/certs")
                 .withEnv("KEYCLOAK_CLIENT_ID", CLIENT_ID)
                 .withEnv("KEYCLOAK_CLIENT_SECRET", CLIENT_SECRET)
-                .withEnv("TAXONOMY_SECURITY_SWAGGER_PUBLIC",
+                .withEnv("TAXONOMY_SWAGGER_PUBLIC",
                         Boolean.toString(swaggerPublic))
                 .withEnv("TAXONOMY_EMBEDDING_ENABLED", "false")
                 .withEnv("TAXONOMY_SEARCH_DIRECTORY_TYPE", "local-heap")
@@ -421,61 +428,40 @@ class KeycloakSecurityContainerIT {
     }
 
     private String passwordToken(
-            String clientId,
-            String clientSecret,
-            String username,
-            String password) throws Exception {
-        Map<String, String> fields = new LinkedHashMap<>();
-        fields.put("grant_type", "password");
-        fields.put("client_id", clientId);
-        fields.put("client_secret", clientSecret);
-        fields.put("username", username);
-        fields.put("password", password);
-        String body = fields.entrySet().stream()
-                .map(entry -> urlEncode(entry.getKey())
-                        + "=" + urlEncode(entry.getValue()))
-                .collect(Collectors.joining("&"));
-
-        HttpResponse<String> response = request(
-                hostKeycloakUri(
-                        "/realms/" + REALM + "/protocol/openid-connect/token"),
-                "POST", null, "application/x-www-form-urlencoded", body, Map.of());
-        assertThat(response.statusCode())
-                .as("Keycloak token response for %s: %s", clientId, response.body())
-                .isEqualTo(200);
-        JsonNode tokenResponse = MAPPER.readTree(response.body());
-        assertThat(tokenResponse.hasNonNull("access_token"))
-                .as("Keycloak access token response for %s: %s",
-                        clientId, response.body())
-                .isTrue();
-        return tokenResponse.get("access_token").asText();
+            String clientId, String clientSecret, String username, String password)
+            throws Exception {
+        String form = form(Map.of(
+                "grant_type", "password",
+                "client_id", clientId,
+                "client_secret", clientSecret,
+                "username", username,
+                "password", password,
+                "scope", "openid profile email roles"));
+        HttpResponse<String> response = hostKeycloakPost(
+                "/realms/" + REALM + "/protocol/openid-connect/token", form);
+        assertThat(response.statusCode()).isEqualTo(200);
+        return MAPPER.readTree(response.body()).get("access_token").asText();
     }
 
     private JsonNode jwtClaims(String token) throws Exception {
         String[] parts = token.split("\\.");
-        assertThat(parts).hasSize(3);
-        return MAPPER.readTree(new String(
-                Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
+        assertThat(parts).hasSizeGreaterThanOrEqualTo(2);
+        return MAPPER.readTree(Base64.getUrlDecoder().decode(parts[1]));
     }
 
-    private HttpResponse<String> jsonPost(String path, String token, String body)
-            throws Exception {
+    private HttpResponse<String> jsonPost(
+            String path, String token, String json) throws Exception {
         return appRequest(
-                "POST", path, token, "application/json", body, Map.of());
+                "POST", path, token, "application/json", json, Map.of());
     }
 
     private HttpResponse<String> emptyMultipartPost(String path, String token)
             throws Exception {
-        String boundary = "taxonomy-keycloak-boundary";
-        String body = "--" + boundary + "\r\n"
-                + "Content-Disposition: form-data; name=\"file\"; "
-                + "filename=\"empty.xml\"\r\n"
-                + "Content-Type: application/xml\r\n\r\n"
-                + "\r\n--" + boundary + "--\r\n";
+        String boundary = "taxonomy-boundary";
         return appRequest(
                 "POST", path, token,
                 "multipart/form-data; boundary=" + boundary,
-                body,
+                "--" + boundary + "--\r\n",
                 Map.of());
     }
 
@@ -487,15 +473,31 @@ class KeycloakSecurityContainerIT {
             String body,
             Map<String, String> headers) throws Exception {
         return request(
-                appUri(path), method, bearerToken, contentType, body, headers);
+                URI.create("http://" + appContainer.getHost() + ":"
+                        + appContainer.getMappedPort(8080) + path),
+                method,
+                bearerToken,
+                contentType,
+                body,
+                headers);
     }
 
     private HttpResponse<String> hostKeycloakGet(String path) throws Exception {
         return request(
-                hostKeycloakUri(path), "GET", null, null, null, Map.of());
+                URI.create("http://" + keycloakContainer.getHost() + ":"
+                        + keycloakContainer.getMappedPort(8080) + path),
+                "GET", null, null, null, Map.of());
     }
 
-    private HttpResponse<String> request(
+    private HttpResponse<String> hostKeycloakPost(String path, String body)
+            throws Exception {
+        return request(
+                URI.create("http://" + keycloakContainer.getHost() + ":"
+                        + keycloakContainer.getMappedPort(8080) + path),
+                "POST", null, "application/x-www-form-urlencoded", body, Map.of());
+    }
+
+    private static HttpResponse<String> request(
             URI uri,
             String method,
             String bearerToken,
@@ -503,7 +505,7 @@ class KeycloakSecurityContainerIT {
             String body,
             Map<String, String> headers) throws Exception {
         HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
-                .timeout(Duration.ofSeconds(20))
+                .timeout(Duration.ofSeconds(30))
                 .header("Accept", "application/json");
         if (bearerToken != null) {
             builder.header("Authorization", "Bearer " + bearerToken);
@@ -512,35 +514,27 @@ class KeycloakSecurityContainerIT {
             builder.header("Content-Type", contentType);
         }
         headers.forEach(builder::header);
-        HttpRequest.BodyPublisher publisher = body == null
-                ? HttpRequest.BodyPublishers.noBody()
-                : HttpRequest.BodyPublishers.ofString(
-                        body, StandardCharsets.UTF_8);
-        return HTTP.send(
-                builder.method(method, publisher).build(),
-                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if ("POST".equals(method)) {
+            builder.POST(HttpRequest.BodyPublishers.ofString(body == null ? "" : body));
+        } else {
+            builder.GET();
+        }
+        return HTTP.send(builder.build(), HttpResponse.BodyHandlers.ofString());
     }
 
-    private URI appUri(String path) {
-        return URI.create("http://" + appContainer.getHost() + ":"
-                + appContainer.getMappedPort(8080) + path);
-    }
-
-    private URI hostKeycloakUri(String path) {
-        return URI.create("http://" + keycloakContainer.getHost() + ":"
-                + keycloakContainer.getMappedPort(8080) + path);
+    private static String form(Map<String, String> values) {
+        Map<String, String> ordered = new LinkedHashMap<>(values);
+        return ordered.entrySet().stream()
+                .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+                        + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
     }
 
     private static Set<String> jsonStringSet(JsonNode array) {
         return array == null || !array.isArray()
                 ? Set.of()
-                : java.util.stream.StreamSupport.stream(
-                                array.spliterator(), false)
-                        .map(JsonNode::asText)
-                        .collect(Collectors.toSet());
-    }
-
-    private static String urlEncode(String value) {
-        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+                : java.util.stream.StreamSupport.stream(array.spliterator(), false)
+                .map(JsonNode::asText)
+                .collect(Collectors.toSet());
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
@@ -1,0 +1,546 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Real Keycloak acceptance test for browser OIDC sessions and stateless bearer
+ * clients. No security filter chain, JWT decoder or identity-provider endpoint
+ * is mocked.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@EnabledIfSystemProperty(named = "runKeycloakTests", matches = "true")
+class KeycloakSecurityContainerIT {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    private static final String KEYCLOAK_ALIAS = "keycloak.test";
+    private static final String KEYCLOAK_ORIGIN =
+            "http://" + KEYCLOAK_ALIAS + ":8080";
+    private static final String REALM = "taxonomy-test";
+    private static final String ISSUER = KEYCLOAK_ORIGIN + "/realms/" + REALM;
+    private static final String CLIENT_ID = "taxonomy-app";
+    private static final String CLIENT_SECRET = "taxonomy-test-secret";
+    private static final String KEYCLOAK_IMAGE = System.getProperty(
+            "keycloak.container.image", "quay.io/keycloak/keycloak:26.7.0");
+
+    private Network network;
+    private GenericContainer<?> keycloakContainer;
+    private GenericContainer<?> appContainer;
+    private ContainerTestUtils.BrowserSession browserSession;
+    private WebDriver driver;
+
+    private String adminToken;
+    private String architectToken;
+    private String userToken;
+    private String unsupportedRoleToken;
+    private String missingRoleClaimToken;
+    private String malformedRoleClaimToken;
+
+    @BeforeAll
+    void startIdentityProviderAndApplication() throws Exception {
+        network = Network.newNetwork();
+        keycloakContainer = keycloakContainer();
+        keycloakContainer.start();
+
+        appContainer = keycloakApp(true, false);
+        appContainer.start();
+
+        adminToken = passwordToken(CLIENT_ID, CLIENT_SECRET, "admin", "admin");
+        architectToken = passwordToken(
+                CLIENT_ID, CLIENT_SECRET, "architect", "architect");
+        userToken = passwordToken(CLIENT_ID, CLIENT_SECRET, "user", "user");
+        unsupportedRoleToken = passwordToken(
+                CLIENT_ID, CLIENT_SECRET, "unsupported", "unsupported");
+        missingRoleClaimToken = passwordToken(
+                "taxonomy-missing-claims", "taxonomy-missing-secret", "user", "user");
+        malformedRoleClaimToken = passwordToken(
+                "taxonomy-malformed-claims", "taxonomy-malformed-secret", "user", "user");
+
+        browserSession = ContainerTestUtils.startBrowser(network);
+        driver = browserSession.driver();
+        driver.manage().window().setSize(new org.openqa.selenium.Dimension(1400, 900));
+    }
+
+    private GenericContainer<?> keycloakContainer() {
+        return new GenericContainer<>(DockerImageName.parse(KEYCLOAK_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(KEYCLOAK_ALIAS)
+                .withExposedPorts(8080)
+                .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "bootstrap-admin")
+                .withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "bootstrap-admin-password")
+                .withEnv("KC_HEALTH_ENABLED", "true")
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource(
+                                "keycloak/taxonomy-test-realm.json"),
+                        "/opt/keycloak/data/import/taxonomy-test-realm.json")
+                .withCommand(
+                        "start-dev",
+                        "--import-realm",
+                        "--http-port=8080",
+                        "--hostname=" + KEYCLOAK_ORIGIN,
+                        "--hostname-backchannel-dynamic=true")
+                .waitingFor(Wait.forHttp(
+                                "/realms/" + REALM
+                                        + "/.well-known/openid-configuration")
+                        .forPort(8080)
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+    }
+
+    @AfterAll
+    void stopContainers() throws Exception {
+        ContainerTestUtils.closeAll(
+                browserSession, appContainer, keycloakContainer, network);
+    }
+
+    @Test
+    @Order(1)
+    void privateSwaggerAndNoLocalPasswordFallbackAreEnforced() throws Exception {
+        HttpResponse<String> login = appRequest(
+                "GET", "/login", null, null, null, Map.of());
+        assertThat(login.statusCode()).isEqualTo(200);
+        assertThat(login.body()).contains("/oauth2/authorization/keycloak");
+        assertThat(login.body()).doesNotContain("name=\"password\"");
+
+        HttpResponse<String> privateDocs = appRequest(
+                "GET", "/v3/api-docs", null, null, null, Map.of());
+        assertThat(privateDocs.statusCode()).isIn(302, 401);
+
+        HttpResponse<String> authenticatedDocs = appRequest(
+                "GET", "/v3/api-docs", userToken, null, null, Map.of());
+        assertThat(authenticatedDocs.statusCode()).isEqualTo(200);
+        assertThat(authenticatedDocs.body()).contains("\"openapi\"");
+    }
+
+    @Test
+    @Order(2)
+    void realTokensMapPrincipalAndRolesForAllSupportedUsers() throws Exception {
+        assertAccount(adminToken, "admin", Set.of("USER", "ARCHITECT", "ADMIN"));
+        assertAccount(architectToken, "architect", Set.of("USER", "ARCHITECT"));
+        assertAccount(userToken, "user", Set.of("USER"));
+
+        HttpResponse<String> health = appRequest(
+                "GET", "/actuator/health", adminToken, null, null, Map.of());
+        assertThat(health.statusCode()).isEqualTo(200);
+        assertThat(MAPPER.readTree(health.body()).get("status").asText())
+                .isEqualTo("UP");
+        assertThat(health.body()).contains("keycloak");
+
+        HttpResponse<String> discovery = hostKeycloakGet(
+                "/realms/" + REALM + "/.well-known/openid-configuration");
+        assertThat(discovery.statusCode()).isEqualTo(200);
+        assertThat(MAPPER.readTree(discovery.body()).get("issuer").asText())
+                .isEqualTo(ISSUER);
+    }
+
+    @Test
+    @Order(3)
+    void bearerAuthorizationAndCsrfExemptionMatchTheRoleModel() throws Exception {
+        assertThat(appRequest(
+                "GET", "/api/relations", userToken, null, null, Map.of())
+                .statusCode()).isEqualTo(200);
+
+        assertThat(jsonPost("/api/relations", userToken, "{}").statusCode())
+                .isEqualTo(403);
+        assertThat(jsonPost("/api/relations", architectToken, "{}").statusCode())
+                .isEqualTo(400);
+        assertThat(jsonPost("/api/relations", adminToken, "{}").statusCode())
+                .isEqualTo(400);
+
+        assertThat(appRequest(
+                "GET", "/api/preferences", userToken, null, null, Map.of())
+                .statusCode()).isEqualTo(403);
+        assertThat(appRequest(
+                "GET", "/api/preferences", architectToken, null, null, Map.of())
+                .statusCode()).isEqualTo(403);
+        assertThat(appRequest(
+                "GET", "/api/preferences", adminToken, null, null, Map.of())
+                .statusCode()).isEqualTo(200);
+
+        assertThat(emptyMultipartPost(
+                "/api/import/preview/c4", userToken).statusCode()).isEqualTo(400);
+        assertThat(emptyMultipartPost(
+                "/api/import/c4", userToken).statusCode()).isEqualTo(403);
+        assertThat(emptyMultipartPost(
+                "/api/import/c4", architectToken).statusCode()).isEqualTo(400);
+        assertThat(emptyMultipartPost(
+                "/api/documents/upload", userToken).statusCode()).isEqualTo(403);
+        assertThat(emptyMultipartPost(
+                "/api/documents/upload", architectToken).statusCode()).isEqualTo(400);
+    }
+
+    @Test
+    @Order(4)
+    void missingMalformedAndUnsupportedRoleClaimsFailClosed() throws Exception {
+        JsonNode missingClaims = jwtClaims(missingRoleClaimToken);
+        assertThat(missingClaims.has("realm_access")).isFalse();
+        assertNoApplicationRoles(missingRoleClaimToken, "user");
+
+        JsonNode malformedClaims = jwtClaims(malformedRoleClaimToken);
+        assertThat(malformedClaims.get("realm_access").isTextual()).isTrue();
+        assertThat(malformedClaims.get("realm_access").asText())
+                .isEqualTo("not-an-object");
+        assertNoApplicationRoles(malformedRoleClaimToken, "user");
+
+        JsonNode unsupportedClaims = jwtClaims(unsupportedRoleToken);
+        assertThat(unsupportedClaims.toString()).contains("ROLE_UNSUPPORTED");
+        assertNoApplicationRoles(unsupportedRoleToken, "unsupported");
+
+        HttpResponse<String> invalidJwt = appRequest(
+                "GET", "/api/account/me", "not-a-jwt", null, null, Map.of());
+        assertThat(invalidJwt.statusCode()).isEqualTo(401);
+        assertThat(invalidJwt.body()).contains("Authentication required");
+    }
+
+    @Test
+    @Order(5)
+    void browserAuthorizationCodeSessionKeepsCsrfAndPerformsRpInitiatedLogout()
+            throws Exception {
+        loginBrowser("architect", "architect");
+
+        JsonNode account = browserJson("/api/account/me");
+        assertThat(account.get("username").asText()).isEqualTo("architect");
+        assertThat(jsonStringSet(account.get("roles")))
+                .containsExactlyInAnyOrder("USER", "ARCHITECT");
+
+        String sessionCookie = browserCookieHeader();
+        String csrfToken = browserMeta("_csrf", "");
+        String csrfHeader = browserMeta("_csrf_header", "X-CSRF-TOKEN");
+        assertThat(csrfToken).isNotBlank();
+
+        HttpResponse<String> withoutCsrf = appRequest(
+                "POST", "/api/relations", null, "application/json", "{}",
+                Map.of("Cookie", sessionCookie));
+        assertThat(withoutCsrf.statusCode()).isEqualTo(403);
+
+        HttpResponse<String> withCsrf = appRequest(
+                "POST", "/api/relations", null, "application/json", "{}",
+                Map.of("Cookie", sessionCookie, csrfHeader, csrfToken));
+        assertThat(withCsrf.statusCode()).isEqualTo(400);
+
+        ((JavascriptExecutor) driver).executeScript("""
+                const form = document.createElement('form');
+                form.method = 'post';
+                form.action = '/logout';
+                const csrf = document.createElement('input');
+                csrf.type = 'hidden';
+                csrf.name = '_csrf';
+                csrf.value = arguments[0];
+                form.appendChild(csrf);
+                document.body.appendChild(form);
+                form.submit();
+                """, csrfToken);
+
+        new WebDriverWait(driver, Duration.ofSeconds(30))
+                .until(ExpectedConditions.visibilityOfElementLocated(By.id("username")));
+        assertThat(driver.getCurrentUrl()).startsWith(KEYCLOAK_ORIGIN);
+
+        HttpResponse<String> staleSession = appRequest(
+                "GET", "/api/account/me", null, null, null,
+                Map.of("Cookie", sessionCookie));
+        assertThat(staleSession.statusCode()).isNotEqualTo(200);
+    }
+
+    @Test
+    @Order(6)
+    void swaggerCanBePublicByExplicitConfiguration() throws Exception {
+        GenericContainer<?> publicSwaggerApp = keycloakApp(false, true);
+        try {
+            publicSwaggerApp.start();
+            HttpResponse<String> response = request(
+                    URI.create("http://" + publicSwaggerApp.getHost() + ":"
+                            + publicSwaggerApp.getMappedPort(8080)
+                            + "/v3/api-docs"),
+                    "GET", null, null, null, Map.of());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body()).contains("\"openapi\"");
+        } finally {
+            publicSwaggerApp.stop();
+        }
+    }
+
+    @Test
+    @Order(7)
+    void keycloakOutageMarksApplicationHealthDownWithoutLocalFallback()
+            throws Exception {
+        keycloakContainer.stop();
+
+        HttpResponse<String> health = null;
+        long deadline = System.nanoTime() + Duration.ofSeconds(30).toNanos();
+        while (System.nanoTime() < deadline) {
+            health = appRequest(
+                    "GET", "/actuator/health", null, null, null, Map.of());
+            if (health.statusCode() == 503) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
+        assertThat(health).isNotNull();
+        assertThat(health.statusCode()).isEqualTo(503);
+        assertThat(MAPPER.readTree(health.body()).get("status").asText())
+                .isEqualTo("DOWN");
+
+        HttpResponse<String> login = appRequest(
+                "GET", "/login", null, null, null, Map.of());
+        assertThat(login.statusCode()).isEqualTo(200);
+        assertThat(login.body()).contains("/oauth2/authorization/keycloak");
+        assertThat(login.body()).doesNotContain("name=\"password\"");
+    }
+
+    private GenericContainer<?> keycloakApp(
+            boolean assignNetworkAlias, boolean swaggerPublic) {
+        GenericContainer<?> container = new GenericContainer<>(
+                ContainerTestUtils.sharedImage())
+                .withNetwork(network)
+                .withExposedPorts(8080)
+                .withEnv("ADMIN_PASSWORD", ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                .withEnv("TAXONOMY_ADMIN_PASSWORD",
+                        ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                .withEnv("TAXONOMY_REQUIRE_PASSWORD_CHANGE", "false")
+                .withEnv("SPRING_PROFILES_ACTIVE", "keycloak")
+                .withEnv("KEYCLOAK_ISSUER_URI", ISSUER)
+                .withEnv("KEYCLOAK_JWK_SET_URI",
+                        ISSUER + "/protocol/openid-connect/certs")
+                .withEnv("KEYCLOAK_CLIENT_ID", CLIENT_ID)
+                .withEnv("KEYCLOAK_CLIENT_SECRET", CLIENT_SECRET)
+                .withEnv("TAXONOMY_SECURITY_SWAGGER_PUBLIC",
+                        Boolean.toString(swaggerPublic))
+                .withEnv("TAXONOMY_EMBEDDING_ENABLED", "false")
+                .withEnv("TAXONOMY_SEARCH_DIRECTORY_TYPE", "local-heap")
+                .withEnv("TAXONOMY_LAZY_INIT", "false")
+                .withEnv("TAXONOMY_THYMELEAF_CACHE", "false")
+                .withEnv("LLM_MOCK", "true")
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        if (assignNetworkAlias) {
+            container.withNetworkAliases(ContainerTestUtils.APP_NETWORK_ALIAS);
+        }
+        return container;
+    }
+
+    private void assertAccount(
+            String token, String username, Set<String> expectedRoles)
+            throws Exception {
+        HttpResponse<String> response = appRequest(
+                "GET", "/api/account/me", token, null, null, Map.of());
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode account = MAPPER.readTree(response.body());
+        assertThat(account.get("username").asText()).isEqualTo(username);
+        assertThat(jsonStringSet(account.get("roles"))).isEqualTo(expectedRoles);
+    }
+
+    private void assertNoApplicationRoles(String token, String expectedUsername)
+            throws Exception {
+        assertAccount(token, expectedUsername, Set.of());
+        assertThat(jsonPost("/api/relations", token, "{}").statusCode())
+                .isEqualTo(403);
+        assertThat(appRequest(
+                "GET", "/api/preferences", token, null, null, Map.of())
+                .statusCode()).isEqualTo(403);
+    }
+
+    private void loginBrowser(String username, String password) {
+        driver.get(ContainerTestUtils.APP_ORIGIN
+                + "/oauth2/authorization/keycloak");
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(30));
+        WebElement usernameField = wait.until(
+                ExpectedConditions.visibilityOfElementLocated(By.id("username")));
+        usernameField.sendKeys(username);
+        driver.findElement(By.id("password")).sendKeys(password);
+        driver.findElement(By.id("kc-login")).click();
+        wait.until(currentDriver -> currentDriver.getCurrentUrl()
+                .startsWith(ContainerTestUtils.APP_ORIGIN));
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.id("taxonomyTree")));
+    }
+
+    private String browserMeta(String name, String fallback) {
+        return (String) ((JavascriptExecutor) driver).executeScript(
+                "return document.querySelector('meta[name=\"' + arguments[0]"
+                        + " + '\"]')?.content || arguments[1];",
+                name,
+                fallback);
+    }
+
+    private JsonNode browserJson(String path) throws Exception {
+        String response = (String) ((JavascriptExecutor) driver).executeAsyncScript("""
+                const done = arguments[arguments.length - 1];
+                fetch(arguments[0], {headers: {'Accept': 'application/json'}})
+                  .then(result => result.text())
+                  .then(done)
+                  .catch(error => done(JSON.stringify({error: String(error)})));
+                """, path);
+        return MAPPER.readTree(response);
+    }
+
+    private String browserCookieHeader() {
+        return driver.manage().getCookies().stream()
+                .map(cookie -> cookie.getName() + "=" + cookie.getValue())
+                .collect(Collectors.joining("; "));
+    }
+
+    private String passwordToken(
+            String clientId,
+            String clientSecret,
+            String username,
+            String password) throws Exception {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("grant_type", "password");
+        fields.put("client_id", clientId);
+        fields.put("client_secret", clientSecret);
+        fields.put("username", username);
+        fields.put("password", password);
+        String body = fields.entrySet().stream()
+                .map(entry -> urlEncode(entry.getKey())
+                        + "=" + urlEncode(entry.getValue()))
+                .collect(Collectors.joining("&"));
+
+        HttpResponse<String> response = request(
+                hostKeycloakUri(
+                        "/realms/" + REALM + "/protocol/openid-connect/token"),
+                "POST", null, "application/x-www-form-urlencoded", body, Map.of());
+        assertThat(response.statusCode())
+                .as("Keycloak token response for %s: %s", clientId, response.body())
+                .isEqualTo(200);
+        JsonNode tokenResponse = MAPPER.readTree(response.body());
+        assertThat(tokenResponse.hasNonNull("access_token"))
+                .as("Keycloak access token response for %s: %s",
+                        clientId, response.body())
+                .isTrue();
+        return tokenResponse.get("access_token").asText();
+    }
+
+    private JsonNode jwtClaims(String token) throws Exception {
+        String[] parts = token.split("\\.");
+        assertThat(parts).hasSize(3);
+        return MAPPER.readTree(new String(
+                Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
+    }
+
+    private HttpResponse<String> jsonPost(String path, String token, String body)
+            throws Exception {
+        return appRequest(
+                "POST", path, token, "application/json", body, Map.of());
+    }
+
+    private HttpResponse<String> emptyMultipartPost(String path, String token)
+            throws Exception {
+        String boundary = "taxonomy-keycloak-boundary";
+        String body = "--" + boundary + "\r\n"
+                + "Content-Disposition: form-data; name=\"file\"; "
+                + "filename=\"empty.xml\"\r\n"
+                + "Content-Type: application/xml\r\n\r\n"
+                + "\r\n--" + boundary + "--\r\n";
+        return appRequest(
+                "POST", path, token,
+                "multipart/form-data; boundary=" + boundary,
+                body,
+                Map.of());
+    }
+
+    private HttpResponse<String> appRequest(
+            String method,
+            String path,
+            String bearerToken,
+            String contentType,
+            String body,
+            Map<String, String> headers) throws Exception {
+        return request(
+                appUri(path), method, bearerToken, contentType, body, headers);
+    }
+
+    private HttpResponse<String> hostKeycloakGet(String path) throws Exception {
+        return request(
+                hostKeycloakUri(path), "GET", null, null, null, Map.of());
+    }
+
+    private HttpResponse<String> request(
+            URI uri,
+            String method,
+            String bearerToken,
+            String contentType,
+            String body,
+            Map<String, String> headers) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(20))
+                .header("Accept", "application/json");
+        if (bearerToken != null) {
+            builder.header("Authorization", "Bearer " + bearerToken);
+        }
+        if (contentType != null) {
+            builder.header("Content-Type", contentType);
+        }
+        headers.forEach(builder::header);
+        HttpRequest.BodyPublisher publisher = body == null
+                ? HttpRequest.BodyPublishers.noBody()
+                : HttpRequest.BodyPublishers.ofString(
+                        body, StandardCharsets.UTF_8);
+        return HTTP.send(
+                builder.method(method, publisher).build(),
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private URI appUri(String path) {
+        return URI.create("http://" + appContainer.getHost() + ":"
+                + appContainer.getMappedPort(8080) + path);
+    }
+
+    private URI hostKeycloakUri(String path) {
+        return URI.create("http://" + keycloakContainer.getHost() + ":"
+                + keycloakContainer.getMappedPort(8080) + path);
+    }
+
+    private static Set<String> jsonStringSet(JsonNode array) {
+        return array == null || !array.isArray()
+                ? Set.of()
+                : java.util.stream.StreamSupport.stream(
+                                array.spliterator(), false)
+                        .map(JsonNode::asText)
+                        .collect(Collectors.toSet());
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakHealthIndicatorTest.java
@@ -1,0 +1,98 @@
+package com.taxonomy.security.keycloak;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeycloakHealthIndicatorTest {
+
+    @Test
+    void reportsUpWhenJwksEndpointIsReachable() throws Exception {
+        try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(200, "{\"keys\":[]}")) {
+            Health health = healthFor(endpoint.url());
+
+            assertThat(health.getStatus().getCode()).isEqualTo("UP");
+            assertThat(health.getDetails()).containsEntry("jwksEndpoint", endpoint.url());
+        }
+    }
+
+    @Test
+    void reportsDownWhenJwksEndpointReturnsAnError() throws Exception {
+        try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(503, "unavailable")) {
+            Health health = healthFor(endpoint.url());
+
+            assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+            assertThat(health.getDetails())
+                    .containsEntry("jwksEndpoint", endpoint.url())
+                    .containsEntry("statusCode", 503);
+        }
+    }
+
+    @Test
+    void reportsDownForInvalidJwksConfiguration() {
+        Health health = healthFor("not a valid URI");
+
+        assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+        assertThat(health.getDetails()).containsEntry("jwksEndpoint", "not a valid URI");
+        assertThat(health.getDetails().get("error").toString())
+                .startsWith("IllegalArgumentException:");
+    }
+
+    @Test
+    void reportsDownWhenIdentityProviderIsUnavailable() throws Exception {
+        int unusedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            unusedPort = socket.getLocalPort();
+        }
+        String url = "http://127.0.0.1:" + unusedPort + "/certs";
+
+        Health health = healthFor(url);
+
+        assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+        assertThat(health.getDetails()).containsEntry("jwksEndpoint", url);
+        assertThat(health.getDetails().get("error").toString())
+                .startsWith("ConnectException");
+    }
+
+    private static Health healthFor(String jwksEndpoint) {
+        KeycloakHealthIndicator indicator = new KeycloakHealthIndicator();
+        ReflectionTestUtils.setField(indicator, "jwkSetUri", jwksEndpoint);
+        return indicator.health();
+    }
+
+    private static final class TestHttpEndpoint implements AutoCloseable {
+        private final HttpServer server;
+
+        private TestHttpEndpoint(HttpServer server) {
+            this.server = server;
+        }
+
+        static TestHttpEndpoint responding(int status, String body) throws Exception {
+            HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            byte[] response = body.getBytes(StandardCharsets.UTF_8);
+            server.createContext("/certs", exchange -> {
+                exchange.sendResponseHeaders(status, response.length);
+                exchange.getResponseBody().write(response);
+                exchange.close();
+            });
+            server.start();
+            return new TestHttpEndpoint(server);
+        }
+
+        String url() {
+            return "http://127.0.0.1:" + server.getAddress().getPort() + "/certs";
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakHealthIndicatorTest.java
@@ -7,9 +7,15 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class KeycloakHealthIndicatorTest {
 
@@ -59,6 +65,30 @@ class KeycloakHealthIndicatorTest {
         assertThat(health.getDetails()).containsEntry("jwksEndpoint", url);
         assertThat(health.getDetails().get("error").toString())
                 .startsWith("ConnectException");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void preservesThreadInterruptionWhileReportingDown() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.send(
+                any(HttpRequest.class),
+                any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new InterruptedException("cancelled"));
+        KeycloakHealthIndicator indicator = new KeycloakHealthIndicator(httpClient);
+        ReflectionTestUtils.setField(
+                indicator, "jwkSetUri", "http://keycloak.test/realms/taxonomy/certs");
+
+        try {
+            Health health = indicator.health();
+
+            assertThat(health.getStatus().getCode()).isEqualTo("DOWN");
+            assertThat(health.getDetails().get("error").toString())
+                    .startsWith("InterruptedException:");
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        } finally {
+            Thread.interrupted();
+        }
     }
 
     private static Health healthFor(String jwksEndpoint) {

--- a/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakLogoutHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/KeycloakLogoutHandlerTest.java
@@ -8,19 +8,22 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-/**
- * Unit tests for {@link KeycloakLogoutHandler}.
- */
+/** Unit tests for {@link KeycloakLogoutHandler}. */
 class KeycloakLogoutHandlerTest {
 
     @Test
-    void redirectsToKeycloakLogoutEndpoint() throws Exception {
+    void redirectsToKeycloakLogoutThenFreshOidcChallenge() throws Exception {
         KeycloakLogoutHandler handler = new KeycloakLogoutHandler();
         handler.setIssuerUri("http://localhost:8180/realms/taxonomy");
 
@@ -37,8 +40,8 @@ class KeycloakLogoutHandlerTest {
                 "test-id-token-value",
                 Instant.now(),
                 Instant.now().plusSeconds(300),
-                Map.of("sub", "user-uuid", "iss", "http://localhost:8180/realms/taxonomy")
-        );
+                Map.of("sub", "user-uuid",
+                        "iss", "http://localhost:8180/realms/taxonomy"));
         when(oidcUser.getIdToken()).thenReturn(idToken);
 
         Authentication auth = mock(Authentication.class);
@@ -47,9 +50,12 @@ class KeycloakLogoutHandlerTest {
         handler.onLogoutSuccess(request, response, auth);
 
         verify(response).sendRedirect(argThat(url -> {
-            assertTrue(url.startsWith("http://localhost:8180/realms/taxonomy/protocol/openid-connect/logout"));
-            assertTrue(url.contains("id_token_hint=test-id-token-value"));
-            assertTrue(url.contains("post_logout_redirect_uri="));
+            String decoded = URLDecoder.decode(url, StandardCharsets.UTF_8);
+            assertTrue(decoded.startsWith(
+                    "http://localhost:8180/realms/taxonomy/protocol/openid-connect/logout"));
+            assertTrue(decoded.contains("id_token_hint=test-id-token-value"));
+            assertTrue(decoded.contains("post_logout_redirect_uri="
+                    + "http://localhost:8080/oauth2/authorization/keycloak"));
             return true;
         }));
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/SwaggerKeycloakConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/keycloak/SwaggerKeycloakConfigTest.java
@@ -1,0 +1,37 @@
+package com.taxonomy.security.keycloak;
+
+import com.taxonomy.shared.config.OpenApiConfig;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SwaggerKeycloakConfigTest {
+
+    @Test
+    void keycloakProfileCustomizesTheSingleSharedOpenApiBean() {
+        try (AnnotationConfigApplicationContext context =
+                     new AnnotationConfigApplicationContext()) {
+            context.getEnvironment().setActiveProfiles("keycloak");
+            context.register(OpenApiConfig.class, SwaggerKeycloakConfig.class);
+            context.refresh();
+
+            assertThat(context.getBeansOfType(OpenAPI.class))
+                    .containsOnlyKeys("taxonomyOpenAPI");
+
+            OpenAPI openApi = context.getBean(OpenAPI.class);
+            context.getBeansOfType(OpenApiCustomizer.class).values()
+                    .forEach(customizer -> customizer.customise(openApi));
+
+            assertThat(openApi.getSecurity()).hasSize(1);
+            assertThat(openApi.getSecurity().getFirst()).containsKey("keycloak");
+            assertThat(openApi.getComponents().getSecuritySchemes())
+                    .containsKey("keycloak");
+            assertThat(openApi.getComponents().getSecuritySchemes().get("keycloak")
+                    .getFlows().getAuthorizationCode().getAuthorizationUrl())
+                    .endsWith("/protocol/openid-connect/auth");
+        }
+    }
+}

--- a/taxonomy-app/src/test/resources/keycloak/taxonomy-test-realm.json
+++ b/taxonomy-app/src/test/resources/keycloak/taxonomy-test-realm.json
@@ -1,0 +1,194 @@
+{
+  "realm": "taxonomy-test",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "rememberMe": false,
+  "roles": {
+    "realm": [
+      { "name": "ROLE_USER", "description": "Read-only user" },
+      { "name": "ROLE_ARCHITECT", "description": "Can mutate architecture" },
+      { "name": "ROLE_ADMIN", "description": "Full administration" },
+      { "name": "ROLE_UNSUPPORTED", "description": "Must not map to an application authority" }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "taxonomy-app",
+      "name": "Taxonomy application integration test",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "taxonomy-test-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": ["http://taxonomy.test:8080/login/oauth2/code/keycloak"],
+      "webOrigins": ["http://taxonomy.test:8080"],
+      "baseUrl": "http://taxonomy.test:8080/",
+      "attributes": {
+        "post.logout.redirect.uris": "http://taxonomy.test:8080/*"
+      },
+      "defaultClientScopes": ["profile", "email", "roles"],
+      "protocolMappers": [
+        {
+          "name": "preferred username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "application realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "usermodel.realmRoleMapping.rolePrefix": "",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "taxonomy-missing-claims",
+      "name": "Missing role claim integration fixture",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "taxonomy-missing-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": false,
+      "defaultClientScopes": ["profile"],
+      "protocolMappers": [
+        {
+          "name": "preferred username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "taxonomy-malformed-claims",
+      "name": "Malformed role claim integration fixture",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "taxonomy-malformed-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": false,
+      "defaultClientScopes": ["profile"],
+      "protocolMappers": [
+        {
+          "name": "preferred username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "username",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "malformed realm access",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access",
+            "claim.value": "not-an-object",
+            "jsonType.label": "String",
+            "access.token.claim": "true",
+            "id.token.claim": "false",
+            "userinfo.token.claim": "false",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "email": "admin@taxonomy.test",
+      "firstName": "Test",
+      "lastName": "Administrator",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{ "type": "password", "value": "admin", "temporary": false }],
+      "realmRoles": ["ROLE_USER", "ROLE_ARCHITECT", "ROLE_ADMIN"]
+    },
+    {
+      "username": "architect",
+      "email": "architect@taxonomy.test",
+      "firstName": "Test",
+      "lastName": "Architect",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{ "type": "password", "value": "architect", "temporary": false }],
+      "realmRoles": ["ROLE_USER", "ROLE_ARCHITECT"]
+    },
+    {
+      "username": "user",
+      "email": "user@taxonomy.test",
+      "firstName": "Test",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{ "type": "password", "value": "user", "temporary": false }],
+      "realmRoles": ["ROLE_USER"]
+    },
+    {
+      "username": "unsupported",
+      "email": "unsupported@taxonomy.test",
+      "firstName": "Unsupported",
+      "lastName": "Role",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{ "type": "password", "value": "unsupported", "temporary": false }],
+      "realmRoles": ["ROLE_UNSUPPORTED"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Provides repeatable, Maven-owned end-to-end proof for the supported `keycloak` deployment profile on the current `main`, without mocking Spring Security, JWT decoding or OIDC endpoints.

The work exposed and fixes real Keycloak-profile defects: nullable health details, swallowed health-check interruption, duplicate OpenAPI beans, local-password services active in SSO mode, implicit token-claim assumptions, an ambiguous post-logout landing page, a browser authorization request whose `roles` scope was not assigned to the imported test client, and a Swagger test that previously exercised the default rather than the real visibility property.

### Real identity-provider environment

- pin Keycloak 26.7.0 for canonical Maven and development Compose use;
- import an isolated `taxonomy-test` realm with deterministic USER, ARCHITECT and ADMIN users;
- declare `preferred_username` and `realm_access.roles` protocol mappers explicitly;
- assign the requested `roles` client scope to the normal authorization-code client;
- declare username-only and malformed-role clients without relying on implicit realm default scopes;
- keep all credentials and secrets below test resources;
- use Keycloak's management-port-compatible readiness probe.

### Browser OIDC contract

The Selenium flow runs against the packaged Taxonomy application and real Keycloak container. It verifies:

- authorization-code login and human-readable principal mapping;
- USER, ARCHITECT and ADMIN role mapping;
- session CSRF rejection without a token and acceptance with the real page token;
- RP-initiated logout, local-session invalidation and a fresh Keycloak login challenge;
- absence of a local password fallback while the `keycloak` profile is active.

### Bearer/JWT contract

Real Keycloak access tokens verify:

- authenticated read access;
- role parity for administration and architecture mutation;
- preview/import and document-upload authorization;
- CSRF exemption only for an actual bearer request;
- fail-closed behavior for missing, malformed and unsupported role claims;
- JSON 401 behavior for an invalid JWT.

### Profile and configuration corrections

- keep `PasswordChangeService` and `UserManagementService` out of the Keycloak profile;
- add the Keycloak OAuth2 scheme through an `OpenApiCustomizer`, preserving the single shared `OpenAPI` bean;
- make Keycloak health failures always expose a non-null diagnostic type/message and preserve thread interruption;
- return logout through `/oauth2/authorization/keycloak` after IdP session termination so silent SSO is explicitly disproved;
- exercise `TAXONOMY_SWAGGER_PUBLIC=false` in the primary container and `true` only in the dedicated public-docs container.

### Maven authority

Normal `./mvnw verify` remains Docker-free because integration tests are skipped by default. The canonical `./mvnw -B verify -Pci` executes the imported-realm suite. Focused reproduction:

```bash
./mvnw -B verify -pl taxonomy-app -am \
  -DskipITs=false -Dit.test=KeycloakSecurityContainerIT
```

## Verification

- focused Keycloak command above;
- `./mvnw -B verify -Pci -DrunOnnxTests=true`;
- Security Scan and CodeQL.

Closes #474 when all checks are green.
Supersedes #490.