### PR TITLE
Fix release input guidance and publish 1.3.0

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -1,8 +1,8 @@
 {
-  "release_version": "1.2.9",
-  "next_development_version": "1.3.0-SNAPSHOT",
+  "release_version": "1.3.0",
+  "next_development_version": "1.3.1-SNAPSHOT",
   "skip_tests": false,
   "dry_run": false,
-  "request_revision": 4,
-  "requested_after_commit": "4727d09002c91c9de1ab9c65b8429da3d1750d6c"
+  "request_revision": 5,
+  "requested_after_commit": "34fadab90336636e6bfcc73d49369ed7e3df36c9"
 }

--- a/.github/scripts/resolve-release-parameters.py
+++ b/.github/scripts/resolve-release-parameters.py
@@ -112,8 +112,11 @@ def derive_release_versions(
 
     if version_tuple(next_version) <= version_tuple(release_version):
         raise ValueError(
-            f"next development version {next_version} must be newer than "
-            f"release {release_version}"
+            f"current project version {current_version} means this run releases "
+            f"{release_version}; next development version {next_version} must be "
+            "newer. Leave next_development_version empty to use the selected "
+            "patch, minor or major increment, or enter a higher X.Y.Z-SNAPSHOT "
+            "version."
         )
     return release_version, next_version
 

--- a/.github/scripts/test-resolve-release-parameters.py
+++ b/.github/scripts/test-resolve-release-parameters.py
@@ -195,12 +195,17 @@ class ReleaseParameterTest(unittest.TestCase):
             )
 
     def test_dispatch_rejects_next_version_not_newer_than_release(self) -> None:
-        with self.assertRaisesRegex(ValueError, "must be newer"):
+        with self.assertRaisesRegex(
+            ValueError,
+            "current project version 1.3.0-SNAPSHOT means this run releases 1.3.0",
+        ) as raised:
             MODULE.resolve_parameters(
                 "workflow_dispatch",
-                {"INPUT_NEXT_DEVELOPMENT_VERSION": "1.2.9-SNAPSHOT"},
-                current_version="1.2.9-SNAPSHOT",
+                {"INPUT_NEXT_DEVELOPMENT_VERSION": "1.3.0-SNAPSHOT"},
+                current_version="1.3.0-SNAPSHOT",
             )
+        self.assertIn("Leave next_development_version empty", str(raised.exception))
+        self.assertIn("patch, minor or major", str(raised.exception))
 
     def test_push_rejects_next_version_not_newer_than_release(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be newer"):


### PR DESCRIPTION
## Ursache

`main` steht bereits auf `1.3.0-SNAPSHOT`. Der manuelle Lauf wollte daher korrekt `1.3.0` veröffentlichen, erhielt aber gleichzeitig erneut `1.3.0-SNAPSHOT` als **nächste** Entwicklungsversion. Diese kann nach dem Release nicht identisch mit der veröffentlichten Version sein.

## Änderung

- erklärt im Fehler jetzt ausdrücklich, welche Version aus dem aktuellen `pom.xml` veröffentlicht wird
- nennt direkt die beiden gültigen Wege: exaktes Feld leer lassen und `patch`/`minor`/`major` verwenden oder eine höhere `X.Y.Z-SNAPSHOT`-Version angeben
- ergänzt einen Regressionstest exakt für `1.3.0-SNAPSHOT → Release 1.3.0`
- aktualisiert den geprüften Release-Request auf `1.3.0 → 1.3.1-SNAPSHOT`

## Verifikation

- `python3 .github/scripts/test-resolve-release-parameters.py`
- 18 Tests erfolgreich

Beim Merge startet der versionierte Release-Request den Release-Workflow mit den korrekten Parametern.