### PR TITLE
Prioritize analysis workflow on narrow viewports

### DIFF
--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -28,6 +28,8 @@ export async function runRoleStateFlow({
   }
 
   await page.locator('#mainNavTabs [data-page="analyze"]').click();
+  await page.locator('#taxonomyTree [role="treeitem"]').first()
+    .waitFor({ state: 'visible', timeout: 90_000 });
   const interactive = page.locator('#interactiveMode');
   if (await interactive.isChecked()) await interactive.uncheck();
   await page.locator('#businessText').fill(
@@ -148,6 +150,49 @@ export async function runRoleStateFlow({
   assert(forcedColors ? overflow.forcedColors : true, 'Forced-colors profile was not active');
   passed(`reflow at ${zoom}x`);
   if (forcedColors) passed('forced-colors media state');
+
+  const taskHierarchy = await page.evaluate(() => {
+    const left = document.getElementById('leftPanel');
+    const right = document.getElementById('rightPanel');
+    const row = left?.parentElement;
+    const navigation = document.getElementById('mainNavTabs');
+    const visibleLinks = Array.from(navigation?.querySelectorAll('.nav-link') || [])
+      .filter(link => getComputedStyle(link).display !== 'none');
+    const maxLinkHeight = visibleLinks.reduce((maximum, link) =>
+      Math.max(maximum, link.getBoundingClientRect().height), 0);
+    return {
+      viewportWidth: window.innerWidth,
+      leftTop: left?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      rightTop: right?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY,
+      rightPrecedesLeftInDom: Boolean(right && left
+        && (right.compareDocumentPosition(left) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      leftPrecedesRightInDom: Boolean(left && right
+        && (left.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      taskOrder: row?.dataset.taskOrder || '',
+      navigationHeight: navigation?.getBoundingClientRect().height ?? 0,
+      maxLinkHeight,
+      navigationScrollWidth: navigation?.scrollWidth ?? 0,
+      navigationClientWidth: navigation?.clientWidth ?? 0
+    };
+  });
+  if (taskHierarchy.viewportWidth <= 992) {
+    assert(taskHierarchy.rightTop <= taskHierarchy.leftTop,
+      `Primary task must precede taxonomy browser at ${taskHierarchy.viewportWidth}px: `
+      + `${taskHierarchy.rightTop} > ${taskHierarchy.leftTop}`);
+    assert(taskHierarchy.rightPrecedesLeftInDom && taskHierarchy.taskOrder === 'primary-first',
+      'Primary task must also precede the taxonomy browser in reading and focus order');
+    passed('primary task precedes taxonomy browser visually and structurally');
+    assert(taskHierarchy.navigationHeight <= taskHierarchy.maxLinkHeight + 6,
+      `Main navigation wrapped to multiple rows: ${taskHierarchy.navigationHeight} > `
+      + `${taskHierarchy.maxLinkHeight + 6}`);
+    assert(taskHierarchy.navigationScrollWidth >= taskHierarchy.navigationClientWidth,
+      'Main navigation must remain horizontally reachable');
+    passed('single-row scrollable main navigation');
+  } else {
+    assert(taskHierarchy.leftPrecedesRightInDom && taskHierarchy.taskOrder === 'reference-first',
+      'Desktop reading and focus order must match the left-to-right panel layout');
+    passed('desktop panel reading order matches visual layout');
+  }
 
   const expectedHttpFailure = failure => {
     if (failure.status === 503 && failure.path === '/api/analyze') return true;

--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -175,7 +175,8 @@ export async function runRoleStateFlow({
       navigationClientWidth: navigation?.clientWidth ?? 0
     };
   });
-  if (taskHierarchy.viewportWidth <= 992) {
+  // Bootstrap's lg columns become the desktop two-column layout at exactly 992px.
+  if (taskHierarchy.viewportWidth < 992) {
     assert(taskHierarchy.rightTop <= taskHierarchy.leftTop,
       `Primary task must precede taxonomy browser at ${taskHierarchy.viewportWidth}px: `
       + `${taskHierarchy.rightTop} > ${taskHierarchy.leftTop}`);

--- a/docs/de/ACCESSIBILITY.md
+++ b/docs/de/ACCESSIBILITY.md
@@ -1,6 +1,6 @@
 # Nachweismatrix zur Barrierefreiheit (BITV 2.0 / WCAG 2.1)
 
-**Letzte codebasierte Prüfung:** 21. Juli 2026  
+**Letzte codebasierte Prüfung:** 29. Juli 2026  
 **Ziel:** WCAG 2.1 Level AA / EN 301 549 / BITV 2.0  
 **Aktueller Stand:** Teilweise konform – eine formale BIK-BITV-Prüfung wurde noch nicht durchgeführt.
 
@@ -25,10 +25,11 @@ Bewertet wird die authentifizierte Webanwendung mit Analyse, Taxonomiebaum, Arch
 | Administration | Berechtigung ausschließlich über `ROLE_ADMIN`; Symbolschaltfläche besitzt zugänglichen Namen | Security- und UI-Regressionstests | Umgesetzt |
 | Veraltete Ergebnisse | Änderung der Anforderung nach einer Analyse erzeugt Warnung und Rücksetzaktion | Screenshot- und Verhaltenstest | Umgesetzt |
 | Touch-Bedienung | Knotenaktionen werden bei groben Zeigegeräten eingeblendet; wichtige Bedienelemente erhalten 44-Pixel-Ziele | Responsives Ergonomie-Stylesheet | Umgesetzt |
-| Zoom und Reflow | Navigation, Panels und Aktionen brechen auf schmalen beziehungsweise gezoomten Ansichten um | CSS; manuelle Endprüfung erforderlich | Teilweise |
+| Responsive Aufgabenreihenfolge | Bei schmalen beziehungsweise gezoomten Ansichten wird die primäre Analyseaufgabe im tatsächlichen DOM vor den Referenzbaum verschoben; beim Desktop-Layout wird die ursprüngliche Reihenfolge wiederhergestellt | `taxonomy-utils.js` sowie Rollen-/Zustandstests für Geometrie, DOM-, Lese- und Fokusreihenfolge | Umgesetzt |
+| Zoom und Reflow | Navigation bleibt eine einzeilige horizontal erreichbare Leiste; Panels und Aktionen brechen ohne wesentlichen horizontalen Inhaltsverlust um | Responsives Stylesheet und Maven-gesteuerte Rollen-/Zustandsmatrix; manuelle Geräteprüfung bleibt erforderlich | Teilweise |
 | Reduzierte Bewegung | Animationen und Übergänge werden bei `prefers-reduced-motion` minimiert | CSS | Umgesetzt |
 | Graphen und Diagramme | Mehrere Ansichten besitzen Tabellen oder Detaildarstellungen; die vollständige inhaltliche Gleichwertigkeit ist noch manuell zu prüfen | Manuelle Prüfung | Teilweise |
-| DSL-Editor | CodeMirror stellt eine eigene Accessibility-Struktur bereit; separate Prüfung nötig | Manuelle Tastatur-/Screenreader-Prüfung | Teilweise |
+| DSL-Editor | CodeMirror bleibt in der automatisierten Browser-/axe-Abdeckung enthalten; seine komplexe Editor-Semantik benötigt zusätzlich eine eigene Tastatur- und Screenreader-Testmatrix | Automatisierte Browsermatrix plus manuelle Tastatur-/Screenreader-Prüfung | Teilweise |
 | Kontraste | Bootstrap-Grundfarben und explizite Textfarben; vollständige Prüfung aller Zustände bleibt erforderlich | axe plus manuelle Prüfung | Teilweise |
 
 ## Automatischer Accessibility-Gate

--- a/docs/en/ACCESSIBILITY.md
+++ b/docs/en/ACCESSIBILITY.md
@@ -1,6 +1,6 @@
 # Accessibility Evidence and Conformance Plan (BITV 2.0 / WCAG 2.1)
 
-**Last code-based review:** 21 July 2026  
+**Last code-based review:** 29 July 2026  
 **Target:** WCAG 2.1 Level AA / EN 301 549 / BITV 2.0  
 **Current status:** Partially conformant — no formal BIK BITV certification has been completed.
 
@@ -25,10 +25,11 @@ The assessment covers the authenticated single-page application, including analy
 | Admin control | Admin state derives from authenticated `ROLE_ADMIN`; icon-only display has an accessible name | Security and UI regression tests | Implemented |
 | Stale-result feedback | Editing a requirement after analysis adds a visible warning and reset action | Screenshot and UI behavior tests | Implemented |
 | Touch operation | Node actions are displayed on coarse pointers; important controls receive 44 px touch targets | Responsive ergonomics stylesheet | Implemented |
-| Zoom and reflow | Navigation, panels and node actions wrap on narrow/zoomed layouts | Responsive ergonomics stylesheet; manual verification still required | Partial |
+| Responsive task order | At narrow/zoomed widths the primary analysis task is moved before the reference tree in the actual DOM; desktop order is restored when the two-column layout returns | `taxonomy-utils.js` plus role/state assertions for geometry, DOM, reading and focus order | Implemented |
+| Zoom and reflow | Navigation remains a single horizontally reachable row; panels and actions reflow without essential horizontal loss | Responsive stylesheet and Maven-owned role/state matrix; manual device verification still required | Partial |
 | Reduced motion | Animations and transitions are minimized when `prefers-reduced-motion` is active | Responsive ergonomics stylesheet | Implemented |
 | Graphs and diagrams | Several views provide tables or detail lists, but not every visual relation is guaranteed to have an equivalent linear representation | Manual review required | Partial |
-| DSL editor | CodeMirror exposes its own accessibility tree; it is excluded from the general axe scan and must be tested separately | Manual keyboard/screen-reader test | Partial |
+| DSL editor | CodeMirror remains included in automated browser/axe coverage, but its complex editor semantics also require a dedicated keyboard and screen-reader test matrix | Automated browser matrix plus manual keyboard/screen-reader test | Partial |
 | Contrast | Bootstrap defaults and explicit high-score text colors are used; a full state-by-state contrast audit remains necessary | axe detects many contrast failures, but manual checks are still required | Partial |
 
 ## Automated accessibility gate

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -188,8 +188,35 @@
     #rightPanel {
         width: 100% !important;
     }
+    /* The requirement-analysis task is the primary workflow. When the two
+       desktop columns stack, put that task before the reference taxonomy tree. */
+    #rightPanel {
+        order: 1;
+    }
+    #leftPanel {
+        order: 2;
+    }
     .card-body[style*="max-height"] {
         max-height: none !important;
+    }
+    /* Keep every destination directly available without spending several rows
+       of the initial viewport on wrapped navigation tabs. */
+    #mainNavTabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-inline: contain;
+        scroll-snap-type: inline proximity;
+        scrollbar-width: thin;
+        -webkit-overflow-scrolling: touch;
+    }
+    #mainNavTabs .nav-item {
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+    }
+    #mainNavTabs .nav-link {
+        width: auto;
+        white-space: nowrap;
     }
 }
 
@@ -198,13 +225,27 @@
     .navbar-brand {
         width: 100%;
         white-space: normal;
+        font-size: 1rem;
+        line-height: 1.25;
+    }
+    /* These badges duplicate information available in the analysis and context
+       surfaces. Hiding the duplicates preserves controls while reducing the
+       mobile header from several rows to the brand plus one utility row. */
+    #aiStatusBadge,
+    #embeddingStatusBadge,
+    #workspaceUserBadge {
+        display: none !important;
+    }
+    #navbarVersion {
+        display: none;
     }
     #mainNavTabs .nav-item {
-        flex: 1 1 9rem;
+        flex: 0 0 auto;
     }
     #mainNavTabs .nav-link {
-        width: 100%;
-        text-align: left;
+        width: auto;
+        min-width: max-content;
+        text-align: center;
     }
     #businessText {
         min-height: 12rem;

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -175,8 +175,9 @@
     }
 }
 
-/* Prevent tiny controls even with mouse/trackpad when zoomed. */
-@media (max-width: 992px) {
+/* Prevent tiny controls even with mouse/trackpad when zoomed. Bootstrap's lg
+   columns become two-column at 992px, so the stacking contract ends below it. */
+@media (max-width: 991.98px) {
     .tax-node-actions {
         display: inline-flex;
         flex-wrap: wrap;

--- a/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
+++ b/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
@@ -326,6 +326,7 @@ window.TaxonomyUtils = (function () {
                 resolve(value);
             });
             dialog.showModal();
+            input.focus();
         });
     }
 

--- a/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
+++ b/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
@@ -110,7 +110,8 @@ window.TaxonomyUtils = (function () {
         if (!leftPanel || !rightPanel || leftPanel.parentElement !== rightPanel.parentElement) return;
 
         var row = leftPanel.parentElement;
-        var narrowViewport = window.matchMedia('(max-width: 992px)');
+        // Bootstrap's lg columns become the desktop two-column layout at 992px.
+        var narrowViewport = window.matchMedia('(max-width: 991.98px)');
         var synchronize = function () {
             if (narrowViewport.matches) {
                 if (rightPanel.nextElementSibling !== leftPanel) {
@@ -325,7 +326,6 @@ window.TaxonomyUtils = (function () {
                 resolve(value);
             });
             dialog.showModal();
-            input.focus();
         });
     }
 

--- a/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
+++ b/taxonomy-app/src/main/resources/static/js/shared/taxonomy-utils.js
@@ -103,6 +103,36 @@ window.TaxonomyUtils = (function () {
         });
     }
 
+    // ── Responsive task reading and focus order ───────────────────────────
+    function installResponsiveTaskOrder() {
+        var leftPanel = document.getElementById('leftPanel');
+        var rightPanel = document.getElementById('rightPanel');
+        if (!leftPanel || !rightPanel || leftPanel.parentElement !== rightPanel.parentElement) return;
+
+        var row = leftPanel.parentElement;
+        var narrowViewport = window.matchMedia('(max-width: 992px)');
+        var synchronize = function () {
+            if (narrowViewport.matches) {
+                if (rightPanel.nextElementSibling !== leftPanel) {
+                    row.insertBefore(rightPanel, leftPanel);
+                }
+                row.dataset.taskOrder = 'primary-first';
+            } else {
+                if (leftPanel.nextElementSibling !== rightPanel) {
+                    row.insertBefore(leftPanel, rightPanel);
+                }
+                row.dataset.taskOrder = 'reference-first';
+            }
+        };
+
+        synchronize();
+        if (typeof narrowViewport.addEventListener === 'function') {
+            narrowViewport.addEventListener('change', synchronize);
+        } else {
+            narrowViewport.addListener(synchronize);
+        }
+    }
+
     // ── Dynamic tree accessibility ────────────────────────────────────────
     function syncTreeItemAccessibility(item) {
         if (!item || item.getAttribute('role') !== 'treeitem') return;
@@ -332,6 +362,7 @@ window.TaxonomyUtils = (function () {
         loadErgonomicsStyles();
         syncMainNavigation();
         installMainNavigationKeyboardSupport();
+        installResponsiveTaskOrder();
         installTreeAccessibilityObserver();
         installManualScoreDialog();
         window.alert = function (message) { showMessage(message); };


### PR DESCRIPTION
## Summary

Current-main replacement for #503 implementing the narrow/mobile task-hierarchy slice of #479 for the next release.

### Narrow-layout task hierarchy

- place the primary analysis/task panel before the reference taxonomy tree only while Bootstrap's desktop columns are stacked;
- use the same `< 992 px` contract in CSS, DOM reordering and Playwright assertions;
- keep exactly 992 px in the Bootstrap `lg` desktop layout with left-tree/right-task reading order;
- align visual, DOM, screen-reader and keyboard-focus order;
- keep main navigation in one horizontally scrollable row;
- retain 44 px touch targets, zoom reflow, forced-colors and reduced-motion behavior;
- document the structural contract in English and German accessibility guidance.

### Combined regression coverage

The role/state flow preserves both the process-reuse and responsive contracts:

- wait for a real taxonomy tree item before interacting with analysis controls;
- observe transient status mutations before activation for warm reused processes;
- require final model scores and visible badges;
- assert narrow and desktop visual/DOM order plus single-row navigation;
- keep role-local application reuse and accepted-proposal idempotency from #515.

All review threads are resolved. The branch includes the current release dependencies merged from `main` and requires fresh verification on head `de8aba6`.

Supersedes #503
Refs #479.