### PR TITLE
Generate and expose release-specific license evidence

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -172,9 +172,10 @@ Generate and verify the runtime licence report together with the application:
 ```
 
 The report is packaged as `THIRD-PARTY-RUNTIME.txt`. A missing runtime licence
-causes the Maven build to fail. Verified metadata exceptions belong in
-`src/license/THIRD-PARTY.properties` and must cite the canonical upstream
-licence during review.
+causes the Maven build to fail. Verified metadata overrides belong in
+`taxonomy-app/src/license/override-THIRD-PARTY.properties`. The build reads this
+file but never generates or deletes it. Every override must cite the canonical
+upstream licence in its reviewing pull request.
 
 Generate the CycloneDX SBOM through the normal Maven lifecycle:
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,236 +1,199 @@
 # Third-Party Notices
 
-Taxonomy Architecture Analyzer incorporates components from the following third-party projects.
+Taxonomy Architecture Analyzer incorporates third-party software. This document
+contains the curated notices that cannot be derived reliably from the Maven
+runtime graph alone, especially browser assets, optional containers, AI models
+and special distribution terms.
 
-> **SBOM:** A machine-readable Software Bill of Materials (CycloneDX format) is generated
-> at build time via `mvn package`. The SBOM files are located at
-> `target/taxonomy-sbom.json` and `target/taxonomy-sbom.xml`.
->
-> The optional OpenTelemetry Java agent is copied into the container image rather
-> than added as a Maven runtime dependency. The optional Collector and Jaeger run
-> as separate containers. Include all three in container-level SBOM generation and
-> vulnerability scanning in addition to the Maven SBOM.
+## Authoritative evidence for a concrete build
+
+The About dialog and `/api/about` expose four complementary artefacts:
+
+1. **`LICENSE`** — the MIT license of Taxonomy itself.
+2. **`NOTICE`** — product-level attribution notices that must accompany the
+   distribution.
+3. **`THIRD-PARTY-RUNTIME.txt`** — generated from the packaged Maven runtime
+   dependency graph during `generate-resources`. The build fails when a runtime
+   dependency has no usable license metadata and no repository-reviewed
+   override.
+4. **CycloneDX SBOM (`taxonomy-sbom.json` and `taxonomy-sbom.xml`)** — exact
+   component names, versions, package URLs, checksums and dependency relations
+   for the build.
+
+The generated runtime report and SBOM are authoritative for the versions in a
+specific artefact. This checked-in document provides context and notices; it is
+not a manually maintained replacement for the generated inventory.
+
+The optional OpenTelemetry Java agent is copied into the container image rather
+than added as a Maven runtime dependency. The optional Collector and Jaeger run
+as separate containers. A container-level SBOM and vulnerability/license scan
+must therefore cover those images and the Java runtime base image in addition
+to the Maven SBOM.
 
 ---
 
-## License Summary
+## License overview
 
-| License | Components | Government Use |
+| License or terms | Representative components | Distribution note |
 |---|---|---|
-| Apache License 2.0 | Spring Boot, Apache POI, Apache PDFBox, Lucene, Hibernate, springdoc, DJL, Micrometer, OpenTelemetry, Jaeger, JaCoCo | ✅ Permissive, no restrictions |
-| MIT License | Bootstrap, jsPDF, svg2pdf.js, ONNX Runtime, CodeMirror | ✅ Permissive, no restrictions |
-| ISC License | D3.js | ✅ Permissive, no restrictions |
-| BSD Licenses | HSQLDB, PostgreSQL JDBC, XStream, Flexmark-java | ✅ Permissive, no restrictions |
-| Eclipse Distribution License 1.0 | JGit | ✅ BSD-style, no restrictions |
-| Eclipse Public License 2.0 | JUnit, JaCoCo | ✅ Test-only; not included in runtime |
-| Oracle FUTC | Oracle JDBC Driver | ⚠️ Dev/test only; production requires Oracle license |
-| Microsoft MSSQL JDBC | Microsoft JDBC Driver | ⚠️ Check terms for government use |
+| Apache License 2.0 | Spring Boot, Apache POI, Apache PDFBox, Lucene, Hibernate, springdoc, DJL, Micrometer, OpenTelemetry | Permissive; preserve required notices and license text |
+| MIT License | Taxonomy, Bootstrap, jsPDF, svg2pdf.js, ONNX Runtime, CodeMirror, Microsoft JDBC Driver | Permissive; preserve copyright and permission notice |
+| ISC License | D3.js | Permissive; preserve copyright, permission and disclaimer text |
+| BSD 2-Clause / BSD 3-Clause | HSQLDB, PostgreSQL JDBC, XStream, Flexmark-java | Permissive; preserve copyright, conditions and disclaimers |
+| Eclipse Distribution License 1.0 | JGit | BSD-style terms; preserve the required license material |
+| Eclipse Public License 2.0 | JUnit and JaCoCo | Build/test tooling; not part of the application runtime report |
+| Oracle Free Use Terms and Conditions (FUTC) | Oracle JDBC Driver (`ojdbc11`) | Runtime driver distributed under FUTC; preserve Oracle terms and notices |
 
-**All runtime dependencies use permissive open-source licenses** (Apache 2.0, MIT, BSD, ISC, EDL 1.0) that are compatible with government procurement requirements. No copyleft (GPL/LGPL) dependencies are included in the runtime classpath.
+Do not infer licence compliance from this summary alone. The generated report is
+the release-specific source of truth and the applicable upstream terms remain
+controlling.
 
 ---
 
-## Apache License 2.0
+## Apache License 2.0 components
 
 Full license text: https://www.apache.org/licenses/LICENSE-2.0
 
-### Spring Boot / Spring Framework
-Copyright © Pivotal Software, Inc. / VMware, Inc.
-https://spring.io/
+Representative projects include:
 
-### Apache POI
-Copyright © The Apache Software Foundation
-https://poi.apache.org/
+- Spring Boot, Spring Framework and Spring Security — https://spring.io/
+- Apache POI — https://poi.apache.org/
+- Apache PDFBox — https://pdfbox.apache.org/
+- Apache Lucene — https://lucene.apache.org/
+- Hibernate ORM and Hibernate Search — https://hibernate.org/
+- springdoc-openapi — https://springdoc.org/
+- Deep Java Library (DJL) — https://djl.ai/
+- Micrometer — https://micrometer.io/
+- OpenTelemetry Java instrumentation and Collector — https://opentelemetry.io/
+- Jaeger — https://www.jaegertracing.io/
 
-### Apache PDFBox
-Copyright © The Apache Software Foundation
-https://pdfbox.apache.org/
+The OpenTelemetry Java agent is present only in the container distribution and
+is disabled by default. Collector and Jaeger are optional deployment services,
+not Taxonomy application-classpath dependencies.
 
-### Apache Lucene
-Copyright © The Apache Software Foundation
-https://lucene.apache.org/
-
-### Hibernate ORM / Hibernate Search
-Copyright © Red Hat, Inc.
-https://hibernate.org/
-
-### springdoc-openapi
-Copyright © springdoc
-https://springdoc.org/
-
-### DJL (Deep Java Library)
-Copyright © Amazon.com, Inc. or its affiliates
-https://djl.ai/
-
-### Micrometer
-Copyright © VMware, Inc.
-https://micrometer.io/
-
-### OpenTelemetry Java instrumentation and Collector
-Copyright © OpenTelemetry Authors
-https://opentelemetry.io/
-
-> **Note:** The Java agent is present in the container image but disabled by
-> default. The Collector is used only by the optional observability deployment.
-
-### Jaeger
-Copyright © The Jaeger Authors
-https://www.jaegertracing.io/
-
-> **Note:** Jaeger is an optional trace backend and is not included in the
-> Taxonomy application runtime classpath.
-
-### Spring Security
-Copyright © Pivotal Software, Inc. / VMware, Inc.
-https://spring.io/projects/spring-security
-
-### Testcontainers
-Copyright © Testcontainers Contributors
-https://testcontainers.com/
+Testcontainers is Apache-2.0-licensed test infrastructure and is excluded from
+the generated runtime report.
 
 ---
 
-## MIT License
+## MIT-licensed components
 
 Full license text: https://opensource.org/licenses/MIT
 
-### Bootstrap 5.3
-Copyright © The Bootstrap Authors
-https://getbootstrap.com/
+Representative projects include:
 
-### jsPDF
-Copyright © James Hall, yWorks GmbH
-https://github.com/parallax/jsPDF
+- Bootstrap — https://getbootstrap.com/
+- jsPDF — https://github.com/parallax/jsPDF
+- svg2pdf.js — https://github.com/yWorks/svg2pdf.js
+- ONNX Runtime — https://onnxruntime.ai/
+- CodeMirror — https://codemirror.net/
+- Microsoft JDBC Driver for SQL Server — https://github.com/microsoft/mssql-jdbc
 
-### svg2pdf.js
-Copyright © yWorks GmbH
-https://github.com/yWorks/svg2pdf.js
-
-### ONNX Runtime
-Copyright © Microsoft Corporation
-https://onnxruntime.ai/
-
-### CodeMirror 6
-Copyright © Marijn Haverbeke
-https://codemirror.net/
+The Microsoft JDBC driver is an MIT-licensed runtime dependency. Licensing of a
+Microsoft SQL Server installation or hosted service is a separate operator
+responsibility and is not determined by the driver license.
 
 ---
 
-## ISC License
+## ISC and BSD components
 
-Full license text: https://opensource.org/licenses/ISC
+ISC license text: https://opensource.org/licenses/ISC
 
-### D3.js
-Copyright © Mike Bostock
-https://d3js.org/
+- D3.js — https://d3js.org/
 
----
+BSD 2-Clause license text: https://opensource.org/licenses/BSD-2-Clause
 
-## BSD Licenses
+- PostgreSQL JDBC Driver — https://jdbc.postgresql.org/
+- Flexmark-java — https://github.com/vsch/flexmark-java
 
-### HSQLDB (BSD-style)
-Copyright © The HSQL Development Group
-https://hsqldb.org/
+BSD 3-Clause license text: https://opensource.org/licenses/BSD-3-Clause
 
-### PostgreSQL JDBC Driver (BSD 2-Clause)
-Copyright © PostgreSQL Global Development Group
-https://jdbc.postgresql.org/
+- XStream — https://x-stream.github.io/
 
-Full license text: https://opensource.org/licenses/BSD-2-Clause
-
-### XStream (BSD 3-Clause)
-Copyright © Joe Walnes and XStream Committers
-https://x-stream.github.io/
-
-Full license text: https://opensource.org/licenses/BSD-3-Clause
-
-### Flexmark-java (BSD 2-Clause)
-Copyright © Vladimir Schneider
-https://github.com/vsch/flexmark-java
-
-Full license text: https://opensource.org/licenses/BSD-2-Clause
+HSQLDB uses its BSD-style license. See https://hsqldb.org/ and the exact entry in
+`THIRD-PARTY-RUNTIME.txt` for the packaged version.
 
 ---
 
-## Eclipse Distribution License 1.0 (BSD-style)
+## Eclipse licenses
 
-Full license text: https://www.eclipse.org/org/documents/edl-v10.php
+Eclipse Distribution License 1.0:
+https://www.eclipse.org/org/documents/edl-v10.php
 
-### JGit
-Copyright © Eclipse Foundation
-https://www.eclipse.org/jgit/
+- JGit — https://www.eclipse.org/jgit/
 
----
+Eclipse Public License 2.0:
+https://www.eclipse.org/legal/epl-2.0/
 
-## Eclipse Public License 2.0 (Test-Only)
-
-Full license text: https://www.eclipse.org/legal/epl-2.0/
-
-### JUnit 5
-Copyright © Eclipse Foundation
-https://junit.org/junit5/
-
-> **Note:** JUnit is used only for testing and is not included in the runtime distribution.
-
-### JaCoCo
-Copyright © Mountainminds GmbH & Co. KG and Contributors
-https://www.jacoco.org/
-
-> **Note:** JaCoCo is used only for code coverage analysis and is not included in the runtime distribution.
+- JUnit 5 — test only; not included in the application runtime distribution
+- JaCoCo — build-time coverage tooling; not included in the application runtime
+  distribution
 
 ---
 
-## Other Licenses
+## Oracle JDBC Driver
 
-### Oracle JDBC Driver (ojdbc)
-Oracle Free Use Terms and Conditions (FUTC)
+`com.oracle.database.jdbc:ojdbc11` is a packaged runtime dependency. Its Maven
+metadata declares the **Oracle Free Use Terms and Conditions (FUTC)**:
+
 https://www.oracle.com/downloads/licenses/oracle-free-license.html
-Use is permitted for development, testing, prototyping, and demonstrations.
 
-> **Note:** For production use with Oracle databases, ensure a valid Oracle database license is in place.
+The FUTC governs use and redistribution of the unmodified JDBC driver and
+requires preservation of Oracle notices and the applicable terms. It must not
+be described as a development/test-only dependency.
 
-### Microsoft JDBC Driver for SQL Server
-MIT License
-https://github.com/microsoft/mssql-jdbc
-
----
-
-## AI Model Licenses
-
-### BAAI/bge-small-en-v1.5 (Local Embedding Model)
-MIT License
-Copyright © Beijing Academy of Artificial Intelligence (BAAI)
-https://huggingface.co/BAAI/bge-small-en-v1.5
-
-> **Note:** The embedding model is downloaded on first use. For air-gapped deployments, pre-download via `TAXONOMY_EMBEDDING_MODEL_DIR`.
+The driver licence does **not** grant a licence for an Oracle Database server.
+Operators remain responsible for the separate licence or service terms of the
+Oracle Database instance to which Taxonomy connects.
 
 ---
 
-## Generating the SBOM
+## AI model licence
 
-A CycloneDX Software Bill of Materials is generated during the Maven build:
+### BAAI/bge-small-en-v1.5
+
+- License: MIT
+- Copyright: Beijing Academy of Artificial Intelligence (BAAI)
+- Model page: https://huggingface.co/BAAI/bge-small-en-v1.5
+
+The model is not a Maven dependency. Taxonomy pins a reviewed model revision and
+can use either a pre-provisioned local directory or the controlled model-download
+step. Container and air-gapped distributions that include the model must retain
+its licence and attribution and include it in container-level inventory.
+
+---
+
+## Build and audit commands
+
+Generate and verify the runtime licence report together with the application:
 
 ```bash
-mvn package
+./mvnw clean verify
 ```
 
-Output files:
-- `target/taxonomy-sbom.json` — JSON format (machine-readable)
-- `target/taxonomy-sbom.xml` — XML format (CycloneDX standard)
+The report is packaged as `THIRD-PARTY-RUNTIME.txt`. A missing runtime licence
+causes the Maven build to fail. Verified metadata exceptions belong in
+`src/license/THIRD-PARTY.properties` and must cite the canonical upstream
+licence during review.
 
-The Maven SBOM includes:
-- All direct and transitive Maven dependencies
-- Package names, versions, and checksums
-- License information per dependency
-- Dependency tree structure
+Generate the CycloneDX SBOM through the normal Maven lifecycle:
 
-Additionally generate or inspect a container-level SBOM for:
-- the Java runtime base image;
+```bash
+./mvnw package
+```
+
+Outputs:
+
+- `target/taxonomy-sbom.json`
+- `target/taxonomy-sbom.xml`
+
+The Maven SBOM covers direct and transitive Maven components. Additionally
+inspect a container-level SBOM for:
+
+- the Java runtime base image and operating-system packages;
 - the bundled OpenTelemetry Java agent;
-- the optional OpenTelemetry Collector image;
-- the optional Jaeger image.
+- optional OpenTelemetry Collector and Jaeger images;
+- a bundled local embedding model.
 
-Use the SBOMs for:
-- **BSI IT-Grundschutz** software supply chain requirements
-- **Vulnerability scanning** (import into tools like Dependency-Track)
-- **License compliance** audits for government procurement
+Use the generated artefacts for vulnerability scanning, Dependency-Track or an
+equivalent inventory system, procurement evidence and release review.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -165,10 +165,11 @@ its licence and attribution and include it in container-level inventory.
 
 ## Build and audit commands
 
-Generate and verify the runtime licence report together with the application:
+Generate and verify the runtime licence report together with the complete
+release-grade application test suite:
 
 ```bash
-./mvnw clean verify
+./mvnw -B clean verify -Pci
 ```
 
 The report is packaged as `THIRD-PARTY-RUNTIME.txt`. A missing runtime licence

--- a/src/license/THIRD-PARTY.properties
+++ b/src/license/THIRD-PARTY.properties
@@ -1,0 +1,8 @@
+# Repository-owned license metadata overrides for packaged runtime dependencies.
+#
+# The Maven license gate writes missing entries here using this key format:
+# groupId--artifactId--version=Canonical license name
+#
+# Keep this file limited to dependencies whose published Maven POM does not
+# declare usable license metadata. Every entry must be verified against the
+# upstream project's canonical license before it is committed.

--- a/src/license/THIRD-PARTY.properties
+++ b/src/license/THIRD-PARTY.properties
@@ -1,8 +1,9 @@
 # Repository-owned license metadata overrides for packaged runtime dependencies.
 #
-# The Maven license gate writes missing entries here using this key format:
+# Key format:
 # groupId--artifactId--version=Canonical license name
 #
-# Keep this file limited to dependencies whose published Maven POM does not
-# declare usable license metadata. Every entry must be verified against the
-# upstream project's canonical license before it is committed.
+# The Maven build reads this file as an override database and never generates or
+# deletes it. Add an entry only when the published dependency POM has no usable
+# license metadata, after verifying the canonical upstream license and recording
+# that evidence in the reviewing pull request.

--- a/src/license/THIRD-PARTY.properties
+++ b/src/license/THIRD-PARTY.properties
@@ -1,9 +1,0 @@
-# Repository-owned license metadata overrides for packaged runtime dependencies.
-#
-# Key format:
-# groupId--artifactId--version=Canonical license name
-#
-# The Maven build reads this file as an override database and never generates or
-# deletes it. Add an entry only when the published dependency POM has no usable
-# license metadata, after verifying the canonical upstream license and recording
-# that evidence in the reviewing pull request.

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -324,6 +324,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.7.1</version>
+                <executions>
+                    <execution>
+                        <id>generate-runtime-third-party-report</id>
+                        <phase>generate-resources</phase>
+                        <goals><goal>add-third-party</goal></goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-resources/runtime-licenses</outputDirectory>
+                            <thirdPartyFilename>THIRD-PARTY-RUNTIME.txt</thirdPartyFilename>
+                            <addOutputDirectoryAsResourceDir>true</addOutputDirectoryAsResourceDir>
+                            <includedScopes>compile,runtime</includedScopes>
+                            <excludedGroups>com\.taxonomy</excludedGroups>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <includeOptional>true</includeOptional>
+                            <useMissingFile>true</useMissingFile>
+                            <missingFile>${maven.multiModuleProjectDirectory}/src/license/THIRD-PARTY.properties</missingFile>
+                            <useRepositoryMissingFiles>false</useRepositoryMissingFiles>
+                            <deployMissingFile>false</deployMissingFile>
+                            <failOnMissing>true</failOnMissing>
+                            <force>true</force>
+                            <sortArtifactByName>true</sortArtifactByName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
@@ -392,6 +420,14 @@
                                         <include>NOTICE</include>
                                         <include>THIRD-PARTY-NOTICES.md</include>
                                         <include>LICENSE</include>
+                                    </includes>
+                                </resource>
+                                <resource>
+                                    <directory>${maven.multiModuleProjectDirectory}/target</directory>
+                                    <filtering>false</filtering>
+                                    <includes>
+                                        <include>taxonomy-sbom.json</include>
+                                        <include>taxonomy-sbom.xml</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -342,7 +342,6 @@
                             <includeOptional>true</includeOptional>
                             <useMissingFile>true</useMissingFile>
                             <missingFile>${project.build.directory}/missing-runtime-licenses.properties</missingFile>
-                            <overrideFile>${maven.multiModuleProjectDirectory}/src/license/THIRD-PARTY.properties</overrideFile>
                             <useRepositoryMissingFiles>false</useRepositoryMissingFiles>
                             <deployMissingFile>false</deployMissingFile>
                             <failOnMissing>true</failOnMissing>

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -341,7 +341,8 @@
                             <includeTransitiveDependencies>true</includeTransitiveDependencies>
                             <includeOptional>true</includeOptional>
                             <useMissingFile>true</useMissingFile>
-                            <missingFile>${maven.multiModuleProjectDirectory}/src/license/THIRD-PARTY.properties</missingFile>
+                            <missingFile>${project.build.directory}/missing-runtime-licenses.properties</missingFile>
+                            <overrideFile>${maven.multiModuleProjectDirectory}/src/license/THIRD-PARTY.properties</overrideFile>
                             <useRepositoryMissingFiles>false</useRepositoryMissingFiles>
                             <deployMissingFile>false</deployMissingFile>
                             <failOnMissing>true</failOnMissing>

--- a/taxonomy-app/src/license/override-THIRD-PARTY.properties
+++ b/taxonomy-app/src/license/override-THIRD-PARTY.properties
@@ -1,0 +1,9 @@
+# Repository-owned license metadata overrides for packaged runtime dependencies.
+#
+# Key format:
+# groupId--artifactId--version=Canonical license name
+#
+# license-maven-plugin reads this conventional file as an override database and
+# never generates or deletes it. Add an entry only when the published dependency
+# POM has no usable license metadata, after verifying the canonical upstream
+# license and recording that evidence in the reviewing pull request.

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/controller/AboutController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/controller/AboutController.java
@@ -21,7 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * REST API for application version, build info, license, and third-party notices.
+ * REST API for application version, build info, licenses, notices and SBOMs.
  */
 @RestController
 @RequestMapping("/api/about")
@@ -29,6 +29,8 @@ import java.util.Map;
 public class AboutController {
 
     private static final Logger log = LoggerFactory.getLogger(AboutController.class);
+    private static final MediaType MARKDOWN = MediaType.parseMediaType("text/markdown;charset=UTF-8");
+    private static final MediaType UTF8_TEXT = MediaType.parseMediaType("text/plain;charset=UTF-8");
 
     private final BuildProperties buildProperties;
     private final GitProperties gitProperties;
@@ -45,7 +47,7 @@ public class AboutController {
     }
 
     @GetMapping
-    @Operation(summary = "Application info", description = "Returns version, build time, git commit, license, and copyright information.")
+    @Operation(summary = "Application info", description = "Returns version, build, source and packaged legal-resource information.")
     public ResponseEntity<Map<String, Object>> about() {
         Map<String, Object> info = new LinkedHashMap<>();
         info.put("product", "Taxonomy Architecture Analyzer");
@@ -58,26 +60,64 @@ public class AboutController {
         info.put("copyright", "Copyright 2026 Carsten Hammer");
         info.put("sourceUrl", "https://github.com/carstenartur/Taxonomy");
         info.put("apiDocsUrl", "/swagger-ui.html");
-        info.put("thirdPartyNoticesUrl", "/THIRD-PARTY-NOTICES.md");
+        info.put("projectLicenseUrl", "/api/about/license");
+        info.put("noticeUrl", "/api/about/notice");
+        info.put("thirdPartyNoticesUrl", "/api/about/third-party");
+        info.put("runtimeThirdPartyLicensesUrl", "/api/about/runtime-licenses");
+        info.put("sbomJsonUrl", "/api/about/sbom.json");
+        info.put("sbomXmlUrl", "/api/about/sbom.xml");
         return ResponseEntity.ok(info);
     }
 
+    @GetMapping("/license")
+    @Operation(summary = "Project license", description = "Returns the packaged Taxonomy MIT license.")
+    public ResponseEntity<String> license() {
+        return classpathText("static/LICENSE", UTF8_TEXT);
+    }
+
+    @GetMapping("/notice")
+    @Operation(summary = "Product notice", description = "Returns the packaged product NOTICE file.")
+    public ResponseEntity<String> notice() {
+        return classpathText("static/NOTICE", UTF8_TEXT);
+    }
+
     @GetMapping("/third-party")
-    @Operation(summary = "Third-party notices", description = "Returns the content of THIRD-PARTY-NOTICES.md.")
+    @Operation(summary = "Curated third-party notices", description = "Returns curated notices for browser assets, models, containers and special distribution terms.")
     public ResponseEntity<String> thirdParty() {
-        try {
-            ClassPathResource resource = new ClassPathResource("static/THIRD-PARTY-NOTICES.md");
-            try (InputStream is = resource.getInputStream()) {
-                String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-                return ResponseEntity.ok()
-                        .contentType(MediaType.parseMediaType("text/markdown;charset=UTF-8"))
-                        .body(content);
-            }
+        return classpathText("static/THIRD-PARTY-NOTICES.md", MARKDOWN);
+    }
+
+    @GetMapping("/runtime-licenses")
+    @Operation(summary = "Generated runtime dependency licenses", description = "Returns the build-generated report for packaged Maven runtime dependencies.")
+    public ResponseEntity<String> runtimeLicenses() {
+        return classpathText("THIRD-PARTY-RUNTIME.txt", UTF8_TEXT);
+    }
+
+    @GetMapping("/sbom.json")
+    @Operation(summary = "CycloneDX SBOM as JSON", description = "Returns the build-specific packaged CycloneDX software bill of materials.")
+    public ResponseEntity<String> sbomJson() {
+        return classpathText("static/taxonomy-sbom.json", MediaType.APPLICATION_JSON);
+    }
+
+    @GetMapping("/sbom.xml")
+    @Operation(summary = "CycloneDX SBOM as XML", description = "Returns the build-specific packaged CycloneDX software bill of materials.")
+    public ResponseEntity<String> sbomXml() {
+        return classpathText("static/taxonomy-sbom.xml", MediaType.APPLICATION_XML);
+    }
+
+    private ResponseEntity<String> classpathText(String path, MediaType contentType) {
+        ClassPathResource resource = new ClassPathResource(path);
+        if (!resource.exists()) {
+            log.warn("About resource not found on classpath: {}", path);
+            return ResponseEntity.notFound().build();
+        }
+        try (InputStream input = resource.getInputStream()) {
+            String content = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return ResponseEntity.ok().contentType(contentType).body(content);
         } catch (IOException e) {
-            log.warn("THIRD-PARTY-NOTICES.md not found on classpath: {}", e.getMessage());
-            return ResponseEntity.ok()
-                    .contentType(MediaType.TEXT_PLAIN)
-                    .body("Third-party notices file not available.");
+            log.warn("Could not read about resource {}: {}", path, e.getMessage());
+            return ResponseEntity.internalServerError().contentType(UTF8_TEXT)
+                    .body("Packaged legal resource could not be read.");
         }
     }
 }

--- a/taxonomy-app/src/main/resources/static/js/shared/taxonomy-about.js
+++ b/taxonomy-app/src/main/resources/static/js/shared/taxonomy-about.js
@@ -1,11 +1,12 @@
 /**
  * About Modal — fetches /api/about and displays version, build, commit info,
- * copyright, and third-party notices.
+ * packaged legal resources, third-party notices and supply-chain evidence.
  */
 window.TaxonomyAbout = (function () {
     'use strict';
 
     var noticesLoaded = false;
+    var aboutInfo = null;
 
     function el(id) { return document.getElementById(id); }
 
@@ -17,10 +18,67 @@ window.TaxonomyAbout = (function () {
         try { return new Date(val).toLocaleString(); } catch (e) { return String(val); }
     }
 
+    function localized(english, german) {
+        var language = (document.documentElement.lang || navigator.language || '').toLowerCase();
+        return language.indexOf('de') === 0 ? german : english;
+    }
+
+    function appendResourceLink(container, label, url) {
+        if (!url) return;
+        var link = document.createElement('a');
+        link.className = 'btn btn-sm btn-outline-secondary';
+        link.href = url;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.textContent = label;
+        container.appendChild(link);
+    }
+
+    function renderLegalResources(data) {
+        var contentEl = el('aboutThirdPartyContent');
+        if (!contentEl || !contentEl.parentNode) return;
+
+        var container = el('aboutLegalResources');
+        if (!container) {
+            container = document.createElement('div');
+            container.id = 'aboutLegalResources';
+            container.className = 'mb-3 p-2 border rounded bg-light';
+            contentEl.parentNode.insertBefore(container, contentEl);
+        }
+        container.textContent = '';
+
+        var heading = document.createElement('div');
+        heading.className = 'fw-semibold mb-1';
+        heading.textContent = localized('Legal and supply-chain evidence', 'Lizenz- und Lieferkettennachweise');
+        container.appendChild(heading);
+
+        var explanation = document.createElement('div');
+        explanation.className = 'small text-muted mb-2';
+        explanation.textContent = localized(
+            'The runtime report and SBOM describe this exact build; the curated notices cover non-Maven and optional components.',
+            'Der Runtime-Bericht und die SBOM beschreiben exakt diesen Build; die kuratierten Hinweise decken Nicht-Maven- und optionale Komponenten ab.'
+        );
+        container.appendChild(explanation);
+
+        var links = document.createElement('div');
+        links.className = 'd-flex flex-wrap gap-2';
+        appendResourceLink(links, 'LICENSE', data.projectLicenseUrl);
+        appendResourceLink(links, 'NOTICE', data.noticeUrl);
+        appendResourceLink(links,
+            localized('Curated notices', 'Kuratierte Hinweise'), data.thirdPartyNoticesUrl);
+        appendResourceLink(links,
+            localized('Runtime licenses', 'Runtime-Lizenzen'), data.runtimeThirdPartyLicensesUrl);
+        appendResourceLink(links, 'CycloneDX JSON', data.sbomJsonUrl);
+        appendResourceLink(links, 'CycloneDX XML', data.sbomXmlUrl);
+        container.appendChild(links);
+    }
+
     function loadAboutInfo() {
         fetch('/api/about')
             .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
             .then(function (data) {
+                aboutInfo = data;
+
                 // Update navbar version
                 var navVer = el('navbarVersion');
                 if (navVer && data.version && data.version !== 'unknown') {
@@ -57,9 +115,10 @@ window.TaxonomyAbout = (function () {
 
                 var branchEl = el('aboutBranch');
                 if (branchEl) branchEl.textContent = data.branch || '—';
+                renderLegalResources(data);
             })
             .catch(function () {
-                // silently fail — info not critical
+                // Build information is useful but not required for the main UI.
             });
     }
 
@@ -68,7 +127,9 @@ window.TaxonomyAbout = (function () {
         noticesLoaded = true;
         var contentEl = el('aboutThirdPartyContent');
         if (!contentEl) return;
-        fetch('/api/about/third-party')
+        var noticesUrl = aboutInfo && aboutInfo.thirdPartyNoticesUrl
+            ? aboutInfo.thirdPartyNoticesUrl : '/api/about/third-party';
+        fetch(noticesUrl)
             .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
             .then(function (text) {
                 contentEl.textContent = text;
@@ -83,7 +144,7 @@ window.TaxonomyAbout = (function () {
         tabs.forEach(function (tab) {
             tab.addEventListener('click', function (e) {
                 e.preventDefault();
-                tabs.forEach(function (t) { t.classList.remove('active'); });
+                tabs.forEach(function (candidate) { candidate.classList.remove('active'); });
                 tab.classList.add('active');
 
                 var target = tab.getAttribute('data-about-tab');
@@ -117,7 +178,7 @@ window.TaxonomyAbout = (function () {
 
         initTabs();
 
-        // Update navbar version on page load
+        // Update navbar version and legal-resource links on page load.
         loadAboutInfo();
     });
 

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
@@ -74,7 +74,6 @@ class AboutControllerTest {
         mockMvc.perform(get("/api/about/runtime-licenses"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("text/plain"))
-                .andExpect(content().string(containsString("third-party")))
                 .andExpect(content().string(containsString("com.oracle.database.jdbc:ojdbc11")))
                 .andExpect(content().string(not(containsString("org.junit.jupiter"))))
                 .andExpect(content().string(not(containsString("org.testcontainers"))));

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
@@ -75,4 +75,17 @@ class AboutControllerTest {
                 .andExpect(content().contentTypeCompatibleWith("text/plain"))
                 .andExpect(content().string(containsString("third-party")));
     }
+
+    @Test
+    void sbomEndpointsReturnBuildSpecificCycloneDxDocuments() throws Exception {
+        mockMvc.perform(get("/api/about/sbom.json"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(content().string(containsString("\"bomFormat\" : \"CycloneDX\"")));
+
+        mockMvc.perform(get("/api/about/sbom.xml"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/xml"))
+                .andExpect(content().string(containsString("<bom")));
+    }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
@@ -7,8 +7,11 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Integration tests for {@link AboutController}.
@@ -22,7 +25,7 @@ class AboutControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    void aboutEndpointReturnsOk() throws Exception {
+    void aboutEndpointReturnsBuildAndLegalResourceLinks() throws Exception {
         mockMvc.perform(get("/api/about"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.product").value("Taxonomy Architecture Analyzer"))
@@ -30,16 +33,46 @@ class AboutControllerTest {
                 .andExpect(jsonPath("$.copyright").value("Copyright 2026 Carsten Hammer"))
                 .andExpect(jsonPath("$.sourceUrl").value("https://github.com/carstenartur/Taxonomy"))
                 .andExpect(jsonPath("$.apiDocsUrl").value("/swagger-ui.html"))
-                .andExpect(jsonPath("$.thirdPartyNoticesUrl").value("/THIRD-PARTY-NOTICES.md"))
+                .andExpect(jsonPath("$.projectLicenseUrl").value("/api/about/license"))
+                .andExpect(jsonPath("$.noticeUrl").value("/api/about/notice"))
+                .andExpect(jsonPath("$.thirdPartyNoticesUrl").value("/api/about/third-party"))
+                .andExpect(jsonPath("$.runtimeThirdPartyLicensesUrl").value("/api/about/runtime-licenses"))
+                .andExpect(jsonPath("$.sbomJsonUrl").value("/api/about/sbom.json"))
+                .andExpect(jsonPath("$.sbomXmlUrl").value("/api/about/sbom.xml"))
                 .andExpect(jsonPath("$.version").exists())
                 .andExpect(jsonPath("$.commit").exists())
                 .andExpect(jsonPath("$.branch").exists());
     }
 
     @Test
-    void aboutThirdPartyEndpointReturnsOk() throws Exception {
+    void projectLicenseEndpointReturnsPackagedMitText() throws Exception {
+        mockMvc.perform(get("/api/about/license"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/plain"))
+                .andExpect(content().string(containsString("MIT License")));
+    }
+
+    @Test
+    void noticeEndpointReturnsPackagedProductNotice() throws Exception {
+        mockMvc.perform(get("/api/about/notice"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/plain"))
+                .andExpect(content().string(containsString("Taxonomy Architecture Analyzer")));
+    }
+
+    @Test
+    void curatedThirdPartyEndpointReturnsNotices() throws Exception {
         mockMvc.perform(get("/api/about/third-party"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.emptyString())));
+                .andExpect(content().contentTypeCompatibleWith("text/markdown"))
+                .andExpect(content().string(containsString("Third-Party Notices")));
+    }
+
+    @Test
+    void runtimeLicenseEndpointReturnsBuildGeneratedDependencyReport() throws Exception {
+        mockMvc.perform(get("/api/about/runtime-licenses"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/plain"))
+                .andExpect(content().string(containsString("third-party")));
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/controller/AboutControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -69,11 +70,14 @@ class AboutControllerTest {
     }
 
     @Test
-    void runtimeLicenseEndpointReturnsBuildGeneratedDependencyReport() throws Exception {
+    void runtimeLicenseEndpointContainsRuntimeButNoTestDependencies() throws Exception {
         mockMvc.perform(get("/api/about/runtime-licenses"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith("text/plain"))
-                .andExpect(content().string(containsString("third-party")));
+                .andExpect(content().string(containsString("third-party")))
+                .andExpect(content().string(containsString("com.oracle.database.jdbc:ojdbc11")))
+                .andExpect(content().string(not(containsString("org.junit.jupiter"))))
+                .andExpect(content().string(not(containsString("org.testcontainers"))));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Makes the existing About dialog and packaged legal files suitable as release-specific licence evidence instead of relying on a manually maintained component inventory.

### Build-owned runtime report

- runs `license-maven-plugin:add-third-party` in the normal Maven `generate-resources` lifecycle for `taxonomy-app`;
- analyses only compile/runtime dependencies, including transitive and optional packaged dependencies;
- excludes Taxonomy's own modules while retaining their transitive runtime dependencies;
- generates and packages `THIRD-PARTY-RUNTIME.txt`;
- fails the Maven build when a packaged dependency has no usable licence metadata;
- writes generated missing-licence diagnostics only below `target/`;
- reads repository-reviewed overrides from the plugin's conventional, read-only `taxonomy-app/src/license/override-THIRD-PARTY.properties` and disables repository-supplied implicit missing files.

### About and packaged evidence

- exposes `LICENSE`, `NOTICE`, curated third-party notices, generated runtime licences and CycloneDX JSON/XML through `/api/about` endpoints;
- adds direct legal/supply-chain links to the existing About modal;
- packages the build-specific CycloneDX SBOM into the application artefact;
- returns 404 rather than a misleading success fallback when a legal artefact is absent.

### Notice corrections

- identifies Oracle JDBC as a packaged runtime dependency under Oracle FUTC;
- separates JDBC-driver terms from the operator's Oracle Database licence;
- identifies Microsoft JDBC correctly as MIT-licensed;
- removes the manually asserted blanket runtime-compliance claim;
- separates Maven runtime, test tooling, browser assets, optional observability containers and the embedding model.

## Verification

Required checks:

- canonical Maven verification, including the new fail-closed licence gate;
- About controller integration tests proving the packaged project licence, NOTICE, curated notices, generated runtime report and both build-specific SBOM representations;
- normal Security Scan and CodeQL;
- packaged JAR contains runtime report and build-specific SBOM resources.

The first packaging audit generated the runtime report without any missing-licence entry. The application CycloneDX build resolved 260 components, and no repository override is currently needed. Future overrides may only be added after verification against the canonical upstream licence.