### PR TITLE
Keep release transitions atomic and version-consistent

### DIFF
--- a/.github/scripts/check-version-state.py
+++ b/.github/scripts/check-version-state.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Fail closed when Maven, release metadata and Helm disagree about the version state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+MAVEN_NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+RELEASE_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+DEVELOPMENT_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$")
+
+
+def text(element: ET.Element, path: str) -> str | None:
+    value = element.findtext(path, namespaces=MAVEN_NS)
+    return value.strip() if value and value.strip() else None
+
+
+def root_version(root: Path) -> str:
+    project = ET.parse(root / "pom.xml").getroot()
+    version = text(project, "m:version")
+    if not version:
+        raise ValueError("Root pom.xml has no project version")
+    return version
+
+
+def pom_failures(root: Path, expected: str) -> list[str]:
+    failures: list[str] = []
+    for pom in sorted(root.rglob("pom.xml")):
+        if "target" in pom.parts or ".git" in pom.parts:
+            continue
+        project = ET.parse(pom).getroot()
+        parent_group = text(project, "m:parent/m:groupId")
+        parent_artifact = text(project, "m:parent/m:artifactId")
+        parent_version = text(project, "m:parent/m:version")
+        if parent_group == "com.taxonomy" and parent_artifact == "taxonomy":
+            if parent_version != expected:
+                failures.append(
+                    f"{pom.relative_to(root)} parent version {parent_version!r} != {expected!r}"
+                )
+        group = text(project, "m:groupId") or parent_group
+        own_version = text(project, "m:version")
+        if group == "com.taxonomy" and own_version and own_version != expected:
+            failures.append(
+                f"{pom.relative_to(root)} project version {own_version!r} != {expected!r}"
+            )
+    return failures
+
+
+def metadata_failures(root: Path, expected: str, release_mode: bool) -> list[str]:
+    failures: list[str] = []
+
+    citation = (root / "CITATION.cff").read_text(encoding="utf-8")
+    cff_version = re.search(r'^version: "([^"]+)"$', citation, flags=re.MULTILINE)
+    if not cff_version or cff_version.group(1) != expected:
+        failures.append("CITATION.cff version does not match the Maven version")
+    cff_has_date = bool(re.search(r"^date-released: ", citation, flags=re.MULTILINE))
+    if cff_has_date != release_mode:
+        failures.append("CITATION.cff release-date state does not match the requested mode")
+
+    citation_md = (root / "CITATION.md").read_text(encoding="utf-8")
+    preferred = re.search(
+        r"Taxonomy Architecture Analyzer\*\*\. Version ([0-9A-Za-z.-]+)\.", citation_md
+    )
+    bibtex = re.search(r"^\s*version\s+= \{([^}]+)\},$", citation_md, flags=re.MULTILINE)
+    if not preferred or preferred.group(1) != expected:
+        failures.append("CITATION.md preferred citation version does not match")
+    if not bibtex or bibtex.group(1) != expected:
+        failures.append("CITATION.md BibTeX version does not match")
+    md_has_date = bool(re.search(r"^\s*date\s+= \{[^}]+\},$", citation_md, flags=re.MULTILINE))
+    if md_has_date != release_mode:
+        failures.append("CITATION.md release-date state does not match the requested mode")
+
+    for name, version_key, date_key in (
+        (".zenodo.json", "version", "publication_date"),
+        ("codemeta.json", "version", "datePublished"),
+    ):
+        data = json.loads((root / name).read_text(encoding="utf-8"))
+        if data.get(version_key) != expected:
+            failures.append(f"{name} version does not match")
+        if (date_key in data) != release_mode:
+            failures.append(f"{name} release-date state does not match the requested mode")
+
+    chart = root / "deploy" / "helm" / "taxonomy" / "Chart.yaml"
+    if chart.is_file():
+        chart_text = chart.read_text(encoding="utf-8")
+        match = re.search(r'^appVersion:\s*["\']?([^"\'\s]+)["\']?\s*$', chart_text, re.MULTILINE)
+        if not match or match.group(1) != expected:
+            failures.append("Helm Chart.yaml appVersion does not match the Maven version")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--mode", choices=("development", "release"), required=True)
+    parser.add_argument("--expected-version")
+    parser.add_argument("--tag", help="Optional release tag, for example v1.2.3")
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    try:
+        actual = root_version(root)
+    except (OSError, ET.ParseError, ValueError) as error:
+        print(f"Version-state check failed: {error}", file=sys.stderr)
+        return 1
+
+    expected = args.expected_version or actual
+    failures: list[str] = []
+    if actual != expected:
+        failures.append(f"Root Maven version {actual!r} != expected {expected!r}")
+
+    release_mode = args.mode == "release"
+    pattern = RELEASE_VERSION if release_mode else DEVELOPMENT_VERSION
+    if not pattern.fullmatch(actual):
+        failures.append(f"Version {actual!r} is not a valid {args.mode} version")
+
+    if args.tag:
+        expected_tag = f"v{actual}"
+        if not release_mode:
+            failures.append("A release tag is only valid in release mode")
+        elif args.tag != expected_tag:
+            failures.append(f"Tag {args.tag!r} != expected {expected_tag!r}")
+
+    try:
+        failures.extend(pom_failures(root, actual))
+        failures.extend(metadata_failures(root, actual, release_mode))
+    except (OSError, ET.ParseError, json.JSONDecodeError) as error:
+        failures.append(f"Could not inspect version metadata: {error}")
+
+    if failures:
+        print("Inconsistent repository version state:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(f"Repository version state is consistent: {actual} ({args.mode}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 : "${RELEASE_VERSION:?RELEASE_VERSION is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${METADATA_HELPER:?METADATA_HELPER is required}"
+: "${VERSION_STATE_HELPER:?VERSION_STATE_HELPER is required}"
 : "${VEX_HELPER:?VEX_HELPER is required}"
 
 NEXT_VERSION_INPUT=${NEXT_VERSION_INPUT:-}
@@ -15,29 +16,21 @@ RENDER_DEPLOY_HOOK_URL=${RENDER_DEPLOY_HOOK_URL:-}
 TAG_NAME="v${RELEASE_VERSION}"
 MAJOR_MINOR=$(echo "${RELEASE_VERSION}" | sed 's/\.[^.]*$//')
 MAINTENANCE_BRANCH="maintenance/${MAJOR_MINOR}.x"
+TEMP_BRANCH="release-temp-${RELEASE_VERSION}"
+
+fail() {
+  echo "::error::$*"
+  exit 1
+}
 
 if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "::error::release_version must use X.Y.Z without a leading v"
-  exit 1
+  fail "release_version must use X.Y.Z without a leading v"
 fi
-
 if [[ "$SOURCE_BRANCH" != "main" && "$DRY_RUN" != "true" ]]; then
-  echo "::error::Real releases must be dispatched from main, not $SOURCE_BRANCH"
-  exit 1
+  fail "Real releases must be dispatched from main, not $SOURCE_BRANCH"
 fi
-
-CURRENT_VERSION=$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)
-if [[ "$CURRENT_VERSION" != *-SNAPSHOT ]]; then
-  echo "::error::Current Maven version must be a SNAPSHOT, but was $CURRENT_VERSION"
-  exit 1
-fi
-if [[ "${CURRENT_VERSION%-SNAPSHOT}" != "$RELEASE_VERSION" ]]; then
-  if [[ "$DRY_RUN" == "true" ]]; then
-    echo "::warning::Release $RELEASE_VERSION does not match current version $CURRENT_VERSION"
-  else
-    echo "::error::Release $RELEASE_VERSION does not match current version $CURRENT_VERSION"
-    exit 1
-  fi
+if [[ "$SKIP_TESTS" == "true" && "$DRY_RUN" != "true" ]]; then
+  fail "skip_tests is allowed only for a dry run; published releases require the canonical verification suite"
 fi
 
 if [[ -n "$NEXT_VERSION_INPUT" ]]; then
@@ -47,73 +40,18 @@ else
   NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
 fi
 if ! [[ "$NEXT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
-  echo "::error::next_development_version must use X.Y.Z-SNAPSHOT"
-  exit 1
+  fail "next_development_version must use X.Y.Z-SNAPSHOT"
 fi
-
-verify_metadata() {
-  local expected=$1
-  local release_mode=$2
-  local maven_version
-  maven_version=$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)
-  if [[ "$maven_version" != "$expected" ]]; then
-    echo "::error::Maven version $maven_version != $expected"
-    exit 1
-  fi
-
-  EXPECTED_VERSION="$expected" RELEASE_MODE="$release_mode" python3 - <<'PY'
-import json
+RELEASE_VERSION="$RELEASE_VERSION" NEXT_VERSION="$NEXT_VERSION" python3 - <<'PY'
 import os
-import re
-from pathlib import Path
-
-expected = os.environ['EXPECTED_VERSION']
-release_mode = os.environ['RELEASE_MODE'] == 'true'
-
-citation = Path('CITATION.cff').read_text(encoding='utf-8')
-version_match = re.search(r'^version: "([^"]+)"$', citation, flags=re.MULTILINE)
-if not version_match or version_match.group(1) != expected:
-    raise SystemExit(f'CITATION.cff version does not match {expected!r}')
-has_date_released = bool(re.search(r'^date-released: ', citation, flags=re.MULTILINE))
-if release_mode and not has_date_released:
-    raise SystemExit('CITATION.cff date-released is missing')
-if not release_mode and has_date_released:
-    raise SystemExit('CITATION.cff still contains date-released for a development snapshot')
-
-citation_md = Path('CITATION.md').read_text(encoding='utf-8')
-preferred = re.search(r'Taxonomy Architecture Analyzer\*\*\. Version ([^.]+(?:\.[^.]+){1,2}(?:-SNAPSHOT)?)\.', citation_md)
-bibtex = re.search(r'^\s*version\s+= \{([^}]+)\},$', citation_md, flags=re.MULTILINE)
-if not preferred or preferred.group(1) != expected:
-    raise SystemExit(f'CITATION.md preferred citation version does not match {expected!r}')
-if not bibtex or bibtex.group(1) != expected:
-    raise SystemExit(f'CITATION.md BibTeX version does not match {expected!r}')
-has_bibtex_date = bool(re.search(r'^\s*date\s+= \{[^}]+\},$', citation_md, flags=re.MULTILINE))
-if release_mode and not has_bibtex_date:
-    raise SystemExit('CITATION.md BibTeX release date is missing')
-if not release_mode and has_bibtex_date:
-    raise SystemExit('CITATION.md still contains a BibTeX release date for a development snapshot')
-
-with open('.zenodo.json', encoding='utf-8') as handle:
-    zenodo = json.load(handle)
-if zenodo.get('version') != expected:
-    raise SystemExit(f'.zenodo.json version {zenodo.get("version")!r} != {expected!r}')
-has_publication_date = 'publication_date' in zenodo
-if release_mode and not has_publication_date:
-    raise SystemExit('.zenodo.json publication_date is missing')
-if not release_mode and has_publication_date:
-    raise SystemExit('.zenodo.json still contains publication_date for a development snapshot')
-
-with open('codemeta.json', encoding='utf-8') as handle:
-    codemeta = json.load(handle)
-if codemeta.get('version') != expected:
-    raise SystemExit(f'codemeta.json version {codemeta.get("version")!r} != {expected!r}')
-has_date_published = 'datePublished' in codemeta
-if release_mode and not has_date_published:
-    raise SystemExit('codemeta.json datePublished is missing')
-if not release_mode and has_date_published:
-    raise SystemExit('codemeta.json still contains datePublished for a development snapshot')
+release = tuple(map(int, os.environ['RELEASE_VERSION'].split('.')))
+next_version = tuple(map(int, os.environ['NEXT_VERSION'].removesuffix('-SNAPSHOT').split('.')))
+if next_version <= release:
+    raise SystemExit(
+        f"next development version {os.environ['NEXT_VERSION']} must be newer than "
+        f"release {os.environ['RELEASE_VERSION']}"
+    )
 PY
-}
 
 ensure_no_snapshot_poms() {
   local remaining
@@ -137,7 +75,6 @@ generate_release_notes() {
     | head -n 1 || true)
 
   if [[ -n "$previous_tag" ]]; then
-    echo "Getting closed issues since $previous_tag"
     local previous_date
     previous_date=$(git log -1 --format=%aI "$previous_tag")
     gh issue list --state closed --search "closed:>$previous_date" \
@@ -154,7 +91,6 @@ generate_release_notes() {
 collect_release_artifacts() {
   rm -rf target/release-artifacts
   mkdir -p target/release-artifacts
-
   find . -path './target/release-artifacts' -prune -o \
     -path '*/target/*.jar' -type f \
     ! -name '*-sources.jar' \
@@ -162,33 +98,20 @@ collect_release_artifacts() {
     ! -name 'original-*' \
     -exec cp {} target/release-artifacts/ \;
 
-  for f in target/taxonomy-sbom.json target/taxonomy-sbom.xml target/taxonomy-vex.json; do
-    if [[ -f "$f" ]]; then
-      cp "$f" target/release-artifacts/
+  for file in target/taxonomy-sbom.json target/taxonomy-sbom.xml target/taxonomy-vex.json; do
+    if [[ -f "$file" ]]; then
+      cp "$file" target/release-artifacts/
     else
-      echo "::warning::$f not found"
+      echo "::warning::$file not found"
     fi
   done
-
-  echo "Release artifacts:"
   find target/release-artifacts -maxdepth 1 -type f -print | sort
 }
 
-push_release_commit_to_main() {
+materialize_commit() {
   local commit_sha=$1
-  local temp_branch="release-temp-${RELEASE_VERSION}"
-
-  git push origin ":refs/heads/${temp_branch}" || true
-  git push origin "${commit_sha}:refs/heads/${temp_branch}"
-
-  if gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/main" \
-      --method PATCH \
-      -f sha="$commit_sha"; then
-    git push origin ":refs/heads/${temp_branch}" || true
-  else
-    git push origin ":refs/heads/${temp_branch}" || true
-    return 1
-  fi
+  git push origin ":refs/heads/${TEMP_BRANCH}" >/dev/null 2>&1 || true
+  git push origin "${commit_sha}:refs/heads/${TEMP_BRANCH}"
 }
 
 create_tag_ref() {
@@ -219,30 +142,40 @@ create_maintenance_branch_if_missing() {
   fi
 }
 
+remote_main_version() {
+  git show origin/main:pom.xml | python3 -c '
+import sys, xml.etree.ElementTree as ET
+root = ET.fromstring(sys.stdin.read())
+ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+value = root.findtext("m:version", namespaces=ns)
+if not value:
+    raise SystemExit("origin/main pom.xml has no project version")
+print(value.strip())
+'
+}
+
 git config user.name 'github-actions[bot]'
 git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-echo "Release version: $RELEASE_VERSION"
-echo "Current version: $CURRENT_VERSION"
-echo "Next development version: $NEXT_VERSION"
-echo "Dry run: $DRY_RUN"
-echo "Skip tests: $SKIP_TESTS"
+git fetch origin main --tags --force
+ORIGINAL_HEAD=$(git rev-parse HEAD)
+ORIGINAL_MAIN=$(git rev-parse origin/main)
+if [[ "$DRY_RUN" != "true" && "$ORIGINAL_HEAD" != "$ORIGINAL_MAIN" ]]; then
+  fail "Checked-out commit $ORIGINAL_HEAD is stale; origin/main is $ORIGINAL_MAIN"
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  fail "Release checkout is not clean before version preparation"
+fi
 
-verify_metadata "$CURRENT_VERSION" false
-./mvnw -B validate
-
-git fetch origin --tags --force
+CURRENT_VERSION=$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)
 TAG_EXISTS=false
 if git rev-parse "${TAG_NAME}^{commit}" >/dev/null 2>&1; then
   TAG_EXISTS=true
 fi
-
 RELEASE_STATE=$(gh release view "$TAG_NAME" --json isDraft --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || true)
 if [[ -n "$RELEASE_STATE" && "$TAG_EXISTS" != "true" ]]; then
-  echo "::error::A GitHub release exists for ${TAG_NAME}, but its tag is missing"
-  exit 1
+  fail "A GitHub release exists for ${TAG_NAME}, but its tag is missing"
 fi
-
 if [[ -n "$RELEASE_STATE" ]]; then
   STATE=$RELEASE_STATE
 elif [[ "$TAG_EXISTS" == "true" ]]; then
@@ -251,18 +184,42 @@ else
   STATE=new
 fi
 
+MAIN_ALREADY_ADVANCED=false
+if [[ "$CURRENT_VERSION" == "$NEXT_VERSION" && "$TAG_EXISTS" == "true" ]]; then
+  MAIN_ALREADY_ADVANCED=true
+  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+elif [[ "$CURRENT_VERSION" == "${RELEASE_VERSION}-SNAPSHOT" ]]; then
+  python3 "$VERSION_STATE_HELPER" --mode development \
+    --expected-version "${RELEASE_VERSION}-SNAPSHOT"
+else
+  fail "Current version $CURRENT_VERSION is neither ${RELEASE_VERSION}-SNAPSHOT nor finalized $NEXT_VERSION"
+fi
+
+echo "Release version: $RELEASE_VERSION"
+echo "Current version: $CURRENT_VERSION"
+echo "Next development version: $NEXT_VERSION"
 echo "Release state: $STATE"
+echo "Main already advanced: $MAIN_ALREADY_ADVANCED"
+echo "Dry run: $DRY_RUN"
+
+./mvnw -B validate
 
 if [[ "$STATE" == "new" ]]; then
   ./mvnw -B versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
   python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
-  verify_metadata "$RELEASE_VERSION" true
+  python3 "$VERSION_STATE_HELPER" --mode release --expected-version "$RELEASE_VERSION"
   ensure_no_snapshot_poms
   git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
+  if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+    git add deploy/helm/taxonomy/Chart.yaml
+  fi
   git commit -m "Release version $RELEASE_VERSION"
+  RELEASE_COMMIT=$(git rev-parse HEAD)
 else
-  git checkout --detach "$TAG_NAME"
-  verify_metadata "$RELEASE_VERSION" true
+  RELEASE_COMMIT=$(git rev-parse "${TAG_NAME}^{commit}")
+  git checkout --detach "$RELEASE_COMMIT"
+  python3 "$VERSION_STATE_HELPER" --mode release \
+    --expected-version "$RELEASE_VERSION" --tag "$TAG_NAME"
 fi
 
 if [[ "$SKIP_TESTS" == "true" ]]; then
@@ -270,21 +227,17 @@ if [[ "$SKIP_TESTS" == "true" ]]; then
 else
   ./mvnw -B clean verify -Pci
 fi
-
 python3 "$VEX_HELPER"
 collect_release_artifacts
-
 generate_release_notes
 
 PUBLISHED_THIS_RUN=false
 if [[ "$DRY_RUN" != "true" && "$STATE" == "new" ]]; then
-  RELEASE_COMMIT=$(git rev-parse HEAD)
-  push_release_commit_to_main "$RELEASE_COMMIT"
+  materialize_commit "$RELEASE_COMMIT"
   create_tag_ref "$RELEASE_COMMIT"
   create_maintenance_branch_if_missing "$RELEASE_COMMIT"
   STATE=tagged
 fi
-
 if [[ "$DRY_RUN" != "true" && "$STATE" == "tagged" ]]; then
   gh release create "$TAG_NAME" \
     --verify-tag \
@@ -293,6 +246,48 @@ if [[ "$DRY_RUN" != "true" && "$STATE" == "tagged" ]]; then
     --notes-file release_notes.md \
     --generate-notes
   STATE=draft
+fi
+
+# Prepare the next snapshot before publishing the release. main therefore remains a
+# development snapshot throughout: it moves once, by fast-forward, from the old
+# snapshot to the next snapshot while the release commit is addressed only by tag.
+if [[ "$MAIN_ALREADY_ADVANCED" == "true" ]]; then
+  git checkout --detach "$ORIGINAL_MAIN"
+  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+else
+  git checkout --detach "$RELEASE_COMMIT"
+  ./mvnw -B versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
+  python3 "$METADATA_HELPER" "$NEXT_VERSION"
+  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+  git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
+  if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+    git add deploy/helm/taxonomy/Chart.yaml
+  fi
+  git commit -m "Prepare next development version $NEXT_VERSION"
+  NEXT_COMMIT=$(git rev-parse HEAD)
+
+  if [[ "$DRY_RUN" != "true" ]]; then
+    git fetch origin main --force
+    REMOTE_MAIN=$(git rev-parse origin/main)
+    if [[ "$REMOTE_MAIN" != "$ORIGINAL_MAIN" ]]; then
+      fail "origin/main moved from $ORIGINAL_MAIN to $REMOTE_MAIN during the release; refusing to overwrite it"
+    fi
+    git merge-base --is-ancestor "$ORIGINAL_MAIN" "$NEXT_COMMIT" \
+      || fail "Next-development commit is not a fast-forward of the original main"
+    git push origin "${NEXT_COMMIT}:refs/heads/${TEMP_BRANCH}" --force
+    gh api "repos/${GITHUB_REPOSITORY}/git/refs/heads/main" \
+      --method PATCH \
+      -f sha="$NEXT_COMMIT"
+    git fetch origin main --force
+    if [[ "$(git rev-parse origin/main)" != "$NEXT_COMMIT" ]]; then
+      fail "origin/main did not advance to the prepared development commit"
+    fi
+    if [[ "$(remote_main_version)" != "$NEXT_VERSION" ]]; then
+      fail "origin/main does not expose development version $NEXT_VERSION"
+    fi
+    git push origin ":refs/heads/${TEMP_BRANCH}" || true
+    echo "main advanced atomically from ${RELEASE_VERSION}-SNAPSHOT to $NEXT_VERSION."
+  fi
 fi
 
 if [[ "$DRY_RUN" != "true" && "$STATE" == "draft" ]]; then
@@ -306,10 +301,8 @@ if [[ "$DRY_RUN" != "true" && "$STATE" == "draft" ]]; then
   STATE=published
   PUBLISHED_THIS_RUN=true
 fi
-
 if [[ "$DRY_RUN" != "true" ]]; then
-  IS_DRAFT=$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')
-  test "$IS_DRAFT" = false
+  test "$(gh release view "$TAG_NAME" --json isDraft --jq '.isDraft')" = false
 fi
 
 if [[ "$DRY_RUN" != "true" && "$PUBLISHED_THIS_RUN" == "true" ]]; then
@@ -321,56 +314,6 @@ if [[ "$DRY_RUN" != "true" && "$PUBLISHED_THIS_RUN" == "true" ]]; then
   fi
 fi
 
-./mvnw -B versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
-python3 "$METADATA_HELPER" "$NEXT_VERSION"
-verify_metadata "$NEXT_VERSION" false
-
-NEXT_BRANCH="release/prepare-next-${NEXT_VERSION}"
-git switch -C "$NEXT_BRANCH"
-git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
-if git diff --cached --quiet; then
-  echo "No next-development version changes to commit"
-else
-  git commit -m "Prepare next development version $NEXT_VERSION"
-fi
-
-if [[ "$DRY_RUN" != "true" ]]; then
-  REMOTE_SHA=$(git ls-remote --heads origin "refs/heads/${NEXT_BRANCH}" | awk '{print $1}')
-  if [[ -n "$REMOTE_SHA" ]]; then
-    git push --force-with-lease="refs/heads/${NEXT_BRANCH}:${REMOTE_SHA}" origin "HEAD:refs/heads/${NEXT_BRANCH}"
-  else
-    git push origin "HEAD:refs/heads/${NEXT_BRANCH}"
-  fi
-
-  cat > /tmp/next-development-pr.md <<EOF
-Automated follow-up after release ${RELEASE_VERSION}.
-
-## Changes
-- Bump all Maven modules to ${NEXT_VERSION}
-- Update CITATION.cff to ${NEXT_VERSION}
-- Update CITATION.md to ${NEXT_VERSION}
-- Update .zenodo.json to ${NEXT_VERSION}
-- Update codemeta.json to ${NEXT_VERSION}
-- Remove release-only date metadata from the development snapshot
-
-## Release notes
-
-EOF
-  cat release_notes.md >> /tmp/next-development-pr.md
-
-  EXISTING_PR=$(gh pr list --base main --head "$NEXT_BRANCH" \
-    --state open --json number --jq '.[0].number // empty')
-  if [[ -n "$EXISTING_PR" ]]; then
-    gh pr edit "$EXISTING_PR" \
-      --title "Prepare next development version ${NEXT_VERSION}" \
-      --body-file /tmp/next-development-pr.md
-  else
-    gh pr create \
-      --title "Prepare next development version ${NEXT_VERSION}" \
-      --body-file /tmp/next-development-pr.md \
-      --base main \
-      --head "$NEXT_BRANCH"
-  fi
-else
-  echo "Dry run completed; no remote refs, release, deploy hook or PR were changed."
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry run completed; no remote refs, release or deploy hook were changed."
 fi

--- a/.github/scripts/test-check-version-state.py
+++ b/.github/scripts/test-check-version-state.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Focused regression tests for check-version-state.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("check-version-state.py")
+
+
+def write_repository(root: Path, version: str, release: bool = False) -> None:
+    root.joinpath("module").mkdir(parents=True)
+    root.joinpath("deploy/helm/taxonomy").mkdir(parents=True)
+    root.joinpath("pom.xml").write_text(
+        """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<modelVersion>4.0.0</modelVersion><groupId>com.taxonomy</groupId>
+<artifactId>taxonomy</artifactId><version>{version}</version></project>
+""".format(version=version), encoding="utf-8")
+    root.joinpath("module/pom.xml").write_text(
+        """<project xmlns="http://maven.apache.org/POM/4.0.0">
+<modelVersion>4.0.0</modelVersion><parent><groupId>com.taxonomy</groupId>
+<artifactId>taxonomy</artifactId><version>{version}</version></parent>
+<artifactId>module</artifactId></project>
+""".format(version=version), encoding="utf-8")
+    date_line = 'date-released: "2026-07-31"\n' if release else ""
+    root.joinpath("CITATION.cff").write_text(
+        f'version: "{version}"\n{date_line}', encoding="utf-8")
+    bibtex_date = "  date         = {2026-07-31},\n" if release else ""
+    root.joinpath("CITATION.md").write_text(
+        f"Carsten Hammer. **Taxonomy Architecture Analyzer**. Version {version}. 2026.\n"
+        f"  version      = {{{version}}},\n{bibtex_date}", encoding="utf-8")
+    zenodo = {"version": version}
+    codemeta = {"version": version}
+    if release:
+        zenodo["publication_date"] = "2026-07-31"
+        codemeta["datePublished"] = "2026-07-31"
+    root.joinpath(".zenodo.json").write_text(json.dumps(zenodo), encoding="utf-8")
+    root.joinpath("codemeta.json").write_text(json.dumps(codemeta), encoding="utf-8")
+    root.joinpath("deploy/helm/taxonomy/Chart.yaml").write_text(
+        f'apiVersion: v2\nname: taxonomy\nappVersion: "{version}"\n', encoding="utf-8")
+
+
+def run_check(root: Path, mode: str, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), "--mode", mode, *extra],
+        text=True, capture_output=True, check=False,
+    )
+
+
+class VersionStateTest(unittest.TestCase):
+    def test_accepts_consistent_development_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, "1.2.9-SNAPSHOT")
+            result = run_check(root, "development")
+            self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_accepts_consistent_release_state_and_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, "1.2.9", release=True)
+            result = run_check(root, "release", "--tag", "v1.2.9")
+            self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_rejects_snapshot_on_release_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, "1.2.9-SNAPSHOT")
+            result = run_check(root, "release")
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("not a valid release version", result.stderr)
+
+    def test_rejects_helm_version_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_repository(root, "1.2.9-SNAPSHOT")
+            root.joinpath("deploy/helm/taxonomy/Chart.yaml").write_text(
+                'apiVersion: v2\nname: taxonomy\nappVersion: "1.2.8"\n', encoding="utf-8")
+            result = run_check(root, "development")
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Helm Chart.yaml appVersion", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update-release-metadata.py
+++ b/.github/scripts/update-release-metadata.py
@@ -97,6 +97,18 @@ def update_citation_md(version: str, release_date: str | None) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def update_helm_chart(version: str) -> None:
+    path = ROOT / "deploy" / "helm" / "taxonomy" / "Chart.yaml"
+    if not path.is_file():
+        return
+    text = path.read_text(encoding="utf-8")
+    pattern = r'^appVersion:\s*.*$'
+    line = f'appVersion: "{version}"'
+    if not re.search(pattern, text, flags=re.MULTILINE):
+        raise SystemExit(f"{path} has no appVersion field")
+    path.write_text(re.sub(pattern, line, text, flags=re.MULTILINE), encoding="utf-8")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("version", help="Version to write to metadata files")
@@ -107,6 +119,7 @@ def main() -> None:
     update_zenodo(args.version, release_date)
     update_codemeta(args.version, release_date)
     update_citation_md(args.version, release_date)
+    update_helm_chart(args.version)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,18 @@ jobs:
           distribution: temurin
           cache: maven
 
+      - name: Verify repository version state
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/test-check-version-state.py
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            python3 .github/scripts/check-version-state.py \
+              --mode release --tag "${GITHUB_REF_NAME}"
+          else
+            python3 .github/scripts/check-version-state.py --mode development
+          fi
+
       - name: Verify Docker availability
         run: docker info
 

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -135,6 +135,14 @@ jobs:
         if: steps.release_parameters.outputs.dry_run != 'true'
         run: git checkout --detach "v${{ steps.release_parameters.outputs.release_version }}"
 
+      - name: Describe immutable release source
+        id: release_source
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        shell: bash
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "created=$(git show -s --format=%cI HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to GitHub Container Registry
         if: steps.release_parameters.outputs.dry_run != 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
@@ -154,10 +162,10 @@ jobs:
             org.opencontainers.image.title=Taxonomy Architecture Analyzer
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.release_parameters.outputs.release_version }}
-            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.revision=${{ steps.release_source.outputs.sha }}
           build-args: |
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.release_source.outputs.created }}
+            VCS_REF=${{ steps.release_source.outputs.sha }}
             VERSION=${{ steps.release_parameters.outputs.release_version }}
 
       - name: Verify final main snapshot with canonical CI

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -18,20 +18,20 @@ on:
         type: string
         default: ''
       skip_tests:
-        description: 'Skip tests during release build'
+        description: 'Skip tests in a dry run only. Published releases always run the canonical verification suite.'
         required: false
         type: boolean
         default: false
       dry_run:
-        description: 'Validate without changing remote refs, releases, deploy hooks or pull requests'
+        description: 'Validate and build without changing remote refs, releases, images or deploy hooks.'
         required: false
         type: boolean
         default: false
 
 permissions:
+  actions: write
   contents: write
-  issues: write
-  pull-requests: write
+  issues: read
   packages: write
 
 concurrency:
@@ -40,8 +40,9 @@ concurrency:
 
 jobs:
   release:
-    name: Build, publish and prepare next development version
+    name: Build, publish and advance to the next snapshot
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -102,10 +103,16 @@ jobs:
           cp .github/scripts/release.sh "$RUNNER_TEMP/release.sh"
           cp .github/scripts/update-release-metadata.py \
             "$RUNNER_TEMP/update-release-metadata.py"
+          cp .github/scripts/check-version-state.py \
+            "$RUNNER_TEMP/check-version-state.py"
           cp .github/scripts/generate-vex.py "$RUNNER_TEMP/generate-vex.py"
           chmod +x "$RUNNER_TEMP/release.sh" \
             "$RUNNER_TEMP/update-release-metadata.py" \
+            "$RUNNER_TEMP/check-version-state.py" \
             "$RUNNER_TEMP/generate-vex.py"
+
+      - name: Test version-state guard
+        run: python3 .github/scripts/test-check-version-state.py
 
       - name: Build, publish and prepare next development version
         env:
@@ -117,8 +124,67 @@ jobs:
           DRY_RUN: ${{ steps.release_parameters.outputs.dry_run }}
           SOURCE_BRANCH: ${{ github.ref_name }}
           METADATA_HELPER: ${{ runner.temp }}/update-release-metadata.py
+          VERSION_STATE_HELPER: ${{ runner.temp }}/check-version-state.py
           VEX_HELPER: ${{ runner.temp }}/generate-vex.py
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
         run: "$RUNNER_TEMP/release.sh"
+
+      - name: Checkout immutable release source
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        run: git checkout --detach "v${{ steps.release_parameters.outputs.release_version }}"
+
+      - name: Log in to GitHub Container Registry
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish immutable release image
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/taxonomy:v${{ steps.release_parameters.outputs.release_version }}
+          labels: |
+            org.opencontainers.image.title=Taxonomy Architecture Analyzer
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.release_parameters.outputs.release_version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            BUILD_DATE=${{ github.event.repository.updated_at }}
+            VCS_REF=${{ github.sha }}
+            VERSION=${{ steps.release_parameters.outputs.release_version }}
+
+      - name: Verify final main snapshot with canonical CI
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --force
+          main_sha=$(git rev-parse origin/main)
+          gh workflow run ci-cd.yml --ref main
+
+          run_id=""
+          for _ in $(seq 1 60); do
+            run_id=$(gh run list \
+              --workflow ci-cd.yml \
+              --event workflow_dispatch \
+              --commit "$main_sha" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')
+            if [[ -n "$run_id" ]]; then break; fi
+            sleep 5
+          done
+          if [[ -z "$run_id" ]]; then
+            echo "::error::Could not locate the post-release CI run for $main_sha"
+            exit 1
+          fi
+          gh run watch "$run_id" --exit-status


### PR DESCRIPTION
## Summary

Hardens the release workflow so the default branch never has to remain on a non-SNAPSHOT release version.

### Atomic branch transition
- builds and verifies the release commit without moving `main`;
- materializes the release commit through a temporary branch, tag and maintenance branch;
- prepares the next development snapshot on top of the release commit;
- fast-forwards `main` exactly once from the old snapshot to the next snapshot;
- aborts if `main` changes while the release is running;
- supports recovery when a tag or draft release already exists.

### Fail-closed version state
- adds a repository version-state validator for Maven POMs, CITATION files, Zenodo, CodeMeta and Helm `appVersion`;
- adds focused regression tests for development, release, tag and Helm-drift states;
- keeps Helm metadata synchronized through the existing release metadata helper;
- forbids `skip_tests` for published releases.

### Release delivery
- publishes an immutable `vX.Y.Z` container image from the tagged release commit;
- dispatches and waits for canonical CI on the final `main` snapshot;
- preserves dry-run behavior without remote changes.

The branch will be refreshed onto the final UI/Kubernetes merge state before merge.