### PR TITLE
Harden container acceptance cancellation and cleanup

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ContainerTestUtils.java
@@ -29,11 +29,16 @@ final class ContainerTestUtils {
      */
     static final String TEST_ADMIN_PASSWORD = "admin";
 
+    /** Same immutable runtime manifest used by the production Dockerfile. */
+    private static final String APP_RUNTIME_IMAGE =
+            "eclipse-temurin@sha256:"
+                    + "d63bd8d9b171999cbed8576f2c76e874dd4856791a358536e5c4d407e77edc13";
+
     private static final Future<String> SHARED_IMAGE = new ImageFromDockerfile(
             "taxonomy-app-it", false)
             .withFileFromPath("app.jar", findApplicationJar())
             .withDockerfileFromBuilder(builder -> builder
-                    .from("eclipse-temurin:21-jre")
+                    .from(APP_RUNTIME_IMAGE)
                     .workDir("/app")
                     .copy("app.jar", "app.jar")
                     .expose(8080)

--- a/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/LocalOnnxPipelineIT.java
@@ -158,7 +158,13 @@ class LocalOnnxPipelineIT {
                     return;
                 }
             }
-            Thread.sleep(500);
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Interrupted while waiting for the full-text index", exception);
+            }
         }
 
         throw new AssertionError(

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -327,13 +327,14 @@ class OnnxSeleniumIT {
                                             + "rect.left+rect.width/2,rect.top+rect.height/2);"
                                             + "return top===target || target.contains(top);",
                                     element);
-                    return Boolean.TRUE.equals(unobscured)
-                            && element.isDisplayed()
-                            && element.isEnabled()
-                            ? element
-                            : null;
-                })
-                .click();
+                    if (!Boolean.TRUE.equals(unobscured)
+                            || !element.isDisplayed()
+                            || !element.isEnabled()) {
+                        return false;
+                    }
+                    element.click();
+                    return true;
+                });
     }
 
     private void executeUiSearch(String mode, String query) {

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -223,7 +224,9 @@ class OnnxSeleniumIT {
         WebElement firstResult = items.getFirst();
         String code = firstResult.getAttribute("data-code");
         assertThat(code).isNotNull().isNotEmpty();
-        clickWhenUnobscured(firstResult);
+        clickWhenUnobscured(By.cssSelector(
+                "#searchResultsArea .search-result-item[data-code='"
+                        + code.replace("'", "\\'") + "']"));
 
         WebElement highlightedHeader = new WebDriverWait(driver, Duration.ofSeconds(10))
                 .until(currentDriver -> currentDriver.findElements(
@@ -272,7 +275,14 @@ class OnnxSeleniumIT {
                     return;
                 }
             }
-            Thread.sleep(1_000);
+            try {
+                Thread.sleep(1_000);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(
+                        "Interrupted while waiting for the LOCAL_ONNX semantic index",
+                        exception);
+            }
         }
 
         throw new AssertionError(
@@ -301,12 +311,14 @@ class OnnxSeleniumIT {
                         .isEnabled());
     }
 
-    private void clickWhenUnobscured(WebElement element) {
-        ((JavascriptExecutor) driver).executeScript(
-                "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
-                element);
+    private void clickWhenUnobscured(By locator) {
         new WebDriverWait(driver, Duration.ofSeconds(10))
+                .ignoring(StaleElementReferenceException.class)
                 .until(currentDriver -> {
+                    WebElement element = currentDriver.findElement(locator);
+                    ((JavascriptExecutor) currentDriver).executeScript(
+                            "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
+                            element);
                     Boolean unobscured = (Boolean) ((JavascriptExecutor) currentDriver)
                             .executeScript(
                                     "const target=arguments[0];"
@@ -339,7 +351,7 @@ class OnnxSeleniumIT {
                         + "arguments[0].dispatchEvent(new Event('input'));",
                 searchInput,
                 query);
-        clickWhenUnobscured(driver.findElement(By.id("searchBtn")));
+        clickWhenUnobscured(By.id("searchBtn"));
     }
 
     private void waitForSearchResults() {

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -1,6 +1,6 @@
 package com.taxonomy;
 
-import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import org.awaitility.Awaitility;
@@ -138,8 +138,9 @@ class ProductionPersistenceRestartIT {
             DockerClientFactory.instance().client()
                     .removeVolumeCmd(volumeName)
                     .exec();
-        } catch (NotFoundException ignored) {
-            // A failed container creation may not have created the named volume yet.
+        } catch (DockerException ignored) {
+            // Cleanup must never mask the original assertion or container failure. This also
+            // covers volumes that were never created or remain attached after a failed stop.
         }
     }
 


### PR DESCRIPTION
## Summary

Current-main replacement for #513, containing only the reviewed container/ONNX/Selenium hardening required before the next release.

- preserve interrupt status and fail fast when full-text or semantic ONNX readiness polling is cancelled;
- re-find Selenium targets on every wait iteration;
- perform the click inside the stale-element-tolerant wait so a DOM re-render between readiness and activation is retried;
- make named-volume removal best-effort for docker-java failures without hiding unrelated programming errors;
- build the shared integration-test application image from the same immutable Temurin manifest used by the production Dockerfile.

The digest-only Testcontainers image reference is intentional: the generated-image parser rejects the combined `tag@sha256` syntax, whereas raw Dockerfile `FROM` instructions support it.

## Verification

- canonical Maven verification with ONNX and container acceptance enabled;
- Security Scan and CodeQL;
- all review threads resolved.

The branch includes the current release dependencies merged from `main` and requires fresh checks on head `3d3c32f`.

Supersedes #513
Follow-up to #502 and #506.