### PR TITLE
Correlate Taxonomy operation logs with live traces

### DIFF
--- a/docs/de/OBSERVABILITY.md
+++ b/docs/de/OBSERVABILITY.md
@@ -133,6 +133,14 @@ OTEL_METRICS_EXPORTER=none
 
 Dadurch entsteht kein zweiter Metrikpfad und es werden Spring-Boot-, JVM-, Hibernate- und Connection-Pool-Metriken nicht doppelt exportiert. Hibernate-Statistiken sind in der Anwendung bereits aktiviert und über den vorhandenen Micrometer-/Prometheus-Pfad verfügbar.
 
+Taxonomy-eigene Micrometer-Observations ergänzen am selben Endpunkt begrenzte fachliche Timer. Der Metrikname wird aus der Observation-Grenze abgeleitet, beispielsweise:
+
+```text
+taxonomy_workspace_resolve_seconds_count
+```
+
+Verwendet werden ausschließlich feste, niedrig-kardinale Labels: `taxonomy.component`, `taxonomy.operation` und das normalisierte `outcome` (`success` oder `error`). Benutzernamen, Workspace- oder Repository-Namen, Suchanfragen, Prompts, Dateinamen und Exception-Meldungen werden niemals Metrik-Labels. Die Live-Containerprüfung ruft `/api/relations` auf und verlangt den Workspace-Timer mit `component=workspace`, `operation=resolveCurrentContext` und `outcome=success`.
+
 ## Log-Korrelation
 
 Das Spring-Profil `observability` formatiert die OpenTelemetry-MDC-Felder so:
@@ -142,6 +150,14 @@ Das Spring-Profil `observability` formatiert die OpenTelemetry-MDC-Felder so:
 ```
 
 Mit diesen Kennungen kann der zugehörige Trace beziehungsweise Span gefunden werden. Wenn kein Span aktiv ist, erscheint `none`. Logs bleiben in dieser ersten Implementierung bei der Anwendung; der OTLP-Logexport ist deaktiviert.
+
+Taxonomy kann an einer beobachteten fachlichen Grenze zusätzlich genau eine begrenzte DEBUG-Meldung ausgeben:
+
+```text
+Observed taxonomy operation component=workspace operation=resolveCurrentContext outcome=success
+```
+
+Sie wird nur bei Bedarf mit `LOGGING_LEVEL_COM_TAXONOMY_OBSERVABILITY=DEBUG` aktiviert. Der normale INFO-Betrieb bleibt unverändert. Die Meldung enthält ausschließlich feste Komponenten-/Operationsnamen und ein normalisiertes Ergebnis; Methodenargumente, Rückgabewerte, Identitäten, Inhalte und Exception-Meldungen werden nie ausgegeben. Der Live-Abnahmetest verlangt für diese Zeile dieselbe `trace_id` wie im exportierten HTTP-/Domain-Trace.
 
 ## Datenminimierung
 

--- a/docs/en/OBSERVABILITY.md
+++ b/docs/en/OBSERVABILITY.md
@@ -133,6 +133,14 @@ OTEL_METRICS_EXPORTER=none
 
 This avoids creating a second metric pipeline or duplicating Spring Boot, JVM, Hibernate and database-pool metrics. Hibernate statistics are already enabled in the application and available through the existing Micrometer/Prometheus path.
 
+Taxonomy-owned Micrometer observations add bounded domain timers to the same endpoint. Metric names are derived from the observation boundary, for example:
+
+```text
+taxonomy_workspace_resolve_seconds_count
+```
+
+Only fixed low-cardinality labels are used: `taxonomy.component`, `taxonomy.operation` and the normalized `outcome` (`success` or `error`). Usernames, workspace or repository names, queries, prompts, filenames and exception messages are never metric labels. The live container verification exercises `/api/relations` and requires the workspace-resolution timer with `component=workspace`, `operation=resolveCurrentContext` and `outcome=success`.
+
 ## Log correlation
 
 The `observability` Spring profile formats the OpenTelemetry MDC fields as:
@@ -142,6 +150,14 @@ The `observability` Spring profile formats the OpenTelemetry MDC fields as:
 ```
 
 Use those identifiers to locate the corresponding trace and span. When no span is active, the fields show `none`. Logs remain local/application-managed in this first implementation; OTLP log export is disabled.
+
+Taxonomy can additionally emit one bounded DEBUG message at an observed domain boundary:
+
+```text
+Observed taxonomy operation component=workspace operation=resolveCurrentContext outcome=success
+```
+
+Enable it only when needed with `LOGGING_LEVEL_COM_TAXONOMY_OBSERVABILITY=DEBUG`. Normal INFO logging is unchanged. The message contains only fixed component/operation names and a normalized outcome; it never includes method arguments, return values, identities, content or exception messages. The live acceptance test requires this line to carry the same `trace_id` as the exported HTTP/domain trace.
 
 ## Data minimisation
 

--- a/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
@@ -19,6 +19,7 @@ import org.springframework.util.ClassUtils;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Adds low-cardinality Micrometer observations to Taxonomy-owned service boundaries.
@@ -35,9 +36,12 @@ public class TaxonomyObservationConfiguration {
     @Bean
     static BeanPostProcessor taxonomyObservationBeanPostProcessor(
             ObjectProvider<ObservationRegistry> registryProvider) {
-        ObservationRegistry registry = registryProvider.getIfAvailable(
+        // BeanPostProcessors are created before many ordinary infrastructure beans.
+        // Resolve the registry only when an observed operation is invoked so an early
+        // NOOP fallback cannot become permanent for the lifetime of the application.
+        Supplier<ObservationRegistry> registrySupplier = () -> registryProvider.getIfAvailable(
                 () -> ObservationRegistry.NOOP);
-        return new TaxonomyObservationBeanPostProcessor(registry);
+        return new TaxonomyObservationBeanPostProcessor(registrySupplier);
     }
 
     record TargetDescriptor(String observationName, String component,
@@ -86,10 +90,11 @@ public class TaxonomyObservationConfiguration {
                                         "importFromJson")))
         );
 
-        private final ObservationRegistry observationRegistry;
+        private final Supplier<ObservationRegistry> registrySupplier;
 
-        TaxonomyObservationBeanPostProcessor(ObservationRegistry observationRegistry) {
-            this.observationRegistry = observationRegistry;
+        TaxonomyObservationBeanPostProcessor(
+                Supplier<ObservationRegistry> registrySupplier) {
+            this.registrySupplier = registrySupplier;
         }
 
         @Override
@@ -102,7 +107,7 @@ public class TaxonomyObservationConfiguration {
             }
 
             MethodInterceptor interceptor =
-                    new TaxonomyObservationInterceptor(observationRegistry, descriptor);
+                    new TaxonomyObservationInterceptor(registrySupplier, descriptor);
             if (bean instanceof Advised advised) {
                 advised.addAdvice(interceptor);
                 return bean;
@@ -125,12 +130,17 @@ public class TaxonomyObservationConfiguration {
         private static final Logger log = LoggerFactory.getLogger(
                 TaxonomyObservationInterceptor.class);
 
-        private final ObservationRegistry observationRegistry;
+        private final Supplier<ObservationRegistry> registrySupplier;
         private final TargetDescriptor descriptor;
 
         TaxonomyObservationInterceptor(ObservationRegistry observationRegistry,
                                        TargetDescriptor descriptor) {
-            this.observationRegistry = observationRegistry;
+            this(() -> observationRegistry, descriptor);
+        }
+
+        TaxonomyObservationInterceptor(Supplier<ObservationRegistry> registrySupplier,
+                                       TargetDescriptor descriptor) {
+            this.registrySupplier = registrySupplier;
             this.descriptor = descriptor;
         }
 
@@ -141,6 +151,10 @@ public class TaxonomyObservationConfiguration {
                 return invocation.proceed();
             }
 
+            ObservationRegistry observationRegistry = registrySupplier.get();
+            if (observationRegistry == null) {
+                observationRegistry = ObservationRegistry.NOOP;
+            }
             Observation observation = Observation.createNotStarted(
                             descriptor.observationName(), observationRegistry)
                     .lowCardinalityKeyValue("taxonomy.component", descriptor.component())

--- a/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/observability/TaxonomyObservationConfiguration.java
@@ -4,6 +4,8 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
@@ -120,6 +122,9 @@ public class TaxonomyObservationConfiguration {
 
     static final class TaxonomyObservationInterceptor implements MethodInterceptor {
 
+        private static final Logger log = LoggerFactory.getLogger(
+                TaxonomyObservationInterceptor.class);
+
         private final ObservationRegistry observationRegistry;
         private final TargetDescriptor descriptor;
 
@@ -144,12 +149,16 @@ public class TaxonomyObservationConfiguration {
             try (Observation.Scope ignored = observation.openScope()) {
                 Object result = invocation.proceed();
                 observation.lowCardinalityKeyValue("outcome", "success");
+                log.debug("Observed taxonomy operation component={} operation={} outcome=success",
+                        descriptor.component(), operation);
                 return result;
             } catch (Throwable failure) {
-                // The exception is deliberately not attached to the Observation because its
-                // message may contain imported, DSL or LLM content. Agent method spans retain
+                // The exception is deliberately not attached to the Observation or log because
+                // its message may contain imported, DSL or LLM content. Agent method spans retain
                 // exception type and error status independently.
                 observation.lowCardinalityKeyValue("outcome", "error");
+                log.debug("Observed taxonomy operation component={} operation={} outcome=error",
+                        descriptor.component(), operation);
                 throw failure;
             } finally {
                 observation.stop();

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
@@ -132,6 +132,11 @@ class ObservabilityContainerIT {
                 "/actuator/prometheus", "text/plain");
         assertThat(prometheus.statusCode()).isEqualTo(200);
         assertThat(prometheus.body()).contains("jvm_memory");
+        assertThat(prometheus.body())
+                .contains("taxonomy_workspace_resolve_seconds_count")
+                .contains("taxonomy_component=\"workspace\"")
+                .contains("taxonomy_operation=\"resolveCurrentContext\"")
+                .contains("outcome=\"success\"");
 
         TraceEvidence evidence = awaitCorrelatedTrace();
         assertThat(evidence.spanNames())

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java
@@ -50,6 +50,9 @@ class ObservabilityContainerIT {
     private static final String COLLECTOR_ALIAS = "otel-collector.test";
     private static final String APP_ALIAS = "taxonomy-observability.test";
     private static final String DEBUG_EXPORT_START = "ResourceSpans #";
+    private static final String SAFE_OPERATION_LOG =
+            "Observed taxonomy operation component=workspace "
+                    + "operation=resolveCurrentContext outcome=success";
     private static final String BASIC_AUTH = "Basic "
             + Base64.getEncoder().encodeToString(
                     ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
@@ -93,6 +96,7 @@ class ObservabilityContainerIT {
                 .withEnv("TAXONOMY_EMBEDDING_ENABLED", "false")
                 .withEnv("TAXONOMY_THYMELEAF_CACHE", "false")
                 .withEnv("LLM_MOCK", "true")
+                .withEnv("LOGGING_LEVEL_COM_TAXONOMY_OBSERVABILITY", "DEBUG")
                 .withEnv("JAVA_TOOL_OPTIONS",
                         "-javaagent:/tmp/opentelemetry-javaagent.jar")
                 .withEnv("OTEL_JAVAAGENT_CONFIGURATION_FILE",
@@ -142,6 +146,7 @@ class ObservabilityContainerIT {
                         "taxonomy.document.filename",
                         "gen_ai.prompt",
                         "llm.prompt");
+        awaitCorrelatedApplicationLog(evidence.traceId());
 
         collector.stop();
 
@@ -198,6 +203,28 @@ class ObservabilityContainerIT {
         throw new AssertionError(
                 "No correlated HTTP and Taxonomy spans were exported. Collector tail:\n"
                         + lastLogs.substring(start));
+    }
+
+    private void awaitCorrelatedApplicationLog(String traceId)
+            throws InterruptedException {
+        Pattern correlatedLog = Pattern.compile(
+                "trace_id=" + Pattern.quote(traceId)
+                        + "\\s+span_id=[0-9a-fA-F]{16}.*"
+                        + Pattern.quote(SAFE_OPERATION_LOG),
+                Pattern.CASE_INSENSITIVE);
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        String lastLogs = "";
+        while (System.nanoTime() < deadline) {
+            lastLogs = application.getLogs();
+            if (correlatedLog.matcher(lastLogs).find()) {
+                return;
+            }
+            Thread.sleep(100);
+        }
+        int start = Math.max(0, lastLogs.length() - 8_000);
+        throw new AssertionError(
+                "No safe application log was correlated with trace " + traceId
+                        + ". Application tail:\n" + lastLogs.substring(start));
     }
 
     private static String exportedTelemetry(String collectorLogs) {

--- a/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
@@ -1,18 +1,25 @@
 package com.taxonomy.observability;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TaxonomyObservationConfigurationTest {
 
@@ -60,6 +67,41 @@ class TaxonomyObservationConfigurationTest {
                 .tag("outcome", "error")
                 .timer();
         assertEquals(1, timer.count());
+    }
+
+    @Test
+    void logsOnlyBoundedOperationMetadata() throws Throwable {
+        Logger logger = (Logger) LoggerFactory.getLogger(
+                TaxonomyObservationConfiguration.TaxonomyObservationInterceptor.class);
+        Level previousLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        logger.setLevel(Level.DEBUG);
+        try {
+            var descriptor = new TaxonomyObservationConfiguration.TargetDescriptor(
+                    "taxonomy.test", "test-component", Set.of("work"));
+            var interceptor =
+                    new TaxonomyObservationConfiguration.TaxonomyObservationInterceptor(
+                            ObservationRegistry.NOOP, descriptor);
+
+            interceptor.invoke(new StubInvocation(false));
+            assertThrows(IllegalStateException.class,
+                    () -> interceptor.invoke(new StubInvocation(true)));
+
+            String logged = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .reduce("", (left, right) -> left + "\n" + right);
+            assertTrue(logged.contains(
+                    "component=test-component operation=work outcome=success"));
+            assertTrue(logged.contains(
+                    "component=test-component operation=work outcome=error"));
+            assertFalse(logged.contains("sensitive content"));
+        } finally {
+            logger.detachAppender(appender);
+            logger.setLevel(previousLevel);
+            appender.stop();
+        }
     }
 
     private static final class StubInvocation implements MethodInvocation {

--- a/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/observability/TaxonomyObservationConfigurationTest.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -44,6 +45,33 @@ class TaxonomyObservationConfigurationTest {
                 .tag("outcome", "success")
                 .timer();
         assertEquals(1, timer.count());
+    }
+
+    @Test
+    void resolvesRegistryWhenInfrastructureBecomesAvailableLater() throws Throwable {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry realRegistry = ObservationRegistry.create();
+        realRegistry.observationConfig().observationHandler(
+                new DefaultMeterObservationHandler(meterRegistry));
+        AtomicReference<ObservationRegistry> currentRegistry =
+                new AtomicReference<>(ObservationRegistry.NOOP);
+
+        var descriptor = new TaxonomyObservationConfiguration.TargetDescriptor(
+                "taxonomy.test", "test-component", Set.of("work"));
+        var interceptor = new TaxonomyObservationConfiguration.TaxonomyObservationInterceptor(
+                currentRegistry::get, descriptor);
+
+        interceptor.invoke(new StubInvocation(false));
+        currentRegistry.set(realRegistry);
+        interceptor.invoke(new StubInvocation(false));
+
+        Timer timer = meterRegistry.get("taxonomy.test")
+                .tag("taxonomy.component", "test-component")
+                .tag("taxonomy.operation", "work")
+                .tag("outcome", "success")
+                .timer();
+        assertEquals(1, timer.count(),
+                "only the invocation after the real registry appears should be metered");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds the next bounded slice of #483 on the current `main`: prove that an operator can correlate a safe Taxonomy domain log and domain metric with the same real request trace exported by the OpenTelemetry Java agent.

### Safe operation logging

- emit one DEBUG event at existing Micrometer Observation boundaries;
- include only the fixed component, method/operation and normalized `success`/`error` outcome;
- never include invocation arguments, return values, usernames, workspace/repository names, queries, prompts, responses, filenames or exception messages;
- keep logging disabled at the normal INFO level unless an operator enables DEBUG for `com.taxonomy.observability`.

### Live correlation and metric proof

The existing Testcontainers acceptance test now:

- enables the observability package logger only in the isolated test application;
- calls the authenticated `/api/relations` path;
- requires the existing Prometheus domain timer `taxonomy_workspace_resolve_seconds_count` with only `component=workspace`, `operation=resolveCurrentContext` and `outcome=success`;
- obtains the correlated HTTP and `WorkspaceContextResolver.resolveCurrentContext` trace ID from the Collector debug export;
- requires a safe application log line with that exact `trace_id` and a valid `span_id`;
- retains privacy, JVM/Prometheus and Collector fail-open assertions.

A focused unit test captures Logback events and proves both success/error metadata are present while the deliberately sensitive exception message is absent.

No second tracing SDK, logging exporter or telemetry backend is introduced. The optional profile continues to use the Java agent's `trace_id`/`span_id` MDC keys and Spring Boot's correlation pattern.

### Operations documentation

English and German observability guides now document:

- Taxonomy-owned Prometheus timer names and their fixed low-cardinality labels;
- explicit DEBUG activation without changing normal INFO logging;
- the bounded domain-operation message and same-trace correlation contract;
- the fields that must never become log or metric values.

## Verification

- unit tests for bounded observation tags and log content;
- focused `ObservabilityContainerIT` for metric, trace and log correlation;
- canonical Maven verification, Security Scan and CodeQL.

Refs #483.