### PR TITLE
Scope observability performance checks to actual PR changes

### DIFF
--- a/.github/scripts/check-observability-performance-scope.py
+++ b/.github/scripts/check-observability-performance-scope.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Keep the expensive observability performance gate scoped to actual PR changes."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci-cd.yml"
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    required = (
+        "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+        "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+        'git diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" --',
+        ".github/scripts/run-observability-performance.sh",
+        "TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE: 'true'",
+        "run: bash .github/scripts/run-observability-performance.sh",
+    )
+    for needle in required:
+        if needle not in workflow:
+            failures.append(f"ci-cd.yml is missing {needle!r}")
+
+    try:
+        start = workflow.index("- name: Detect observability performance changes")
+        end = workflow.index("- name: Measure OpenTelemetry performance budget")
+        scope_block = workflow[start:end]
+    except ValueError as error:
+        failures.append(f"Could not locate observability scope steps: {error}")
+        scope_block = ""
+
+    if "...HEAD" in scope_block:
+        failures.append(
+            "Scope detection must compare base.sha with head.sha, not the synthetic PR merge HEAD"
+        )
+    if ".github/workflows/ci-cd.yml" in scope_block:
+        failures.append(
+            "Editing unrelated CI steps must not force the expensive observability benchmark"
+        )
+
+    if failures:
+        print("Observability performance scope contract failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Observability performance scope is limited to actual PR observability changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
             python3 .github/scripts/check-version-state.py --mode development
           fi
 
-      - name: Verify release delivery contract
+      - name: Verify release and performance-scope contracts
         shell: bash
         run: |
           set -euo pipefail
@@ -56,6 +56,7 @@ jobs:
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
           python3 .github/scripts/check-release-delivery-contract.py
+          python3 .github/scripts/check-observability-performance-scope.py
 
       - name: Install verified Helm 3.21.0
         env:
@@ -73,17 +74,19 @@ jobs:
       - name: Detect observability performance changes
         id: observability-performance-scope
         if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          if git diff --quiet "${{ github.event.pull_request.base.sha }}...HEAD" -- \
+          if git diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" -- \
             observability \
             taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java \
             taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java \
             taxonomy-app/src/test/resources/observability \
             .github/scripts/run-observability-performance.sh \
-            docs/dev/OBSERVABILITY_PERFORMANCE.md \
-            .github/workflows/ci-cd.yml; then
+            docs/dev/OBSERVABILITY_PERFORMANCE.md; then
             echo 'run=false' >> "$GITHUB_OUTPUT"
           else
             echo 'run=true' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes a CI scope error exposed while revalidating #530 after `main` advanced.

The pull-request workflow currently compares the event's base SHA with the synthetic PR merge `HEAD`. For older PRs this includes unrelated commits that landed on `main` later and can therefore run the expensive OpenTelemetry performance suite even when the PR changes no observability code.

This change:

- compares the event base SHA with the actual pull-request head SHA;
- removes the whole CI workflow file from the observability path scope, so unrelated workflow edits do not force the benchmark;
- retains all actual observability implementation, test, configuration and documentation paths;
- adds a fail-closed static contract that rejects a return to `...HEAD`, missing base/head variables, missing enforcement, or accidental broad workflow scoping.

## Verification

Requires the canonical Maven suite, Helm/release contracts, Security Scan and CodeQL on this exact head.