### PR TITLE
Accept optimized JGit Core index contracts

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -466,18 +466,38 @@ public class JgitStorageSchemaMigrationConfig {
                 List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
-    private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
-        requireLegacyCoreIndexes(schema);
-        requireIndex(
+    /**
+     * Validate the actual managed lookup paths rather than redundant exact indexes.
+     *
+     * <p>Since Core 0.1.17 the unique pack identity index supplies the left prefixes
+     * {@code (repository_name)} and {@code (repository_name, pack_name)}, while the
+     * ordered reflog index extends {@code (repository_name, ref_name)} with the row id.
+     * Older released schemas remain valid because their exact indexes satisfy the same
+     * left-prefix contract.</p>
+     */
+    private static void requireManagedCoreIndexes(SchemaSnapshot schema) {
+        requireIndexPrefix(
                 "git_packs",
                 schema.packIndexes(),
-                false,
-                List.of("REPOSITORY_NAME", "COMMITTED"));
+                List.of("REPOSITORY_NAME", "PACK_NAME"));
         requireIndex(
                 "git_packs",
                 schema.packIndexes(),
                 true,
                 List.of("REPOSITORY_NAME", "PACK_NAME", "PACK_EXTENSION"));
+        requireIndex(
+                "git_packs",
+                schema.packIndexes(),
+                false,
+                List.of("REPOSITORY_NAME", "COMMITTED"));
+        requireIndexPrefix(
+                "git_reflog",
+                schema.reflogIndexes(),
+                List.of("REPOSITORY_NAME", "REF_NAME"));
+    }
+
+    private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
+        requireManagedCoreIndexes(schema);
     }
 
     private static void requireCurrentCoreIndexes(SchemaSnapshot schema) {
@@ -487,6 +507,22 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 false,
                 List.of("REPOSITORY_NAME", "COMMITTED", "WRITE_LEASE_UNTIL"));
+    }
+
+    private static void requireIndexPrefix(
+            String table,
+            Map<String, IndexSignature> indexes,
+            List<String> columns) {
+        boolean covered = indexes.values().stream()
+                .map(IndexSignature::columns)
+                .anyMatch(indexColumns -> indexColumns.size() >= columns.size()
+                        && indexColumns.subList(0, columns.size()).equals(columns));
+        if (covered) {
+            return;
+        }
+        throw unsafeSchema(
+                table + " is missing an index with leading columns " + columns
+                        + "; actual indexes=" + indexes);
     }
 
     private static void requireIndex(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
@@ -1,0 +1,85 @@
+package com.taxonomy.dsl.storage;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+import org.flywaydb.core.Flyway;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JgitStorageOptimizedIndexContractTest {
+
+    @Test
+    void acceptsReleasedOptimizedIndexesThroughLeadingKeyCoverage() throws Exception {
+        DataSource dataSource = dataSource("optimized");
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+        installOptimizedIndexShape(dataSource);
+
+        assertDoesNotThrow(() ->
+                JgitStorageSchemaMigrationConfig.migrateCoreSchema(
+                        flyway(dataSource), false));
+    }
+
+    @Test
+    void stillRejectsOptimizedSchemaWithoutPackIdentityAccessPath() throws Exception {
+        DataSource dataSource = dataSource("missing-pack-identity");
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+        installOptimizedIndexShape(dataSource);
+        execute(dataSource,
+                "alter table git_packs drop constraint uk_pack_repo_name_ext");
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(
+                        flyway(dataSource), false));
+
+        assertTrue(error.getMessage().contains(
+                "leading columns [REPOSITORY_NAME, PACK_NAME]"));
+    }
+
+    private static void installOptimizedIndexShape(DataSource dataSource)
+            throws SQLException {
+        execute(dataSource, "drop index idx_pack_repo");
+        execute(dataSource, "drop index idx_pack_repo_name");
+        execute(dataSource, "drop index idx_reflog_repo");
+        execute(dataSource, "drop index idx_reflog_repo_ref");
+        execute(dataSource, "create index idx_reflog_repo_ref_id "
+                + "on git_reflog (repository_name, ref_name, id desc)");
+    }
+
+    private static DataSource dataSource(String purpose) {
+        JDBCDataSource dataSource = new JDBCDataSource();
+        String databaseName = purpose + "_"
+                + UUID.randomUUID().toString().replace("-", "");
+        dataSource.setUrl("jdbc:hsqldb:mem:" + databaseName
+                + ";DB_CLOSE_DELAY=-1");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private static Flyway flyway(DataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+    }
+
+    private static void execute(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
@@ -55,7 +55,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
-        assertEquals(
+        assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -69,7 +69,7 @@ class JgitStorageSchemaMigrationConfigTest {
 
         assertTrue(tableExists(dataSource, "application_marker"));
         assertTrue(tableExists(dataSource, "git_packs"));
-        assertEquals(
+        assertVersionPrefix(
                 List.of("0", "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -135,7 +135,7 @@ class JgitStorageSchemaMigrationConfigTest {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
-        assertEquals(
+        assertVersionPrefix(
                 ADOPTED_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
@@ -177,7 +177,7 @@ class JgitStorageSchemaMigrationConfigTest {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
-        assertEquals(
+        assertVersionPrefix(
                 ADOPTED_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
@@ -206,7 +206,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertArrayEquals(
                 original,
                 packData(dataSource, "managed", "pack-existing", "pack"));
-        assertEquals(
+        assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -288,7 +288,7 @@ class JgitStorageSchemaMigrationConfigTest {
 
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
 
-        assertEquals(
+        assertVersionPrefix(
                 List.of("0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
@@ -476,6 +476,18 @@ class JgitStorageSchemaMigrationConfigTest {
             assertTrue(resultSet.next());
             return resultSet.getString(1);
         }
+    }
+
+    private static void assertVersionPrefix(
+            List<String> expectedPrefix, List<String> actual) {
+        assertTrue(
+                actual.size() >= expectedPrefix.size(),
+                () -> "Expected migration prefix " + expectedPrefix + " but found " + actual);
+        assertEquals(expectedPrefix, actual.subList(0, expectedPrefix.size()));
+        assertEquals(
+                actual.size(),
+                new HashSet<>(actual).size(),
+                "Successful Core migration versions must remain unique");
     }
 
     private static List<String> successfulVersions(


### PR DESCRIPTION
## Summary

Unblocks the current `jgit-storage-hibernate-core` 0.1.17 update without restoring the redundant indexes intentionally removed upstream.

### Verified incompatibility

Taxonomy's consumer-side schema preflight required exact standalone indexes on:

- `git_packs(repository_name)`;
- `git_packs(repository_name, pack_name)`;
- `git_reflog(repository_name)`;
- `git_reflog(repository_name, ref_name)`.

Core 0.1.17 removes those redundant indexes. Its unique pack identity index already covers the first two leading-key access paths, and its ordered reflog index extends `(repository_name, ref_name)` with `id DESC`. The canonical and database-compatibility runs for #510 therefore failed before the application context could start even though the released schema retained every required query path.

### Consumer contract fix

- keep the exact pre-library legacy-adoption contract unchanged;
- validate managed schemas by required leading-column coverage where later released indexes may add ordering/identity columns;
- continue requiring the unique pack identity index, committed scan, write-lease cleanup and reflog access path;
- fail closed when the pack identity path is actually removed;
- treat the ordinary Core Flyway stream as append-only: known safe history must remain the prefix and all successful versions must remain unique, while the separate legacy-adoption history stays exact.

### Regression coverage

A focused HSQLDB test installs the current released schema, converts it to the 0.1.17 optimized index shape and proves restart succeeds. A second case removes the unique pack identity constraint and proves startup is still rejected. Existing fresh/shared/adopted/unversioned migration tests retain their known-version assertions while allowing later published Core migrations to append.

This PR changes no Flyway SQL and creates no compatibility indexes at runtime.

## Verification

- `JgitStorageSchemaMigrationConfigTest` and `JgitStorageOptimizedIndexContractTest`;
- canonical Maven verification, Database Compatibility, Security Scan and CodeQL.

Unblocks #510.