### PR TITLE
Reconcile final streaming scores with the rendered taxonomy

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
-    "verify:ui": "npm run test:ui-evidence-policy && node scripts/run-ui-suite.mjs"
+    "test:state-render-consistency": "node --test scripts/taxonomy-state.test.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && npm run test:state-render-consistency && node scripts/run-ui-suite.mjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "4.12.1",

--- a/.github/scripts/taxonomy-state.test.mjs
+++ b/.github/scripts/taxonomy-state.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..', '..');
+const stateScript = await readFile(path.join(
+  repoRoot,
+  'taxonomy-app/src/main/resources/static/js/core/taxonomy-state.js'
+), 'utf8');
+
+function createHarness({ renderedCodes = [], currentView = 'list' } = {}) {
+  const scheduled = [];
+  const allCodes = ['BP', 'BR'];
+  const nodes = allCodes.map(code => ({
+    dataset: { code },
+    querySelector: () => renderedCodes.includes(code) ? { className: 'tax-pct' } : null
+  }));
+  let renderCalls = 0;
+
+  const window = {
+    requestAnimationFrame: callback => scheduled.push(callback),
+    setTimeout: callback => scheduled.push(callback)
+  };
+  const document = {
+    querySelectorAll: selector => {
+      assert.equal(selector, '#taxonomyTree .tax-node[data-code]');
+      return nodes;
+    }
+  };
+
+  vm.runInNewContext(stateScript, {
+    window,
+    document,
+    console,
+    Array,
+    Map,
+    Number,
+    Object,
+    Set
+  }, { filename: 'taxonomy-state.js' });
+
+  window.TaxonomyState.taxonomyData = [{ code: 'BP' }];
+  window.TaxonomyState.currentView = currentView;
+  window.TaxonomyBrowse = {
+    renderView(data, scores) {
+      renderCalls += 1;
+      assert.equal(data, window.TaxonomyState.taxonomyData);
+      assert.equal(scores, window.TaxonomyState.currentScores);
+    }
+  };
+
+  return {
+    state: window.TaxonomyState,
+    flush() {
+      while (scheduled.length > 0) scheduled.shift()();
+    },
+    renderCalls: () => renderCalls
+  };
+}
+
+test('reconciles an authoritative final score map when badges are missing', () => {
+  const harness = createHarness();
+  harness.state.currentScores = { BP: 85, BR: 0 };
+  harness.flush();
+  assert.equal(harness.renderCalls(), 1);
+});
+
+test('does not render twice when the caller already rendered the replacement map', () => {
+  const harness = createHarness({ renderedCodes: ['BP'] });
+  harness.state.currentScores = { BP: 85 };
+  harness.flush();
+  assert.equal(harness.renderCalls(), 0);
+});
+
+test('does not interfere with incremental mutations of the streaming score object', () => {
+  const harness = createHarness();
+  harness.state.currentScores = {};
+  harness.flush();
+  Object.assign(harness.state.currentScores, { BP: 85 });
+  harness.flush();
+  assert.equal(harness.renderCalls(), 0);
+});
+
+test('leaves graphical views to their dedicated renderers', () => {
+  const harness = createHarness({ currentView: 'sunburst' });
+  harness.state.currentScores = { BP: 85 };
+  harness.flush();
+  assert.equal(harness.renderCalls(), 0);
+});

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-state.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-state.js
@@ -3,9 +3,11 @@
 (function () {
     'use strict';
 
-    window.TaxonomyState = {
+    var currentScores = null;
+    var renderConsistencyCheck = 0;
+
+    var state = {
         taxonomyData: [],
-        currentScores: null,
         currentReasons: {},   // code → reason string
         currentDiscrepancies: [], // TaxonomyDiscrepancy list from analysis
         currentArchView: null, // latest architecture view from analysis
@@ -22,5 +24,64 @@
         currentProposalFilter: 'PENDING',
         pendingProposalNodeCode: null // node code for propose modal
     };
+
+    /**
+     * A streaming analysis updates the current score object incrementally and
+     * finally replaces it with the server's authoritative total score map. If an
+     * incremental browser event or DOM update was missed, the state could then be
+     * complete while the list/tabs view still contained no score badges.
+     *
+     * Defer one frame so normal callers can render synchronously. Only when the
+     * rendered nodes still disagree with the replacement map do we rebuild the
+     * current list/tabs view from the authoritative state.
+     */
+    function scheduleScoreRenderConsistencyCheck(scores) {
+        var check = ++renderConsistencyCheck;
+        if (!scores || typeof scores !== 'object') return;
+
+        var positiveCodes = Object.keys(scores).filter(function (code) {
+            return Number(scores[code]) > 0;
+        });
+        if (positiveCodes.length === 0) return;
+
+        var schedule = typeof window.requestAnimationFrame === 'function'
+            ? function (callback) { window.requestAnimationFrame(callback); }
+            : function (callback) { window.setTimeout(callback, 0); };
+
+        schedule(function () {
+            if (check !== renderConsistencyCheck || currentScores !== scores) return;
+            if (state.currentView !== 'list' && state.currentView !== 'tabs') return;
+            if (!Array.isArray(state.taxonomyData) || state.taxonomyData.length === 0) return;
+            if (!window.TaxonomyBrowse || typeof window.TaxonomyBrowse.renderView !== 'function') return;
+
+            var nodesByCode = new Map();
+            document.querySelectorAll('#taxonomyTree .tax-node[data-code]').forEach(function (node) {
+                if (node.dataset.code) nodesByCode.set(node.dataset.code, node);
+            });
+
+            var renderableCodes = positiveCodes.filter(function (code) {
+                return nodesByCode.has(code);
+            });
+            var missingBadge = renderableCodes.some(function (code) {
+                return !nodesByCode.get(code)
+                    .querySelector(':scope > .tax-node-header > .tax-pct');
+            });
+
+            if (renderableCodes.length > 0 && missingBadge) {
+                window.TaxonomyBrowse.renderView(state.taxonomyData, scores);
+            }
+        });
+    }
+
+    Object.defineProperty(state, 'currentScores', {
+        enumerable: true,
+        get: function () { return currentScores; },
+        set: function (scores) {
+            currentScores = scores;
+            scheduleScoreRenderConsistencyCheck(scores);
+        }
+    });
+
+    window.TaxonomyState = state;
 
 })();


### PR DESCRIPTION
## Summary

Fixes the concrete UI failure reproduced by the canonical Maven run on #513 after all Java, container and coverage work had passed.

The 400% zoom scenario received a successful streaming completion with 309 matched nodes, but the final DOM contained no `.tax-pct` score badges. `runStreamingAnalysis()` replaces `TaxonomyState.currentScores` with the authoritative `totalScores` map on the final SSE event, while the view previously depended entirely on every incremental score event having reached and updated the DOM.

### Fix

- make `currentScores` an observable state property;
- after an authoritative non-empty replacement, defer one animation frame so normal synchronous renderers can finish;
- for list/tabs views, compare positive score codes with direct score badges on the corresponding rendered nodes;
- rebuild the current view from `taxonomyData` and the authoritative score map only when that consistency check finds missing badges;
- leave incremental `Object.assign` updates and graphical views unchanged.

This is a product-side consistency repair, not a relaxed test or longer timeout.

### Regression coverage

Adds four Node tests proving that:

- missing final badges trigger exactly one reconciliation render;
- an already rendered replacement is not rendered twice;
- incremental streaming mutations do not trigger full re-renders;
- graphical views remain under their dedicated renderers.

The focused regression test passes locally: 4 tests, 0 failures.

## Evidence

The failing canonical run completed the application and aggregate coverage modules successfully and failed only in the Maven-owned UI build-policy stage. Its 400% zoom report showed an effective 360 × 250 CSS-pixel viewport, a completed analysis with 309 matches, and zero rendered score badges.

Refs #480
Follow-up to #502 and #513.