### PR TITLE
Update CodeQL action consistently to 4.37.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: java-kotlin
           build-mode: manual
@@ -60,7 +60,7 @@ jobs:
           -Dtaxonomy.quality.skip=true
 
       - name: Analyze Java to local SARIF
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: /language:java-kotlin
           upload: false
@@ -97,14 +97,14 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-extended,security-and-quality
 
       - name: Analyze JavaScript to local SARIF
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: /language:javascript-typescript
           upload: false


### PR DESCRIPTION
## Summary

Replaces the split Dependabot updates #523 and #524 with one atomic update.

`github/codeql-action/init` and `github/codeql-action/analyze` form one installation and must run from the same immutable action commit. Each split PR leaves the workflow in a mixed-version state and therefore fails the repository's own CodeQL workflow.

## Changes

- update both Java `init` and `analyze` steps;
- update both JavaScript `init` and `analyze` steps;
- pin all four uses to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4);
- retain the already merged matching `upload-sarif` update from #522.

## Verification

The combined branch must pass CodeQL, CI/CD and Security Scan before merge.

Closes #523 and #524 as superseded once merged.