### PR TITLE
Measure and gate OpenTelemetry runtime overhead

### DIFF
--- a/.github/scripts/run-observability-performance.sh
+++ b/.github/scripts/run-observability-performance.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$ROOT"
+
+ENFORCE=${TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE:-true}
+WARMUP_REQUESTS=${TAXONOMY_OBSERVABILITY_PERFORMANCE_WARMUP_REQUESTS:-12}
+MEASURED_REQUESTS=${TAXONOMY_OBSERVABILITY_PERFORMANCE_MEASURED_REQUESTS:-80}
+
+exec ./mvnw -B -pl taxonomy-app -am verify \
+  -DskipITs=false \
+  -Dit.test=ObservabilityPerformanceIT \
+  -Dtest=ObservabilityConfigurationTest,TaxonomyObservationConfigurationTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -DexcludedGroups=real-llm,onnx,db-postgres,db-mssql,db-oracle \
+  -Dtaxonomy.model.download.skip=true \
+  -Dtaxonomy.ui.skip=true \
+  -Dtaxonomy.quality.skip=true \
+  -Dtaxonomy.observability.performance.enabled=true \
+  -Dtaxonomy.observability.performance.enforce="$ENFORCE" \
+  -Dtaxonomy.observability.performance.warmup-requests="$WARMUP_REQUESTS" \
+  -Dtaxonomy.observability.performance.measured-requests="$MEASURED_REQUESTS"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Java 21
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
@@ -37,6 +38,32 @@ jobs:
 
       - name: Verify Docker availability
         run: docker info
+
+      - name: Detect observability performance changes
+        id: observability-performance-scope
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet "${{ github.event.pull_request.base.sha }}...HEAD" -- \
+            observability \
+            taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java \
+            taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java \
+            taxonomy-app/src/test/resources/observability \
+            .github/scripts/run-observability-performance.sh \
+            docs/dev/OBSERVABILITY_PERFORMANCE.md \
+            .github/workflows/ci-cd.yml; then
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Measure OpenTelemetry performance budget
+        if: steps.observability-performance-scope.outputs.run == 'true'
+        env:
+          TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE: 'true'
+        shell: bash
+        run: bash .github/scripts/run-observability-performance.sh
 
       - name: Run the canonical Maven verification suite
         env:
@@ -89,6 +116,11 @@ jobs:
             target/taxonomy-vex.json; do
             if [ -f "$evidence" ]; then cp "$evidence" target/quality-reports/evidence/; fi
           done
+          if [ -d target/observability-performance ]; then
+            mkdir -p target/quality-reports/evidence/observability-performance
+            cp -a target/observability-performance/. \
+              target/quality-reports/evidence/observability-performance/
+          fi
           printf 'Verified commit: %s\n' "$GITHUB_SHA" > target/quality-reports/README.txt
 
       - name: Upload verified reports

--- a/docs/dev/OBSERVABILITY_PERFORMANCE.md
+++ b/docs/dev/OBSERVABILITY_PERFORMANCE.md
@@ -4,22 +4,25 @@ This document defines the reproducible performance evidence for the optional Ope
 
 ## Scope
 
-The harness starts the same packaged Taxonomy application JAR three times in otherwise identical pinned runtime containers:
+The harness builds the application test image **before any timing starts**, performs one unmeasured application lifecycle to prime Docker filesystem/page caches, and then starts the same packaged Taxonomy application JAR in three otherwise identical pinned runtime containers:
 
 1. **baseline** — no Java agent is attached;
 2. **agent-always-on** — the bundled agent exports every sampled trace to the test Collector;
 3. **agent-sampled-10-percent** — the agent uses `parentbased_traceidratio` with `0.10`.
 
-All modes use the HSQLDB and observability Spring profiles, mock LLM operation, disabled embeddings, the same HTTP client, the same `/api/relations` workload and the same host. The OpenTelemetry Collector configuration is the privacy-filtered integration-test configuration already used by `ObservabilityContainerIT`.
+The eager image build is essential: without it, the first baseline start would include Testcontainers' one-off Docker build while later agent modes reused the finished image. The unmeasured lifecycle similarly prevents a first-ever container start from being mistaken for application or agent overhead.
+
+All measured modes use the HSQLDB and observability Spring profiles, mock LLM operation, disabled embeddings, the same HTTP client, the same `/api/relations` workload and the same host. The OpenTelemetry Collector configuration is the privacy-filtered integration-test configuration already used by `ObservabilityContainerIT`.
 
 The report records:
 
-- application startup duration until `/actuator/health` is ready;
+- application startup duration until `/actuator/health` is ready, excluding the Docker image build;
 - cgroup memory peak;
 - cgroup CPU consumption per measured request;
 - HTTP p50 and p95 latency;
 - exported spans per request;
-- the difference between no sampling, full sampling and 10-percent sampling.
+- the difference between no sampling, full sampling and 10-percent sampling;
+- an explicit flag proving image build and runtime prewarming happened before timing.
 
 ## Run locally
 
@@ -29,7 +32,7 @@ Docker must be available. Execute from any repository directory:
 bash .github/scripts/run-observability-performance.sh
 ```
 
-The script is Maven-owned and runs only the relevant observability unit tests plus `ObservabilityPerformanceIT`. The integration test is guarded by the system property `taxonomy.observability.performance.enabled`; therefore ordinary `./mvnw verify` and release builds discover but skip the expensive three-container measurement.
+The script is Maven-owned and runs only the relevant observability unit tests plus `ObservabilityPerformanceIT`. The integration test is guarded by the system property `taxonomy.observability.performance.enabled`; therefore ordinary `./mvnw verify` and release builds discover but skip the expensive multi-container measurement.
 
 Outputs:
 
@@ -38,7 +41,7 @@ target/observability-performance/report.json
 target/observability-performance/report.md
 ```
 
-The JSON schema version is included in the report so later tooling can reject incompatible evidence.
+The JSON schema version is included in the report so later tooling can reject incompatible evidence. The Markdown report is also printed in the Maven log so the measured values remain reviewable even if artifact publication fails.
 
 ## Repetition and workload size
 
@@ -75,17 +78,20 @@ The canonical `.github/workflows/ci-cd.yml` remains the single workflow authorit
 
 ## Interpretation cautions
 
-- Container start time includes image/container setup and therefore has more variance than steady-state latency.
+- Container start time includes container creation and JVM startup, but not application-image construction or the unmeasured cache-priming lifecycle.
 - cgroup memory peak covers startup and workload execution, which is intentional for deployment sizing.
 - exported span counts include all spans produced by the measured HTTP requests, not only HTTP root spans.
 - the 10-percent sampler is probabilistic; compare span volume over the complete request set rather than expecting exactly eight sampled requests out of eighty.
 - negative overhead is possible due to host noise and does not prove that instrumentation improves performance.
+- CI runners are noisy. A result close to a budget should be repeated before changing instrumentation or policy.
 
 ---
 
 # Deutsche Betriebszusammenfassung
 
-Der Test startet dasselbe gepackte Taxonomy-JAR in drei identischen, versionsfesten Containern: ohne Agent, mit vollständigem Sampling und mit zehn Prozent Sampling. Er misst Startzeit, cgroup-Speicherspitze, CPU je Anfrage, p50/p95 sowie exportierte Spans je Anfrage.
+Der Test baut das Anwendungs-Image zuerst **außerhalb jeder Zeitmessung**, startet die Anwendung einmal ungemessen zum Vorwärmen der Docker-Dateisystem-/Seitencaches und misst danach dasselbe gepackte Taxonomy-JAR in drei Konfigurationen: ohne Agent, mit vollständigem Sampling und mit zehn Prozent Sampling. Er misst Startzeit, cgroup-Speicherspitze, CPU je Anfrage, p50/p95 sowie exportierte Spans je Anfrage.
+
+Diese Reihenfolge verhindert, dass der einmalige Docker-Build fälschlich der Baseline zugerechnet wird und die Agent-Varianten dadurch künstlich günstiger aussehen.
 
 Ausführung:
 

--- a/docs/dev/OBSERVABILITY_PERFORMANCE.md
+++ b/docs/dev/OBSERVABILITY_PERFORMANCE.md
@@ -1,0 +1,105 @@
+# OpenTelemetry performance verification
+
+This document defines the reproducible performance evidence for the optional OpenTelemetry Java agent. The German operational summary follows the English procedure.
+
+## Scope
+
+The harness starts the same packaged Taxonomy application JAR three times in otherwise identical pinned runtime containers:
+
+1. **baseline** — no Java agent is attached;
+2. **agent-always-on** — the bundled agent exports every sampled trace to the test Collector;
+3. **agent-sampled-10-percent** — the agent uses `parentbased_traceidratio` with `0.10`.
+
+All modes use the HSQLDB and observability Spring profiles, mock LLM operation, disabled embeddings, the same HTTP client, the same `/api/relations` workload and the same host. The OpenTelemetry Collector configuration is the privacy-filtered integration-test configuration already used by `ObservabilityContainerIT`.
+
+The report records:
+
+- application startup duration until `/actuator/health` is ready;
+- cgroup memory peak;
+- cgroup CPU consumption per measured request;
+- HTTP p50 and p95 latency;
+- exported spans per request;
+- the difference between no sampling, full sampling and 10-percent sampling.
+
+## Run locally
+
+Docker must be available. Execute from any repository directory:
+
+```bash
+bash .github/scripts/run-observability-performance.sh
+```
+
+The script is Maven-owned and runs only the relevant observability unit tests plus `ObservabilityPerformanceIT`. The integration test is guarded by the system property `taxonomy.observability.performance.enabled`; therefore ordinary `./mvnw verify` and release builds discover but skip the expensive three-container measurement.
+
+Outputs:
+
+```text
+target/observability-performance/report.json
+target/observability-performance/report.md
+```
+
+The JSON schema version is included in the report so later tooling can reject incompatible evidence.
+
+## Repetition and workload size
+
+The default workload uses 12 warm-up requests and 80 measured requests per mode. Override it without changing source code:
+
+```bash
+TAXONOMY_OBSERVABILITY_PERFORMANCE_WARMUP_REQUESTS=20 \
+TAXONOMY_OBSERVABILITY_PERFORMANCE_MEASURED_REQUESTS=200 \
+bash .github/scripts/run-observability-performance.sh
+```
+
+For release decisions, repeat the run on the intended production CPU architecture and container runtime. CI evidence is a regression signal, not a substitute for capacity testing with representative search, analysis, repository and export workloads.
+
+## Budgets
+
+Two levels are deliberately separated:
+
+- **investigation threshold:** more than 10 percent always-on p95 overhead is reported as `investigationRequired=true`;
+- **hard regression ceiling:** CI fails only when the relative increase is also operationally material, avoiding a false failure caused by a one-millisecond baseline.
+
+Default hard ceilings are:
+
+- p95: more than 100 percent **and** more than 30 ms absolute increase;
+- startup: more than 100 percent **and** more than 30 s absolute increase;
+- memory: more than 256 MiB peak increase.
+
+Override the hard ceilings with the documented system properties when a deployment has stricter budgets. Set `TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE=false` to collect evidence without enforcing the hard ceiling; CI uses enforcement.
+
+A result above the 10-percent investigation threshold must be reviewed even when it remains below the hard ceiling. Prefer reducing span volume, instrumentation scope or sampling ratio before increasing Collector queues or memory.
+
+## CI behavior
+
+The canonical `.github/workflows/ci-cd.yml` remains the single workflow authority. It detects changes to observability runtime configuration, the performance harness, its runner or this document and then executes the targeted Maven command before the normal canonical verification. The generated JSON and Markdown are copied into the existing `quality-reports` artifact; no separate workflow is introduced.
+
+## Interpretation cautions
+
+- Container start time includes image/container setup and therefore has more variance than steady-state latency.
+- cgroup memory peak covers startup and workload execution, which is intentional for deployment sizing.
+- exported span counts include all spans produced by the measured HTTP requests, not only HTTP root spans.
+- the 10-percent sampler is probabilistic; compare span volume over the complete request set rather than expecting exactly eight sampled requests out of eighty.
+- negative overhead is possible due to host noise and does not prove that instrumentation improves performance.
+
+---
+
+# Deutsche Betriebszusammenfassung
+
+Der Test startet dasselbe gepackte Taxonomy-JAR in drei identischen, versionsfesten Containern: ohne Agent, mit vollständigem Sampling und mit zehn Prozent Sampling. Er misst Startzeit, cgroup-Speicherspitze, CPU je Anfrage, p50/p95 sowie exportierte Spans je Anfrage.
+
+Ausführung:
+
+```bash
+bash .github/scripts/run-observability-performance.sh
+```
+
+Ergebnisse:
+
+```text
+target/observability-performance/report.json
+target/observability-performance/report.md
+```
+
+Mehr als zehn Prozent p95-Overhead wird immer als untersuchungsbedürftig markiert. Der harte CI-Grenzwert greift erst bei zugleich relativ und absolut erheblicher Verschlechterung: standardmäßig über 100 Prozent und über 30 ms p95-Zuwachs, über 100 Prozent und über 30 Sekunden zusätzliche Startzeit oder über 256 MiB zusätzliche Speicherspitze.
+
+Die CI verwendet weiterhin ausschließlich den kanonischen Maven-Workflow. Bei Änderungen am Observability-Bereich wird der gezielte Vergleich zusätzlich ausgeführt und der Bericht in das bestehende `quality-reports`-Artefakt aufgenommen.

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java
@@ -1,0 +1,478 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+import tools.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproducible relative performance measurement for the optional OpenTelemetry
+ * Java agent. This is deliberately a dedicated opt-in integration test rather
+ * than part of every developer build. Run it through
+ * {@code .github/scripts/run-observability-performance.sh}.
+ */
+@Tag("observability-performance")
+@EnabledIfSystemProperty(
+        named = "taxonomy.observability.performance.enabled",
+        matches = "true")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ObservabilityPerformanceIT {
+
+    private static final String AGENT_IMAGE =
+            "otel/autoinstrumentation-java:2.28.1@sha256:"
+                    + "41b92978e61d13d4f32c6eb20c6ae7821a73ffdec8539bc6a73858e884b411d8";
+    private static final String RUNTIME_IMAGE =
+            "eclipse-temurin:21-jre-jammy@sha256:"
+                    + "d63bd8d9b171999cbed8576f2c76e874dd4856791a358536e5c4d407e77edc13";
+    private static final String COLLECTOR_IMAGE =
+            "otel/opentelemetry-collector-contrib@sha256:"
+                    + "f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6";
+    private static final String COLLECTOR_ALIAS = "otel-performance-collector.test";
+    private static final int WARMUP_REQUESTS = Integer.getInteger(
+            "taxonomy.observability.performance.warmup-requests", 12);
+    private static final int MEASURED_REQUESTS = Integer.getInteger(
+            "taxonomy.observability.performance.measured-requests", 80);
+    private static final double INVESTIGATION_THRESHOLD_PERCENT = 10.0;
+    private static final double HARD_P95_PERCENT = Double.parseDouble(System.getProperty(
+            "taxonomy.observability.performance.hard-p95-percent", "100"));
+    private static final long HARD_P95_ABSOLUTE_MILLIS = Long.getLong(
+            "taxonomy.observability.performance.hard-p95-absolute-millis", 30L);
+    private static final long HARD_STARTUP_ABSOLUTE_MILLIS = Long.getLong(
+            "taxonomy.observability.performance.hard-startup-absolute-millis", 30_000L);
+    private static final long HARD_MEMORY_DELTA_MIB = Long.getLong(
+            "taxonomy.observability.performance.hard-memory-delta-mib", 256L);
+    private static final Pattern EXPORTED_SPAN = Pattern.compile("Trace ID\\s*:");
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    private static final String BASIC_AUTH = "Basic "
+            + Base64.getEncoder().encodeToString(
+                    ("admin:" + ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                            .getBytes(StandardCharsets.UTF_8));
+
+    private Network network;
+    private GenericContainer<?> collector;
+    private Future<String> applicationImage;
+
+    @BeforeAll
+    void startCollectorAndBuildApplicationImage() {
+        network = Network.newNetwork();
+        collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(COLLECTOR_ALIAS)
+                .withCopyFileToContainer(
+                        MountableFile.forClasspathResource(
+                                "observability/otel-collector-test-config.yml"),
+                        "/etc/otelcol-contrib/config.yaml")
+                .withCommand("--config=/etc/otelcol-contrib/config.yaml")
+                .waitingFor(Wait.forLogMessage(".*Everything is ready.*\\n", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
+        collector.start();
+        applicationImage = performanceApplicationImage();
+    }
+
+    @AfterAll
+    void stopInfrastructure() throws Exception {
+        ContainerTestUtils.closeAll(collector, network);
+    }
+
+    @Test
+    void measuresAgentAndSamplingOverheadAndWritesEvidence() throws Exception {
+        ModeResult baseline = measure(new Mode("baseline", false, "none", null));
+        ModeResult alwaysOn = measure(new Mode("agent-always-on", true, "always_on", null));
+        ModeResult sampled = measure(new Mode(
+                "agent-sampled-10-percent", true, "parentbased_traceidratio", "0.10"));
+
+        assertThat(baseline.exportedSpans()).as("baseline exported spans").isZero();
+        assertThat(alwaysOn.exportedSpans()).as("always-on exported spans").isPositive();
+        assertThat(sampled.exportedSpans())
+                .as("sampling must reduce exported span volume")
+                .isLessThan(alwaysOn.exportedSpans());
+
+        double p95Overhead = overheadPercent(baseline.p95Millis(), alwaysOn.p95Millis());
+        double sampledP95Overhead = overheadPercent(baseline.p95Millis(), sampled.p95Millis());
+        double startupOverhead = overheadPercent(
+                baseline.startupMillis(), alwaysOn.startupMillis());
+        long memoryDeltaMiB = Math.round(
+                (alwaysOn.memoryPeakBytes() - baseline.memoryPeakBytes())
+                        / (1024.0 * 1024.0));
+
+        boolean p95HardLimit = p95Overhead > HARD_P95_PERCENT
+                && alwaysOn.p95Millis() - baseline.p95Millis()
+                > HARD_P95_ABSOLUTE_MILLIS;
+        boolean startupHardLimit = startupOverhead > 100.0
+                && alwaysOn.startupMillis() - baseline.startupMillis()
+                > HARD_STARTUP_ABSOLUTE_MILLIS;
+        boolean memoryHardLimit = memoryDeltaMiB > HARD_MEMORY_DELTA_MIB;
+        BudgetEvaluation budget = new BudgetEvaluation(
+                INVESTIGATION_THRESHOLD_PERCENT,
+                p95Overhead,
+                sampledP95Overhead,
+                startupOverhead,
+                memoryDeltaMiB,
+                p95Overhead > INVESTIGATION_THRESHOLD_PERCENT,
+                p95HardLimit,
+                startupHardLimit,
+                memoryHardLimit,
+                p95HardLimit || startupHardLimit || memoryHardLimit);
+
+        PerformanceReport report = new PerformanceReport(
+                1,
+                Instant.now().toString(),
+                System.getProperty("java.version"),
+                Runtime.getRuntime().availableProcessors(),
+                WARMUP_REQUESTS,
+                MEASURED_REQUESTS,
+                "/api/relations",
+                List.of(baseline, alwaysOn, sampled),
+                budget);
+        Path reportDirectory = writeReport(report);
+
+        if (Boolean.getBoolean("taxonomy.observability.performance.enforce")) {
+            assertThat(budget.hardBudgetExceeded())
+                    .as("OpenTelemetry hard performance budget; inspect %s",
+                            reportDirectory.resolve("report.md"))
+                    .isFalse();
+        }
+    }
+
+    private ModeResult measure(Mode mode) throws Exception {
+        GenericContainer<?> application = applicationContainer(mode);
+        long startupStarted = System.nanoTime();
+        application.start();
+        long startupMillis = elapsedMillis(startupStarted);
+
+        try {
+            for (int i = 0; i < WARMUP_REQUESTS; i++) {
+                assertSuccessful(applicationGet(application, "/api/relations"));
+            }
+            awaitCollectorQuiet();
+            int collectorOffset = collector.getLogs().length();
+            long cpuBeforeMicros = readCpuMicros(application);
+
+            List<Long> latencyNanos = new ArrayList<>(MEASURED_REQUESTS);
+            for (int i = 0; i < MEASURED_REQUESTS; i++) {
+                long started = System.nanoTime();
+                HttpResponse<String> response = applicationGet(application, "/api/relations");
+                latencyNanos.add(System.nanoTime() - started);
+                assertSuccessful(response);
+            }
+
+            long cpuAfterMicros = readCpuMicros(application);
+            awaitCollectorQuiet();
+            String collectorLogs = collector.getLogs();
+            String newCollectorLogs = collectorLogs.length() >= collectorOffset
+                    ? collectorLogs.substring(collectorOffset)
+                    : collectorLogs;
+            long memoryPeakBytes = readMemoryPeakBytes(application);
+            latencyNanos.sort(Comparator.naturalOrder());
+
+            long p50Millis = percentileMillis(latencyNanos, 50);
+            long p95Millis = percentileMillis(latencyNanos, 95);
+            long cpuMicros = Math.max(0, cpuAfterMicros - cpuBeforeMicros);
+            int spans = countSpans(newCollectorLogs);
+            return new ModeResult(
+                    mode.name(),
+                    mode.agentAttached(),
+                    mode.sampler(),
+                    mode.samplerArgument(),
+                    startupMillis,
+                    memoryPeakBytes,
+                    cpuMicros,
+                    cpuMicros / (double) MEASURED_REQUESTS,
+                    p50Millis,
+                    p95Millis,
+                    spans,
+                    spans / (double) MEASURED_REQUESTS);
+        } finally {
+            application.stop();
+        }
+    }
+
+    private GenericContainer<?> applicationContainer(Mode mode) {
+        GenericContainer<?> application = new GenericContainer<>(applicationImage)
+                .withNetwork(network)
+                .withExposedPorts(8080)
+                .withEnv("SPRING_PROFILES_ACTIVE", "hsqldb,observability")
+                .withEnv("TAXONOMY_ADMIN_PASSWORD", ContainerTestUtils.TEST_ADMIN_PASSWORD)
+                .withEnv("TAXONOMY_REQUIRE_PASSWORD_CHANGE", "false")
+                .withEnv("TAXONOMY_EMBEDDING_ENABLED", "false")
+                .withEnv("TAXONOMY_THYMELEAF_CACHE", "true")
+                .withEnv("LLM_MOCK", "true")
+                .waitingFor(Wait.forHttp("/actuator/health")
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        if (!mode.agentAttached()) {
+            return application;
+        }
+        application
+                .withEnv("JAVA_TOOL_OPTIONS", "-javaagent:/tmp/opentelemetry-javaagent.jar")
+                .withEnv("OTEL_JAVAAGENT_CONFIGURATION_FILE", "/tmp/javaagent.properties")
+                .withEnv("OTEL_SERVICE_NAME", "taxonomy-observability-performance")
+                .withEnv("OTEL_TRACES_EXPORTER", "otlp")
+                .withEnv("OTEL_METRICS_EXPORTER", "none")
+                .withEnv("OTEL_LOGS_EXPORTER", "none")
+                .withEnv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+                .withEnv("OTEL_EXPORTER_OTLP_ENDPOINT",
+                        "http://" + COLLECTOR_ALIAS + ":4318")
+                .withEnv("OTEL_TRACES_SAMPLER", mode.sampler())
+                .withEnv("OTEL_BSP_SCHEDULE_DELAY", "100")
+                .withEnv("OTEL_BSP_EXPORT_TIMEOUT", "1000");
+        if (mode.samplerArgument() != null) {
+            application.withEnv("OTEL_TRACES_SAMPLER_ARG", mode.samplerArgument());
+        }
+        return application;
+    }
+
+    private Future<String> performanceApplicationImage() {
+        Path root = repositoryRoot();
+        String dockerfile = """
+                FROM %s AS opentelemetry
+                FROM %s
+                WORKDIR /app
+                COPY app.jar /app/app.jar
+                COPY javaagent.properties /tmp/javaagent.properties
+                COPY --from=opentelemetry /javaagent.jar /tmp/opentelemetry-javaagent.jar
+                EXPOSE 8080
+                ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+                """.formatted(AGENT_IMAGE, RUNTIME_IMAGE);
+        return new ImageFromDockerfile("taxonomy-observability-performance-it", false)
+                .withFileFromString("Dockerfile", dockerfile)
+                .withFileFromPath("app.jar", ContainerTestUtils.findApplicationJar())
+                .withFileFromPath(
+                        "javaagent.properties",
+                        root.resolve("observability/javaagent.properties"));
+    }
+
+    private static HttpResponse<String> applicationGet(
+            GenericContainer<?> application, String path) throws Exception {
+        URI uri = URI.create("http://" + application.getHost() + ":"
+                + application.getMappedPort(8080) + path);
+        HttpRequest request = HttpRequest.newBuilder(uri)
+                .timeout(Duration.ofSeconds(20))
+                .header("Accept", "application/json")
+                .header("Authorization", BASIC_AUTH)
+                .GET()
+                .build();
+        return HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static void assertSuccessful(HttpResponse<String> response) {
+        assertThat(response.statusCode())
+                .withFailMessage("Performance workload returned %s: %s",
+                        response.statusCode(), response.body())
+                .isEqualTo(200);
+    }
+
+    private void awaitCollectorQuiet() throws InterruptedException {
+        int unchanged = 0;
+        int previousLength = -1;
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (System.nanoTime() < deadline && unchanged < 3) {
+            int currentLength = collector.getLogs().length();
+            if (currentLength == previousLength) {
+                unchanged++;
+            } else {
+                unchanged = 0;
+                previousLength = currentLength;
+            }
+            Thread.sleep(250);
+        }
+    }
+
+    private static long readCpuMicros(GenericContainer<?> application) throws Exception {
+        String command = """
+                if [ -r /sys/fs/cgroup/cpu.stat ]; then
+                  awk '$1 == "usage_usec" { print $2; exit }' /sys/fs/cgroup/cpu.stat
+                elif [ -r /sys/fs/cgroup/cpuacct/cpuacct.usage ]; then
+                  awk '{ printf "%.0f\\n", $1 / 1000 }' /sys/fs/cgroup/cpuacct/cpuacct.usage
+                else
+                  echo 0
+                fi
+                """;
+        return parseLong(application.execInContainer("sh", "-c", command), "CPU usage");
+    }
+
+    private static long readMemoryPeakBytes(GenericContainer<?> application) throws Exception {
+        String command = """
+                if [ -r /sys/fs/cgroup/memory.peak ]; then
+                  cat /sys/fs/cgroup/memory.peak
+                elif [ -r /sys/fs/cgroup/memory/memory.max_usage_in_bytes ]; then
+                  cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+                elif [ -r /sys/fs/cgroup/memory.current ]; then
+                  cat /sys/fs/cgroup/memory.current
+                else
+                  echo 0
+                fi
+                """;
+        return parseLong(application.execInContainer("sh", "-c", command), "memory usage");
+    }
+
+    private static long parseLong(Container.ExecResult result, String measurement) {
+        assertThat(result.getExitCode())
+                .withFailMessage("Failed to read %s: %s", measurement, result.getStderr())
+                .isZero();
+        return Long.parseLong(result.getStdout().trim());
+    }
+
+    private static int countSpans(String logs) {
+        int count = 0;
+        Matcher matcher = EXPORTED_SPAN.matcher(logs);
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    private static long percentileMillis(List<Long> values, int percentile) {
+        int index = Math.max(0, (int) Math.ceil(percentile / 100.0 * values.size()) - 1);
+        return Math.max(1, Duration.ofNanos(values.get(index)).toMillis());
+    }
+
+    private static long elapsedMillis(long startedNanos) {
+        return Duration.ofNanos(System.nanoTime() - startedNanos).toMillis();
+    }
+
+    private static double overheadPercent(long baseline, long observed) {
+        if (baseline <= 0) {
+            return observed <= 0 ? 0.0 : 100.0;
+        }
+        return (observed - baseline) * 100.0 / baseline;
+    }
+
+    private static Path writeReport(PerformanceReport report) throws Exception {
+        Path directory = repositoryRoot().resolve("target/observability-performance");
+        Files.createDirectories(directory);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(directory.resolve("report.json").toFile(), report);
+        Files.writeString(directory.resolve("report.md"), markdown(report), StandardCharsets.UTF_8);
+        return directory;
+    }
+
+    private static String markdown(PerformanceReport report) {
+        StringBuilder markdown = new StringBuilder("# OpenTelemetry performance evidence\n\n")
+                .append("Generated: `").append(report.generatedAt()).append("`  \n")
+                .append("Java: `").append(report.javaVersion()).append("`  \n")
+                .append("Workload: ").append(report.measuredRequests())
+                .append(" requests to `").append(report.endpoint()).append("` after ")
+                .append(report.warmupRequests()).append(" warm-up requests.\n\n")
+                .append("| Mode | Startup ms | Memory peak MiB | CPU µs/request | p50 ms | p95 ms | Spans/request |\n")
+                .append("|---|---:|---:|---:|---:|---:|---:|\n");
+        for (ModeResult mode : report.modes()) {
+            markdown.append(String.format(Locale.ROOT,
+                    "| %s | %d | %.1f | %.1f | %d | %d | %.2f |%n",
+                    mode.name(), mode.startupMillis(),
+                    mode.memoryPeakBytes() / (1024.0 * 1024.0),
+                    mode.cpuMicrosPerRequest(), mode.p50Millis(), mode.p95Millis(),
+                    mode.spansPerRequest()));
+        }
+        BudgetEvaluation budget = report.budget();
+        markdown.append("\n## Budget evaluation\n\n")
+                .append(String.format(Locale.ROOT,
+                        "- Always-on p95 overhead: **%.1f%%**.%n", budget.p95OverheadPercent()))
+                .append(String.format(Locale.ROOT,
+                        "- Sampled p95 overhead: **%.1f%%**.%n", budget.sampledP95OverheadPercent()))
+                .append(String.format(Locale.ROOT,
+                        "- Always-on startup overhead: **%.1f%%**.%n", budget.startupOverheadPercent()))
+                .append("- Always-on memory delta: **").append(budget.memoryDeltaMiB())
+                .append(" MiB**.\n")
+                .append("- More than ").append(budget.investigationThresholdPercent())
+                .append("% p95 overhead requires investigation: **")
+                .append(budget.investigationRequired()).append("**.\n")
+                .append("- Hard regression budget exceeded: **")
+                .append(budget.hardBudgetExceeded()).append("**.\n");
+        return markdown.toString();
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("project.basedir", "."))
+                .toAbsolutePath().normalize();
+        if (Files.isRegularFile(current.resolve("taxonomy-app/pom.xml"))) {
+            return current;
+        }
+        if ("taxonomy-app".equals(current.getFileName().toString())
+                && Files.isRegularFile(current.resolve("pom.xml"))) {
+            return current.getParent();
+        }
+        throw new IllegalStateException(
+                "Cannot locate Taxonomy repository root from " + current);
+    }
+
+    private record Mode(
+            String name,
+            boolean agentAttached,
+            String sampler,
+            String samplerArgument) {
+    }
+
+    private record ModeResult(
+            String name,
+            boolean agentAttached,
+            String sampler,
+            String samplerArgument,
+            long startupMillis,
+            long memoryPeakBytes,
+            long cpuMicros,
+            double cpuMicrosPerRequest,
+            long p50Millis,
+            long p95Millis,
+            int exportedSpans,
+            double spansPerRequest) {
+    }
+
+    private record BudgetEvaluation(
+            double investigationThresholdPercent,
+            double p95OverheadPercent,
+            double sampledP95OverheadPercent,
+            double startupOverheadPercent,
+            long memoryDeltaMiB,
+            boolean investigationRequired,
+            boolean p95HardLimitExceeded,
+            boolean startupHardLimitExceeded,
+            boolean memoryHardLimitExceeded,
+            boolean hardBudgetExceeded) {
+    }
+
+    private record PerformanceReport(
+            int schemaVersion,
+            String generatedAt,
+            String javaVersion,
+            int availableProcessors,
+            int warmupRequests,
+            int measuredRequests,
+            String endpoint,
+            List<ModeResult> modes,
+            BudgetEvaluation budget) {
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java
@@ -29,7 +29,6 @@ import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -82,10 +81,10 @@ class ObservabilityPerformanceIT {
 
     private Network network;
     private GenericContainer<?> collector;
-    private Future<String> applicationImage;
+    private String applicationImage;
 
     @BeforeAll
-    void startCollectorAndBuildApplicationImage() {
+    void startCollectorAndBuildApplicationImage() throws Exception {
         network = Network.newNetwork();
         collector = new GenericContainer<>(DockerImageName.parse(COLLECTOR_IMAGE))
                 .withNetwork(network)
@@ -98,7 +97,16 @@ class ObservabilityPerformanceIT {
                 .waitingFor(Wait.forLogMessage(".*Everything is ready.*\\n", 1)
                         .withStartupTimeout(Duration.ofMinutes(2)));
         collector.start();
-        applicationImage = performanceApplicationImage();
+
+        // Resolve the lazy Testcontainers image future before any stopwatch is
+        // started. Otherwise the first (baseline) start would include the one-off
+        // Docker build while the agent modes would reuse the finished image.
+        applicationImage = performanceApplicationImage().get();
+
+        // Prime Docker's filesystem/page cache with an unmeasured application
+        // lifecycle. This keeps the comparison focused on agent/runtime effects
+        // rather than a first-ever container start on the runner.
+        warmApplicationRuntime();
     }
 
     @AfterAll
@@ -154,9 +162,11 @@ class ObservabilityPerformanceIT {
                 WARMUP_REQUESTS,
                 MEASURED_REQUESTS,
                 "/api/relations",
+                true,
                 List.of(baseline, alwaysOn, sampled),
                 budget);
         Path reportDirectory = writeReport(report);
+        System.out.println(markdown(report));
 
         if (Boolean.getBoolean("taxonomy.observability.performance.enforce")) {
             assertThat(budget.hardBudgetExceeded())
@@ -164,6 +174,18 @@ class ObservabilityPerformanceIT {
                             reportDirectory.resolve("report.md"))
                     .isFalse();
         }
+    }
+
+    private void warmApplicationRuntime() throws Exception {
+        GenericContainer<?> application = applicationContainer(
+                new Mode("unmeasured-prewarm", false, "none", null));
+        application.start();
+        try {
+            assertSuccessful(applicationGet(application, "/api/relations"));
+        } finally {
+            application.stop();
+        }
+        awaitCollectorQuiet();
     }
 
     private ModeResult measure(Mode mode) throws Exception {
@@ -220,7 +242,8 @@ class ObservabilityPerformanceIT {
     }
 
     private GenericContainer<?> applicationContainer(Mode mode) {
-        GenericContainer<?> application = new GenericContainer<>(applicationImage)
+        GenericContainer<?> application = new GenericContainer<>(
+                DockerImageName.parse(applicationImage))
                 .withNetwork(network)
                 .withExposedPorts(8080)
                 .withEnv("SPRING_PROFILES_ACTIVE", "hsqldb,observability")
@@ -254,7 +277,7 @@ class ObservabilityPerformanceIT {
         return application;
     }
 
-    private Future<String> performanceApplicationImage() {
+    private ImageFromDockerfile performanceApplicationImage() {
         Path root = repositoryRoot();
         String dockerfile = """
                 FROM %s AS opentelemetry
@@ -384,6 +407,8 @@ class ObservabilityPerformanceIT {
         StringBuilder markdown = new StringBuilder("# OpenTelemetry performance evidence\n\n")
                 .append("Generated: `").append(report.generatedAt()).append("`  \n")
                 .append("Java: `").append(report.javaVersion()).append("`  \n")
+                .append("Application image built and runtime-prewarmed before timing: `")
+                .append(report.imageBuiltAndRuntimePrewarmed()).append("`  \n")
                 .append("Workload: ").append(report.measuredRequests())
                 .append(" requests to `").append(report.endpoint()).append("` after ")
                 .append(report.warmupRequests()).append(" warm-up requests.\n\n")
@@ -472,6 +497,7 @@ class ObservabilityPerformanceIT {
             int warmupRequests,
             int measuredRequests,
             String endpoint,
+            boolean imageBuiltAndRuntimePrewarmed,
             List<ModeResult> modes,
             BudgetEvaluation budget) {
     }


### PR DESCRIPTION
## Summary

Completes the remaining measurable acceptance work from #483 with a repository-owned, locally reproducible harness.

### Unbiased three-mode comparison

The same packaged Taxonomy application JAR is started in otherwise identical pinned runtime containers as:

1. baseline without the Java agent;
2. agent attached with `always_on` sampling;
3. agent attached with `parentbased_traceidratio=0.10`.

The Testcontainers image is built before any stopwatch starts, followed by one unmeasured application lifecycle to prime Docker filesystem/page caches. This prevents the baseline from absorbing the one-off image build or first-ever container start while the agent modes reuse cached layers.

All measured modes use the same HSQLDB/observability profiles, mock LLM, disabled embeddings, HTTP client, Collector privacy configuration and `/api/relations` workload.

### Recorded evidence

The generated JSON and Markdown reports contain:

- startup duration to healthy application, excluding image construction;
- cgroup memory peak;
- cgroup CPU consumption per request;
- p50 and p95 HTTP latency;
- exported spans per request;
- always-on and sampled overhead against baseline;
- an explicit flag proving image build and runtime prewarming happened before timing.

A 10% p95 investigation threshold is reported separately from noise-tolerant hard CI ceilings. Sampling must reduce exported span volume. The Markdown result is also printed into the Maven log so values remain reviewable if artifact publication fails.

### Maven and CI ownership

- `.github/scripts/run-observability-performance.sh` is the single local/CI entry point;
- the expensive test is opt-in and skipped during ordinary builds and releases;
- the canonical CI workflow invokes it only when observability/harness inputs change;
- reports are added to the existing `quality-reports` artifact rather than creating another workflow authority;
- the normal full `-Pci` verification still runs afterwards.

## Verification

Requires the targeted four-lifecycle run (one unmeasured prewarm plus three measured modes), the complete canonical Maven suite, Security Scan and CodeQL on this exact head. The measured report must be reviewed before merge; any p95 result above 10% remains explicitly marked for investigation.

Closes #483.