### PR TITLE
Add a locally reproducible Maven release check

### DIFF
--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when release staging, recovery and publication cease to be atomic."""
+"""Fail closed when release verification or publication ceases to be atomic."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ from pathlib import Path
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
+ROOT_POM = ROOT / "pom.xml"
+RELEASE_PLAN_CHECK = ROOT / ".github" / "scripts" / "check-release-plan.py"
 RELEASE_SCRIPT = ROOT / ".github" / "scripts" / "release.sh"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-release.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci-cd.yml"
@@ -18,18 +20,52 @@ def require(text: str, needle: str, source: Path, failures: list[str]) -> None:
 
 
 def main() -> int:
+    pom = ROOT_POM.read_text(encoding="utf-8")
+    plan_check = RELEASE_PLAN_CHECK.read_text(encoding="utf-8")
     script = RELEASE_SCRIPT.read_text(encoding="utf-8")
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     failures: list[str] = []
 
     for needle in (
+        "<id>release-check</id>",
+        ".github/scripts/check-release-plan.py",
+        "<argument>${releaseVersion}</argument>",
+        "<argument>${nextDevelopmentVersion}</argument>",
+        "<argument>${releaseCheckCurrentState}</argument>",
+        "<argument>${releaseCheckRequireClean}</argument>",
+    ):
+        require(pom, needle, ROOT_POM, failures)
+
+    if "<artifactId>maven-release-plugin</artifactId>" in pom:
+        failures.append(
+            "pom.xml must not introduce maven-release-plugin as a competing SCM authority"
+        )
+
+    for needle in (
+        "release verification requires a clean checkout",
+        "maven-release-plugin would create a second SCM release authority",
+        "external {kind}",
+        'state in {"development", "advanced"}',
+        'if state == "release"',
+    ):
+        require(plan_check, needle, RELEASE_PLAN_CHECK, failures)
+
+    for needle in (
         "DEFER_RELEASE_PUBLICATION=${DEFER_RELEASE_PUBLICATION:-false}",
+        "run_maven_release_check()",
+        'run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate',
+        "run_maven_release_check release release-check,ci clean verify",
         'if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then',
         "remains a draft until downstream artifacts and final CI succeed",
         'test "$RELEASE_IS_DRAFT" = true',
     ):
         require(script, needle, RELEASE_SCRIPT, failures)
+
+    if "./mvnw -B clean verify -Pci" in script:
+        failures.append(
+            "release.sh bypasses the Maven release-check profile during verification"
+        )
 
     for needle in (
         "next_development_version:",
@@ -80,12 +116,14 @@ def main() -> int:
                 f"unsafe or unsupported release configuration {forbidden!r}"
             )
 
-    require(
-        ci_workflow,
+    for needle in (
         "python3 .github/scripts/test-resolve-release-parameters.py",
-        CI_WORKFLOW,
-        failures,
-    )
+        "python3 .github/scripts/test-check-release-plan.py",
+        "./mvnw -B -Prelease-check validate",
+        '-DreleaseVersion="$release_version"',
+        '-DnextDevelopmentVersion="$next_version"',
+    ):
+        require(ci_workflow, needle, CI_WORKFLOW, failures)
 
     if "main_sha=$(git rev-parse origin/main)" in workflow:
         failures.append(
@@ -186,9 +224,9 @@ def main() -> int:
         return 1
 
     print(
-        "Release delivery contract is atomic, freely versionable and resumable: "
-        "the triggering source is preserved, an exact next development version may "
-        "override the convenience increment, immutable sources are fetched "
+        "Release delivery contract is Maven-verifiable, atomic, freely versionable "
+        "and resumable: the local profile validates the release plan without SCM "
+        "mutation, the triggering source is preserved, immutable sources are fetched "
         "explicitly, the exact main snapshot is verified, and publication remains "
         "the final gate."
     )

--- a/.github/scripts/check-release-plan.py
+++ b/.github/scripts/check-release-plan.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Validate Taxonomy's Maven release plan without creating SCM state."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+NS = {"m": "http://maven.apache.org/POM/4.0.0"}
+VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+DEVELOPMENT_VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$")
+PROPERTY_PATTERN = re.compile(r"\$\{([^}]+)}")
+STATES = {"development", "release", "advanced"}
+
+
+@dataclass(frozen=True)
+class Coordinate:
+    group_id: str
+    artifact_id: str
+
+
+@dataclass(frozen=True)
+class PomModel:
+    path: Path
+    root: ET.Element
+    group_id: str
+    artifact_id: str
+    version: str
+    properties: dict[str, str]
+
+
+def text(element: ET.Element | None) -> str:
+    return (element.text or "").strip() if element is not None else ""
+
+
+def child_text(root: ET.Element, name: str) -> str:
+    return text(root.find(f"m:{name}", NS))
+
+
+def normalized_version(value: str, field: str, pattern: re.Pattern[str]) -> str:
+    normalized = value.strip()
+    if normalized.startswith("${"):
+        raise ValueError(
+            f"{field} was not supplied. Pass -D{field} with an explicit version."
+        )
+    if not pattern.fullmatch(normalized):
+        expected = (
+            "X.Y.Z-SNAPSHOT" if pattern is DEVELOPMENT_VERSION_PATTERN else "X.Y.Z"
+        )
+        raise ValueError(f"{field} must use {expected}, got {normalized!r}")
+    return normalized
+
+
+def version_tuple(version: str) -> tuple[int, int, int]:
+    return tuple(map(int, version.removesuffix("-SNAPSHOT").split(".")))
+
+
+def expected_current_version(
+    release_version: str, next_development_version: str, state: str
+) -> str:
+    if state == "development":
+        return f"{release_version}-SNAPSHOT"
+    if state == "release":
+        return release_version
+    if state == "advanced":
+        return next_development_version
+    raise ValueError(f"releaseCheckCurrentState must be one of {sorted(STATES)}")
+
+
+def pom_paths(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("pom.xml")
+        if ".git" not in path.parts and "target" not in path.parts
+    )
+
+
+def model_for(path: Path) -> PomModel:
+    root = ET.parse(path).getroot()
+    parent = root.find("m:parent", NS)
+    group_id = child_text(root, "groupId")
+    version = child_text(root, "version")
+    if parent is not None:
+        group_id = group_id or child_text(parent, "groupId")
+        version = version or child_text(parent, "version")
+    artifact_id = child_text(root, "artifactId")
+    properties = {
+        property_element.tag.rsplit("}", 1)[-1]: text(property_element)
+        for property_element in root.findall("m:properties/*", NS)
+    }
+    properties.update(
+        {
+            "project.groupId": group_id,
+            "pom.groupId": group_id,
+            "project.artifactId": artifact_id,
+            "pom.artifactId": artifact_id,
+            "project.version": version,
+            "pom.version": version,
+        }
+    )
+    if parent is not None:
+        properties.update(
+            {
+                "project.parent.groupId": child_text(parent, "groupId"),
+                "project.parent.artifactId": child_text(parent, "artifactId"),
+                "project.parent.version": child_text(parent, "version"),
+            }
+        )
+    return PomModel(path, root, group_id, artifact_id, version, properties)
+
+
+def resolve_properties(value: str, properties: dict[str, str]) -> str:
+    result = value.strip()
+    for _ in range(12):
+        changed = False
+
+        def replace(match: re.Match[str]) -> str:
+            nonlocal changed
+            key = match.group(1)
+            replacement = properties.get(key)
+            if replacement is None:
+                return match.group(0)
+            changed = True
+            return replacement
+
+        resolved = PROPERTY_PATTERN.sub(replace, result)
+        result = resolved
+        if not changed:
+            break
+    return result
+
+
+def effective_properties(model: PomModel, root_properties: dict[str, str]) -> dict[str, str]:
+    return root_properties | model.properties
+
+
+def versioned_elements(model: PomModel) -> list[tuple[str, Coordinate | None, str]]:
+    entries: list[tuple[str, Coordinate | None, str]] = []
+    for dependency in model.root.findall(".//m:dependency", NS):
+        version = child_text(dependency, "version")
+        if version:
+            entries.append(
+                (
+                    "dependency",
+                    Coordinate(
+                        child_text(dependency, "groupId"),
+                        child_text(dependency, "artifactId"),
+                    ),
+                    version,
+                )
+            )
+    for plugin in model.root.findall(".//m:plugin", NS):
+        version = child_text(plugin, "version")
+        artifact_id = child_text(plugin, "artifactId")
+        if artifact_id == "maven-release-plugin":
+            entries.append(("forbidden-plugin", None, version or "<managed>"))
+        elif version:
+            entries.append(
+                (
+                    "plugin",
+                    Coordinate(
+                        child_text(plugin, "groupId") or "org.apache.maven.plugins",
+                        artifact_id,
+                    ),
+                    version,
+                )
+            )
+    for extension in model.root.findall(".//m:extension", NS):
+        version = child_text(extension, "version")
+        if version:
+            entries.append(
+                (
+                    "build extension",
+                    Coordinate(
+                        child_text(extension, "groupId"),
+                        child_text(extension, "artifactId"),
+                    ),
+                    version,
+                )
+            )
+    return entries
+
+
+def check_git_clean(root: Path) -> None:
+    if not (root / ".git").exists():
+        return
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ValueError(f"git status failed: {result.stderr.strip()}")
+    if result.stdout.strip():
+        raise ValueError(
+            "release verification requires a clean checkout; commit or stash local changes"
+        )
+
+
+def validate_release_plan(
+    root: Path,
+    current_version: str,
+    release_version: str,
+    next_development_version: str,
+    state: str = "development",
+    *,
+    require_clean: bool = True,
+) -> dict[str, object]:
+    root = root.resolve()
+    release_version = normalized_version(
+        release_version, "releaseVersion", VERSION_PATTERN
+    )
+    next_development_version = normalized_version(
+        next_development_version,
+        "nextDevelopmentVersion",
+        DEVELOPMENT_VERSION_PATTERN,
+    )
+    current_version = current_version.strip()
+    if state not in STATES:
+        raise ValueError(f"releaseCheckCurrentState must be one of {sorted(STATES)}")
+    if version_tuple(next_development_version) <= version_tuple(release_version):
+        raise ValueError(
+            f"next development version {next_development_version} must be newer than "
+            f"release {release_version}"
+        )
+
+    expected = expected_current_version(
+        release_version, next_development_version, state
+    )
+    if current_version != expected:
+        raise ValueError(
+            f"release state {state} expects project version {expected}, "
+            f"but Maven resolved {current_version}"
+        )
+
+    paths = pom_paths(root)
+    if not paths or root / "pom.xml" not in paths:
+        raise ValueError(f"no root pom.xml found below {root}")
+    models = [model_for(path) for path in paths]
+    root_model = next(model for model in models if model.path == root / "pom.xml")
+    if root_model.version != current_version:
+        raise ValueError(
+            f"root pom.xml declares {root_model.version}, not Maven's {current_version}"
+        )
+
+    internal_coordinates = {
+        Coordinate(model.group_id, model.artifact_id) for model in models
+    }
+    failures: list[str] = []
+    for model in models:
+        relative = model.path.relative_to(root)
+        if model.group_id == root_model.group_id and model.version != current_version:
+            failures.append(
+                f"{relative}: reactor version {model.version!r} differs from {current_version}"
+            )
+        properties = effective_properties(model, root_model.properties)
+        for kind, coordinate, raw_version in versioned_elements(model):
+            if kind == "forbidden-plugin":
+                failures.append(
+                    f"{relative}: maven-release-plugin would create a second SCM release authority"
+                )
+                continue
+            resolved = resolve_properties(raw_version, properties)
+            if "SNAPSHOT" not in resolved.upper():
+                continue
+            if (
+                kind == "dependency"
+                and coordinate in internal_coordinates
+                and resolved == current_version
+                and state in {"development", "advanced"}
+            ):
+                continue
+            coordinate_text = (
+                f" {coordinate.group_id}:{coordinate.artifact_id}" if coordinate else ""
+            )
+            failures.append(
+                f"{relative}: external {kind}{coordinate_text} uses snapshot version "
+                f"{raw_version!r} (resolved as {resolved!r})"
+            )
+
+    if (root / "release.properties").exists():
+        failures.append("release.properties: stale Maven Release Plugin state is present")
+    for backup in root.rglob("pom.xml.releaseBackup"):
+        if "target" not in backup.parts:
+            failures.append(
+                f"{backup.relative_to(root)}: stale Maven Release Plugin backup is present"
+            )
+
+    if failures:
+        raise ValueError("release plan validation failed:\n- " + "\n- ".join(failures))
+    if require_clean:
+        check_git_clean(root)
+
+    return {
+        "current_version": current_version,
+        "release_version": release_version,
+        "next_development_version": next_development_version,
+        "state": state,
+        "pom_count": len(models),
+    }
+
+
+def parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise argparse.ArgumentTypeError("expected true or false")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("."))
+    parser.add_argument("--current-version", required=True)
+    parser.add_argument("--release-version", required=True)
+    parser.add_argument("--next-development-version", required=True)
+    parser.add_argument("--state", default="development", choices=sorted(STATES))
+    parser.add_argument("--require-clean", type=parse_bool, default=True)
+    args = parser.parse_args()
+    try:
+        result = validate_release_plan(
+            args.root,
+            args.current_version,
+            args.release_version,
+            args.next_development_version,
+            args.state,
+            require_clean=args.require_clean,
+        )
+    except (OSError, ET.ParseError, ValueError) as error:
+        print(f"Release check failed: {error}", file=sys.stderr)
+        return 1
+    print(
+        "Maven release check passed: "
+        f"{result['current_version']} -> {result['release_version']} -> "
+        f"{result['next_development_version']} "
+        f"({result['state']}, {result['pom_count']} reactor POMs)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -24,6 +24,16 @@ fail() {
   exit 1
 }
 
+run_maven_release_check() {
+  local state=$1
+  local profiles=$2
+  shift 2
+  ./mvnw -B "-P${profiles}" "$@" \
+    -DreleaseVersion="$RELEASE_VERSION" \
+    -DnextDevelopmentVersion="$NEXT_VERSION" \
+    -DreleaseCheckCurrentState="$state"
+}
+
 if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   fail "release_version must use X.Y.Z without a leading v"
 fi
@@ -189,8 +199,10 @@ else
 fi
 
 MAIN_ALREADY_ADVANCED=false
+RELEASE_CHECK_STATE=development
 if [[ "$CURRENT_VERSION" == "$NEXT_VERSION" && "$TAG_EXISTS" == "true" ]]; then
   MAIN_ALREADY_ADVANCED=true
+  RELEASE_CHECK_STATE=advanced
   python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
 elif [[ "$CURRENT_VERSION" == "${RELEASE_VERSION}-SNAPSHOT" ]]; then
   python3 "$VERSION_STATE_HELPER" --mode development \
@@ -207,7 +219,7 @@ echo "Main already advanced: $MAIN_ALREADY_ADVANCED"
 echo "Defer release publication: $DEFER_RELEASE_PUBLICATION"
 echo "Dry run: $DRY_RUN"
 
-./mvnw -B validate
+run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate
 
 if [[ "$STATE" == "new" ]]; then
   ./mvnw -B versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
@@ -228,9 +240,9 @@ else
 fi
 
 if [[ "$SKIP_TESTS" == "true" ]]; then
-  ./mvnw -B clean package -DskipTests
+  run_maven_release_check release release-check clean package -DskipTests
 else
-  ./mvnw -B clean verify -Pci
+  run_maven_release_check release release-check,ci clean verify
 fi
 python3 "$VEX_HELPER"
 collect_release_artifacts

--- a/.github/scripts/test-check-release-plan.py
+++ b/.github/scripts/test-check-release-plan.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Regression tests for the Maven-owned Taxonomy release check."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("check-release-plan.py").resolve()
+SPEC = importlib.util.spec_from_file_location("check_release_plan", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+ROOT_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.taxonomy</groupId>
+  <artifactId>taxonomy</artifactId>
+  <version>{version}</version>
+  <packaging>pom</packaging>
+  <properties><external.version>{external}</external.version></properties>
+  <modules><module>module-a</module></modules>
+  {extra}
+</project>
+"""
+MODULE_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.taxonomy</groupId>
+    <artifactId>taxonomy</artifactId>
+    <version>{version}</version>
+  </parent>
+  <artifactId>module-a</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>com.taxonomy</groupId>
+      <artifactId>taxonomy</artifactId>
+      <version>${{project.version}}</version>
+    </dependency>
+    {dependency}
+  </dependencies>
+</project>
+"""
+
+
+def write_project(
+    root: Path,
+    version: str = "1.3.0-SNAPSHOT",
+    external: str = "1.0.0",
+    extra: str = "",
+    dependency: str = "",
+) -> None:
+    root.joinpath("pom.xml").write_text(
+        ROOT_TEMPLATE.format(version=version, external=external, extra=extra),
+        encoding="utf-8",
+    )
+    module = root / "module-a"
+    module.mkdir()
+    module.joinpath("pom.xml").write_text(
+        MODULE_TEMPLATE.format(version=version, dependency=dependency),
+        encoding="utf-8",
+    )
+
+
+class ReleasePlanTest(unittest.TestCase):
+    def validate(
+        self,
+        root: Path,
+        current: str = "1.3.0-SNAPSHOT",
+        release: str = "1.3.0",
+        next_version: str = "1.3.1-SNAPSHOT",
+        state: str = "development",
+    ) -> dict[str, object]:
+        return MODULE.validate_release_plan(
+            root,
+            current,
+            release,
+            next_version,
+            state,
+            require_clean=False,
+        )
+
+    def test_development_plan_allows_internal_snapshot_reactor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            result = self.validate(root)
+            self.assertEqual(2, result["pom_count"])
+
+    def test_major_next_version_is_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            result = self.validate(root, next_version="2.0.0-SNAPSHOT")
+            self.assertEqual("2.0.0-SNAPSHOT", result["next_development_version"])
+
+    def test_repeated_current_snapshot_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            with self.assertRaisesRegex(ValueError, "must be newer"):
+                self.validate(root, next_version="1.3.0-SNAPSHOT")
+
+    def test_release_state_requires_release_poms(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root, version="1.3.0")
+            result = self.validate(root, current="1.3.0", state="release")
+            self.assertEqual("release", result["state"])
+
+    def test_advanced_state_accepts_next_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root, version="1.3.1-SNAPSHOT")
+            result = self.validate(
+                root, current="1.3.1-SNAPSHOT", state="advanced"
+            )
+            self.assertEqual("advanced", result["state"])
+
+    def test_external_snapshot_dependency_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dependency = """<dependency>
+              <groupId>example</groupId><artifactId>unstable</artifactId>
+              <version>${external.version}</version>
+            </dependency>"""
+            write_project(
+                root, external="9.0.0-SNAPSHOT", dependency=dependency
+            )
+            with self.assertRaisesRegex(
+                ValueError, "external dependency example:unstable"
+            ):
+                self.validate(root)
+
+    def test_reactor_version_mismatch_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            module_pom = root / "module-a" / "pom.xml"
+            module_pom.write_text(
+                module_pom.read_text(encoding="utf-8").replace(
+                    "1.3.0-SNAPSHOT", "1.2.9-SNAPSHOT"
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "reactor version"):
+                self.validate(root)
+
+    def test_maven_release_plugin_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extra = """<build><plugins><plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <version>3.1.1</version>
+            </plugin></plugins></build>"""
+            write_project(root, extra=extra)
+            with self.assertRaisesRegex(ValueError, "second SCM release authority"):
+                self.validate(root)
+
+    def test_unresolved_maven_property_reports_missing_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            with self.assertRaisesRegex(ValueError, "was not supplied"):
+                self.validate(root, release="${releaseVersion}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,11 +53,23 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/test-resolve-release-parameters.py
+          python3 .github/scripts/test-check-release-plan.py
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
           python3 .github/scripts/check-release-delivery-contract.py
           python3 .github/scripts/check-observability-performance-scope.py
+
+          current_version=$(./mvnw -q -DforceStdout help:evaluate \
+            -Dexpression=project.version)
+          if [[ "$current_version" == *-SNAPSHOT ]]; then
+            release_version=${current_version%-SNAPSHOT}
+            IFS='.' read -r major minor patch <<< "$release_version"
+            next_version="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+            ./mvnw -B -Prelease-check validate \
+              -DreleaseVersion="$release_version" \
+              -DnextDevelopmentVersion="$next_version"
+          fi
 
       - name: Install verified Helm 3.21.0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,12 @@ target/
 taxonomy-app/codemirror-build/node_modules/
 taxonomy-app/codemirror-build/package-lock.json
 
+# Python guard tests import repository scripts during local and CI verification.
+__pycache__/
+*.py[cod]
+
 # LLM recording manifest is a runtime artifact, not a source file
 **/llm-recordings/manifest.json
-
 
 # Maven-owned browser tooling is installed locally from package-lock.json
 .github/node_modules/

--- a/docs/dev/06-testing-by-change-type.md
+++ b/docs/dev/06-testing-by-change-type.md
@@ -2,7 +2,9 @@
 
 All functional verification is Maven-owned. Start with the smallest applicable
 profile and finish a pull request with the canonical command documented in
-[Maven Verification Authority](MAVEN_VERIFICATION.md).
+[Maven Verification Authority](MAVEN_VERIFICATION.md). Release preparation and
+publication are documented separately in
+[Release Verification and Publication](RELEASE_PROCESS.md).
 
 ## Commands by change type
 
@@ -22,6 +24,7 @@ profile and finish a pull request with the canonical command documented in
 | Local ONNX | `./mvnw -B verify -Ponnx` | `./mvnw -B verify -Pci` |
 | UI/CSS/JavaScript | `./mvnw -B verify -Pui-tests -DskipTests -DskipITs=true` | `./mvnw -B verify -Pci` |
 | Dependency or workflow policy | `./mvnw -B verify -Pquality -DskipTests -DskipITs=true` | `./mvnw -B verify -Pci` |
+| Release plan or release code | `./mvnw -B -Prelease-check validate -DreleaseVersion=X.Y.Z -DnextDevelopmentVersion=X.Y.Z-SNAPSHOT` | `./mvnw -B -Prelease-check,ci clean verify` with the same versions |
 | Documentation screenshots | `./mvnw -B verify -Pscreenshots` | manual visual review before publication |
 
 ## Stable lifecycle scopes

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -21,7 +21,7 @@ Run this before starting a release:
 
 The command is non-mutating. It verifies:
 
-1. the current root and reactor versions match `1.3.0-SNAPSHOT`;
+1. the current root and reactor versions match `${releaseVersion}-SNAPSHOT`;
 2. the release version uses `X.Y.Z` and the next version uses
    `X.Y.Z-SNAPSHOT`;
 3. the next version is numerically newer, including freely selected major or

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -1,0 +1,109 @@
+# Release Verification and Publication
+
+Taxonomy separates release verification from publication.
+
+- Maven owns the locally reproducible version, reactor, dependency and test checks.
+- `.github/scripts/release.sh` owns the atomic Git state transition.
+- `.github/workflows/deploy-release.yml` owns GitHub Release, Helm, container and
+  deployment publication gates.
+
+There is deliberately no second SCM authority through `maven-release-plugin`.
+
+## Fast local release-plan check
+
+Run this before starting a release:
+
+```bash
+./mvnw -B -Prelease-check validate \
+  -DreleaseVersion=1.3.0 \
+  -DnextDevelopmentVersion=1.3.1-SNAPSHOT
+```
+
+The command is non-mutating. It verifies:
+
+1. the current root and reactor versions match `1.3.0-SNAPSHOT`;
+2. the release version uses `X.Y.Z` and the next version uses
+   `X.Y.Z-SNAPSHOT`;
+3. the next version is numerically newer, including freely selected major or
+   minor transitions;
+4. all Taxonomy modules use one consistent reactor version;
+5. no external dependency, plugin or build extension uses a SNAPSHOT version;
+6. the checkout is clean;
+7. no `release.properties`, `pom.xml.releaseBackup` or
+   `maven-release-plugin` configuration introduces a competing release path.
+
+For example, a major transition is valid:
+
+```bash
+./mvnw -B -Prelease-check validate \
+  -DreleaseVersion=1.3.0 \
+  -DnextDevelopmentVersion=2.0.0-SNAPSHOT
+```
+
+Repeating `1.3.0-SNAPSHOT` as the next version is invalid because the current
+snapshot is the source of release `1.3.0`; development must continue at a newer
+version.
+
+## Complete local release verification
+
+The complete release candidate check combines the release contract with the
+same canonical suite used by pull requests:
+
+```bash
+./mvnw -B -Prelease-check,ci clean verify \
+  -DreleaseVersion=1.3.0 \
+  -DnextDevelopmentVersion=1.3.1-SNAPSHOT
+```
+
+This command requires the same Docker, browser and model-download prerequisites
+as `./mvnw -B -Pci verify`. It still creates no tag, branch, GitHub Release,
+container image or deployment.
+
+## States used by the publication state machine
+
+The profile defaults to `development`:
+
+| State | Expected checked-out project version | Purpose |
+|---|---|---|
+| `development` | `${releaseVersion}-SNAPSHOT` | normal local preflight and new release |
+| `release` | `${releaseVersion}` | immutable release commit verification |
+| `advanced` | `${nextDevelopmentVersion}` | safe resume after `main` already advanced |
+
+`release.sh` selects these states itself. Direct use is mainly useful when
+reproducing a failed release stage:
+
+```bash
+./mvnw -B -Prelease-check validate \
+  -DreleaseVersion=1.3.0 \
+  -DnextDevelopmentVersion=1.3.1-SNAPSHOT \
+  -DreleaseCheckCurrentState=advanced
+```
+
+The clean-check can be disabled only for focused development of the validator:
+
+```bash
+-DreleaseCheckRequireClean=false
+```
+
+It is never disabled by the real publication path.
+
+## Publication responsibilities
+
+After the Maven-owned check succeeds, the existing release state machine still
+performs the project-specific operations that a generic Maven release plugin
+cannot safely replace:
+
+- synchronize Maven, citation, Zenodo, Codemeta and Helm versions;
+- create and verify the immutable release commit and annotated tag;
+- create a maintenance branch without overwriting an existing one;
+- keep the GitHub Release as a draft until downstream artifacts are complete;
+- generate and attach JAR, SBOM, VEX and Helm artifacts;
+- build the container image from the immutable tag;
+- advance `main` once, by fast-forward, to the selected next snapshot;
+- verify the exact resulting `main` commit with canonical CI;
+- publish and deploy only after every preceding gate succeeds;
+- resume a staged release without recreating its tag or version commits.
+
+This division keeps the Maven checks reproducible on a developer checkout while
+preserving the stronger atomic publication guarantees already required by
+Taxonomy.

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
         <exec-maven-plugin.version>3.6.3</exec-maven-plugin.version>
         <frontend-maven-plugin.version>2.0.2</frontend-maven-plugin.version>
         <node.version>v24.18.0</node.version>
+        <releaseCheckCurrentState>development</releaseCheckCurrentState>
+        <releaseCheckRequireClean>true</releaseCheckRequireClean>
         <taxonomy.model.revision>5c38ec7c405ec4b44b94cc5a9bb96e735b38267a</taxonomy.model.revision>
         <taxonomy.model.download.skip>true</taxonomy.model.download.skip>
         <taxonomy.ui.skip>true</taxonomy.ui.skip>
@@ -311,6 +313,45 @@
                 <taxonomy.quality.skip>false</taxonomy.quality.skip>
                 <taxonomy.ui.suite>all</taxonomy.ui.suite>
             </properties>
+        </profile>
+        <profile>
+            <id>release-check</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec-maven-plugin.version}</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>validate-release-plan</id>
+                                <phase>validate</phase>
+                                <goals><goal>exec</goal></goals>
+                                <configuration>
+                                    <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                                    <executable>python3</executable>
+                                    <arguments>
+                                        <argument>.github/scripts/check-release-plan.py</argument>
+                                        <argument>--root</argument>
+                                        <argument>${maven.multiModuleProjectDirectory}</argument>
+                                        <argument>--current-version</argument>
+                                        <argument>${project.version}</argument>
+                                        <argument>--release-version</argument>
+                                        <argument>${releaseVersion}</argument>
+                                        <argument>--next-development-version</argument>
+                                        <argument>${nextDevelopmentVersion}</argument>
+                                        <argument>--state</argument>
+                                        <argument>${releaseCheckCurrentState}</argument>
+                                        <argument>--require-clean</argument>
+                                        <argument>${releaseCheckRequireClean}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>quality</id>


### PR DESCRIPTION
## Ziel

Trennt die lokal reproduzierbare Release-Verifikation klar von der GitHub-Publikation, ohne die bestehende atomare Release-Zustandsmaschine zu ersetzen.

## Maven-owned release check

- neues Root-Profil `release-check`
- schneller, nicht mutierender Plan-Check über `validate`
- vollständige lokale Prüfung über `-Prelease-check,ci clean verify`
- validiert Development-, Release- und bereits fortgeschriebenen Resume-Zustand
- prüft Reactor-Versionskonsistenz, numerisch höhere Folgeversion, externe SNAPSHOT-Abhängigkeiten/Plugins/Extensions und sauberen Git-Stand
- verweigert `maven-release-plugin`, `release.properties` und Backup-POMs als konkurrierenden SCM-Releaseweg

## Einbindung

- `release.sh` führt den Maven-Check vor der Versionsmutation und erneut auf dem unveränderlichen Release-Commit aus
- die kanonische CI testet den Validator und führt das Maven-Profil mit einem abgeleiteten Patch-Plan aus
- der bestehende GitHub-Workflow behält Tags, Maintenance Branch, Draft Release, SBOM/VEX, Helm, Container, exakte Main-CI und Deployment
- der Release-Delivery-Vertrag schützt diese Aufgabentrennung gegen spätere Regressionen

## Lokal

```bash
./mvnw -B -Prelease-check validate \
  -DreleaseVersion=1.3.0 \
  -DnextDevelopmentVersion=1.3.1-SNAPSHOT

./mvnw -B -Prelease-check,ci clean verify \
  -DreleaseVersion=1.3.0 \
  -DnextDevelopmentVersion=1.3.1-SNAPSHOT
```

## Verifikation

- 9 Unit-Tests des Validators erfolgreich
- tatsächlicher Maven-Profillauf `-Prelease-check validate` erfolgreich
- kanonische Maven-/Browser-Suite erfolgreich
- PostgreSQL-, SQL-Server- und Oracle-Matrix erfolgreich
- Security Scan und CodeQL erfolgreich
- Copilot-Review bearbeitet und Thread geschlossen

## Merge-Koordination

Der PR bleibt bis zum eindeutig abgeschlossenen oder fehlgeschlagenen, bereits zuvor gestarteten Release 1.3.0 offen. Ein Merge während dessen atomarer Zustandsänderung würde den vorgesehenen Schutz gegen ein zwischenzeitlich verändertes `main` auslösen.