### PR TITLE
Harden container acceptance cancellation and cleanup

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
@@ -29,9 +29,9 @@ final class ContainerTestUtils {
      */
     static final String TEST_ADMIN_PASSWORD = "admin";
 
-    /** Same immutable runtime base used by the production Dockerfile. */
+    /** Same immutable runtime manifest used by the production Dockerfile. */
     private static final String APP_RUNTIME_IMAGE =
-            "eclipse-temurin:21-jre-jammy@sha256:"
+            "eclipse-temurin@sha256:"
                     + "d63bd8d9b171999cbed8576f2c76e874dd4856791a358536e5c4d407e77edc13";
 
     private static final Future<String> SHARED_IMAGE = new ImageFromDockerfile(

--- a/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
@@ -29,11 +29,16 @@ final class ContainerTestUtils {
      */
     static final String TEST_ADMIN_PASSWORD = "admin";
 
+    /** Same immutable runtime base used by the production Dockerfile. */
+    private static final String APP_RUNTIME_IMAGE =
+            "eclipse-temurin:21-jre-jammy@sha256:"
+                    + "d63bd8d9b171999cbed8576f2c76e874dd4856791a358536e5c4d407e77edc13";
+
     private static final Future<String> SHARED_IMAGE = new ImageFromDockerfile(
             "taxonomy-app-it", false)
             .withFileFromPath("app.jar", findApplicationJar())
             .withDockerfileFromBuilder(builder -> builder
-                    .from("eclipse-temurin:21-jre")
+                    .from(APP_RUNTIME_IMAGE)
                     .workDir("/app")
                     .copy("app.jar", "app.jar")
                     .expose(8080)

--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -158,7 +158,13 @@ class LocalOnnxPipelineIT {
                     return;
                 }
             }
-            Thread.sleep(500);
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Interrupted while waiting for the full-text index", exception);
+            }
         }
 
         throw new AssertionError(

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -272,7 +273,14 @@ class OnnxSeleniumIT {
                     return;
                 }
             }
-            Thread.sleep(1_000);
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Interrupted while waiting for the LOCAL_ONNX semantic index",
+                        exception);
+            }
         }
 
         throw new AssertionError(
@@ -306,6 +314,7 @@ class OnnxSeleniumIT {
                 "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
                 element);
         new WebDriverWait(driver, Duration.ofSeconds(10))
+                .ignoring(StaleElementReferenceException.class)
                 .until(currentDriver -> {
                     Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
                             .executeScript(

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -224,7 +224,9 @@ class OnnxSeleniumIT {
         WebElement firstResult = items.getFirst();
         String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        clickWhenUnobscured(firstResult);
+        clickWhenUnobscured(By.cssSelector(
+                "#searchResultsArea .search-result-item[data-code='"
+                        + code.replace("'", "\\'") + "']"));
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -309,13 +311,14 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
-    private void clickWhenUnobscured(WebElement element) {
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
-                element);
+    private void clickWhenUnobscured(By locator) {
         new WebDriverWait(driver, Duration.ofSeconds(10))
                 .ignoring(StaleElementReferenceException.class)
                 .until(currentDriver -> {
+                    WebElement element = currentDriver.findElement(locator);
+                    ((JavascriptExecutor) currentDriver).executeScript(
+                            "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                            element);
                     Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
                             .executeScript(
                                     "const target=arguments[0];"
@@ -348,7 +351,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
+        clickWhenUnobscured(By.id("searchBtn"));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,5 +1,6 @@
 package com.taxonomy;
 
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
@@ -137,7 +138,7 @@ class ProductionPersistenceRestartIT {
             DockerClientFactory.instance().client()
                     .removeVolumeCmd(volumeName)
                     .exec();
-        } catch (RuntimeException ignored) {
+        } catch (DockerException ignored) {
             // Cleanup must never mask the original assertion or container failure. This also
             // covers volumes that were never created or remain attached after a failed stop.
         }

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,6 +1,5 @@
 package com.taxonomy;
 
-import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
@@ -138,8 +137,9 @@ class ProductionPersistenceRestartIT {
             DockerClientFactory.instance().client()
                     .removeVolumeCmd(volumeName)
                     .exec();
-        } catch (NotFoundException ignored) {
-            // A failed container creation may not have created the named volume yet.
+        } catch (RuntimeException ignored) {
+            // Cleanup must never mask the original assertion or container failure. This also
+            // covers volumes that were never created or remain attached after a failed stop.
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses valid review findings that survived as outdated threads after the container-stabilization branch was squash-merged and removes one remaining source of container-test drift.

- preserve the interrupted status and fail immediately when full-text or semantic ONNX polling is cancelled;
- re-find Selenium targets on every readiness poll so a DOM re-render can be retried instead of leaving a permanently stale element reference;
- make named-volume removal best-effort for Docker-client failures so cleanup cannot mask the original assertion or container-start/stop error;
- keep unrelated programming errors visible by catching `DockerException`, not every runtime exception;
- build the shared application integration-test image from the same immutable Temurin runtime digest as the production Dockerfile instead of a mutable `eclipse-temurin:21-jre` tag.

These are test-infrastructure and supply-chain-alignment changes only; application behavior is unchanged.

## Verification

- canonical Maven verification with ONNX and container acceptance enabled;
- Security Scan and CodeQL.

Follow-up to #502; intended to merge after #506 so the production and test runtime pins advance together.