### PR TITLE
chore(deps): bump jgit-storage-hibernate to 0.1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <hibernate-search.version>8.4.0.Final</hibernate-search.version>
         <hibernate-search-backend.version>${hibernate-search.version}</hibernate-search-backend.version>
         <jgit.version>7.7.1.202607240634-r</jgit.version>
-        <jgit-storage-hibernate.version>0.1.17</jgit-storage-hibernate.version>
+        <jgit-storage-hibernate.version>0.1.18</jgit-storage-hibernate.version>
         <d3-hierarchy.version>3.1.2</d3-hierarchy.version>
         <springdoc.version>3.0.3</springdoc.version>
         <postgresql.version>42.7.12</postgresql.version>

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -49,9 +49,12 @@ public class JgitStorageSchemaMigrationConfig {
     private static final int LEGACY_TAXONOMY_PACK_EXTENSION_LENGTH = 255;
     private static final int REQUIRED_REF_NAME_LENGTH = 1024;
     private static final int LEGACY_TAXONOMY_REF_NAME_LENGTH = 255;
-    private static final String LATEST_CORE_SCHEMA_VERSION = "0.1.14.2";
-    private static final String LATEST_CORE_BASELINE_DESCRIPTION =
+    private static final String PRE_PACK_DESCRIPTION_SCHEMA_VERSION = "0.1.14.2";
+    private static final String PRE_PACK_DESCRIPTION_BASELINE_DESCRIPTION =
             "jgit-storage-hibernate-core 0.1.14";
+    private static final String LATEST_CORE_SCHEMA_VERSION = "0.1.18";
+    private static final String LATEST_CORE_BASELINE_DESCRIPTION =
+            "jgit-storage-hibernate-core 0.1.18";
 
     private static final Set<String> LEGACY_PACK_COLUMNS = Set.of(
             "ID",
@@ -74,8 +77,8 @@ public class JgitStorageSchemaMigrationConfig {
             "CREATED_AT",
             "COMMITTED_AT");
 
-    /** Exact physical pack shape released by jgit-storage-hibernate 0.1.14. */
-    private static final Set<String> CURRENT_PACK_COLUMNS = Set.of(
+    /** Exact physical pack shape released from 0.1.14.2 through 0.1.17. */
+    private static final Set<String> PRE_PACK_DESCRIPTION_PACK_COLUMNS = Set.of(
             "ID",
             "REPOSITORY_NAME",
             "PACK_NAME",
@@ -87,6 +90,27 @@ public class JgitStorageSchemaMigrationConfig {
             "COMMITTED_AT",
             "WRITE_TOKEN",
             "WRITE_LEASE_UNTIL");
+
+    /** Exact physical pack shape released by jgit-storage-hibernate 0.1.18. */
+    private static final Set<String> CURRENT_PACK_COLUMNS = Set.of(
+            "ID",
+            "REPOSITORY_NAME",
+            "PACK_NAME",
+            "PACK_EXTENSION",
+            "DATA",
+            "FILE_SIZE",
+            "COMMITTED",
+            "CREATED_AT",
+            "COMMITTED_AT",
+            "WRITE_TOKEN",
+            "WRITE_LEASE_UNTIL",
+            "PACK_SOURCE",
+            "LAST_MODIFIED",
+            "OBJECT_COUNT",
+            "DELTA_COUNT",
+            "INDEX_VERSION",
+            "MIN_UPDATE_INDEX",
+            "MAX_UPDATE_INDEX");
 
     private static final Set<String> REFLOG_COLUMNS = Set.of(
             "ID",
@@ -197,6 +221,12 @@ public class JgitStorageSchemaMigrationConfig {
             return;
         }
 
+        if (schema.packColumns().equals(PRE_PACK_DESCRIPTION_PACK_COLUMNS)) {
+            establishUnversionedPrePackDescriptionSchema(
+                    configuration, family, dataSource, schema);
+            return;
+        }
+
         if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
             establishUnversionedCurrentSchema(configuration, family, dataSource, schema);
             return;
@@ -224,6 +254,26 @@ public class JgitStorageSchemaMigrationConfig {
         requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
     }
 
+    private static void establishUnversionedPrePackDescriptionSchema(
+            Configuration configuration,
+            DatabaseFamily family,
+            DataSource dataSource,
+            SchemaSnapshot schema) {
+        requireSafePackRows(dataSource, false);
+        requireCurrentCoreColumnLengths(schema);
+        requireRepositoryLockTable(schema);
+        requireCurrentCoreIndexes(schema);
+        log.info(
+                "Establishing Flyway history for an exact unversioned 0.1.14.2-0.1.17 schema on {}",
+                family.displayName());
+        migrateNormalWithBaseline(
+                configuration,
+                family,
+                PRE_PACK_DESCRIPTION_SCHEMA_VERSION,
+                PRE_PACK_DESCRIPTION_BASELINE_DESCRIPTION);
+        requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
+    }
+
     private static void establishUnversionedCurrentSchema(
             Configuration configuration,
             DatabaseFamily family,
@@ -231,9 +281,10 @@ public class JgitStorageSchemaMigrationConfig {
             SchemaSnapshot schema) {
         requireSafePackRows(dataSource, false);
         requireCurrentCoreColumnLengths(schema);
+        requireCurrentCoreTables(schema);
         requireCurrentCoreIndexes(schema);
         log.info(
-                "Establishing Flyway history for an exact unversioned 0.1.14 schema on {}",
+                "Establishing Flyway history for an exact unversioned 0.1.18 schema on {}",
                 family.displayName());
         migrateNormalWithBaseline(
                 configuration,
@@ -385,7 +436,13 @@ public class JgitStorageSchemaMigrationConfig {
             requirePreWriteLeaseCoreIndexes(schema);
             return;
         }
+        if (schema.packColumns().equals(PRE_PACK_DESCRIPTION_PACK_COLUMNS)) {
+            requireRepositoryLockTable(schema);
+            requireCurrentCoreIndexes(schema);
+            return;
+        }
         if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
+            requireCurrentCoreTables(schema);
             requireCurrentCoreIndexes(schema);
             return;
         }
@@ -394,6 +451,7 @@ public class JgitStorageSchemaMigrationConfig {
 
     private static void requireCurrentCoreShape(SchemaSnapshot schema) {
         requireCoreTables(schema);
+        requireCurrentCoreTables(schema);
         requireExactColumns("git_packs", schema.packColumns(), CURRENT_PACK_COLUMNS);
         requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
         requireCurrentCoreColumnLengths(schema);
@@ -404,6 +462,21 @@ public class JgitStorageSchemaMigrationConfig {
         if (!schema.hasTable("git_packs") || !schema.hasTable("git_reflog")) {
             throw unsafeSchema(
                     "The Core Flyway history exists but one or both owned tables are missing.");
+        }
+    }
+
+    private static void requireRepositoryLockTable(SchemaSnapshot schema) {
+        if (!schema.hasTable("git_repository_lock")) {
+            throw unsafeSchema(
+                    "The released Core schema requires the git_repository_lock table.");
+        }
+    }
+
+    private static void requireCurrentCoreTables(SchemaSnapshot schema) {
+        requireRepositoryLockTable(schema);
+        if (!schema.hasTable("git_repository_lifecycle")) {
+            throw unsafeSchema(
+                    "The 0.1.18 Core schema requires the git_repository_lifecycle table.");
         }
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
@@ -63,7 +63,7 @@ class JgitStoragePostgresMigrationIT {
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
         assertEquals(
-                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2", "0.1.17"),
+                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2", "0.1.17", "0.1.18"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
 
         SQLException duplicate = assertThrows(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
@@ -37,9 +37,20 @@ import org.junit.jupiter.api.Test;
 class JgitStorageSchemaMigrationConfigTest {
 
     private static final List<String> FULL_CORE_HISTORY = List.of(
-            "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2");
+            "0.1.4",
+            "0.1.5",
+            "0.1.14",
+            "0.1.14.1",
+            "0.1.14.2",
+            "0.1.17",
+            "0.1.18");
     private static final List<String> ADOPTED_CORE_HISTORY = List.of(
-            "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2");
+            "0.1.5",
+            "0.1.14",
+            "0.1.14.1",
+            "0.1.14.2",
+            "0.1.17",
+            "0.1.18");
 
     @Test
     void installsCoreSchemaIntoEmptyDatabase() throws Exception {
@@ -50,9 +61,12 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(tableExists(dataSource, "git_packs"));
         assertTrue(tableExists(dataSource, "git_reflog"));
         assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
         assertTrue(tableExists(dataSource, "git_pack_chunks"));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_TOKEN"));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+        assertTrue(columns(dataSource, "git_packs").contains("LAST_MODIFIED"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
         assertVersionPrefix(
@@ -69,8 +83,17 @@ class JgitStorageSchemaMigrationConfigTest {
 
         assertTrue(tableExists(dataSource, "application_marker"));
         assertTrue(tableExists(dataSource, "git_packs"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
         assertVersionPrefix(
-                List.of("0", "0.1.4", "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2"),
+                List.of(
+                        "0",
+                        "0.1.4",
+                        "0.1.5",
+                        "0.1.14",
+                        "0.1.14.1",
+                        "0.1.14.2",
+                        "0.1.17",
+                        "0.1.18"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
     }
 
@@ -111,7 +134,9 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(packColumns.contains("COMMITTED_AT"));
         assertTrue(packColumns.contains("WRITE_TOKEN"));
         assertTrue(packColumns.contains("WRITE_LEASE_UNTIL"));
+        assertTrue(packColumns.contains("PACK_SOURCE"));
         assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
         assertTrue(tableExists(dataSource, "git_pack_chunks"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
@@ -183,6 +208,8 @@ class JgitStorageSchemaMigrationConfigTest {
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
         assertArrayEquals(original, packData(dataSource, "legacy", "pack-v1", "reftable"));
         assertEquals(refName, reflogRefName(dataSource));
 
@@ -201,11 +228,31 @@ class JgitStorageSchemaMigrationConfigTest {
 
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_TOKEN"));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
         assertTrue(tableExists(dataSource, "git_repository_lock"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
         assertTrue(tableExists(dataSource, "git_pack_chunks"));
         assertArrayEquals(
                 original,
                 packData(dataSource, "managed", "pack-existing", "pack"));
+        assertVersionPrefix(
+                FULL_CORE_HISTORY,
+                successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+    }
+
+    @Test
+    void upgradesManagedPrePackDescriptionSchemaAndPreservesPackPayload() throws Exception {
+        DataSource dataSource = dataSource("managed-017");
+        flyway(dataSource, "0.1.17").migrate();
+        byte[] original = new byte[] {21, 22, 23, 24};
+        insertVersionedPack(dataSource, "managed", "pack-017", "pack", original);
+        assertFalse(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
+        assertArrayEquals(original, packData(dataSource, "managed", "pack-017", "pack"));
         assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
@@ -281,6 +328,21 @@ class JgitStorageSchemaMigrationConfigTest {
     }
 
     @Test
+    void establishesHistoryForExactUnversionedPrePackDescriptionCoreSchema() throws Exception {
+        DataSource dataSource = dataSource("unversioned-017");
+        flyway(dataSource, "0.1.17").migrate();
+        dropTable(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
+
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+
+        assertVersionPrefix(
+                List.of("0.1.14.2", "0.1.17", "0.1.18"),
+                successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
+    }
+
+    @Test
     void establishesHistoryForExactUnversionedCurrentCoreSchema() throws Exception {
         DataSource dataSource = dataSource("unversioned-current");
         flyway(dataSource).migrate();
@@ -289,9 +351,11 @@ class JgitStorageSchemaMigrationConfigTest {
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
 
         assertVersionPrefix(
-                List.of("0.1.14.2"),
+                List.of("0.1.18"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
+        assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
+        assertTrue(tableExists(dataSource, "git_repository_lifecycle"));
     }
 
     private static DataSource dataSource(String purpose) {


### PR DESCRIPTION
## Summary
- update `jgit-storage-hibernate.version` from `0.1.17` to `0.1.18`
- extend Taxonomy's fail-closed Core-schema classifier for the exact 0.1.18 pack metadata columns
- preserve explicit migration support for the pre-write-lease and 0.1.14.2–0.1.17 schema shapes
- require the 0.1.18 repository lock and lifecycle tables before accepting an unversioned/current schema
- update migration tests to expect the complete published history through `0.1.18`

## Failures found and fixed
The first CI run resolved 0.1.18 successfully, then rejected its migrated `git_packs` table because Taxonomy still treated the seven new metadata columns as unexpected. The schema check now recognizes only the concrete released shapes rather than weakening validation to permit arbitrary columns.

A later canonical verification run proved that the actual PostgreSQL migration completed successfully through `0.1.18`, but one integration-test assertion still expected the history to end at `0.1.17`. That stale expectation is now corrected.

## Verification
- the final correction is exactly one assertion-line change in `JgitStoragePostgresMigrationIT`
- HSQLDB schema installation, adoption, upgrade, index-contract, and JGit integration tests pass with 0.1.18
- Security Scan passes on commit `283f2bd93303d230b7f53036bb47eef117acb55f`
- canonical Maven verification plus PostgreSQL, SQL Server, Oracle, and CodeQL checks are running on the same commit