### PR TITLE
Fix ADMIN health dashboard warning contrast

### DIFF
--- a/taxonomy-app/src/main/resources/static/css/git-status.css
+++ b/taxonomy-app/src/main/resources/static/css/git-status.css
@@ -470,10 +470,10 @@ body.dark-mode .restore-preview {
     color: #664d03 !important;
 }
 
-body.dark-mode #healthOverallBadge.text-warning,
-body.dark-mode #healthAiBadge.text-warning,
-body.dark-mode #healthEmbeddingBadge.text-warning,
-body.dark-mode #healthMemoryBadge.text-warning {
+[data-bs-theme="dark"] #healthOverallBadge.text-warning,
+[data-bs-theme="dark"] #healthAiBadge.text-warning,
+[data-bs-theme="dark"] #healthEmbeddingBadge.text-warning,
+[data-bs-theme="dark"] #healthMemoryBadge.text-warning {
     color: #ffda6a !important;
 }
 

--- a/taxonomy-app/src/main/resources/static/css/git-status.css
+++ b/taxonomy-app/src/main/resources/static/css/git-status.css
@@ -457,3 +457,31 @@ body.dark-mode .restore-preview {
         color: ButtonText !important;
     }
 }
+
+/* ── ADMIN health status contrast ─────────────────────────
+ * Bootstrap's warning yellow (#ffc107) has only 1.63:1 contrast on a white
+ * card. Keep the semantic warning class set by the dashboard while overriding
+ * its foreground on the four health values to WCAG AA colours.
+ */
+#healthOverallBadge.text-warning,
+#healthAiBadge.text-warning,
+#healthEmbeddingBadge.text-warning,
+#healthMemoryBadge.text-warning {
+    color: #664d03 !important;
+}
+
+body.dark-mode #healthOverallBadge.text-warning,
+body.dark-mode #healthAiBadge.text-warning,
+body.dark-mode #healthEmbeddingBadge.text-warning,
+body.dark-mode #healthMemoryBadge.text-warning {
+    color: #ffda6a !important;
+}
+
+@media (forced-colors: active) {
+    #healthOverallBadge.text-warning,
+    #healthAiBadge.text-warning,
+    #healthEmbeddingBadge.text-warning,
+    #healthMemoryBadge.text-warning {
+        color: CanvasText !important;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/AdminHealthStatusContrastContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/AdminHealthStatusContrastContractTest.java
@@ -23,10 +23,32 @@ class AdminHealthStatusContrastContractTest {
                 .contains("#healthAiBadge.text-warning")
                 .contains("#healthEmbeddingBadge.text-warning")
                 .contains("#healthMemoryBadge.text-warning")
-                .contains("color: #664d03 !important;")
-                .contains("body.dark-mode #healthOverallBadge.text-warning")
-                .contains("color: #ffda6a !important;")
-                .contains("color: CanvasText !important;");
+                .contains("""
+                        #healthOverallBadge.text-warning,
+                        #healthAiBadge.text-warning,
+                        #healthEmbeddingBadge.text-warning,
+                        #healthMemoryBadge.text-warning {
+                            color: #664d03 !important;
+                        }
+                        """.stripIndent())
+                .contains("""
+                        [data-bs-theme="dark"] #healthOverallBadge.text-warning,
+                        [data-bs-theme="dark"] #healthAiBadge.text-warning,
+                        [data-bs-theme="dark"] #healthEmbeddingBadge.text-warning,
+                        [data-bs-theme="dark"] #healthMemoryBadge.text-warning {
+                            color: #ffda6a !important;
+                        }
+                        """.stripIndent())
+                .contains("""
+                        @media (forced-colors: active) {
+                            #healthOverallBadge.text-warning,
+                            #healthAiBadge.text-warning,
+                            #healthEmbeddingBadge.text-warning,
+                            #healthMemoryBadge.text-warning {
+                                color: CanvasText !important;
+                            }
+                        }
+                        """.stripIndent());
 
         assertThat(contrastRatio("#664d03", "#ffffff"))
                 .isGreaterThanOrEqualTo(WCAG_AA_NORMAL_TEXT);

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/AdminHealthStatusContrastContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/AdminHealthStatusContrastContractTest.java
@@ -1,0 +1,66 @@
+package com.taxonomy.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Locks the ADMIN health dashboard warning states to WCAG AA text contrast. */
+class AdminHealthStatusContrastContractTest {
+
+    private static final double WCAG_AA_NORMAL_TEXT = 4.5;
+
+    @Test
+    void warningStatesUseScopedAccessibleColoursInLightAndDarkThemes()
+            throws IOException {
+        String stylesheet = resource("/static/css/git-status.css");
+
+        assertThat(stylesheet)
+                .contains("#healthOverallBadge.text-warning")
+                .contains("#healthAiBadge.text-warning")
+                .contains("#healthEmbeddingBadge.text-warning")
+                .contains("#healthMemoryBadge.text-warning")
+                .contains("color: #664d03 !important;")
+                .contains("body.dark-mode #healthOverallBadge.text-warning")
+                .contains("color: #ffda6a !important;")
+                .contains("color: CanvasText !important;");
+
+        assertThat(contrastRatio("#664d03", "#ffffff"))
+                .isGreaterThanOrEqualTo(WCAG_AA_NORMAL_TEXT);
+        assertThat(contrastRatio("#ffda6a", "#1a1a2e"))
+                .isGreaterThanOrEqualTo(WCAG_AA_NORMAL_TEXT);
+    }
+
+    private static String resource(String path) throws IOException {
+        try (InputStream input = AdminHealthStatusContrastContractTest.class
+                .getResourceAsStream(path)) {
+            assertThat(input).as("classpath resource %s", path).isNotNull();
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static double contrastRatio(String first, String second) {
+        double firstLuminance = relativeLuminance(first);
+        double secondLuminance = relativeLuminance(second);
+        double lighter = Math.max(firstLuminance, secondLuminance);
+        double darker = Math.min(firstLuminance, secondLuminance);
+        return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    private static double relativeLuminance(String colour) {
+        int red = Integer.parseInt(colour.substring(1, 3), 16);
+        int green = Integer.parseInt(colour.substring(3, 5), 16);
+        int blue = Integer.parseInt(colour.substring(5, 7), 16);
+        return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue);
+    }
+
+    private static double linear(int channel) {
+        double value = channel / 255.0;
+        return value <= 0.04045
+                ? value / 12.92
+                : Math.pow((value + 0.055) / 1.055, 2.4);
+    }
+}


### PR DESCRIPTION
## Summary

Repairs the exact failure from CI/CD run `30663294227` on the merged #530 head.

The mobile ADMIN role flow reached the health dashboard with an inactive embedding model. The dashboard applied Bootstrap `text-warning`, whose `#ffc107` foreground has only 1.63:1 contrast on the white card. Axe therefore blocked the canonical Maven suite in `role-operation-feedback`.

This change:

- keeps the dashboard's semantic `text-warning` state;
- scopes an accessible `#664d03` foreground to all four health values in the light theme;
- supplies `#ffda6a` for the application's dark theme;
- delegates to `CanvasText` under forced-colors;
- adds a JUnit contract that covers every health badge and calculates WCAG contrast ratios for the light and dark colour pairs.

No accessibility rule or browser scenario is disabled.

## Verification

Requires the complete canonical Maven/browser suite, Security Scan and CodeQL on this exact head.