### PR TITLE
Add production-ready Rancher and Kubernetes deployment

### DIFF
--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fail closed when release staging and publication cease to be atomic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_SCRIPT = ROOT / ".github" / "scripts" / "release.sh"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-release.yml"
+
+
+def require(text: str, needle: str, source: Path, failures: list[str]) -> None:
+    if needle not in text:
+        failures.append(f"{source.relative_to(ROOT)} is missing {needle!r}")
+
+
+def main() -> int:
+    script = RELEASE_SCRIPT.read_text(encoding="utf-8")
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    for needle in (
+        "DEFER_RELEASE_PUBLICATION=${DEFER_RELEASE_PUBLICATION:-false}",
+        'if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then',
+        "remains a draft until downstream artifacts and final CI succeed",
+        'test "$RELEASE_IS_DRAFT" = true',
+    ):
+        require(script, needle, RELEASE_SCRIPT, failures)
+
+    for needle in (
+        "DEFER_RELEASE_PUBLICATION: 'true'",
+        "- name: Package and stage immutable Helm artifacts",
+        "- name: Build and publish immutable release image",
+        "- name: Verify final main snapshot with canonical CI",
+        "- name: Publish complete release and trigger deployment",
+        'docker buildx imagetools inspect "$image"',
+        'gh release edit "$tag" --draft=false --latest',
+        "Draft release is missing required Helm asset",
+        "Render deployment triggered after complete release publication.",
+    ):
+        require(workflow, needle, RELEASE_WORKFLOW, failures)
+
+    try:
+        stage = workflow.index("- name: Build and stage release, then prepare next development version")
+        checkout_tag = workflow.index("- name: Checkout immutable release source")
+        image = workflow.index("- name: Build and publish immutable release image")
+        final_ci = workflow.index("- name: Verify final main snapshot with canonical CI")
+        publish = workflow.index("- name: Publish complete release and trigger deployment")
+        if not stage < checkout_tag < image < final_ci < publish:
+            failures.append(
+                "deploy-release.yml must stage first, then build the immutable image, "
+                "verify final main, and publish last"
+            )
+        stage_block = workflow[stage:checkout_tag]
+        if "RENDER_DEPLOY_HOOK_URL" in stage_block:
+            failures.append("The staging step must not receive the deployment hook")
+        publish_block = workflow[publish:]
+        if "RENDER_DEPLOY_HOOK_URL" not in publish_block:
+            failures.append("Only the final publication step may trigger deployment")
+    except ValueError as error:
+        failures.append(f"Could not determine release step order: {error}")
+
+    if failures:
+        print("Release delivery contract failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Release delivery contract is atomic: publication remains the final gate.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -31,10 +31,14 @@ def main() -> int:
 
     for needle in (
         "DEFER_RELEASE_PUBLICATION: 'true'",
+        "- name: Record exact final main snapshot",
         "- name: Package and stage immutable Helm artifacts",
         "- name: Build and publish immutable release image",
-        "- name: Verify final main snapshot with canonical CI",
+        "- name: Verify exact final main snapshot with canonical CI",
         "- name: Publish complete release and trigger deployment",
+        "EXPECTED_MAIN_SHA: ${{ steps.final_main.outputs.sha }}",
+        '--commit "$EXPECTED_MAIN_SHA"',
+        'run_sha=$(gh run view "$run_id" --json headSha --jq \'.headSha\')',
         'docker buildx imagetools inspect "$image"',
         'gh release edit "$tag" --draft=false --latest',
         "Draft release is missing required Helm asset",
@@ -42,20 +46,38 @@ def main() -> int:
     ):
         require(workflow, needle, RELEASE_WORKFLOW, failures)
 
+    if "main_sha=$(git rev-parse origin/main)" in workflow:
+        failures.append(
+            "deploy-release.yml must not substitute the then-current main SHA "
+            "for the release-generated snapshot"
+        )
+
     try:
-        stage = workflow.index("- name: Build and stage release, then prepare next development version")
+        stage = workflow.index(
+            "- name: Build and stage release, then prepare next development version"
+        )
+        record_main = workflow.index("- name: Record exact final main snapshot")
         checkout_tag = workflow.index("- name: Checkout immutable release source")
         image = workflow.index("- name: Build and publish immutable release image")
-        final_ci = workflow.index("- name: Verify final main snapshot with canonical CI")
-        publish = workflow.index("- name: Publish complete release and trigger deployment")
-        if not stage < checkout_tag < image < final_ci < publish:
+        final_ci = workflow.index(
+            "- name: Verify exact final main snapshot with canonical CI"
+        )
+        publish = workflow.index(
+            "- name: Publish complete release and trigger deployment"
+        )
+        if not stage < record_main < checkout_tag < image < final_ci < publish:
             failures.append(
-                "deploy-release.yml must stage first, then build the immutable image, "
-                "verify final main, and publish last"
+                "deploy-release.yml must stage first, record the exact main commit, "
+                "build the immutable image, verify that exact commit, and publish last"
             )
         stage_block = workflow[stage:checkout_tag]
         if "RENDER_DEPLOY_HOOK_URL" in stage_block:
             failures.append("The staging step must not receive the deployment hook")
+        final_ci_block = workflow[final_ci:publish]
+        if 'run_sha" != "$EXPECTED_MAIN_SHA' not in final_ci_block:
+            failures.append(
+                "The final CI step must compare the selected run head to the recorded SHA"
+            )
         publish_block = workflow[publish:]
         if "RENDER_DEPLOY_HOOK_URL" not in publish_block:
             failures.append("Only the final publication step may trigger deployment")
@@ -68,7 +90,10 @@ def main() -> int:
             print(f"- {failure}", file=sys.stderr)
         return 1
 
-    print("Release delivery contract is atomic: publication remains the final gate.")
+    print(
+        "Release delivery contract is atomic: the exact release-generated main "
+        "snapshot is verified and publication remains the final gate."
+    )
     return 0
 
 

--- a/.github/scripts/install-helm.sh
+++ b/.github/scripts/install-helm.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HELM_VERSION=${HELM_VERSION:-v3.21.0}
+HELM_INSTALL_DIR=${HELM_INSTALL_DIR:-"${HOME}/.local/bin"}
+
+if [[ "${HELM_VERSION}" != "v3.21.0" ]]; then
+  echo "Unsupported Helm version ${HELM_VERSION}; add and review its official checksum before updating" >&2
+  exit 1
+fi
+
+case "$(uname -s)" in
+  Linux) platform=linux ;;
+  *)
+    echo "This verified installer currently supports Linux runners only" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    arch=amd64
+    sha256=0093eb572e3d2380f094df162ddb525e219249de88957afe24cfbb19632acd36
+    ;;
+  aarch64|arm64)
+    arch=arm64
+    sha256=8de5a0c9a47431e59fd560e91e0779c8cf9316c383da7efb84128a4c339ecb2d
+    ;;
+  *)
+    echo "Unsupported runner architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+archive="helm-${HELM_VERSION}-${platform}-${arch}.tar.gz"
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+curl --fail --silent --show-error --location --retry 3 \
+  "https://get.helm.sh/${archive}" \
+  --output "${tmp_dir}/${archive}"
+printf '%s  %s\n' "${sha256}" "${tmp_dir}/${archive}" | sha256sum --check --strict -
+
+tar --extract --gzip --file "${tmp_dir}/${archive}" --directory "${tmp_dir}"
+mkdir -p "${HELM_INSTALL_DIR}"
+install -m 0755 "${tmp_dir}/${platform}-${arch}/helm" "${HELM_INSTALL_DIR}/helm"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  printf '%s\n' "${HELM_INSTALL_DIR}" >> "${GITHUB_PATH}"
+fi
+
+"${HELM_INSTALL_DIR}/helm" version --short

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -12,6 +12,7 @@ SKIP_TESTS=${SKIP_TESTS:-false}
 DRY_RUN=${DRY_RUN:-false}
 SOURCE_BRANCH=${SOURCE_BRANCH:-main}
 RENDER_DEPLOY_HOOK_URL=${RENDER_DEPLOY_HOOK_URL:-}
+DEFER_RELEASE_PUBLICATION=${DEFER_RELEASE_PUBLICATION:-false}
 
 TAG_NAME="v${RELEASE_VERSION}"
 MAJOR_MINOR=$(echo "${RELEASE_VERSION}" | sed 's/\.[^.]*$//')
@@ -31,6 +32,9 @@ if [[ "$SOURCE_BRANCH" != "main" && "$DRY_RUN" != "true" ]]; then
 fi
 if [[ "$SKIP_TESTS" == "true" && "$DRY_RUN" != "true" ]]; then
   fail "skip_tests is allowed only for a dry run; published releases require the canonical verification suite"
+fi
+if [[ "$DEFER_RELEASE_PUBLICATION" != "true" && "$DEFER_RELEASE_PUBLICATION" != "false" ]]; then
+  fail "DEFER_RELEASE_PUBLICATION must be true or false"
 fi
 
 if [[ -n "$NEXT_VERSION_INPUT" ]]; then
@@ -200,6 +204,7 @@ echo "Current version: $CURRENT_VERSION"
 echo "Next development version: $NEXT_VERSION"
 echo "Release state: $STATE"
 echo "Main already advanced: $MAIN_ALREADY_ADVANCED"
+echo "Defer release publication: $DEFER_RELEASE_PUBLICATION"
 echo "Dry run: $DRY_RUN"
 
 ./mvnw -B validate
@@ -297,12 +302,21 @@ if [[ "$DRY_RUN" != "true" && "$STATE" == "draft" ]]; then
   else
     echo "::warning::No release artifacts found to upload"
   fi
-  gh release edit "$TAG_NAME" --draft=false --latest
-  STATE=published
-  PUBLISHED_THIS_RUN=true
+  if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then
+    echo "Release $TAG_NAME remains a draft until downstream artifacts and final CI succeed."
+  else
+    gh release edit "$TAG_NAME" --draft=false --latest
+    STATE=published
+    PUBLISHED_THIS_RUN=true
+  fi
 fi
 if [[ "$DRY_RUN" != "true" ]]; then
-  test "$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')" = false
+  RELEASE_IS_DRAFT=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')
+  if [[ "$STATE" == "draft" ]]; then
+    test "$RELEASE_IS_DRAFT" = true
+  else
+    test "$RELEASE_IS_DRAFT" = false
+  fi
 fi
 
 if [[ "$DRY_RUN" != "true" && "$PUBLISHED_THIS_RUN" == "true" ]]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,8 +48,17 @@ jobs:
             python3 .github/scripts/check-version-state.py --mode development
           fi
 
+      - name: Set up Helm 3.19.0
+        uses: Azure/setup-helm@7a9c28ba04c99ae42726a8472c6eba25beab7bee # v5.0.1
+        with:
+          version: v3.19.0
+
       - name: Verify Docker availability
         run: docker info
+
+      - name: Validate production Helm chart
+        shell: bash
+        run: bash deploy/helm/taxonomy/verify.sh target/taxonomy-helm-rendered.yaml
 
       - name: Detect observability performance changes
         id: observability-performance-scope
@@ -125,7 +134,8 @@ jobs:
             target/supply-chain-pins.json \
             target/taxonomy-sbom.json \
             target/taxonomy-sbom.xml \
-            target/taxonomy-vex.json; do
+            target/taxonomy-vex.json \
+            target/taxonomy-helm-rendered.yaml; do
             if [ -f "$evidence" ]; then cp "$evidence" target/quality-reports/evidence/; fi
           done
           if [ -d target/observability-performance ]; then

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,15 @@ jobs:
             python3 .github/scripts/check-version-state.py --mode development
           fi
 
+      - name: Verify release delivery contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n .github/scripts/release.sh
+          bash -n .github/scripts/install-helm.sh
+          bash -n deploy/helm/taxonomy/verify.sh
+          python3 .github/scripts/check-release-delivery-contract.py
+
       - name: Install verified Helm 3.21.0
         env:
           HELM_VERSION: v3.21.0

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,10 +48,11 @@ jobs:
             python3 .github/scripts/check-version-state.py --mode development
           fi
 
-      - name: Set up Helm 3.19.0
-        uses: Azure/setup-helm@7a9c28ba04c99ae42726a8472c6eba25beab7bee # v5.0.1
-        with:
-          version: v3.19.0
+      - name: Install verified Helm 3.21.0
+        env:
+          HELM_VERSION: v3.21.0
+        shell: bash
+        run: bash .github/scripts/install-helm.sh
 
       - name: Verify Docker availability
         run: docker info

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -91,10 +91,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Set up Helm 3.19.0
-        uses: Azure/setup-helm@7a9c28ba04c99ae42726a8472c6eba25beab7bee # v5.0.1
-        with:
-          version: v3.19.0
+      - name: Install verified Helm 3.21.0
+        env:
+          HELM_VERSION: v3.21.0
+        shell: bash
+        run: bash .github/scripts/install-helm.sh
 
       - name: Cache Maven dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -122,8 +122,15 @@ jobs:
             "$RUNNER_TEMP/check-version-state.py" \
             "$RUNNER_TEMP/generate-vex.py"
 
-      - name: Test version-state guard
-        run: python3 .github/scripts/test-check-version-state.py
+      - name: Test release guards
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/test-check-version-state.py
+          bash -n .github/scripts/release.sh
+          bash -n .github/scripts/install-helm.sh
+          bash -n deploy/helm/taxonomy/verify.sh
+          python3 .github/scripts/check-release-delivery-contract.py
 
       - name: Build and stage release, then prepare next development version
         env:

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   release:
-    name: Build, publish and advance to the next snapshot
+    name: Build, stage and advance to the next snapshot
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -125,7 +125,7 @@ jobs:
       - name: Test version-state guard
         run: python3 .github/scripts/test-check-version-state.py
 
-      - name: Build, publish and prepare next development version
+      - name: Build and stage release, then prepare next development version
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -133,11 +133,11 @@ jobs:
           NEXT_VERSION_INPUT: ${{ steps.release_parameters.outputs.next_development_version }}
           SKIP_TESTS: ${{ steps.release_parameters.outputs.skip_tests }}
           DRY_RUN: ${{ steps.release_parameters.outputs.dry_run }}
+          DEFER_RELEASE_PUBLICATION: 'true'
           SOURCE_BRANCH: ${{ github.ref_name }}
           METADATA_HELPER: ${{ runner.temp }}/update-release-metadata.py
           VERSION_STATE_HELPER: ${{ runner.temp }}/check-version-state.py
           VEX_HELPER: ${{ runner.temp }}/generate-vex.py
-          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
         run: "$RUNNER_TEMP/release.sh"
@@ -146,7 +146,7 @@ jobs:
         if: steps.release_parameters.outputs.dry_run != 'true'
         run: git checkout --detach "v${{ steps.release_parameters.outputs.release_version }}"
 
-      - name: Package and publish immutable Helm artifacts
+      - name: Package and stage immutable Helm artifacts
         if: steps.release_parameters.outputs.dry_run != 'true' && hashFiles('deploy/helm/taxonomy/Chart.yaml') != ''
         env:
           GH_TOKEN: ${{ github.token }}
@@ -184,6 +184,7 @@ jobs:
             --set existingSecret=taxonomy-secrets \
             > "$manifest"
           grep -Fq "image: \"ghcr.io/carstenartur/taxonomy:${tag}\"" "$manifest"
+          grep -Fq 'namespace: taxonomy' "$manifest"
           grep -Fq 'readOnlyRootFilesystem: true' "$manifest"
           grep -Fq 'runAsUser: 10001' "$manifest"
 
@@ -256,3 +257,46 @@ jobs:
             exit 1
           fi
           gh run watch "$run_id" --exit-status
+
+      - name: Publish complete release and trigger deployment
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v${RELEASE_VERSION}"
+          image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/taxonomy:${tag}"
+
+          if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+            assets=$(gh release view "$tag" --json assets --jq '.assets[].name')
+            for expected in \
+              "taxonomy-${RELEASE_VERSION}.tgz" \
+              "taxonomy-${RELEASE_VERSION}-kubernetes.yaml" \
+              "taxonomy-${RELEASE_VERSION}-helm.sha256"; do
+              if ! grep -Fxq "$expected" <<< "$assets"; then
+                echo "::error::Draft release is missing required Helm asset $expected"
+                exit 1
+              fi
+            done
+          fi
+
+          docker buildx imagetools inspect "$image" >/dev/null
+
+          is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft')
+          if [[ "$is_draft" == "true" ]]; then
+            gh release edit "$tag" --draft=false --latest
+          elif [[ "$is_draft" != "false" ]]; then
+            echo "::error::Unexpected draft state for $tag: $is_draft"
+            exit 1
+          fi
+          test "$(gh release view "$tag" --json isDraft --jq '.isDraft')" = false
+
+          if [[ -n "$RENDER_DEPLOY_HOOK_URL" ]]; then
+            curl -fSL --retry 3 "$RENDER_DEPLOY_HOOK_URL"
+            echo "Render deployment triggered after complete release publication."
+          else
+            echo "::notice::RENDER_DEPLOY_HOOK_URL secret not set - skipping Render deploy"
+          fi

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -91,12 +91,22 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
+      - name: Set up Helm 3.19.0
+        uses: Azure/setup-helm@7a9c28ba04c99ae42726a8472c6eba25beab7bee # v5.0.1
+        with:
+          version: v3.19.0
+
       - name: Cache Maven dependencies
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
+
+      - name: Verify release Helm chart before publication
+        if: hashFiles('deploy/helm/taxonomy/Chart.yaml') != ''
+        shell: bash
+        run: bash deploy/helm/taxonomy/verify.sh "$RUNNER_TEMP/taxonomy-helm-preflight.yaml"
 
       - name: Preserve release scripts
         run: |
@@ -134,6 +144,55 @@ jobs:
       - name: Checkout immutable release source
         if: steps.release_parameters.outputs.dry_run != 'true'
         run: git checkout --detach "v${{ steps.release_parameters.outputs.release_version }}"
+
+      - name: Package and publish immutable Helm artifacts
+        if: steps.release_parameters.outputs.dry_run != 'true' && hashFiles('deploy/helm/taxonomy/Chart.yaml') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v${RELEASE_VERSION}"
+          artifact_dir="$RUNNER_TEMP/helm-release"
+          mkdir -p "$artifact_dir"
+
+          python3 .github/scripts/check-version-state.py \
+            --mode release --expected-version "$RELEASE_VERSION" --tag "$tag"
+          helm lint deploy/helm/taxonomy \
+            --set "image.tag=${tag}" \
+            --set existingSecret=taxonomy-secrets
+          helm package deploy/helm/taxonomy \
+            --destination "$artifact_dir" \
+            --version "$RELEASE_VERSION" \
+            --app-version "$RELEASE_VERSION"
+          chart_archive="$artifact_dir/taxonomy-${RELEASE_VERSION}.tgz"
+          test -f "$chart_archive"
+
+          chart_version=$(helm show chart "$chart_archive" \
+            | awk '$1 == "version:" {print $2; exit}')
+          app_version=$(helm show chart "$chart_archive" \
+            | awk '$1 == "appVersion:" {gsub(/\"/, "", $2); print $2; exit}')
+          test "$chart_version" = "$RELEASE_VERSION"
+          test "$app_version" = "$RELEASE_VERSION"
+
+          manifest="$artifact_dir/taxonomy-${RELEASE_VERSION}-kubernetes.yaml"
+          helm template taxonomy deploy/helm/taxonomy \
+            --namespace taxonomy \
+            --set "image.tag=${tag}" \
+            --set existingSecret=taxonomy-secrets \
+            > "$manifest"
+          grep -Fq "image: \"ghcr.io/carstenartur/taxonomy:${tag}\"" "$manifest"
+          grep -Fq 'readOnlyRootFilesystem: true' "$manifest"
+          grep -Fq 'runAsUser: 10001' "$manifest"
+
+          (
+            cd "$artifact_dir"
+            sha256sum "taxonomy-${RELEASE_VERSION}.tgz" \
+              "taxonomy-${RELEASE_VERSION}-kubernetes.yaml" \
+              > "taxonomy-${RELEASE_VERSION}-helm.sha256"
+          )
+          gh release upload "$tag" "$artifact_dir"/* --clobber
 
       - name: Describe immutable release source
         id: release_source

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -149,6 +149,21 @@ jobs:
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
         run: "$RUNNER_TEMP/release.sh"
 
+      - name: Record exact final main snapshot
+        id: final_main
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_sha=$(git rev-parse HEAD)
+          git fetch origin main --force
+          remote_sha=$(git rev-parse origin/main)
+          if [[ "$remote_sha" != "$expected_sha" ]]; then
+            echo "::error::release.sh ended at $expected_sha, but origin/main is $remote_sha"
+            exit 1
+          fi
+          echo "sha=$expected_sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout immutable release source
         if: steps.release_parameters.outputs.dry_run != 'true'
         run: git checkout --detach "v${{ steps.release_parameters.outputs.release_version }}"
@@ -236,31 +251,57 @@ jobs:
             VCS_REF=${{ steps.release_source.outputs.sha }}
             VERSION=${{ steps.release_parameters.outputs.release_version }}
 
-      - name: Verify final main snapshot with canonical CI
+      - name: Verify exact final main snapshot with canonical CI
         if: steps.release_parameters.outputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_MAIN_SHA: ${{ steps.final_main.outputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin main --force
-          main_sha=$(git rev-parse origin/main)
-          gh workflow run ci-cd.yml --ref main
-
           run_id=""
-          for _ in $(seq 1 60); do
+
+          # Updating main through the refs API normally emits a push run. Reuse it
+          # so the exact commit is tested even when main advances again meanwhile.
+          for _ in $(seq 1 24); do
             run_id=$(gh run list \
               --workflow ci-cd.yml \
-              --event workflow_dispatch \
-              --commit "$main_sha" \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId // empty')
+              --commit "$EXPECTED_MAIN_SHA" \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq 'sort_by(.createdAt) | last | .databaseId // empty')
             if [[ -n "$run_id" ]]; then break; fi
             sleep 5
           done
+
           if [[ -z "$run_id" ]]; then
-            echo "::error::Could not locate the post-release CI run for $main_sha"
+            git fetch origin main --force
+            remote_sha=$(git rev-parse origin/main)
+            if [[ "$remote_sha" != "$EXPECTED_MAIN_SHA" ]]; then
+              echo "::error::No CI run exists for $EXPECTED_MAIN_SHA and main moved to $remote_sha"
+              exit 1
+            fi
+            gh workflow run ci-cd.yml --ref main
+            for _ in $(seq 1 60); do
+              run_id=$(gh run list \
+                --workflow ci-cd.yml \
+                --event workflow_dispatch \
+                --commit "$EXPECTED_MAIN_SHA" \
+                --limit 10 \
+                --json databaseId,createdAt \
+                --jq 'sort_by(.createdAt) | last | .databaseId // empty')
+              if [[ -n "$run_id" ]]; then break; fi
+              sleep 5
+            done
+          fi
+
+          if [[ -z "$run_id" ]]; then
+            echo "::error::Could not locate canonical CI for exact commit $EXPECTED_MAIN_SHA"
+            exit 1
+          fi
+          run_sha=$(gh run view "$run_id" --json headSha --jq '.headSha')
+          if [[ "$run_sha" != "$EXPECTED_MAIN_SHA" ]]; then
+            echo "::error::Selected CI run $run_id verifies $run_sha, not $EXPECTED_MAIN_SHA"
             exit 1
           fi
           gh run watch "$run_id" --exit-status

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,7 @@ on:
       - 'taxonomy-*/src/**'
       - 'Dockerfile'
       - 'docker-compose*.yml'
+      - 'deploy/helm/**'
       - '.github/workflows/**'
       - '.github/scripts/**'
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,18 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
+# A fixed numeric identity lets Kubernetes enforce runAsNonRoot/runAsUser
+# consistently without relying on image-local user-name lookup.
+ARG TAXONOMY_UID=10001
+ARG TAXONOMY_GID=10001
 # curl is used only by the container-native healthcheck. The application itself
 # remains reachable exclusively through the reverse proxy in production.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/* \
-    && groupadd --system taxonomy \
-    && useradd --system --gid taxonomy --home-dir /app --shell /usr/sbin/nologin taxonomy
+    && groupadd --gid "${TAXONOMY_GID}" taxonomy \
+    && useradd --uid "${TAXONOMY_UID}" --gid "${TAXONOMY_GID}" \
+         --no-create-home --home-dir /app --shell /usr/sbin/nologin taxonomy
 
 WORKDIR /app
 RUN mkdir -p /app/data /opt/opentelemetry \
@@ -84,8 +89,8 @@ COPY --from=build --chown=taxonomy:taxonomy /workspace/taxonomy-app/target/taxon
 COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar /opt/opentelemetry/opentelemetry-javaagent.jar
 COPY --chown=taxonomy:taxonomy observability/javaagent.properties /opt/opentelemetry/javaagent.properties
 
-# Port 8080 is for INTERNAL communication only (e.g. Caddy reverse proxy inside Docker network).
-# NEVER publish this port to the internet. Use docker-compose.prod.yml for HTTPS on port 443.
+# Port 8080 is for INTERNAL communication only (e.g. Caddy or a Kubernetes Service).
+# NEVER publish this port directly to the internet. Terminate TLS at a trusted proxy.
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=5 \
   CMD curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health/readiness >/dev/null || exit 1
@@ -96,10 +101,13 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=5 \
 #                           tier (512 MB) this gives ~256 MB, but -Xmx220m takes precedence as the
 #                           smaller (stricter) value, leaving ~292 MB for off-heap (Lucene mmap, metaspace, OS)
 # -Xmx220m                : hard heap cap for 512 MB containers; prevents OOM kills on Render free tier
-# Override via JAVA_OPTS env var (e.g. in render.yaml or docker run -e JAVA_OPTS=...) without
-# rebuilding the image.
-ENV JAVA_OPTS="-XX:+UseSerialGC -Xss512k -XX:MaxRAMPercentage=50.0 -Xmx220m"
-USER taxonomy
+# -XX:+ExitOnOutOfMemoryError: terminate deterministically so the orchestrator can restart the pod
+# -Djava.io.tmpdir=/tmp   : keep temporary writes on the explicitly writable Kubernetes emptyDir
+# Override via JAVA_OPTS env var without rebuilding the image. The Helm chart uses
+# percentage-based sizing appropriate for its larger default memory limit.
+ENV HOME=/tmp \
+    JAVA_OPTS="-XX:+UseSerialGC -Xss512k -XX:MaxRAMPercentage=50.0 -Xmx220m -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp"
+USER 10001:10001
 STOPSIGNAL SIGTERM
 # exec replaces the shell with the JVM so Java becomes PID 1 and receives
 # Docker's SIGTERM directly. This allows Spring, HikariCP, HSQLDB and Lucene to

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-# A fixed numeric identity provides a secure portable default. Writable image
-# paths are also root-group compatible so OpenShift can inject an arbitrary
-# non-root UID without rebuilding the image.
+# A fixed numeric identity provides a secure portable default. Image paths are
+# also root-group readable so OpenShift can inject an arbitrary non-root UID;
+# only the explicit data directory becomes group-writable.
 ARG TAXONOMY_UID=10001
 ARG TAXONOMY_GID=10001
 # curl is used only by the container-native healthcheck. The application itself
@@ -89,11 +89,11 @@ RUN mkdir -p /app/data /opt/opentelemetry \
 COPY --from=build --chown=taxonomy:taxonomy /workspace/taxonomy-app/target/taxonomy-app-*.jar app.jar
 COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar /opt/opentelemetry/opentelemetry-javaagent.jar
 COPY --chown=taxonomy:taxonomy observability/javaagent.properties /opt/opentelemetry/javaagent.properties
-# OpenShift runs arbitrary UIDs with root-group membership. Mirror owner
-# permissions to group 0 after all copies so those UIDs can read the application
-# and write only to the explicitly writable data directory when it is mounted.
+# OpenShift runs arbitrary UIDs with root-group membership. Preserve the
+# read-only modes of application code and the agent while granting group write
+# only to the explicit data directory. /tmp is supplied as a writable volume.
 RUN chgrp -R 0 /app /opt/opentelemetry \
-    && chmod -R g=u /app /opt/opentelemetry
+    && chmod -R g=u /app/data
 
 # Port 8080 is for INTERNAL communication only (e.g. Caddy or a Kubernetes Service).
 # NEVER publish this port directly to the internet. Terminate TLS at a trusted proxy.

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,9 @@ LABEL org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.version="${VERSION}"
 
-# A fixed numeric identity lets Kubernetes enforce runAsNonRoot/runAsUser
-# consistently without relying on image-local user-name lookup.
+# A fixed numeric identity provides a secure portable default. Writable image
+# paths are also root-group compatible so OpenShift can inject an arbitrary
+# non-root UID without rebuilding the image.
 ARG TAXONOMY_UID=10001
 ARG TAXONOMY_GID=10001
 # curl is used only by the container-native healthcheck. The application itself
@@ -88,6 +89,11 @@ RUN mkdir -p /app/data /opt/opentelemetry \
 COPY --from=build --chown=taxonomy:taxonomy /workspace/taxonomy-app/target/taxonomy-app-*.jar app.jar
 COPY --from=opentelemetry --chown=taxonomy:taxonomy /javaagent.jar /opt/opentelemetry/opentelemetry-javaagent.jar
 COPY --chown=taxonomy:taxonomy observability/javaagent.properties /opt/opentelemetry/javaagent.properties
+# OpenShift runs arbitrary UIDs with root-group membership. Mirror owner
+# permissions to group 0 after all copies so those UIDs can read the application
+# and write only to the explicitly writable data directory when it is mounted.
+RUN chgrp -R 0 /app /opt/opentelemetry \
+    && chmod -R g=u /app /opt/opentelemetry
 
 # Port 8080 is for INTERNAL communication only (e.g. Caddy or a Kubernetes Service).
 # NEVER publish this port directly to the internet. Terminate TLS at a trusted proxy.

--- a/deploy/helm/taxonomy/Chart.yaml
+++ b/deploy/helm/taxonomy/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: taxonomy
+description: Production-oriented Helm chart for Taxonomy on Rancher and Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.2.9-SNAPSHOT"
+home: https://github.com/carstenartur/Taxonomy
+sources:
+  - https://github.com/carstenartur/Taxonomy

--- a/deploy/helm/taxonomy/README.md
+++ b/deploy/helm/taxonomy/README.md
@@ -1,0 +1,208 @@
+# Taxonomy Helm chart
+
+This chart deploys the same Taxonomy image on Rancher/RKE2, K3s, OpenShift and generic Kubernetes. It deliberately contains no Rancher-specific application code.
+
+## Prerequisites
+
+- Kubernetes 1.27 or newer
+- Helm 3 for chart rendering, either on an administrator workstation or in CI
+- An externally managed PostgreSQL database
+- An existing Kubernetes Secret for credentials
+- An ingress controller when ingress is enabled
+- The Prometheus Operator CRDs only when `serviceMonitor.enabled=true`
+
+## Secure installation
+
+Create the namespace and credentials without committing secret values:
+
+```bash
+kubectl create namespace taxonomy
+kubectl -n taxonomy create secret generic taxonomy-secrets \
+  --from-literal=SPRING_DATASOURCE_URL='jdbc:postgresql://postgres.example:5432/taxonomy' \
+  --from-literal=SPRING_DATASOURCE_USERNAME='taxonomy' \
+  --from-literal=SPRING_DATASOURCE_PASSWORD='replace-me' \
+  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-value'
+```
+
+Optional LLM keys may be added to the same Secret. Their mappings are marked optional; database and admin credentials are not.
+
+Install or upgrade with an immutable image reference:
+
+```bash
+helm upgrade --install taxonomy deploy/helm/taxonomy \
+  --namespace taxonomy \
+  --set existingSecret=taxonomy-secrets \
+  --set image.tag=v1.2.8
+```
+
+Replace the example release tag with the intended published version. Supported image references are:
+
+- `image.tag=vX.Y.Z` or a prerelease such as `v1.3.0-rc.1`;
+- `image.tag=sha-<7-40 lowercase hexadecimal commit characters>`;
+- `image.digest=sha256:<64 lowercase hexadecimal characters>`.
+
+The chart rejects an empty image reference, `latest`, arbitrary mutable tags, and simultaneous tag/digest configuration.
+
+## Rancher without a visible Helm command
+
+Rancher does not need application-specific code. There are two equivalent deployment paths:
+
+1. Render or install the chart from an administrator workstation that has cluster access.
+2. Render the manifests in CI or locally and import the resulting YAML through Rancher's **Import YAML** action.
+
+Example rendering:
+
+```bash
+helm template taxonomy deploy/helm/taxonomy \
+  --namespace taxonomy \
+  --set existingSecret=taxonomy-secrets \
+  --set image.tag=v1.2.8 \
+  > taxonomy-rendered.yaml
+```
+
+Create the Secret separately before importing the rendered YAML. Never insert real credentials into the rendered file or ordinary Rancher chart values.
+
+## Ingress and TLS
+
+Example values:
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  hosts:
+    - host: taxonomy.example.org
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: taxonomy-tls
+      hosts:
+        - taxonomy.example.org
+
+networkPolicy:
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: traefik
+```
+
+Use the actual namespace and pod labels of the installed ingress controller. The chart fails closed when ingress and NetworkPolicy are enabled but no ingress-controller rule is supplied.
+
+TLS terminates at the ingress controller. The Kubernetes profile respects trusted forwarded headers so HTTPS redirects and OIDC callback URLs retain the public origin. Configure the ingress controller to overwrite, rather than blindly append, client-supplied forwarding headers.
+
+For outbound TLS that requires a private CA, mount a truststore with `extraVolumes`/`extraVolumeMounts` and add the corresponding JVM properties through `JAVA_OPTS`. Keep truststores in Secrets and never bake environment-specific trust material into the image.
+
+## Health, shutdown and recovery
+
+The chart uses:
+
+- startup: `/actuator/health/liveness`;
+- readiness: `/actuator/health/readiness`;
+- liveness: `/actuator/health/liveness`;
+- a configurable pre-stop delay, default 5 seconds;
+- Spring Boot graceful shutdown, default 30 seconds;
+- a 45-second pod termination grace period;
+- `maxUnavailable: 0` and `maxSurge: 1` for the default stateless rollout;
+- `ExitOnOutOfMemoryError`, allowing Kubernetes to restart a failed JVM.
+
+The startup probe permits up to five minutes for initialization. Increase it for unusually large catalogues or model loading.
+
+## Read-only filesystem and persistence
+
+The container runs as numeric user/group `10001:10001`, drops all capabilities and expects a read-only root filesystem. Writable locations are explicit:
+
+- `/tmp`: ephemeral `emptyDir`;
+- `/app/data`: `emptyDir` by default, or a PVC when `persistence.enabled=true`;
+- additional explicitly configured mounts.
+
+PostgreSQL is the authoritative persistent store. The default in-memory Lucene directory is rebuilt per pod. When `TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem`, the chart requires a PVC and restricts the deployment to one replica.
+
+A ReadWriteOnce PVC cannot safely participate in the default surge rollout. For that reason the chart automatically selects the `Recreate` deployment strategy when persistence is enabled. This avoids multi-attach failures but introduces a controlled restart window. Use database-authoritative state and the default local-heap search configuration when zero-downtime rolling updates are required.
+
+## Scaling and disruption budgets
+
+The supported default is one replica. Multiple replicas remain an explicit operator decision because the following must first be verified for the selected configuration:
+
+1. HTTP sessions are stateless or shared;
+2. taxonomy initialization is idempotent under concurrent starts;
+3. search indexes are independently reproducible or coordinated;
+4. background jobs use leader election or database-backed claiming;
+5. every local file dependency is removed or replicated safely.
+
+The chart requires `scaling.allowMultipleReplicas=true` before accepting more than one replica, and still rejects multi-replica local-filesystem indexing or persistence. This switch records an explicit operational acknowledgement; it is not a support claim.
+
+A PodDisruptionBudget is accepted only with at least two replicas:
+
+```yaml
+replicaCount: 2
+scaling:
+  allowMultipleReplicas: true
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
+## Embedding model
+
+Runtime model download is disabled by default in the chart, and embedding is initially disabled. Production deployments should either:
+
+- mount a verified model directory and set `TAXONOMY_EMBEDDING_MODEL_DIR`, or
+- use a prebuilt image containing an approved model, or
+- deliberately enable downloading with suitable egress, storage and supply-chain controls.
+
+## Prometheus metrics
+
+The application protects `/actuator/prometheus` with the admin token. Enable the optional ServiceMonitor as follows:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: kube-prometheus-stack
+  authorization:
+    enabled: true
+    secretKey: ADMIN_PASSWORD
+```
+
+The ServiceMonitor reads the Bearer credential from `existingSecret` by default. `serviceMonitor.authorization.secretName` can point to a different Secret. Prometheus must be permitted to read that Secret in the release namespace, and its ServiceMonitor selector must match `additionalLabels`.
+
+## Network policy
+
+The default policy permits ingress only from pods in the same namespace and permits egress because database, LLM and optional model endpoints are environment-specific. Replace `networkPolicy.egress` with explicit DNS, PostgreSQL, identity-provider and approved external endpoint rules in high-assurance clusters.
+
+When enabling ingress, add the ingress-controller selectors as shown above. The same mechanism can allow a Prometheus namespace if the Prometheus instance does not scrape through a same-namespace agent.
+
+## Resource tuning
+
+The defaults reserve 768 MiB and limit the pod to 2 GiB. `JAVA_OPTS` sizes heap as a percentage so native memory remains available for Lucene, ONNX, thread stacks and metaspace. Validate limits with production-sized imports and embedding models.
+
+## Reproducible validation
+
+Run the same chart checks as CI:
+
+```bash
+bash deploy/helm/taxonomy/verify.sh
+```
+
+The script performs linting, renders a hardened deployment with ServiceMonitor evidence, and proves that unsafe configurations are rejected.
+
+After deployment:
+
+```bash
+kubectl -n taxonomy rollout status deployment/taxonomy-taxonomy
+kubectl -n taxonomy port-forward service/taxonomy-taxonomy 8080:80
+curl --fail http://127.0.0.1:8080/actuator/health/readiness
+```
+
+For a protected metrics check:
+
+```bash
+TOKEN=$(kubectl -n taxonomy get secret taxonomy-secrets \
+  -o jsonpath='{.data.ADMIN_PASSWORD}' | base64 --decode)
+curl --fail -H "Authorization: Bearer ${TOKEN}" \
+  http://127.0.0.1:8080/actuator/prometheus
+```

--- a/deploy/helm/taxonomy/README.md
+++ b/deploy/helm/taxonomy/README.md
@@ -64,7 +64,7 @@ Create the Secret separately before importing the rendered YAML. Never insert re
 
 ## OpenShift restricted security context
 
-OpenShift commonly assigns an arbitrary non-root UID through the `restricted-v2` Security Context Constraint. The image mirrors owner permissions to group `0`, and the supplied profile removes fixed UID/GID/fsGroup values while retaining `runAsNonRoot`, seccomp, dropped capabilities, no privilege escalation and a read-only root filesystem.
+OpenShift commonly assigns an arbitrary non-root UID through the `restricted-v2` Security Context Constraint. The image assigns application paths to group `0` for read access while granting group write only to `/app/data`; the supplied profile removes fixed UID/GID/fsGroup values while retaining `runAsNonRoot`, seccomp, dropped capabilities, no privilege escalation and a read-only root filesystem.
 
 Install with the OpenShift profile:
 

--- a/deploy/helm/taxonomy/README.md
+++ b/deploy/helm/taxonomy/README.md
@@ -41,7 +41,7 @@ Replace the example release tag with the intended published version. Supported i
 - `image.tag=sha-<7-40 lowercase hexadecimal commit characters>`;
 - `image.digest=sha256:<64 lowercase hexadecimal characters>`.
 
-The chart rejects an empty image reference, `latest`, arbitrary mutable tags, and simultaneous tag/digest configuration.
+The chart rejects an empty image reference, `latest`, arbitrary mutable tags, Docker-invalid SemVer build metadata and simultaneous tag/digest configuration.
 
 ## Rancher without a visible Helm command
 
@@ -61,6 +61,24 @@ helm template taxonomy deploy/helm/taxonomy \
 ```
 
 Create the Secret separately before importing the rendered YAML. Never insert real credentials into the rendered file or ordinary Rancher chart values.
+
+## OpenShift restricted security context
+
+OpenShift commonly assigns an arbitrary non-root UID through the `restricted-v2` Security Context Constraint. The image mirrors owner permissions to group `0`, and the supplied profile removes fixed UID/GID/fsGroup values while retaining `runAsNonRoot`, seccomp, dropped capabilities, no privilege escalation and a read-only root filesystem.
+
+Install with the OpenShift profile:
+
+```bash
+helm upgrade --install taxonomy deploy/helm/taxonomy \
+  --namespace taxonomy \
+  --values deploy/helm/taxonomy/values-openshift.yaml \
+  --set existingSecret=taxonomy-secrets \
+  --set image.tag=v1.2.8
+```
+
+The profile does not request a custom SCC, privileged execution or a fixed UID range. The cluster remains authoritative for the assigned UID and supplemental groups. Use the generic Kubernetes `Ingress` resources from this chart when an ingress controller supports them, or disable `ingress.enabled` and expose the Service through an independently managed OpenShift Route.
+
+Do not combine the OpenShift profile with command-line overrides that restore `podSecurityContext.runAsUser`, `runAsGroup` or `fsGroup` unless the cluster administrator has explicitly allocated those identities.
 
 ## Ingress and TLS
 
@@ -113,7 +131,7 @@ The startup probe permits up to five minutes for initialization. Increase it for
 
 ## Read-only filesystem and persistence
 
-The container runs as numeric user/group `10001:10001`, drops all capabilities and expects a read-only root filesystem. Writable locations are explicit:
+The portable Kubernetes default runs as numeric user/group `10001:10001`, drops all capabilities and expects a read-only root filesystem. The OpenShift profile delegates the numeric identity to the cluster while preserving the same effective restrictions. Writable locations are explicit:
 
 - `/tmp`: ephemeral `emptyDir`;
 - `/app/data`: `emptyDir` by default, or a PVC when `persistence.enabled=true`;
@@ -188,7 +206,7 @@ Run the same chart checks as CI:
 bash deploy/helm/taxonomy/verify.sh
 ```
 
-The script performs linting, renders a hardened deployment with ServiceMonitor evidence, and proves that unsafe configurations are rejected.
+The script performs linting, renders Kubernetes and OpenShift variants with monitoring evidence, and proves that unsafe configurations are rejected.
 
 After deployment:
 

--- a/deploy/helm/taxonomy/templates/_helpers.tpl
+++ b/deploy/helm/taxonomy/templates/_helpers.tpl
@@ -44,10 +44,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s@%s" .Values.image.repository $digest -}}
 {{- else -}}
 {{- $requiredTag := required "image.tag or image.digest is required" $tag -}}
-{{- $releaseTag := regexMatch "^v[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$" $requiredTag -}}
+{{- $releaseTag := regexMatch "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$" $requiredTag -}}
 {{- $commitTag := regexMatch "^sha-[0-9a-f]{7,40}$" $requiredTag -}}
 {{- if not (or $releaseTag $commitTag) -}}
-{{- fail "image.tag must be an immutable release tag (vX.Y.Z) or sha-<7-40 lowercase hex commit>" -}}
+{{- fail "image.tag must be an immutable release tag (vX.Y.Z with optional Docker-safe prerelease suffix) or sha-<7-40 lowercase hex commit>" -}}
 {{- end -}}
 {{- printf "%s:%s" .Values.image.repository $requiredTag -}}
 {{- end -}}

--- a/deploy/helm/taxonomy/templates/_helpers.tpl
+++ b/deploy/helm/taxonomy/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{- define "taxonomy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "taxonomy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name (include "taxonomy.name" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "taxonomy.labels" -}}
+app.kubernetes.io/name: {{ include "taxonomy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{- define "taxonomy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "taxonomy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "taxonomy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "taxonomy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "taxonomy.image" -}}
+{{- $tag := .Values.image.tag | default "" -}}
+{{- $digest := .Values.image.digest | default "" -}}
+{{- if and $tag $digest -}}
+{{- fail "configure exactly one of image.tag or image.digest, not both" -}}
+{{- end -}}
+{{- if $digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" $digest) -}}
+{{- fail "image.digest must use sha256:<64 lowercase hex characters>" -}}
+{{- end -}}
+{{- printf "%s@%s" .Values.image.repository $digest -}}
+{{- else -}}
+{{- $requiredTag := required "image.tag or image.digest is required" $tag -}}
+{{- $releaseTag := regexMatch "^v[0-9]+\\.[0-9]+\\.[0-9]+([-+][0-9A-Za-z.-]+)?$" $requiredTag -}}
+{{- $commitTag := regexMatch "^sha-[0-9a-f]{7,40}$" $requiredTag -}}
+{{- if not (or $releaseTag $commitTag) -}}
+{{- fail "image.tag must be an immutable release tag (vX.Y.Z) or sha-<7-40 lowercase hex commit>" -}}
+{{- end -}}
+{{- printf "%s:%s" .Values.image.repository $requiredTag -}}
+{{- end -}}
+{{- end }}
+
+{{- define "taxonomy.metricsSecretName" -}}
+{{- default .Values.existingSecret .Values.serviceMonitor.authorization.secretName -}}
+{{- end }}

--- a/deploy/helm/taxonomy/templates/resources.yaml
+++ b/deploy/helm/taxonomy/templates/resources.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "taxonomy.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -15,6 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
 spec:
@@ -160,6 +162,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
@@ -181,6 +184,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
 spec:
@@ -199,6 +203,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
 spec:
@@ -213,6 +218,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
 spec:
@@ -246,6 +252,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/deploy/helm/taxonomy/templates/resources.yaml
+++ b/deploy/helm/taxonomy/templates/resources.yaml
@@ -1,0 +1,278 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "taxonomy.serviceAccountName" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- else }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "taxonomy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "taxonomy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "taxonomy.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: taxonomy
+          image: {{ include "taxonomy.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.config }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.existingSecret }}
+            {{- range $envName, $secretSpec := .Values.secretEnv }}
+            - name: {{ $envName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.existingSecret | quote }}
+                  key: {{ $secretSpec.key | quote }}
+                  optional: {{ $secretSpec.optional }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            {{- toYaml .Values.startupProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - {{ printf "sleep %d" (int .Values.preStopDelaySeconds) | quote }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/data
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            {{- with .Values.tmpVolume.sizeLimit }}
+            sizeLimit: {{ . }}
+            {{- end }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "taxonomy.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "taxonomy.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- if .Values.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "taxonomy.selectorLabels" . | nindent 6 }}
+{{- end }}
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "taxonomy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if or .Values.networkPolicy.allowSameNamespace (gt (len .Values.networkPolicy.ingressFrom) 0) }}
+  ingress:
+    - from:
+        {{- if .Values.networkPolicy.allowSameNamespace }}
+        - podSelector: {}
+        {{- end }}
+        {{- with .Values.networkPolicy.ingressFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      ports:
+        - port: {{ .Values.service.targetPort }}
+          protocol: TCP
+  {{- else }}
+  ingress: []
+  {{- end }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+{{- end }}
+{{- if .Values.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "taxonomy.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/taxonomy/templates/servicemonitor.yaml
+++ b/deploy/helm/taxonomy/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "taxonomy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "taxonomy.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}

--- a/deploy/helm/taxonomy/templates/servicemonitor.yaml
+++ b/deploy/helm/taxonomy/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "taxonomy.fullname" . }}
+  labels:
+    {{- include "taxonomy.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "taxonomy.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: /actuator/prometheus
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- if .Values.serviceMonitor.authorization.enabled }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "taxonomy.metricsSecretName" . | quote }}
+          key: {{ .Values.serviceMonitor.authorization.secretKey | quote }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/helm/taxonomy/templates/validation.yaml
+++ b/deploy/helm/taxonomy/templates/validation.yaml
@@ -1,0 +1,40 @@
+{{- /* Fail chart rendering before Kubernetes resources are emitted. */ -}}
+{{- $_ := include "taxonomy.image" . -}}
+{{- $replicas := int .Values.replicaCount -}}
+{{- if lt $replicas 1 -}}
+{{- fail "replicaCount must be at least 1" -}}
+{{- end -}}
+{{- if and (gt $replicas 1) (not .Values.scaling.allowMultipleReplicas) -}}
+{{- fail "replicaCount > 1 requires scaling.allowMultipleReplicas=true after explicitly validating shared state, indexing and job ownership" -}}
+{{- end -}}
+{{- if and .Values.persistence.enabled (gt $replicas 1) -}}
+{{- fail "persistence.enabled cannot be combined with multiple replicas; shared writable Lucene storage is unsupported" -}}
+{{- end -}}
+{{- if and .Values.podDisruptionBudget.enabled (lt $replicas 2) -}}
+{{- fail "podDisruptionBudget.enabled requires at least two replicas" -}}
+{{- end -}}
+{{- if and (gt (len .Values.secretEnv) 0) (empty .Values.existingSecret) -}}
+{{- fail "existingSecret is required while secretEnv contains credential mappings" -}}
+{{- end -}}
+{{- if ge (int .Values.preStopDelaySeconds) (int .Values.terminationGracePeriodSeconds) -}}
+{{- fail "preStopDelaySeconds must be lower than terminationGracePeriodSeconds" -}}
+{{- end -}}
+{{- $directoryType := index .Values.config "TAXONOMY_SEARCH_DIRECTORY_TYPE" | default "local-heap" -}}
+{{- if and (eq $directoryType "local-filesystem") (not .Values.persistence.enabled) -}}
+{{- fail "TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem requires persistence.enabled=true" -}}
+{{- end -}}
+{{- if and (gt $replicas 1) (eq $directoryType "local-filesystem") -}}
+{{- fail "local-filesystem search indexes are restricted to a single replica" -}}
+{{- end -}}
+{{- if and .Values.ingress.enabled .Values.networkPolicy.enabled (eq (len .Values.networkPolicy.ingressFrom) 0) -}}
+{{- fail "ingress.enabled with NetworkPolicy requires networkPolicy.ingressFrom rules for the ingress controller" -}}
+{{- end -}}
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.authorization.enabled -}}
+{{- $metricsSecret := include "taxonomy.metricsSecretName" . | trim -}}
+{{- if empty $metricsSecret -}}
+{{- fail "ServiceMonitor Bearer authorization requires serviceMonitor.authorization.secretName or existingSecret" -}}
+{{- end -}}
+{{- if empty .Values.serviceMonitor.authorization.secretKey -}}
+{{- fail "serviceMonitor.authorization.secretKey is required when authorization is enabled" -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/taxonomy/values-openshift.yaml
+++ b/deploy/helm/taxonomy/values-openshift.yaml
@@ -1,0 +1,17 @@
+# OpenShift restricted-v2 SCC assigns an arbitrary non-root UID and suitable
+# supplemental groups. Null values remove the fixed Kubernetes defaults while
+# retaining runAsNonRoot, seccomp and container hardening.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: null
+  runAsGroup: null
+  fsGroup: null
+  fsGroupChangePolicy: null
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]

--- a/deploy/helm/taxonomy/values.yaml
+++ b/deploy/helm/taxonomy/values.yaml
@@ -48,7 +48,7 @@ service:
   targetPort: 8080
   annotations: {}
 
- ingress:
+ingress:
   enabled: false
   className: ""
   annotations: {}

--- a/deploy/helm/taxonomy/values.yaml
+++ b/deploy/helm/taxonomy/values.yaml
@@ -1,0 +1,182 @@
+replicaCount: 1
+
+# Multi-replica operation is not enabled by default because sessions, local Lucene
+# indexes, initialization and background-job ownership are not yet coordinated.
+scaling:
+  allowMultipleReplicas: false
+
+image:
+  repository: ghcr.io/carstenartur/taxonomy
+  # Required: use vX.Y.Z, sha-<commit>, or set digest to sha256:<64 hex>.
+  tag: ""
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+priorityClassName: ""
+revisionHistoryLimit: 3
+progressDeadlineSeconds: 600
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+  annotations: {}
+
+ ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: taxonomy.example.invalid
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 768Mi
+  limits:
+    cpu: "2"
+    memory: 2Gi
+
+startupProbe:
+  failureThreshold: 60
+  periodSeconds: 5
+  timeoutSeconds: 3
+readinessProbe:
+  failureThreshold: 6
+  periodSeconds: 10
+  timeoutSeconds: 3
+livenessProbe:
+  failureThreshold: 3
+  periodSeconds: 20
+  timeoutSeconds: 3
+
+terminationGracePeriodSeconds: 45
+preStopDelaySeconds: 5
+
+tmpVolume:
+  sizeLimit: 1Gi
+
+persistence:
+  enabled: false
+  accessModes: ["ReadWriteOnce"]
+  size: 10Gi
+  storageClass: ""
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# The default policy permits application access only from the same namespace.
+# When ingress is enabled, add the ingress-controller namespace/pod selectors to
+# ingressFrom. Egress remains open because PostgreSQL, LLM and optional model
+# endpoints are deployment-specific; replace it with explicit rules as required.
+networkPolicy:
+  enabled: true
+  allowSameNamespace: true
+  ingressFrom: []
+  egress:
+    - {}
+
+# Existing Secret containing the keys referenced by secretEnv. Required while
+# secretEnv is non-empty; credentials are never rendered into chart values.
+existingSecret: ""
+secretEnv:
+  SPRING_DATASOURCE_URL:
+    key: SPRING_DATASOURCE_URL
+    optional: false
+  SPRING_DATASOURCE_USERNAME:
+    key: SPRING_DATASOURCE_USERNAME
+    optional: false
+  SPRING_DATASOURCE_PASSWORD:
+    key: SPRING_DATASOURCE_PASSWORD
+    optional: false
+  ADMIN_PASSWORD:
+    key: ADMIN_PASSWORD
+    optional: false
+  GEMINI_API_KEY:
+    key: GEMINI_API_KEY
+    optional: true
+  OPENAI_API_KEY:
+    key: OPENAI_API_KEY
+    optional: true
+  DEEPSEEK_API_KEY:
+    key: DEEPSEEK_API_KEY
+    optional: true
+  DASHSCOPE_API_KEY:
+    key: DASHSCOPE_API_KEY
+    optional: true
+  LLAMA_API_KEY:
+    key: LLAMA_API_KEY
+    optional: true
+  MISTRAL_API_KEY:
+    key: MISTRAL_API_KEY
+    optional: true
+  CUSTOM_LLM_API_KEY:
+    key: CUSTOM_LLM_API_KEY
+    optional: true
+
+config:
+  SPRING_PROFILES_ACTIVE: postgres,kubernetes
+  TAXONOMY_INIT_ASYNC: "true"
+  TAXONOMY_INIT_RELOAD_EXISTING: "false"
+  TAXONOMY_DDL_AUTO: validate
+  TAXONOMY_SEARCH_DIRECTORY_TYPE: local-heap
+  TAXONOMY_SEARCH_SYNC_STRATEGY: write-sync
+  TAXONOMY_SPRINGDOC_ENABLED: "false"
+  TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
+  TAXONOMY_EMBEDDING_ENABLED: "false"
+  TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
+  JAVA_OPTS: -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=20.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp
+
+# Prometheus Operator integration. The application accepts the ADMIN_PASSWORD as
+# a Bearer token for /actuator/prometheus; the ServiceMonitor reads it from a Secret.
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  interval: 30s
+  scrapeTimeout: 10s
+  authorization:
+    enabled: true
+    secretName: ""
+    secretKey: ADMIN_PASSWORD
+  relabelings: []
+  metricRelabelings: []
+
+extraEnv: []
+extraEnvFrom: []
+extraVolumes: []
+extraVolumeMounts: []
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -33,6 +33,7 @@ expect_failure() {
 helm lint "${CHART_DIR}" "${COMMON_VALUES[@]}"
 helm template taxonomy "${CHART_DIR}" \
   "${COMMON_VALUES[@]}" \
+  --namespace taxonomy \
   --set serviceMonitor.enabled=true \
   >"${OUTPUT_FILE}"
 
@@ -40,6 +41,7 @@ for required in \
   'kind: Deployment' \
   'kind: NetworkPolicy' \
   'kind: ServiceMonitor' \
+  'namespace: taxonomy' \
   'automountServiceAccountToken: false' \
   'runAsNonRoot: true' \
   'runAsUser: 10001' \
@@ -53,6 +55,14 @@ for required in \
     exit 1
   fi
 done
+
+PRERELEASE_OUTPUT="${TMP_DIR}/prerelease.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  --namespace taxonomy \
+  --set image.tag=v1.2.3-rc.1 \
+  --set existingSecret=taxonomy-secrets \
+  >"${PRERELEASE_OUTPUT}"
+grep -Fq 'image: "ghcr.io/carstenartur/taxonomy:v1.2.3-rc.1"' "${PRERELEASE_OUTPUT}"
 
 PERSISTENCE_OUTPUT="${TMP_DIR}/persistence.yaml"
 helm template taxonomy "${CHART_DIR}" \
@@ -80,6 +90,9 @@ expect_failure 'mutable latest image tag' \
 expect_failure 'arbitrary mutable image tag' \
   helm template taxonomy "${CHART_DIR}" \
     --set image.tag=stable --set existingSecret=taxonomy-secrets
+expect_failure 'Docker-invalid SemVer build metadata' \
+  helm template taxonomy "${CHART_DIR}" \
+    --set image.tag=v1.2.3+metadata --set existingSecret=taxonomy-secrets
 expect_failure 'simultaneous image tag and digest' \
   helm template taxonomy "${CHART_DIR}" \
     "${COMMON_VALUES[@]}" \

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CHART_DIR="${ROOT_DIR}/deploy/helm/taxonomy"
+OUTPUT_FILE=${1:-"${ROOT_DIR}/target/taxonomy-helm-rendered.yaml"}
+VALID_TAG=sha-0123456789abcdef0123456789abcdef01234567
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "Helm 3 is required to validate ${CHART_DIR}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_FILE}")"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+COMMON_VALUES=(
+  --set "image.tag=${VALID_TAG}"
+  --set existingSecret=taxonomy-secrets
+)
+
+expect_failure() {
+  local description=$1
+  shift
+  local log_file="${TMP_DIR}/failure.log"
+  if "$@" >"${log_file}" 2>&1; then
+    echo "Expected failure was accepted: ${description}" >&2
+    return 1
+  fi
+}
+
+helm lint "${CHART_DIR}" "${COMMON_VALUES[@]}"
+helm template taxonomy "${CHART_DIR}" \
+  "${COMMON_VALUES[@]}" \
+  --set serviceMonitor.enabled=true \
+  >"${OUTPUT_FILE}"
+
+for required in \
+  'kind: Deployment' \
+  'kind: NetworkPolicy' \
+  'kind: ServiceMonitor' \
+  'automountServiceAccountToken: false' \
+  'runAsNonRoot: true' \
+  'runAsUser: 10001' \
+  'readOnlyRootFilesystem: true' \
+  'maxUnavailable: 0' \
+  'path: /actuator/health/readiness' \
+  'type: Bearer' \
+  'key: "ADMIN_PASSWORD"'; do
+  if ! grep -Fq "${required}" "${OUTPUT_FILE}"; then
+    echo "Rendered chart is missing required contract: ${required}" >&2
+    exit 1
+  fi
+done
+
+PERSISTENCE_OUTPUT="${TMP_DIR}/persistence.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  "${COMMON_VALUES[@]}" \
+  --set persistence.enabled=true \
+  --set config.TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem \
+  >"${PERSISTENCE_OUTPUT}"
+grep -Fq 'kind: PersistentVolumeClaim' "${PERSISTENCE_OUTPUT}"
+grep -Fq 'type: Recreate' "${PERSISTENCE_OUTPUT}"
+
+MULTI_OUTPUT="${TMP_DIR}/multi-replica.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  "${COMMON_VALUES[@]}" \
+  --set replicaCount=2 \
+  --set scaling.allowMultipleReplicas=true \
+  --set podDisruptionBudget.enabled=true \
+  >"${MULTI_OUTPUT}"
+grep -Fq 'kind: PodDisruptionBudget' "${MULTI_OUTPUT}"
+
+expect_failure 'missing immutable image reference' \
+  helm template taxonomy "${CHART_DIR}" --set existingSecret=taxonomy-secrets
+expect_failure 'mutable latest image tag' \
+  helm template taxonomy "${CHART_DIR}" \
+    --set image.tag=latest --set existingSecret=taxonomy-secrets
+expect_failure 'arbitrary mutable image tag' \
+  helm template taxonomy "${CHART_DIR}" \
+    --set image.tag=stable --set existingSecret=taxonomy-secrets
+expect_failure 'simultaneous image tag and digest' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" \
+    --set image.digest=sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+expect_failure 'missing credentials Secret' \
+  helm template taxonomy "${CHART_DIR}" --set "image.tag=${VALID_TAG}"
+expect_failure 'multiple replicas without explicit acknowledgement' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set replicaCount=2
+expect_failure 'persistent multi-replica deployment' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" \
+    --set replicaCount=2 \
+    --set scaling.allowMultipleReplicas=true \
+    --set persistence.enabled=true
+expect_failure 'single-replica PodDisruptionBudget' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set podDisruptionBudget.enabled=true
+expect_failure 'disk-backed Lucene without persistence' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" \
+    --set config.TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem
+expect_failure 'Ingress blocked by an unconfigured NetworkPolicy' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set ingress.enabled=true
+expect_failure 'ServiceMonitor authorization without a Secret' \
+  helm template taxonomy "${CHART_DIR}" \
+    --set "image.tag=${VALID_TAG}" \
+    --set-json secretEnv='{}' \
+    --set serviceMonitor.enabled=true
+
+printf 'Helm chart verification passed. Rendered evidence: %s\n' "${OUTPUT_FILE}"

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -64,6 +64,22 @@ helm template taxonomy "${CHART_DIR}" \
   >"${PRERELEASE_OUTPUT}"
 grep -Fq 'image: "ghcr.io/carstenartur/taxonomy:v1.2.3-rc.1"' "${PRERELEASE_OUTPUT}"
 
+OPENSHIFT_OUTPUT="${TMP_DIR}/openshift.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  --namespace taxonomy \
+  --values "${CHART_DIR}/values-openshift.yaml" \
+  --set "image.tag=${VALID_TAG}" \
+  --set existingSecret=taxonomy-secrets \
+  >"${OPENSHIFT_OUTPUT}"
+grep -Fq 'runAsNonRoot: true' "${OPENSHIFT_OUTPUT}"
+grep -Fq 'readOnlyRootFilesystem: true' "${OPENSHIFT_OUTPUT}"
+for forbidden in 'runAsUser:' 'runAsGroup:' 'fsGroup:' 'fsGroupChangePolicy:'; do
+  if grep -Fq "${forbidden}" "${OPENSHIFT_OUTPUT}"; then
+    echo "OpenShift profile must leave ${forbidden%:} to the cluster SCC" >&2
+    exit 1
+  fi
+done
+
 PERSISTENCE_OUTPUT="${TMP_DIR}/persistence.yaml"
 helm template taxonomy "${CHART_DIR}" \
   "${COMMON_VALUES[@]}" \

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
@@ -5,25 +5,31 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 /**
  * Protects sensitive Actuator endpoints (/actuator/metrics, /actuator/prometheus, etc.)
  * using the existing admin password mechanism.
  *
  * <ul>
- *   <li>{@code /actuator/health} and {@code /actuator/health/**} are PUBLIC (needed for Render health checks)</li>
+ *   <li>{@code /actuator/health} and {@code /actuator/health/**} are PUBLIC (needed for platform probes)</li>
  *   <li>{@code /actuator/info} is PUBLIC (non-sensitive)</li>
- *   <li>All other {@code /actuator/**} endpoints require the {@code X-Admin-Token} header
- *       matching the {@code ADMIN_PASSWORD} environment variable.</li>
+ *   <li>All other {@code /actuator/**} endpoints require either the legacy
+ *       {@code X-Admin-Token} header or an {@code Authorization: Bearer ...}
+ *       header matching the {@code ADMIN_PASSWORD} environment variable.</li>
  *   <li>If no {@code ADMIN_PASSWORD} is configured, all endpoints are accessible (backward compatible).</li>
  * </ul>
  */
 @Component
 public class ActuatorSecurityFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
 
     @Value("${admin.token:}")
     private String adminPassword;
@@ -53,16 +59,31 @@ public class ActuatorSecurityFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Check X-Admin-Token header
-        String token = request.getHeader("X-Admin-Token");
-        if (adminPassword.equals(token)) {
+        if (matchesToken(request.getHeader("X-Admin-Token"))
+                || matchesBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION))) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Unauthorized
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.getWriter().write("{\"error\":\"Admin authentication required for actuator endpoints\"}");
+    }
+
+    private boolean matchesBearerToken(String authorization) {
+        if (authorization == null
+                || !authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+            return false;
+        }
+        return matchesToken(authorization.substring(BEARER_PREFIX.length()).trim());
+    }
+
+    private boolean matchesToken(String candidate) {
+        if (candidate == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                adminPassword.getBytes(StandardCharsets.UTF_8),
+                candidate.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
@@ -21,8 +21,9 @@ import java.security.MessageDigest;
  *   <li>{@code /actuator/health} and {@code /actuator/health/**} are PUBLIC (needed for platform probes)</li>
  *   <li>{@code /actuator/info} is PUBLIC (non-sensitive)</li>
  *   <li>All other {@code /actuator/**} endpoints require either the legacy
- *       {@code X-Admin-Token} header or an {@code Authorization: Bearer ...}
- *       header matching the {@code ADMIN_PASSWORD} environment variable.</li>
+ *       {@code X-Admin-Token} header or an Authorization header in the form
+ *       {@code Authorization: Bearer ADMIN_PASSWORD_VALUE}, where the Bearer
+ *       value matches the {@code ADMIN_PASSWORD} environment variable.</li>
  *   <li>If no {@code ADMIN_PASSWORD} is configured, all endpoints are accessible (backward compatible).</li>
  * </ul>
  */

--- a/taxonomy-app/src/main/resources/application-kubernetes.properties
+++ b/taxonomy-app/src/main/resources/application-kubernetes.properties
@@ -1,0 +1,34 @@
+# Kubernetes/Rancher runtime defaults. Activate together with a database profile,
+# for example SPRING_PROFILES_ACTIVE=postgres,kubernetes.
+
+# Allow the platform to drain in-flight requests during rolling updates.
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=${TAXONOMY_SHUTDOWN_TIMEOUT:30s}
+
+# Respect Forwarded/X-Forwarded headers supplied by the trusted ingress controller
+# so redirects, absolute links and OIDC callbacks retain the public HTTPS origin.
+server.forward-headers-strategy=${TAXONOMY_FORWARD_HEADERS_STRATEGY:framework}
+
+# Kubernetes probes are served by Spring Boot Actuator.
+management.endpoint.health.probes.enabled=true
+management.health.livenessstate.enabled=true
+management.health.readinessstate.enabled=true
+
+# Avoid writing application logs into the immutable container filesystem.
+logging.file.name=${TAXONOMY_LOG_FILE:}
+
+# Production-safe defaults; operators may override them explicitly.
+springdoc.api-docs.enabled=${TAXONOMY_SPRINGDOC_ENABLED:false}
+springdoc.swagger-ui.enabled=${TAXONOMY_SPRINGDOC_ENABLED:false}
+taxonomy.security.swagger-public=false
+taxonomy.security.audit-logging=${TAXONOMY_AUDIT_LOGGING:true}
+
+# Persistent deployments must not recreate their schema on every pod start.
+spring.jpa.hibernate.ddl-auto=${TAXONOMY_DDL_AUTO:validate}
+
+# Disk-backed Lucene is available for single-replica deployments. Multi-replica
+# operation requires shared/index-coordination semantics and is therefore not the
+# default; see deploy/helm/taxonomy/README.md.
+spring.jpa.properties.hibernate.search.backend.directory.type=${TAXONOMY_SEARCH_DIRECTORY_TYPE:local-heap}
+spring.jpa.properties.hibernate.search.backend.directory.root=${TAXONOMY_SEARCH_DIRECTORY_ROOT:/app/data/lucene-index}
+spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=${TAXONOMY_SEARCH_SYNC_STRATEGY:write-sync}

--- a/taxonomy-app/src/test/java/com/taxonomy/ContainerPlatformContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ContainerPlatformContractTest.java
@@ -23,7 +23,8 @@ class ContainerPlatformContractTest {
                 .contains("ENV HOME=/tmp")
                 .contains("-Djava.io.tmpdir=/tmp")
                 .contains("RUN chgrp -R 0 /app /opt/opentelemetry")
-                .contains("&& chmod -R g=u /app /opt/opentelemetry")
+                .contains("&& chmod -R g=u /app/data")
+                .doesNotContain("chmod -R g=u /app /opt/opentelemetry")
                 .contains("STOPSIGNAL SIGTERM")
                 .doesNotContain("USER root");
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/ContainerPlatformContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ContainerPlatformContractTest.java
@@ -1,0 +1,77 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Locks the production image and chart to portable non-root container semantics. */
+class ContainerPlatformContractTest {
+
+    @Test
+    void imageProvidesASecureDefaultAndSupportsOpenShiftArbitraryUids()
+            throws IOException {
+        String dockerfile = readRepositoryFile("Dockerfile");
+
+        assertThat(dockerfile)
+                .contains("ARG TAXONOMY_UID=10001")
+                .contains("ARG TAXONOMY_GID=10001")
+                .contains("USER 10001:10001")
+                .contains("ENV HOME=/tmp")
+                .contains("-Djava.io.tmpdir=/tmp")
+                .contains("RUN chgrp -R 0 /app /opt/opentelemetry")
+                .contains("&& chmod -R g=u /app /opt/opentelemetry")
+                .contains("STOPSIGNAL SIGTERM")
+                .doesNotContain("USER root");
+    }
+
+    @Test
+    void openShiftValuesDelegateTheNumericIdentityToTheCluster()
+            throws IOException {
+        String values = readRepositoryFile(
+                "deploy/helm/taxonomy/values-openshift.yaml");
+
+        assertThat(values)
+                .contains("runAsNonRoot: true")
+                .contains("runAsUser: null")
+                .contains("runAsGroup: null")
+                .contains("fsGroup: null")
+                .contains("fsGroupChangePolicy: null")
+                .contains("readOnlyRootFilesystem: true")
+                .contains("allowPrivilegeEscalation: false")
+                .contains("drop: [\"ALL\"]");
+    }
+
+    @Test
+    void defaultValuesRetainThePortableFixedIdentity()
+            throws IOException {
+        String values = readRepositoryFile("deploy/helm/taxonomy/values.yaml");
+
+        assertThat(values)
+                .contains("runAsNonRoot: true")
+                .contains("runAsUser: 10001")
+                .contains("runAsGroup: 10001")
+                .contains("fsGroup: 10001")
+                .contains("readOnlyRootFilesystem: true");
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        return Files.readString(repositoryRoot().resolve(relativePath));
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        if (Files.isRegularFile(current.resolve("taxonomy-app/pom.xml"))) {
+            return current;
+        }
+        if ("taxonomy-app".equals(current.getFileName().toString())
+                && Files.isRegularFile(current.resolve("pom.xml"))) {
+            return current.getParent();
+        }
+        throw new IllegalStateException(
+                "Cannot locate Taxonomy repository root from " + current);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
@@ -1,0 +1,83 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActuatorSecurityFilterTest {
+
+    private static final String ADMIN_TOKEN = "test-admin-token";
+
+    private ActuatorSecurityFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new ActuatorSecurityFilter();
+        ReflectionTestUtils.setField(filter, "adminPassword", ADMIN_TOKEN);
+    }
+
+    @Test
+    void healthEndpointsRemainPublicForPlatformProbes() throws Exception {
+        MockHttpServletResponse response = invoke("/actuator/health/readiness", null, null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void sensitiveEndpointRejectsMissingCredentials() throws Exception {
+        MockHttpServletResponse response = invoke("/actuator/prometheus", null, null);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("Admin authentication required");
+    }
+
+    @Test
+    void sensitiveEndpointAcceptsLegacyAdminHeader() throws Exception {
+        MockHttpServletResponse response = invoke(
+                "/actuator/prometheus", "X-Admin-Token", ADMIN_TOKEN);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void sensitiveEndpointAcceptsBearerTokenForPrometheusOperator() throws Exception {
+        MockHttpServletResponse response = invoke(
+                "/actuator/prometheus", HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void sensitiveEndpointRejectsIncorrectBearerToken() throws Exception {
+        MockHttpServletResponse response = invoke(
+                "/actuator/prometheus", HttpHeaders.AUTHORIZATION, "Bearer wrong-token");
+
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void blankAdminTokenPreservesDevelopmentCompatibility() throws Exception {
+        ReflectionTestUtils.setField(filter, "adminPassword", "");
+
+        MockHttpServletResponse response = invoke("/actuator/prometheus", null, null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    private MockHttpServletResponse invoke(String path, String header, String value)
+            throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", path);
+        if (header != null) {
+            request.addHeader(header, value);
+        }
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #532 with a generic Kubernetes-first deployment that works through Rancher, RKE2, K3s, OpenShift and vanilla Kubernetes without Rancher-specific application code.

The branch was rebuilt from the current `main` after the original implementation became conflict-prone. This preserves the atomic release/version-state guards, canonical Maven authority and observability performance gates added since the PR was opened.

### Hardened container

- fixed numeric non-root default identity (`10001:10001`)
- OpenShift-compatible group-0 read access for arbitrary non-root UIDs, with group write restricted to `/app/data`
- dropped root dependence and Kubernetes-compatible security context
- read-only root filesystem support with explicit `/tmp` and `/app/data` mounts
- `ExitOnOutOfMemoryError`, explicit JVM temp directory and Java as PID 1
- immutable digest-pinned base and OpenTelemetry agent images remain intact

### Kubernetes runtime profile

- graceful shutdown with configurable timeout
- startup/readiness/liveness probe support
- trusted forwarded-header processing for HTTPS ingress and OIDC redirects
- no filesystem logging by default
- Swagger disabled and audit logging enabled by default
- schema validation instead of destructive recreation
- explicit search directory and synchronization settings

### Fail-closed Helm chart

- Deployment, Service, optional Ingress, PVC, PDB, NetworkPolicy and ServiceMonitor
- image references restricted to Docker-safe `vX.Y.Z[-prerelease]`, `sha-<commit>` or `sha256:<digest>`
- required external Secret mappings for database/admin credentials; optional LLM keys
- non-root, seccomp, dropped capabilities, no privilege escalation and read-only root filesystem
- no service-account token automount
- explicit writable volumes and resource requests/limits
- all namespaced resources explicitly target the Helm release namespace
- rolling updates with `maxUnavailable: 0` for stateless deployments
- automatic `Recreate` strategy for a ReadWriteOnce PVC to avoid multi-attach surge failures
- authenticated Prometheus scraping through a Secret-backed Bearer token
- dedicated `values-openshift.yaml` profile that delegates UID/GID/fsGroup assignment to the restricted SCC
- validation rejects unsafe replica/PVC/PDB/Lucene/Ingress/NetworkPolicy combinations

### Reproducible validation

`deploy/helm/taxonomy/verify.sh` is the local and CI authority. It:

- lints and renders the chart;
- verifies namespace, security, probes, rollout and monitoring contracts;
- renders and checks both the fixed-UID Kubernetes default and arbitrary-UID OpenShift profile;
- proves valid release/prerelease, persistence and acknowledged multi-replica cases;
- proves that mutable or Docker-invalid images, missing Secrets, unsafe PDB/PVC/scaling combinations, disk-backed Lucene without persistence and blocked Ingress configurations fail closed.

`ContainerPlatformContractTest` additionally locks the Dockerfile's UID, data-only write and writable-path semantics into the Maven suite. The canonical CI installs the official Helm 3.21.0 binary after checking its fixed upstream SHA-256 digest, invokes the same chart script and retains the rendered manifest as quality evidence. Helm-only changes now also trigger Trivy vulnerability, secret and misconfiguration scanning.

### Atomic release delivery

The release workflow now:

- verifies all version-state, shell and release-delivery contracts before any remote mutation;
- creates or reuses the immutable release tag while keeping the GitHub release as a draft;
- advances `main` atomically from the release snapshot to the next development snapshot;
- records the exact SHA of that release-generated development snapshot before checking out the release tag;
- packages and stages a versioned Helm `.tgz`, a Rancher Import-YAML manifest and SHA-256 checksums;
- builds and publishes the immutable `vX.Y.Z` container image;
- reuses or dispatches canonical CI only for the recorded snapshot SHA and verifies the selected run's `headSha`;
- verifies the required release assets and published container manifest;
- publishes the GitHub release and triggers deployment only as the final gate.

A failure in chart packaging, image publication or exact-SHA final CI therefore leaves a recoverable draft instead of a publicly incomplete release. A later move of `main` cannot silently substitute another commit. `.github/scripts/check-release-delivery-contract.py` locks this ordering in both canonical CI and the release workflow itself.

### Operations documentation

The runbook covers:

- Helm installation and Rancher Import YAML when Helm is not visible in the UI;
- OpenShift restricted-v2 deployment without a custom SCC or fixed UID;
- Secrets, ingress, Routes, TLS and private truststores;
- probes, shutdown, resource tuning and recovery;
- NetworkPolicy configuration for ingress controllers;
- local-heap versus persistent Lucene behavior;
- horizontal-scaling preconditions and PDB restrictions;
- verified embedding-model provisioning;
- authenticated Prometheus Operator integration.

## Scaling boundary

The safe default remains one replica with PostgreSQL-authoritative state and `local-heap` search. More than one replica requires an explicit acknowledgement and is still rejected with persistent/local-filesystem indexing. This avoids claiming silent horizontal scalability before sessions, indexing, initialization and job ownership are coordinated and tested.

## Verification

Requires the complete canonical Maven/browser suite, Helm and exact-SHA atomic-release contract suites, Database Compatibility, Security Scan and CodeQL on this exact head.

Closes #532