### PR TITLE
Make the primary workflow measurable and progressively disclosed

### DIFF
--- a/.github/scripts/ui-primary-import-workflows.mjs
+++ b/.github/scripts/ui-primary-import-workflows.mjs
@@ -3,6 +3,11 @@ import { navigateArchitectureSubtab, navigateToPage } from './ui-role-fixtures.m
 export async function runImportWorkflows({ page, evidence }) {
   const { assert, passed, axeState, saveState, waitForText } = evidence;
   await navigateToPage(page, 'analyze');
+  const secondaryTools = page.locator('#analysisSecondaryTools');
+  await secondaryTools.waitFor({ state: 'visible', timeout: 20_000 });
+  if (!(await secondaryTools.getAttribute('open'))) {
+    await secondaryTools.locator(':scope > summary').click();
+  }
   const documentPanel = page.locator('#documentImportPanel');
   if (!(await documentPanel.getAttribute('open'))) {
     await documentPanel.locator('summary').click();

--- a/.github/scripts/ui-role-state-acceptance.mjs
+++ b/.github/scripts/ui-role-state-acceptance.mjs
@@ -42,6 +42,7 @@ let browser;
 let context;
 let page;
 let evidence;
+let taskMeasurements = null;
 let failureEvidence = null;
 await mkdir(outputDir, { recursive: true });
 
@@ -73,7 +74,7 @@ try {
   page.on('pageerror', error => consoleErrors.push(error.message));
 
   evidence = createRoleStateEvidence({ page, outputDir, checks, findings });
-  await runRoleStateFlow({
+  taskMeasurements = await runRoleStateFlow({
     page, role, zoom, forcedColors, checks, httpFailures,
     externalRequests, consoleErrors, evidence
   });
@@ -95,6 +96,7 @@ try {
     evidenceMode: evidence?.evidenceMode || null,
     curatedStates: evidence?.curatedStates || [],
     states: evidence?.states || [],
+    taskMeasurements,
     checks, findings, externalRequests, httpFailures, consoleErrors,
     auditError, failureEvidence
   };

--- a/.github/scripts/ui-role-state-flow.mjs
+++ b/.github/scripts/ui-role-state-flow.mjs
@@ -10,6 +10,24 @@ export async function runRoleStateFlow({
 }) {
   const passed = name => checks.push(name);
   const { runAxe, saveState } = evidence;
+  const taskStartedAt = Date.now();
+  const taskMeasurements = {
+    roleTask: role === 'ADMIN' ? 'diagnose availability'
+      : role === 'ARCHITECT' ? 'review relation and continue architecture work'
+        : 'analyze a requirement',
+    taskCompleted: false,
+    failedStep: null,
+    timeToPrimaryActionMs: null,
+    timeToTaskCompletionMs: null,
+    preTaskViewportPixels: null,
+    preTaskViewportRatio: null,
+    pageTransitionsBeforePrimaryAction: 1,
+    navigationErrors: 0,
+    primaryActionInsideInitialViewport: false,
+    nextActionInsideInitialViewport: false,
+    operationalContextCollapsedByDefault: false,
+    secondaryToolsCollapsedByDefault: false
+  };
 
   const adminTab = page.locator('#adminNavTab');
   if (role === 'ADMIN') {
@@ -30,10 +48,62 @@ export async function runRoleStateFlow({
   await page.locator('#mainNavTabs [data-page="analyze"]').click();
   await page.locator('#taxonomyTree [role="treeitem"]').first()
     .waitFor({ state: 'visible', timeout: 90_000 });
+
+  const taskSurface = await page.evaluate(() => {
+    const progress = document.getElementById('analysisTaskProgress');
+    const primary = document.getElementById('analyzeBtn');
+    const operations = document.getElementById('operationalContextDetails');
+    const secondary = document.getElementById('analysisSecondaryTools');
+    const progressRect = progress?.getBoundingClientRect();
+    const primaryRect = primary?.getBoundingClientRect();
+    const focusable = Boolean(primary && !primary.disabled
+      && primary.tabIndex >= 0 && getComputedStyle(primary).visibility !== 'hidden');
+    return {
+      progressVisible: Boolean(progressRect && progressRect.width > 0 && progressRect.height > 0),
+      progressTop: progressRect?.top ?? Number.POSITIVE_INFINITY,
+      viewportHeight: window.innerHeight,
+      primaryVisible: Boolean(primaryRect && primaryRect.width > 0 && primaryRect.height > 0),
+      primaryEnabled: Boolean(primary && !primary.disabled),
+      primaryFocusable: focusable,
+      primaryInsideViewport: Boolean(primaryRect && primaryRect.top >= 0
+        && primaryRect.bottom <= window.innerHeight),
+      currentStage: progress?.querySelector('[aria-current="step"]')?.id || '',
+      operationalCollapsed: Boolean(operations && !operations.open),
+      operationalContainsOriginalSurfaces: Boolean(operations
+        && operations.contains(document.getElementById('gitStatusBar'))
+        && operations.contains(document.getElementById('contextBar'))),
+      secondaryCollapsed: Boolean(secondary && !secondary.open),
+      secondaryContainsExpertTools: Boolean(secondary
+        && secondary.contains(document.getElementById('searchPanel'))
+        && secondary.contains(document.getElementById('llmCommLog')))
+    };
+  });
+  assert(taskSurface.progressVisible, 'Explicit analysis task progression is not visible');
+  assert(taskSurface.currentStage === 'taskStageDescribe',
+    `Initial analysis stage was ${taskSurface.currentStage}, expected describe`);
+  assert(taskSurface.primaryVisible && taskSurface.primaryEnabled && taskSurface.primaryFocusable,
+    'Primary Analyze action is not visible, enabled and focusable');
+  assert(taskSurface.operationalCollapsed && taskSurface.operationalContainsOriginalSurfaces,
+    'Operational status must be collapsed by default while retaining original detail surfaces');
+  assert(taskSurface.secondaryCollapsed && taskSurface.secondaryContainsExpertTools,
+    'Secondary analysis tools must be collapsed by default and remain available');
+  taskMeasurements.timeToPrimaryActionMs = Date.now() - taskStartedAt;
+  taskMeasurements.preTaskViewportPixels = Math.max(0, Math.round(taskSurface.progressTop));
+  taskMeasurements.preTaskViewportRatio = Number((Math.max(0, taskSurface.progressTop)
+    / taskSurface.viewportHeight).toFixed(4));
+  taskMeasurements.primaryActionInsideInitialViewport = taskSurface.primaryInsideViewport;
+  taskMeasurements.operationalContextCollapsedByDefault = taskSurface.operationalCollapsed;
+  taskMeasurements.secondaryToolsCollapsedByDefault = taskSurface.secondaryCollapsed;
+  passed('measured primary task visibility and progressive disclosure');
+
   const interactive = page.locator('#interactiveMode');
   if (await interactive.isChecked()) await interactive.uncheck();
   await page.locator('#businessText').fill(
     'Provide resilient hospital communications with traceable architecture decisions.');
+  await page.waitForFunction(() =>
+    document.querySelector('#taskStageAnalyze[data-state="current"]'));
+  passed('requirement entry advances explicit task stage');
+
   // Reused applications can complete a warm mock analysis before Playwright's next
   // wait begins. Observe the real feedback surface before activation and verify the
   // final visible score state independently.
@@ -70,20 +140,43 @@ export async function runRoleStateFlow({
     return scores && Object.keys(scores).length > 0
       && document.querySelectorAll('.tax-pct').length > 0;
   }, null, { timeout: 120_000 });
+  await page.waitForFunction(() =>
+    document.querySelector('#taskStageReview[data-state="current"]')
+      && !document.getElementById('taskNextAction')?.disabled,
+  null, { timeout: 10_000 });
   const statusEvents = await page.evaluate(() => {
     window.__taxonomyQaAnalysisStatusObserver?.disconnect();
     return window.__taxonomyQaAnalysisStatusEvents || [];
   });
   assert(statusEvents.length > 0,
     'Analysis completed without a perceivable status transition');
-  passed('analysis loading and success');
+  const completedTaskState = await page.evaluate(() => {
+    const nextAction = document.getElementById('taskNextAction');
+    const rect = nextAction?.getBoundingClientRect();
+    return {
+      currentStage: document.querySelector('#analysisTaskProgress [aria-current="step"]')?.id || '',
+      nextActionVisible: Boolean(rect && rect.width > 0 && rect.height > 0),
+      nextActionInsideViewport: Boolean(rect && rect.top >= 0 && rect.bottom <= window.innerHeight),
+      nextActionText: nextAction?.textContent?.trim() || ''
+    };
+  });
+  assert(completedTaskState.currentStage === 'taskStageReview',
+    `Completed analysis stage was ${completedTaskState.currentStage}, expected review`);
+  assert(completedTaskState.nextActionVisible && completedTaskState.nextActionText,
+    'Completed analysis has no visible contextual next action');
+  taskMeasurements.taskCompleted = true;
+  taskMeasurements.timeToTaskCompletionMs = Date.now() - taskStartedAt;
+  taskMeasurements.nextActionInsideInitialViewport = completedTaskState.nextActionInsideViewport;
+  passed('analysis loading, success and contextual next action');
   await runAxe('analysis-success');
   await saveState('analysis-success');
 
   await page.locator('#businessText').fill(
     'Provide resilient hospital communications with an emergency notification capability.');
   await page.locator('#businessText.stale-results').waitFor({ state: 'visible', timeout: 10_000 });
-  passed('stale-result indication');
+  await page.waitForFunction(() =>
+    document.querySelector('#taskStageAnalyze[data-state="current"]'));
+  passed('stale-result indication returns focus to analysis stage');
 
   const sunburst = page.locator('#viewSunburst');
   await sunburst.scrollIntoViewIfNeeded();
@@ -100,7 +193,10 @@ export async function runRoleStateFlow({
     return text.includes('error') || text.includes('failed') || text.includes('503')
       || text.includes('unavailable');
   }, null, { timeout: 30_000 });
-  passed('analysis provider error state');
+  await page.waitForFunction(() =>
+    document.querySelector('#taskStageAnalyze[data-state="error"]')
+      && !document.getElementById('taskNextAction')?.disabled);
+  passed('analysis provider error retains hierarchy and retry action');
   await runAxe('analysis-error');
   await saveState('analysis-error');
 
@@ -137,6 +233,17 @@ export async function runRoleStateFlow({
   assert(await page.evaluate(() => document.activeElement?.id === 'businessText'),
     'Dialog did not restore focus to its invoker');
   passed('dialog focus entry and restoration');
+
+  const operationalWasOpen = await page.locator('#operationalContextDetails').evaluate(el => el.open);
+  await page.keyboard.press('Alt+Shift+O');
+  await page.waitForFunction(previous =>
+    document.getElementById('operationalContextDetails')?.open !== previous,
+  operationalWasOpen);
+  assert(await page.evaluate(() =>
+    document.activeElement === document.querySelector('#operationalContextDetails > summary')),
+  'Operational-context shortcut did not move focus to the disclosure');
+  await page.keyboard.press('Alt+Shift+O');
+  passed('expert keyboard access to primary task and operational context');
 
   const overflow = await page.evaluate(() => ({
     scrollWidth: document.documentElement.scrollWidth,
@@ -214,4 +321,6 @@ export async function runRoleStateFlow({
   assert(consoleErrors.length === 0,
     `Browser console errors: ${consoleErrors.join(' | ')}`);
   passed('local assets and clean console');
+
+  return taskMeasurements;
 }

--- a/.github/scripts/ui-special-modes-acceptance.mjs
+++ b/.github/scripts/ui-special-modes-acceptance.mjs
@@ -37,6 +37,14 @@ async function screenshot(state, selector) {
   await writeFile(path.join(outputDir, `${state}.html`), await target.evaluate(node => node.outerHTML), 'utf8');
 }
 
+async function openAnalysisSecondaryTools() {
+  const secondaryTools = page.locator('#analysisSecondaryTools');
+  await secondaryTools.waitFor({ state: 'visible', timeout: 20_000 });
+  if (!(await secondaryTools.getAttribute('open'))) {
+    await secondaryTools.locator(':scope > summary').click();
+  }
+}
+
 async function testPartialAnalysis() {
   await navigateToPage(page, 'analyze');
   const interactive = page.locator('#interactiveMode');
@@ -117,6 +125,7 @@ async function testTextSpacing() {
   await page.waitForFunction(() => Boolean(window.TaxonomyRoleSurface?.ready), null, { timeout: 20_000 });
   await page.evaluate(() => window.TaxonomyRoleSurface.ready);
   await navigateToPage(page, 'analyze');
+  await openAnalysisSecondaryTools();
   const documentPanel = page.locator('#documentImportPanel');
   await documentPanel.waitFor({ state: 'visible', timeout: 20_000 });
   if (!(await documentPanel.getAttribute('open'))) {

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -8,6 +8,150 @@
     display: block;
 }
 
+/* Keep operational detail available without occupying the default task area. */
+.operational-context-details {
+    border-bottom: 1px solid var(--bs-border-color, #dee2e6);
+    background: var(--bs-tertiary-bg, #f8f9fa);
+}
+.operational-context-details > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    min-height: 2.5rem;
+    padding: 0.4rem 1rem;
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    list-style: none;
+}
+.operational-context-details > summary::-webkit-details-marker {
+    display: none;
+}
+.operational-context-details > summary::before {
+    content: "▸";
+    flex: 0 0 auto;
+}
+.operational-context-details[open] > summary::before {
+    content: "▾";
+}
+.operational-context-title {
+    flex: 1 1 auto;
+}
+.operational-context-content {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0 1rem 0.75rem;
+}
+.operational-context-content > #gitStatusBar,
+.operational-context-content > #contextBar {
+    flex: 1 1 100%;
+    margin: 0;
+}
+
+/* Present the primary analysis as an explicit, persistent task progression. */
+.analysis-task-progress {
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.5rem;
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    padding: 0.8rem;
+}
+.analysis-task-stages {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.45rem;
+    padding: 0;
+    margin: 0 0 0.75rem;
+    list-style: none;
+}
+.analysis-task-stages li {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-width: 0;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.4rem;
+    background: var(--bs-body-bg, #fff);
+    color: var(--bs-secondary-color, #6c757d);
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+.analysis-task-stages li > span {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 1.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--bs-secondary-bg, #e9ecef);
+}
+.analysis-task-stages li[data-state="current"] {
+    border-color: var(--bs-primary, #0d6efd);
+    color: var(--bs-body-color, #212529);
+    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.12);
+}
+.analysis-task-stages li[data-state="current"] > span {
+    background: var(--bs-primary, #0d6efd);
+    color: #fff;
+}
+.analysis-task-stages li[data-state="complete"] {
+    border-color: var(--bs-success, #198754);
+    color: var(--bs-body-color, #212529);
+}
+.analysis-task-stages li[data-state="complete"] > span {
+    background: var(--bs-success, #198754);
+    color: #fff;
+}
+.analysis-task-stages li[data-state="error"] {
+    border-color: var(--bs-danger, #dc3545);
+    color: var(--bs-danger-text-emphasis, #842029);
+}
+.analysis-task-stages li[data-state="error"] > span {
+    background: var(--bs-danger, #dc3545);
+    color: #fff;
+}
+.analysis-next-action {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+.analysis-next-action #taskGuidance {
+    max-width: 42rem;
+}
+.analysis-next-action #taskNextAction {
+    flex: 0 0 auto;
+    min-height: 2.5rem;
+}
+
+/* Secondary tools and score explanations remain one keyboard-reachable disclosure. */
+.analysis-secondary-tools,
+.score-legend-details {
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.4rem;
+    background: var(--bs-body-bg, #fff);
+}
+.analysis-secondary-tools > summary,
+.score-legend-details > summary {
+    min-height: 2.5rem;
+    padding: 0.55rem 0.75rem;
+    cursor: pointer;
+}
+.analysis-secondary-tools-content {
+    padding: 0 0.75rem 0.75rem;
+}
+.analysis-secondary-tools-content > details,
+.analysis-secondary-tools-content > div {
+    margin-top: 0.75rem !important;
+}
+.score-legend-details > .card {
+    border: 0;
+    box-shadow: none !important;
+}
+
 /* Keep dense toolbars usable at high zoom and on narrow viewports. */
 #mainNavTabs,
 .card-header,
@@ -60,7 +204,10 @@
 .tax-node-actions button:focus-visible,
 .taxonomy-accessible-dialog button:focus-visible,
 .taxonomy-accessible-dialog input:focus-visible,
-.table-responsive:focus-visible {
+.table-responsive:focus-visible,
+.operational-context-details > summary:focus-visible,
+.analysis-secondary-tools > summary:focus-visible,
+.score-legend-details > summary:focus-visible {
     outline: 3px solid #0d6efd;
     outline-offset: 2px;
 }
@@ -164,7 +311,8 @@
     .tax-toggle,
     #mainNavTabs .nav-link,
     .navbar button,
-    .navbar select {
+    .navbar select,
+    .analysis-next-action button {
         min-height: 44px;
         min-width: 44px;
     }
@@ -219,6 +367,9 @@
         width: auto;
         white-space: nowrap;
     }
+    .analysis-task-stages {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 /* 200–400 % zoom: allow navigation and analysis controls to reflow. */
@@ -229,12 +380,11 @@
         font-size: 1rem;
         line-height: 1.25;
     }
-    /* These badges duplicate information available in the analysis and context
-       surfaces. Hiding the duplicates preserves controls while reducing the
-       mobile header from several rows to the brand plus one utility row. */
-    #aiStatusBadge,
-    #embeddingStatusBadge,
-    #workspaceUserBadge {
+    /* These badges are moved to the compact operational-context disclosure.
+       Hide only a legacy badge that still remains inside the navbar. */
+    .navbar #aiStatusBadge,
+    .navbar #embeddingStatusBadge,
+    .navbar #workspaceUserBadge {
         display: none !important;
     }
     #navbarVersion {
@@ -264,12 +414,37 @@
     #copilotBtn {
         min-width: 0;
     }
+    .analysis-task-stages {
+        grid-template-columns: 1fr;
+    }
+    .analysis-next-action {
+        align-items: stretch;
+        flex-direction: column;
+    }
+    .analysis-next-action #taskNextAction {
+        width: 100%;
+    }
+    .operational-context-details > summary {
+        padding-inline: 0.75rem;
+    }
+    .operational-context-content {
+        padding-inline: 0.75rem;
+    }
     .tax-node {
         font-size: 1rem;
     }
     .tax-pct,
     .tax-justify-btn {
         font-size: 0.875rem;
+    }
+}
+
+@media (forced-colors: active) {
+    .analysis-task-stages li[data-state="current"],
+    .analysis-task-stages li[data-state="complete"],
+    .analysis-task-stages li[data-state="error"] {
+        border-width: 3px;
+        box-shadow: none;
     }
 }
 
@@ -290,6 +465,9 @@
     #systemStatusBar,
     #gitStatusBar,
     #contextBar,
+    #operationalContextDetails,
+    #analysisTaskProgress,
+    #analysisSecondaryTools,
     .tax-node-actions,
     .taxonomy-accessible-dialog {
         display: none !important;

--- a/taxonomy-app/src/main/resources/static/js/shared/taxonomy-onboarding.js
+++ b/taxonomy-app/src/main/resources/static/js/shared/taxonomy-onboarding.js
@@ -1,10 +1,14 @@
-/* taxonomy-onboarding.js – Welcome overlay & progressive disclosure for first-time users */
+/* taxonomy-onboarding.js – Welcome overlay, task focus & progressive disclosure */
 
 (function () {
     'use strict';
     var t = TaxonomyI18n.t;
 
     var STORAGE_KEY = 'taxonomy_onboarded';
+
+    function text(en, de) {
+        return document.documentElement.lang.toLowerCase().startsWith('de') ? de : en;
+    }
 
     /**
      * Show the welcome overlay if the user has not dismissed it before.
@@ -61,13 +65,281 @@
         localStorage.removeItem(STORAGE_KEY);
     }
 
+    function createOperationalContext() {
+        if (document.getElementById('operationalContextDetails')) return;
+
+        var navigation = document.getElementById('mainNavTabs');
+        var navigationBar = navigation ? navigation.closest('.bg-dark') : null;
+        var mainContent = document.getElementById('mainContent');
+        if (!navigationBar || !mainContent) return;
+
+        var details = document.createElement('details');
+        details.id = 'operationalContextDetails';
+        details.className = 'operational-context-details';
+        details.innerHTML =
+            '<summary>' +
+            '  <span class="operational-context-title">' +
+                text('Operational context', 'Betriebszustand') +
+            '  </span>' +
+            '  <span id="operationalContextSummary" class="badge bg-secondary">' +
+                text('Loading', 'Wird geladen') +
+            '  </span>' +
+            '</summary>' +
+            '<div id="operationalContextContent" class="operational-context-content" role="region" aria-label="' +
+                text('Repository, model and workspace details', 'Repository-, Modell- und Arbeitsbereichsdetails') +
+            '"></div>';
+        navigationBar.insertAdjacentElement('afterend', details);
+
+        var content = document.getElementById('operationalContextContent');
+        ['aiStatusBadge', 'embeddingStatusBadge', 'workspaceUserBadge',
+            'gitStatusBar', 'contextBar'].forEach(function (id) {
+            var element = document.getElementById(id);
+            if (element) content.appendChild(element);
+        });
+
+        var languageSelector = document.getElementById('langSelector');
+        if (languageSelector) languageSelector.classList.add('ms-auto');
+
+        function updateSummary() {
+            var summary = document.getElementById('operationalContextSummary');
+            if (!summary) return;
+            var visibleElements = Array.from(content.children).filter(function (element) {
+                return !element.classList.contains('d-none') &&
+                    getComputedStyle(element).display !== 'none';
+            });
+            var combined = visibleElements.map(function (element) {
+                return element.textContent || '';
+            }).join(' ').toLowerCase();
+            var danger = /error|failed|unavailable|conflict|diverged|fehler|nicht verfügbar|konflikt/.test(combined)
+                || visibleElements.some(function (element) {
+                    return element.classList.contains('bg-danger') ||
+                        Boolean(element.querySelector('.bg-danger,.alert-danger,.text-danger'));
+                });
+            var warning = /warning|unknown|stale|behind|ahead|warnung|unbekannt|veraltet/.test(combined)
+                || visibleElements.some(function (element) {
+                    return element.classList.contains('bg-warning') ||
+                        Boolean(element.querySelector('.bg-warning,.alert-warning,.text-warning'));
+                });
+
+            summary.className = 'badge ' + (danger ? 'bg-danger' : warning ?
+                'bg-warning text-dark' : visibleElements.length ? 'bg-success' : 'bg-secondary');
+            summary.textContent = danger ? text('Action required', 'Eingreifen erforderlich') :
+                warning ? text('Check details', 'Details prüfen') :
+                visibleElements.length ? text('Ready', 'Bereit') : text('Loading', 'Wird geladen');
+            if (danger) details.open = true;
+        }
+
+        new MutationObserver(updateSummary).observe(content, {
+            attributes: true, childList: true, subtree: true, characterData: true
+        });
+        updateSummary();
+    }
+
+    function createSecondaryToolsDisclosure() {
+        if (document.getElementById('analysisSecondaryTools')) return;
+        var analyzeTab = document.getElementById('tab-analyze');
+        if (!analyzeTab) return;
+
+        var details = document.createElement('details');
+        details.id = 'analysisSecondaryTools';
+        details.className = 'analysis-secondary-tools mt-3';
+        details.innerHTML =
+            '<summary class="fw-semibold">' +
+                text('Additional analysis tools', 'Weitere Analysewerkzeuge') +
+            '</summary>' +
+            '<div id="analysisSecondaryToolsContent" class="analysis-secondary-tools-content"></div>';
+        analyzeTab.appendChild(details);
+        var content = document.getElementById('analysisSecondaryToolsContent');
+        ['searchPanel', 'analysisLog', 'llmCommLog', 'gapAnalysisPanel',
+            'patternDetectionPanel', 'recommendationPanel', 'documentImportPanel']
+            .forEach(function (id) {
+                var element = document.getElementById(id);
+                if (element) content.appendChild(element);
+            });
+
+        var legend = document.querySelector('#tab-analyze .legend-box');
+        var legendCard = legend ? legend.closest('.card') : null;
+        if (legendCard && !document.getElementById('scoreLegendDetails')) {
+            var legendDetails = document.createElement('details');
+            legendDetails.id = 'scoreLegendDetails';
+            legendDetails.className = 'score-legend-details mb-3';
+            legendDetails.innerHTML = '<summary class="fw-semibold">' +
+                text('How scores are shown', 'Darstellung der Bewertungen') + '</summary>';
+            legendCard.parentNode.insertBefore(legendDetails, legendCard);
+            legendCard.classList.remove('mb-3');
+            legendCard.classList.add('mt-2');
+            legendDetails.appendChild(legendCard);
+        }
+    }
+
+    function createTaskProgress() {
+        if (document.getElementById('analysisTaskProgress')) return;
+        var analyzeTab = document.getElementById('tab-analyze');
+        var firstCard = analyzeTab ? analyzeTab.querySelector('.card') : null;
+        if (!analyzeTab || !firstCard) return;
+
+        var progress = document.createElement('section');
+        progress.id = 'analysisTaskProgress';
+        progress.className = 'analysis-task-progress mb-3';
+        progress.setAttribute('aria-label', text('Analysis progress', 'Fortschritt der Analyse'));
+        progress.innerHTML =
+            '<ol class="analysis-task-stages">' +
+            '  <li id="taskStageDescribe" data-state="current"><span>1</span>' +
+                text('Describe', 'Beschreiben') + '</li>' +
+            '  <li id="taskStageAnalyze" data-state="pending"><span>2</span>' +
+                text('Analyze', 'Analysieren') + '</li>' +
+            '  <li id="taskStageReview" data-state="pending"><span>3</span>' +
+                text('Review', 'Prüfen') + '</li>' +
+            '  <li id="taskStageNext" data-state="pending"><span>4</span>' +
+                text('Continue', 'Weiterarbeiten') + '</li>' +
+            '</ol>' +
+            '<div class="analysis-next-action">' +
+            '  <span id="taskGuidance" class="small"></span>' +
+            '  <button id="taskNextAction" type="button" class="btn btn-sm btn-primary"></button>' +
+            '</div>';
+        firstCard.parentNode.insertBefore(progress, firstCard);
+
+        var businessText = document.getElementById('businessText');
+        var analyzeButton = document.getElementById('analyzeBtn');
+        var statusArea = document.getElementById('statusArea');
+        var taxonomyTree = document.getElementById('taxonomyTree');
+        var nextAction = document.getElementById('taskNextAction');
+        var guidance = document.getElementById('taskGuidance');
+        var action = 'describe';
+
+        function setStage(current, state) {
+            ['describe', 'analyze', 'review', 'next'].forEach(function (name) {
+                var element = document.getElementById('taskStage' +
+                    name.charAt(0).toUpperCase() + name.slice(1));
+                if (!element) return;
+                var order = ['describe', 'analyze', 'review', 'next'];
+                var elementIndex = order.indexOf(name);
+                var currentIndex = order.indexOf(current);
+                element.dataset.state = name === current ? state || 'current' :
+                    elementIndex < currentIndex ? 'complete' : 'pending';
+                if (name === current) element.setAttribute('aria-current', 'step');
+                else element.removeAttribute('aria-current');
+            });
+        }
+
+        function configure(nextActionName, buttonText, guidanceText, disabled) {
+            action = nextActionName;
+            nextAction.textContent = buttonText;
+            nextAction.disabled = Boolean(disabled);
+            guidance.textContent = guidanceText;
+        }
+
+        function hasScores() {
+            var scores = window.TaxonomyState && window.TaxonomyState.currentScores;
+            return Boolean(scores && Object.keys(scores).length &&
+                document.querySelector('#taxonomyTree .tax-pct'));
+        }
+
+        function sync() {
+            var value = businessText ? businessText.value.trim() : '';
+            var status = statusArea ? (statusArea.textContent || '').toLowerCase() : '';
+            var error = /error|failed|unavailable|503|fehler|fehlgeschlagen|nicht verfügbar/.test(status);
+            var stale = businessText && businessText.classList.contains('stale-results');
+            var running = analyzeButton && (analyzeButton.disabled ||
+                !document.getElementById('analyzeSpinner')?.classList.contains('d-none'));
+
+            if (error) {
+                setStage('analyze', 'error');
+                configure('analyze', text('Retry analysis', 'Analyse erneut starten'),
+                    text('Review the message, then retry the primary action.',
+                        'Hinweis prüfen und anschließend die Hauptaktion erneut starten.'), false);
+            } else if (running) {
+                setStage('analyze', 'current');
+                configure('none', text('Analysis running…', 'Analyse läuft…'),
+                    text('The result state and next action will appear here.',
+                        'Ergebniszustand und nächste Aktion erscheinen hier.'), true);
+            } else if (hasScores() && !stale) {
+                setStage('review', 'current');
+                configure('review', text('Review highest matches', 'Beste Treffer prüfen'),
+                    text('The analysis is complete. Inspect the strongest matches next.',
+                        'Die Analyse ist abgeschlossen. Prüfen Sie nun die stärksten Treffer.'), false);
+            } else if (value) {
+                setStage('analyze', 'current');
+                configure('analyze', text('Run analysis', 'Analyse starten'),
+                    text('The requirement is ready for the primary action.',
+                        'Die Anforderung ist bereit für die Hauptaktion.'), false);
+            } else {
+                setStage('describe', 'current');
+                configure('describe', text('Enter requirement', 'Anforderung eingeben'),
+                    text('Start with the requirement or capability to evaluate.',
+                        'Beginnen Sie mit der zu bewertenden Anforderung oder Fähigkeit.'), false);
+            }
+        }
+
+        nextAction.addEventListener('click', function () {
+            if (action === 'describe') {
+                businessText?.focus();
+            } else if (action === 'analyze') {
+                analyzeButton?.focus();
+                analyzeButton?.click();
+            } else if (action === 'review') {
+                var firstScore = document.querySelector('#taxonomyTree .tax-pct');
+                firstScore?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setStage('next', 'current');
+                configure('architecture', text('Open architecture', 'Architektur öffnen'),
+                    text('Continue with relations and architecture decisions.',
+                        'Fahren Sie mit Beziehungen und Architekturentscheidungen fort.'), false);
+            } else if (action === 'architecture') {
+                document.querySelector('#mainNavTabs [data-page="architecture"]')?.click();
+            }
+        });
+
+        businessText?.addEventListener('input', sync);
+        analyzeButton?.addEventListener('click', function () {
+            setStage('analyze', 'current');
+            configure('none', text('Analysis running…', 'Analyse läuft…'),
+                text('The result state and next action will appear here.',
+                    'Ergebniszustand und nächste Aktion erscheinen hier.'), true);
+            setTimeout(sync, 0);
+        });
+        if (statusArea) new MutationObserver(sync).observe(statusArea,
+            { attributes: true, childList: true, subtree: true, characterData: true });
+        if (taxonomyTree) new MutationObserver(sync).observe(taxonomyTree,
+            { attributes: true, childList: true, subtree: true });
+        sync();
+    }
+
+    function installKeyboardShortcuts() {
+        document.addEventListener('keydown', function (event) {
+            if (!event.altKey || !event.shiftKey) return;
+            if (event.key.toLowerCase() === 'a') {
+                event.preventDefault();
+                document.querySelector('#mainNavTabs [data-page="analyze"]')?.click();
+                document.getElementById('businessText')?.focus();
+            } else if (event.key.toLowerCase() === 'o') {
+                event.preventDefault();
+                var details = document.getElementById('operationalContextDetails');
+                if (details) {
+                    details.open = !details.open;
+                    details.querySelector('summary')?.focus();
+                }
+            }
+        });
+    }
+
+    function initTaskFocus() {
+        createOperationalContext();
+        createTaskProgress();
+        createSecondaryToolsDisclosure();
+        installKeyboardShortcuts();
+    }
+
     // Auto-init on DOMContentLoaded
-    document.addEventListener('DOMContentLoaded', init);
+    document.addEventListener('DOMContentLoaded', function () {
+        init();
+        initTaskFocus();
+    });
 
     // Public API
     window.TaxonomyOnboarding = {
         init: init,
         dismiss: dismiss,
-        reset: reset
+        reset: reset,
+        initTaskFocus: initTaskFocus
     };
 })();

--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -181,6 +181,7 @@ class OnnxSeleniumIT {
     @Test
     @Order(11)
     void aiStatusBadgeShowsLimited() {
+        openDetails("operationalContextDetails");
         WebElement badge = new WebDriverWait(driver, Duration.ofSeconds(30))
                 .until(currentDriver -> {
                     WebElement candidate = currentDriver.findElement(By.id("aiStatusBadge"));
@@ -337,7 +338,19 @@ class OnnxSeleniumIT {
                 });
     }
 
+    private void openDetails(String id) {
+        WebElement details = driver.findElement(By.id(id));
+        if (details.getAttribute("open") != null) {
+            return;
+        }
+        clickWhenUnobscured(By.cssSelector("#" + id + " > summary"));
+        new WebDriverWait(driver, Duration.ofSeconds(10))
+                .until(currentDriver -> currentDriver.findElement(By.id(id))
+                        .getAttribute("open") != null);
+    }
+
     private void executeUiSearch(String mode, String query) {
+        openDetails("analysisSecondaryTools");
         WebElement searchPanel = driver.findElement(By.id("searchPanel"));
         if (searchPanel.getAttribute("open") == null) {
             searchPanel.findElement(By.tagName("summary")).click();


### PR DESCRIPTION
## Summary

Completes the remaining software-ergonomics work from #479 by making the main workflow explicit, visually dominant and measurable instead of relying on screenshot judgement alone.

## Changes

- add a persistent four-stage analysis progression: describe, analyze, review and continue;
- present a contextual next action for empty, ready, running, completed, stale and error states;
- move repository, workspace, model and environment detail into a compact operational-context disclosure while preserving the original live surfaces;
- group search, logs, gap analysis, pattern detection, recommendations and document import under one keyboard-reachable secondary-tools disclosure;
- collapse the score legend by default;
- preserve expert access with `Alt+Shift+A` for the analysis task and `Alt+Shift+O` for operational context;
- retain forced-colors, reduced-motion, touch-target, focus-order and mobile reflow behavior.

## Measurable acceptance evidence

The existing role/state browser suite now records per profile:

- time to the visible primary action;
- time to task completion;
- pixels and viewport ratio occupied before task guidance;
- page transitions and navigation errors before the primary action;
- whether the primary and contextual next actions are inside the initial viewport;
- whether operational details and expert tools are collapsed by default.

It also asserts that:

- task stages advance after requirement entry and successful analysis;
- stale input returns focus to the analysis stage;
- provider errors retain hierarchy and expose a retry action;
- role-specific operation feedback, keyboard access and automated accessibility checks remain intact.

Closes #479.