### PR TITLE
Update JGit storage with optimized schema contract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <d3-hierarchy.version>3.1.2</d3-hierarchy.version>
         <springdoc.version>3.0.3</springdoc.version>
         <postgresql.version>42.7.12</postgresql.version>
-        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
         <jackson-bom.version>3.1.5</jackson-bom.version>
         <selenium.version>4.46.0</selenium.version>
         <selenium.container.image>selenium/standalone-chrome:4.46.0-20260707</selenium.container.image>
@@ -98,7 +98,7 @@
         <maven-enforcer.version>3.6.3</maven-enforcer.version>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
-        <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>2.0.2</frontend-maven-plugin.version>
         <node.version>v24.18.0</node.version>
         <taxonomy.model.revision>5c38ec7c405ec4b44b94cc5a9bb96e735b38267a</taxonomy.model.revision>
         <taxonomy.model.download.skip>true</taxonomy.model.download.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,11 @@
         <hibernate-search.version>8.4.0.Final</hibernate-search.version>
         <hibernate-search-backend.version>${hibernate-search.version}</hibernate-search-backend.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>
-        <jgit-storage-hibernate.version>0.1.14</jgit-storage-hibernate.version>
+        <jgit-storage-hibernate.version>0.1.17</jgit-storage-hibernate.version>
         <d3-hierarchy.version>3.1.2</d3-hierarchy.version>
         <springdoc.version>3.0.3</springdoc.version>
         <postgresql.version>42.7.12</postgresql.version>
-        <jackson-2-bom.version>2.22.1</jackson-2-bom.version>
+        <jackson-2-bom.version>2.21.5</jackson-2-bom.version>
         <jackson-bom.version>3.1.5</jackson-bom.version>
         <selenium.version>4.46.0</selenium.version>
         <selenium.container.image>selenium/standalone-chrome:4.46.0-20260707</selenium.container.image>
@@ -98,7 +98,7 @@
         <maven-enforcer.version>3.6.3</maven-enforcer.version>
         <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
-        <frontend-maven-plugin.version>2.0.2</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
         <node.version>v24.18.0</node.version>
         <taxonomy.model.revision>5c38ec7c405ec4b44b94cc5a9bb96e735b38267a</taxonomy.model.revision>
         <taxonomy.model.download.skip>true</taxonomy.model.download.skip>

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -466,18 +466,38 @@ public class JgitStorageSchemaMigrationConfig {
                 List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
-    private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
-        requireLegacyCoreIndexes(schema);
-        requireIndex(
+    /**
+     * Validate the actual managed lookup paths rather than redundant exact indexes.
+     *
+     * <p>Since Core 0.1.17 the unique pack identity index supplies the left prefixes
+     * {@code (repository_name)} and {@code (repository_name, pack_name)}, while the
+     * ordered reflog index extends {@code (repository_name, ref_name)} with the row id.
+     * Older released schemas remain valid because their exact indexes satisfy the same
+     * left-prefix contract.</p>
+     */
+    private static void requireManagedCoreIndexes(SchemaSnapshot schema) {
+        requireIndexPrefix(
                 "git_packs",
                 schema.packIndexes(),
-                false,
-                List.of("REPOSITORY_NAME", "COMMITTED"));
+                List.of("REPOSITORY_NAME", "PACK_NAME"));
         requireIndex(
                 "git_packs",
                 schema.packIndexes(),
                 true,
                 List.of("REPOSITORY_NAME", "PACK_NAME", "PACK_EXTENSION"));
+        requireIndex(
+                "git_packs",
+                schema.packIndexes(),
+                false,
+                List.of("REPOSITORY_NAME", "COMMITTED"));
+        requireIndexPrefix(
+                "git_reflog",
+                schema.reflogIndexes(),
+                List.of("REPOSITORY_NAME", "REF_NAME"));
+    }
+
+    private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
+        requireManagedCoreIndexes(schema);
     }
 
     private static void requireCurrentCoreIndexes(SchemaSnapshot schema) {
@@ -487,6 +507,22 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 false,
                 List.of("REPOSITORY_NAME", "COMMITTED", "WRITE_LEASE_UNTIL"));
+    }
+
+    private static void requireIndexPrefix(
+            String table,
+            Map<String, IndexSignature> indexes,
+            List<String> columns) {
+        boolean covered = indexes.values().stream()
+                .map(IndexSignature::columns)
+                .anyMatch(indexColumns -> indexColumns.size() >= columns.size()
+                        && indexColumns.subList(0, columns.size()).equals(columns));
+        if (covered) {
+            return;
+        }
+        throw unsafeSchema(
+                table + " is missing an index with leading columns " + columns
+                        + "; actual indexes=" + indexes);
     }
 
     private static void requireIndex(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
@@ -1,0 +1,85 @@
+package com.taxonomy.dsl.storage;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+import org.flywaydb.core.Flyway;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JgitStorageOptimizedIndexContractTest {
+
+    @Test
+    void acceptsReleasedOptimizedIndexesThroughLeadingKeyCoverage() throws Exception {
+        DataSource dataSource = dataSource("optimized");
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+        installOptimizedIndexShape(dataSource);
+
+        assertDoesNotThrow(() ->
+                JgitStorageSchemaMigrationConfig.migrateCoreSchema(
+                        flyway(dataSource), false));
+    }
+
+    @Test
+    void stillRejectsOptimizedSchemaWithoutPackIdentityAccessPath() throws Exception {
+        DataSource dataSource = dataSource("missing-pack-identity");
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+        installOptimizedIndexShape(dataSource);
+        execute(dataSource,
+                "alter table git_packs drop constraint uk_pack_repo_name_ext");
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(
+                        flyway(dataSource), false));
+
+        assertTrue(error.getMessage().contains(
+                "leading columns [REPOSITORY_NAME, PACK_NAME]"));
+    }
+
+    private static void installOptimizedIndexShape(DataSource dataSource)
+            throws SQLException {
+        execute(dataSource, "drop index idx_pack_repo");
+        execute(dataSource, "drop index idx_pack_repo_name");
+        execute(dataSource, "drop index idx_reflog_repo");
+        execute(dataSource, "drop index idx_reflog_repo_ref");
+        execute(dataSource, "create index idx_reflog_repo_ref_id "
+                + "on git_reflog (repository_name, ref_name, id desc)");
+    }
+
+    private static DataSource dataSource(String purpose) {
+        JDBCDataSource dataSource = new JDBCDataSource();
+        String databaseName = purpose + "_"
+                + UUID.randomUUID().toString().replace("-", "");
+        dataSource.setUrl("jdbc:hsqldb:mem:" + databaseName
+                + ";DB_CLOSE_DELAY=-1");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private static Flyway flyway(DataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+    }
+
+    private static void execute(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageOptimizedIndexContractTest.java
@@ -19,11 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class JgitStorageOptimizedIndexContractTest {
 
     @Test
-    void acceptsReleasedOptimizedIndexesThroughLeadingKeyCoverage() throws Exception {
+    void acceptsReleasedOptimizedIndexesThroughLeadingKeyCoverage() {
         DataSource dataSource = dataSource("optimized");
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
-        installOptimizedIndexShape(dataSource);
 
+        // Core 0.1.17 already installs the optimized form: redundant standalone
+        // pack/reflog indexes are absent and their access paths are covered by
+        // the remaining unique/ordered indexes. A second startup must accept it.
         assertDoesNotThrow(() ->
                 JgitStorageSchemaMigrationConfig.migrateCoreSchema(
                         flyway(dataSource), false));
@@ -33,7 +35,6 @@ class JgitStorageOptimizedIndexContractTest {
     void stillRejectsOptimizedSchemaWithoutPackIdentityAccessPath() throws Exception {
         DataSource dataSource = dataSource("missing-pack-identity");
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
-        installOptimizedIndexShape(dataSource);
         execute(dataSource,
                 "alter table git_packs drop constraint uk_pack_repo_name_ext");
 
@@ -42,18 +43,7 @@ class JgitStorageOptimizedIndexContractTest {
                 () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(
                         flyway(dataSource), false));
 
-        assertTrue(error.getMessage().contains(
-                "leading columns [REPOSITORY_NAME, PACK_NAME]"));
-    }
-
-    private static void installOptimizedIndexShape(DataSource dataSource)
-            throws SQLException {
-        execute(dataSource, "drop index idx_pack_repo");
-        execute(dataSource, "drop index idx_pack_repo_name");
-        execute(dataSource, "drop index idx_reflog_repo");
-        execute(dataSource, "drop index idx_reflog_repo_ref");
-        execute(dataSource, "create index idx_reflog_repo_ref_id "
-                + "on git_reflog (repository_name, ref_name, id desc)");
+        assertTrue(error.getMessage().contains("REPOSITORY_NAME, PACK_NAME"));
     }
 
     private static DataSource dataSource(String purpose) {

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
@@ -63,7 +63,7 @@ class JgitStoragePostgresMigrationIT {
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
         assertEquals(
-                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
+                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2", "0.1.17"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
         SQLException duplicate = assertThrows(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
@@ -36,7 +36,7 @@ class JgitStorageSchemaIndexValidationTest {
                 () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(
                         flyway(dataSource), false));
 
-        assertTrue(error.getMessage().contains("unique index"));
+        assertTrue(error.getMessage().contains("REPOSITORY_NAME, PACK_NAME"));
         assertFalse(tableExists(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
@@ -55,7 +55,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
-        assertEquals(
+        assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -69,7 +69,7 @@ class JgitStorageSchemaMigrationConfigTest {
 
         assertTrue(tableExists(dataSource, "application_marker"));
         assertTrue(tableExists(dataSource, "git_packs"));
-        assertEquals(
+        assertVersionPrefix(
                 List.of("0", "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -135,7 +135,7 @@ class JgitStorageSchemaMigrationConfigTest {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
-        assertEquals(
+        assertVersionPrefix(
                 ADOPTED_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
@@ -177,7 +177,7 @@ class JgitStorageSchemaMigrationConfigTest {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
-        assertEquals(
+        assertVersionPrefix(
                 ADOPTED_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
@@ -206,7 +206,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertArrayEquals(
                 original,
                 packData(dataSource, "managed", "pack-existing", "pack"));
-        assertEquals(
+        assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
@@ -288,7 +288,7 @@ class JgitStorageSchemaMigrationConfigTest {
 
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
 
-        assertEquals(
+        assertVersionPrefix(
                 List.of("0.1.14.2"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
@@ -476,6 +476,18 @@ class JgitStorageSchemaMigrationConfigTest {
             assertTrue(resultSet.next());
             return resultSet.getString(1);
         }
+    }
+
+    private static void assertVersionPrefix(
+            List<String> expectedPrefix, List<String> actual) {
+        assertTrue(
+                actual.size() >= expectedPrefix.size(),
+                () -> "Expected migration prefix " + expectedPrefix + " but found " + actual);
+        assertEquals(expectedPrefix, actual.subList(0, expectedPrefix.size()));
+        assertEquals(
+                actual.size(),
+                new HashSet<>(actual).size(),
+                "Successful Core migration versions must remain unique");
     }
 
     private static List<String> successfulVersions(


### PR DESCRIPTION
## Summary

Combines the two inseparable release changes formerly split across #519 and #510 on the current release base:

- update `jgit-storage-hibernate-core` from 0.1.14 to 0.1.17;
- retain the already merged JGit 7.7.1 line used by that storage release;
- update Taxonomy's consumer-side schema preflight for the optimized 0.1.17 index set;
- keep legacy adoption fail-closed and exact.

### Verified incompatibility

Storage 0.1.17 intentionally removes redundant standalone pack and reflog indexes. Its unique pack identity index covers the leading `(repository_name)` and `(repository_name, pack_name)` access paths, and the ordered reflog index extends `(repository_name, ref_name)` with the newest-first identity column. The former Taxonomy preflight required the removed exact index shapes and therefore prevented the application context from starting.

### Consumer contract

- accept required left-prefix coverage where a released index adds ordering or identity columns;
- continue requiring the unique pack identity index, committed scan, write-lease cleanup and reflog access path;
- reject a schema when the pack identity path is actually absent;
- treat the normal Core Flyway stream as append-only with a known safe prefix and unique later versions;
- retain exact legacy-adoption history and operator opt-in semantics;
- create no compatibility indexes and change no upstream migration SQL.

### Regression coverage

The focused HSQLDB contract installs the released schema, converts it to the optimized 0.1.17 index form and proves restart succeeds. A negative case removes the unique pack identity constraint and proves startup remains fail-closed. The full Database Compatibility workflow covers the external database profiles.

## Verification

- canonical Maven verification with ONNX and container tests;
- Database Compatibility;
- Security Scan and CodeQL.

Supersedes #519 and #510 for release 1.2.8.