### PR TITLE
Harden the Maven release check after QA

### DIFF
--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -48,12 +48,17 @@ def main() -> int:
         "external {kind}",
         'state in {"development", "advanced"}',
         'if state == "release"',
+        "def reactor_pom_paths",
+        'kind in {"dependency", "parent"}',
+        "declares module",
     ):
         require(plan_check, needle, RELEASE_PLAN_CHECK, failures)
 
     for needle in (
         "DEFER_RELEASE_PUBLICATION=${DEFER_RELEASE_PUBLICATION:-false}",
         "run_maven_release_check()",
+        "stage_version_metadata()",
+        "git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'",
         'run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate',
         "run_maven_release_check release release-check,ci clean verify",
         'if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then',
@@ -62,6 +67,15 @@ def main() -> int:
     ):
         require(script, needle, RELEASE_SCRIPT, failures)
 
+    if script.count("\n  stage_version_metadata\n") != 2:
+        failures.append(
+            "release.sh must stage all tracked Maven POMs for both the release "
+            "commit and the next-development commit"
+        )
+    if "git add pom.xml */pom.xml" in script:
+        failures.append(
+            "release.sh must not use a one-directory POM glob that omits nested modules"
+        )
     if "./mvnw -B clean verify -Pci" in script:
         failures.append(
             "release.sh bypasses the Maven release-check profile during verification"

--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -49,6 +49,9 @@ def main() -> int:
         'state in {"development", "advanced"}',
         'if state == "release"',
         "def reactor_pom_paths",
+        "def reactor_models_by_coordinate",
+        "def effective_properties",
+        "unresolved version property",
         'kind in {"dependency", "parent"}',
         "declares module",
     ):
@@ -60,6 +63,8 @@ def main() -> int:
         "stage_version_metadata()",
         "git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'",
         'run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate',
+        "run_maven_release_check release release-check validate",
+        "-DreleaseCheckRequireClean=false",
         "run_maven_release_check release release-check,ci clean verify",
         'if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then',
         "remains a draft until downstream artifacts and final CI succeed",
@@ -75,6 +80,10 @@ def main() -> int:
     if "git add pom.xml */pom.xml" in script:
         failures.append(
             "release.sh must not use a one-directory POM glob that omits nested modules"
+        )
+    if 'grep -R "SNAPSHOT" --include="pom.xml"' in script:
+        failures.append(
+            "release.sh must not scan unrelated POMs instead of validating the declared reactor"
         )
     if "./mvnw -B clean verify -Pci" in script:
         failures.append(

--- a/.github/scripts/check-release-plan.py
+++ b/.github/scripts/check-release-plan.py
@@ -33,6 +33,7 @@ class PomModel:
     artifact_id: str
     version: str
     properties: dict[str, str]
+    parent_coordinate: Coordinate | None
 
 
 def text(element: ET.Element | None) -> str:
@@ -92,7 +93,9 @@ def reactor_pom_paths(root: Path) -> list[Path]:
         try:
             pom.relative_to(root)
         except ValueError as error:
-            raise ValueError(f"declared Maven module escapes repository root: {pom}") from error
+            raise ValueError(
+                f"declared Maven module escapes repository root: {pom}"
+            ) from error
 
         project = ET.parse(pom).getroot()
         seen.add(pom)
@@ -125,16 +128,21 @@ def reactor_pom_paths(root: Path) -> list[Path]:
 def model_for(path: Path) -> PomModel:
     root = ET.parse(path).getroot()
     parent = root.find("m:parent", NS)
+    parent_coordinate = None
     group_id = child_text(root, "groupId")
     version = child_text(root, "version")
     if parent is not None:
-        group_id = group_id or child_text(parent, "groupId")
+        parent_coordinate = Coordinate(
+            child_text(parent, "groupId"), child_text(parent, "artifactId")
+        )
+        group_id = group_id or parent_coordinate.group_id
         version = version or child_text(parent, "version")
     artifact_id = child_text(root, "artifactId")
     if not group_id or not artifact_id or not version:
         raise ValueError(
             f"{path}: Maven coordinates must provide effective groupId, artifactId and version"
         )
+
     properties = {
         property_element.tag.rsplit("}", 1)[-1]: text(property_element)
         for property_element in root.findall("m:properties/*", NS)
@@ -152,12 +160,20 @@ def model_for(path: Path) -> PomModel:
     if parent is not None:
         properties.update(
             {
-                "project.parent.groupId": child_text(parent, "groupId"),
-                "project.parent.artifactId": child_text(parent, "artifactId"),
+                "project.parent.groupId": parent_coordinate.group_id,
+                "project.parent.artifactId": parent_coordinate.artifact_id,
                 "project.parent.version": child_text(parent, "version"),
             }
         )
-    return PomModel(path, root, group_id, artifact_id, version, properties)
+    return PomModel(
+        path,
+        root,
+        group_id,
+        artifact_id,
+        version,
+        properties,
+        parent_coordinate,
+    )
 
 
 def resolve_properties(value: str, properties: dict[str, str]) -> str:
@@ -167,21 +183,61 @@ def resolve_properties(value: str, properties: dict[str, str]) -> str:
 
         def replace(match: re.Match[str]) -> str:
             nonlocal changed
-            key = match.group(1)
-            replacement = properties.get(key)
+            replacement = properties.get(match.group(1))
             if replacement is None:
                 return match.group(0)
             changed = True
             return replacement
 
-        result = PROPERTY_PATTERN.sub(replace, result)
+        updated = PROPERTY_PATTERN.sub(replace, result)
+        result = updated
         if not changed:
             break
     return result
 
 
-def effective_properties(model: PomModel, root_properties: dict[str, str]) -> dict[str, str]:
-    return root_properties | model.properties
+def reactor_models_by_coordinate(models: list[PomModel]) -> dict[Coordinate, PomModel]:
+    indexed: dict[Coordinate, PomModel] = {}
+    for model in models:
+        coordinate = Coordinate(model.group_id, model.artifact_id)
+        previous = indexed.get(coordinate)
+        if previous is not None:
+            raise ValueError(
+                "duplicate Maven reactor coordinate "
+                f"{coordinate.group_id}:{coordinate.artifact_id}: "
+                f"{previous.path} and {model.path}"
+            )
+        indexed[coordinate] = model
+    return indexed
+
+
+def effective_properties(
+    model: PomModel,
+    models_by_coordinate: dict[Coordinate, PomModel],
+    cache: dict[Path, dict[str, str]],
+    visiting: set[Path] | None = None,
+) -> dict[str, str]:
+    cached = cache.get(model.path)
+    if cached is not None:
+        return cached
+
+    visiting = set() if visiting is None else visiting
+    if model.path in visiting:
+        raise ValueError(f"cyclic Maven parent relationship involving {model.path}")
+    visiting.add(model.path)
+
+    inherited: dict[str, str] = {}
+    if model.parent_coordinate is not None:
+        parent_model = models_by_coordinate.get(model.parent_coordinate)
+        if parent_model is not None:
+            inherited = effective_properties(
+                parent_model, models_by_coordinate, cache, visiting
+            )
+
+    result = inherited | model.properties
+    cache[model.path] = result
+    visiting.remove(model.path)
+    return result
 
 
 def versioned_elements(model: PomModel) -> list[tuple[str, Coordinate | None, str]]:
@@ -190,16 +246,8 @@ def versioned_elements(model: PomModel) -> list[tuple[str, Coordinate | None, st
     if parent is not None:
         parent_version = child_text(parent, "version")
         if parent_version:
-            entries.append(
-                (
-                    "parent",
-                    Coordinate(
-                        child_text(parent, "groupId"),
-                        child_text(parent, "artifactId"),
-                    ),
-                    parent_version,
-                )
-            )
+            entries.append(("parent", model.parent_coordinate, parent_version))
+
     for dependency in model.root.findall(".//m:dependency", NS):
         version = child_text(dependency, "version")
         if version:
@@ -304,22 +352,29 @@ def validate_release_plan(
     root_model = models[0]
     if root_model.path != root / "pom.xml":
         raise ValueError("reactor discovery did not start at the root pom.xml")
-    if root_model.version != current_version:
-        raise ValueError(
-            f"root pom.xml declares {root_model.version}, not Maven's {current_version}"
-        )
 
-    internal_coordinates = {
-        Coordinate(model.group_id, model.artifact_id) for model in models
-    }
+    models_by_coordinate = reactor_models_by_coordinate(models)
+    internal_coordinates = set(models_by_coordinate)
+    property_cache: dict[Path, dict[str, str]] = {}
     failures: list[str] = []
+
     for model in models:
         relative = model.path.relative_to(root)
-        if model.version != current_version:
+        properties = effective_properties(
+            model, models_by_coordinate, property_cache
+        )
+        resolved_model_version = resolve_properties(model.version, properties)
+        if PROPERTY_PATTERN.search(resolved_model_version):
             failures.append(
-                f"{relative}: reactor version {model.version!r} differs from {current_version}"
+                f"{relative}: reactor version {model.version!r} contains an "
+                f"unresolved version property (resolved as {resolved_model_version!r})"
             )
-        properties = effective_properties(model, root_model.properties)
+        elif resolved_model_version != current_version:
+            failures.append(
+                f"{relative}: reactor version {resolved_model_version!r} differs from "
+                f"{current_version}"
+            )
+
         for kind, coordinate, raw_version in versioned_elements(model):
             if kind == "forbidden-plugin":
                 failures.append(
@@ -327,6 +382,15 @@ def validate_release_plan(
                 )
                 continue
             resolved = resolve_properties(raw_version, properties)
+            coordinate_text = (
+                f" {coordinate.group_id}:{coordinate.artifact_id}" if coordinate else ""
+            )
+            if PROPERTY_PATTERN.search(resolved):
+                failures.append(
+                    f"{relative}: {kind}{coordinate_text} uses unresolved version property "
+                    f"{raw_version!r} (resolved as {resolved!r})"
+                )
+                continue
             if "SNAPSHOT" not in resolved.upper():
                 continue
             if (
@@ -336,9 +400,6 @@ def validate_release_plan(
                 and state in {"development", "advanced"}
             ):
                 continue
-            coordinate_text = (
-                f" {coordinate.group_id}:{coordinate.artifact_id}" if coordinate else ""
-            )
             failures.append(
                 f"{relative}: external {kind}{coordinate_text} uses snapshot version "
                 f"{raw_version!r} (resolved as {resolved!r})"

--- a/.github/scripts/check-release-plan.py
+++ b/.github/scripts/check-release-plan.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 import re
@@ -72,12 +73,53 @@ def expected_current_version(
     raise ValueError(f"releaseCheckCurrentState must be one of {sorted(STATES)}")
 
 
-def pom_paths(root: Path) -> list[Path]:
-    return sorted(
-        path
-        for path in root.rglob("pom.xml")
-        if ".git" not in path.parts and "target" not in path.parts
-    )
+def reactor_pom_paths(root: Path) -> list[Path]:
+    """Return only POMs reachable through Maven's declared module graph."""
+    root = root.resolve()
+    root_pom = root / "pom.xml"
+    if not root_pom.is_file():
+        raise ValueError(f"root pom.xml does not exist below {root}")
+
+    pending: deque[Path] = deque([root_pom])
+    discovered: list[Path] = []
+    seen: set[Path] = set()
+    while pending:
+        pom = pending.popleft().resolve()
+        if pom in seen:
+            continue
+        if not pom.is_file():
+            raise ValueError(f"declared Maven module POM does not exist: {pom}")
+        try:
+            pom.relative_to(root)
+        except ValueError as error:
+            raise ValueError(f"declared Maven module escapes repository root: {pom}") from error
+
+        project = ET.parse(pom).getroot()
+        seen.add(pom)
+        discovered.append(pom)
+        for module_element in project.findall("m:modules/m:module", NS):
+            module = text(module_element)
+            if not module:
+                raise ValueError(
+                    f"{pom.relative_to(root)} contains an empty Maven module declaration"
+                )
+            module_path = (pom.parent / module).resolve()
+            module_pom = (
+                module_path if module_path.name == "pom.xml" else module_path / "pom.xml"
+            )
+            try:
+                relative_module = module_pom.relative_to(root)
+            except ValueError as error:
+                raise ValueError(
+                    f"{pom.relative_to(root)} declares module {module!r} outside the repository"
+                ) from error
+            if not module_pom.is_file():
+                raise ValueError(
+                    f"{pom.relative_to(root)} declares module {module!r}, but "
+                    f"{relative_module} does not exist"
+                )
+            pending.append(module_pom)
+    return discovered
 
 
 def model_for(path: Path) -> PomModel:
@@ -89,6 +131,10 @@ def model_for(path: Path) -> PomModel:
         group_id = group_id or child_text(parent, "groupId")
         version = version or child_text(parent, "version")
     artifact_id = child_text(root, "artifactId")
+    if not group_id or not artifact_id or not version:
+        raise ValueError(
+            f"{path}: Maven coordinates must provide effective groupId, artifactId and version"
+        )
     properties = {
         property_element.tag.rsplit("}", 1)[-1]: text(property_element)
         for property_element in root.findall("m:properties/*", NS)
@@ -128,8 +174,7 @@ def resolve_properties(value: str, properties: dict[str, str]) -> str:
             changed = True
             return replacement
 
-        resolved = PROPERTY_PATTERN.sub(replace, result)
-        result = resolved
+        result = PROPERTY_PATTERN.sub(replace, result)
         if not changed:
             break
     return result
@@ -141,6 +186,20 @@ def effective_properties(model: PomModel, root_properties: dict[str, str]) -> di
 
 def versioned_elements(model: PomModel) -> list[tuple[str, Coordinate | None, str]]:
     entries: list[tuple[str, Coordinate | None, str]] = []
+    parent = model.root.find("m:parent", NS)
+    if parent is not None:
+        parent_version = child_text(parent, "version")
+        if parent_version:
+            entries.append(
+                (
+                    "parent",
+                    Coordinate(
+                        child_text(parent, "groupId"),
+                        child_text(parent, "artifactId"),
+                    ),
+                    parent_version,
+                )
+            )
     for dependency in model.root.findall(".//m:dependency", NS):
         version = child_text(dependency, "version")
         if version:
@@ -240,11 +299,11 @@ def validate_release_plan(
             f"but Maven resolved {current_version}"
         )
 
-    paths = pom_paths(root)
-    if not paths or root / "pom.xml" not in paths:
-        raise ValueError(f"no root pom.xml found below {root}")
+    paths = reactor_pom_paths(root)
     models = [model_for(path) for path in paths]
-    root_model = next(model for model in models if model.path == root / "pom.xml")
+    root_model = models[0]
+    if root_model.path != root / "pom.xml":
+        raise ValueError("reactor discovery did not start at the root pom.xml")
     if root_model.version != current_version:
         raise ValueError(
             f"root pom.xml declares {root_model.version}, not Maven's {current_version}"
@@ -256,7 +315,7 @@ def validate_release_plan(
     failures: list[str] = []
     for model in models:
         relative = model.path.relative_to(root)
-        if model.group_id == root_model.group_id and model.version != current_version:
+        if model.version != current_version:
             failures.append(
                 f"{relative}: reactor version {model.version!r} differs from {current_version}"
             )
@@ -271,7 +330,7 @@ def validate_release_plan(
             if "SNAPSHOT" not in resolved.upper():
                 continue
             if (
-                kind == "dependency"
+                kind in {"dependency", "parent"}
                 and coordinate in internal_coordinates
                 and resolved == current_version
                 and state in {"development", "advanced"}

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -42,6 +42,9 @@ stage_version_metadata() {
   if [[ ${#tracked_poms[@]} -eq 0 ]]; then
     fail "No tracked Maven POMs found for release version staging"
   fi
+  # The checkout was required to be clean before versions:set. Adding every tracked
+  # POM therefore stages only files changed by the version transition, including
+  # nested reactor modules, while excluding generated and untracked example POMs.
   git add -- "${tracked_poms[@]}" CITATION.cff CITATION.md .zenodo.json codemeta.json
   if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
     git add -- deploy/helm/taxonomy/Chart.yaml
@@ -80,19 +83,6 @@ if next_version <= release:
         f"release {os.environ['RELEASE_VERSION']}"
     )
 PY
-
-ensure_no_snapshot_poms() {
-  local remaining
-  remaining=$(grep -R "SNAPSHOT" --include="pom.xml" . \
-    | grep -v "target/" \
-    | grep -v "\.git/" \
-    || true)
-  if [[ -n "$remaining" ]]; then
-    echo "::error::SNAPSHOT references still found in pom.xml files after release version update:"
-    echo "$remaining"
-    exit 1
-  fi
-}
 
 generate_release_notes() {
   echo "Generating release notes..."
@@ -239,7 +229,11 @@ if [[ "$STATE" == "new" ]]; then
   ./mvnw -B versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
   python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
   python3 "$VERSION_STATE_HELPER" --mode release --expected-version "$RELEASE_VERSION"
-  ensure_no_snapshot_poms
+  # Validate the actual release-state reactor before committing it. The clean-check
+  # is disabled only for this deliberate, uncommitted transition; the subsequent
+  # canonical release verification runs from the clean immutable commit.
+  run_maven_release_check release release-check validate \
+    -DreleaseCheckRequireClean=false
   stage_version_metadata
   git commit -m "Release version $RELEASE_VERSION"
   RELEASE_COMMIT=$(git rev-parse HEAD)

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -34,6 +34,20 @@ run_maven_release_check() {
     -DreleaseCheckCurrentState="$state"
 }
 
+stage_version_metadata() {
+  local -a tracked_poms=()
+  mapfile -d '' tracked_poms < <(
+    git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'
+  )
+  if [[ ${#tracked_poms[@]} -eq 0 ]]; then
+    fail "No tracked Maven POMs found for release version staging"
+  fi
+  git add -- "${tracked_poms[@]}" CITATION.cff CITATION.md .zenodo.json codemeta.json
+  if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+    git add -- deploy/helm/taxonomy/Chart.yaml
+  fi
+}
+
 if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   fail "release_version must use X.Y.Z without a leading v"
 fi
@@ -226,10 +240,7 @@ if [[ "$STATE" == "new" ]]; then
   python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
   python3 "$VERSION_STATE_HELPER" --mode release --expected-version "$RELEASE_VERSION"
   ensure_no_snapshot_poms
-  git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
-  if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
-    git add deploy/helm/taxonomy/Chart.yaml
-  fi
+  stage_version_metadata
   git commit -m "Release version $RELEASE_VERSION"
   RELEASE_COMMIT=$(git rev-parse HEAD)
 else
@@ -276,10 +287,7 @@ else
   ./mvnw -B versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
   python3 "$METADATA_HELPER" "$NEXT_VERSION"
   python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
-  git add pom.xml */pom.xml CITATION.cff CITATION.md .zenodo.json codemeta.json
-  if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
-    git add deploy/helm/taxonomy/Chart.yaml
-  fi
+  stage_version_metadata
   git commit -m "Prepare next development version $NEXT_VERSION"
   NEXT_COMMIT=$(git rev-parse HEAD)
 

--- a/.github/scripts/test-check-release-plan.py
+++ b/.github/scripts/test-check-release-plan.py
@@ -35,13 +35,14 @@ MODULE_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.taxonomy</groupId>
-    <artifactId>taxonomy</artifactId>
+    <groupId>{parent_group_id}</groupId>
+    <artifactId>{parent_artifact_id}</artifactId>
     <version>{parent_version}</version>
   </parent>
   {group_id}
   <artifactId>{artifact_id}</artifactId>
   {version}
+  {properties}
   <dependencies>
     <dependency>
       <groupId>com.taxonomy</groupId>
@@ -69,10 +70,13 @@ def write_module(
     root: Path,
     path: str = "module-a",
     *,
+    parent_group_id: str = "com.taxonomy",
+    parent_artifact_id: str = "taxonomy",
     parent_version: str = "1.3.0-SNAPSHOT",
     artifact_id: str = "module-a",
     group_id: str = "",
     version: str = "",
+    properties: str = "",
     dependency: str = "",
     extra: str = "",
 ) -> None:
@@ -80,10 +84,13 @@ def write_module(
     module.mkdir(parents=True, exist_ok=True)
     module.joinpath("pom.xml").write_text(
         MODULE_TEMPLATE.format(
+            parent_group_id=parent_group_id,
+            parent_artifact_id=parent_artifact_id,
             parent_version=parent_version,
             artifact_id=artifact_id,
             group_id=f"<groupId>{group_id}</groupId>" if group_id else "",
             version=f"<version>{version}</version>" if version else "",
+            properties=properties,
             dependency=dependency,
             extra=extra,
         ),
@@ -122,11 +129,7 @@ def write_project(
 
 def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", *args],
-        cwd=root,
-        text=True,
-        capture_output=True,
-        check=True,
+        ["git", *args], cwd=root, text=True, capture_output=True, check=True
     )
 
 
@@ -135,13 +138,9 @@ def commit_project(root: Path) -> None:
     git(root, "add", ".")
     git(
         root,
-        "-c",
-        "user.name=Release QA",
-        "-c",
-        "user.email=qa@example.invalid",
-        "commit",
-        "-qm",
-        "initial",
+        "-c", "user.name=Release QA",
+        "-c", "user.email=qa@example.invalid",
+        "commit", "-qm", "initial",
     )
 
 
@@ -157,20 +156,14 @@ class ReleasePlanTest(unittest.TestCase):
         require_clean: bool = False,
     ) -> dict[str, object]:
         return MODULE.validate_release_plan(
-            root,
-            current,
-            release,
-            next_version,
-            state,
-            require_clean=require_clean,
+            root, current, release, next_version, state, require_clean=require_clean
         )
 
     def test_development_plan_allows_internal_snapshot_reactor(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_project(root)
-            result = self.validate(root)
-            self.assertEqual(2, result["pom_count"])
+            self.assertEqual(2, self.validate(root)["pom_count"])
 
     def test_nested_declared_modules_are_discovered(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -186,11 +179,86 @@ class ReleasePlanTest(unittest.TestCase):
             write_module(
                 root,
                 "module-a/nested",
+                parent_artifact_id="module-a",
                 artifact_id="nested",
-                parent_version="1.3.0-SNAPSHOT",
             )
-            result = self.validate(root)
-            self.assertEqual(3, result["pom_count"])
+            self.assertEqual(3, self.validate(root)["pom_count"])
+
+    def test_nested_parent_snapshot_property_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            aggregator = root / "module-a" / "pom.xml"
+            aggregator.write_text(
+                aggregator.read_text(encoding="utf-8").replace(
+                    "</project>",
+                    "<properties><nested.external.version>9.0.0-SNAPSHOT"
+                    "</nested.external.version></properties>"
+                    "<modules><module>nested</module></modules></project>",
+                ),
+                encoding="utf-8",
+            )
+            dependency = """<dependency>
+              <groupId>example</groupId><artifactId>nested-unstable</artifactId>
+              <version>${nested.external.version}</version>
+            </dependency>"""
+            write_module(
+                root,
+                "module-a/nested",
+                parent_artifact_id="module-a",
+                artifact_id="nested",
+                dependency=dependency,
+            )
+            with self.assertRaisesRegex(
+                ValueError, "external dependency example:nested-unstable"
+            ):
+                self.validate(root)
+
+    def test_nested_parent_stable_property_is_inherited(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            aggregator = root / "module-a" / "pom.xml"
+            aggregator.write_text(
+                aggregator.read_text(encoding="utf-8").replace(
+                    "</project>",
+                    "<properties><nested.external.version>9.0.0"
+                    "</nested.external.version></properties>"
+                    "<modules><module>nested</module></modules></project>",
+                ),
+                encoding="utf-8",
+            )
+            dependency = """<dependency>
+              <groupId>example</groupId><artifactId>nested-stable</artifactId>
+              <version>${nested.external.version}</version>
+            </dependency>"""
+            write_module(
+                root,
+                "module-a/nested",
+                parent_artifact_id="module-a",
+                artifact_id="nested",
+                dependency=dependency,
+            )
+            self.assertEqual(3, self.validate(root)["pom_count"])
+
+    def test_unresolved_dependency_property_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dependency = """<dependency>
+              <groupId>example</groupId><artifactId>unknown</artifactId>
+              <version>${missing.version}</version>
+            </dependency>"""
+            write_project(root, dependency=dependency)
+            with self.assertRaisesRegex(ValueError, "unresolved version property"):
+                self.validate(root)
+
+    def test_duplicate_reactor_coordinate_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root, modules=("module-a", "module-b"))
+            write_module(root, "module-b", artifact_id="module-a")
+            with self.assertRaisesRegex(ValueError, "duplicate Maven reactor coordinate"):
+                self.validate(root)
 
     def test_unrelated_pom_is_not_part_of_the_reactor(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -208,8 +276,7 @@ class ReleasePlanTest(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            result = self.validate(root)
-            self.assertEqual(2, result["pom_count"])
+            self.assertEqual(2, self.validate(root)["pom_count"])
 
     def test_missing_declared_module_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -263,17 +330,18 @@ class ReleasePlanTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_project(root, version="1.3.0")
-            result = self.validate(root, current="1.3.0", state="release")
-            self.assertEqual("release", result["state"])
+            self.assertEqual(
+                "release", self.validate(root, current="1.3.0", state="release")["state"]
+            )
 
     def test_advanced_state_accepts_next_snapshot(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_project(root, version="1.3.1-SNAPSHOT")
-            result = self.validate(
-                root, current="1.3.1-SNAPSHOT", state="advanced"
+            self.assertEqual(
+                "advanced",
+                self.validate(root, current="1.3.1-SNAPSHOT", state="advanced")["state"],
             )
-            self.assertEqual("advanced", result["state"])
 
     def test_external_snapshot_parent_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -373,8 +441,7 @@ class ReleasePlanTest(unittest.TestCase):
             root = Path(directory)
             write_project(root)
             commit_project(root)
-            result = self.validate(root, require_clean=True)
-            self.assertEqual(2, result["pom_count"])
+            self.assertEqual(2, self.validate(root, require_clean=True)["pom_count"])
 
     def test_linked_worktree_dirty_state_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/.github/scripts/test-check-release-plan.py
+++ b/.github/scripts/test-check-release-plan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -20,12 +21,13 @@ SPEC.loader.exec_module(MODULE)
 ROOT_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <modelVersion>4.0.0</modelVersion>
+  {parent}
   <groupId>com.taxonomy</groupId>
   <artifactId>taxonomy</artifactId>
   <version>{version}</version>
   <packaging>pom</packaging>
   <properties><external.version>{external}</external.version></properties>
-  <modules><module>module-a</module></modules>
+  <modules>{modules}</modules>
   {extra}
 </project>
 """
@@ -35,9 +37,11 @@ MODULE_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
   <parent>
     <groupId>com.taxonomy</groupId>
     <artifactId>taxonomy</artifactId>
-    <version>{version}</version>
+    <version>{parent_version}</version>
   </parent>
-  <artifactId>module-a</artifactId>
+  {group_id}
+  <artifactId>{artifact_id}</artifactId>
+  {version}
   <dependencies>
     <dependency>
       <groupId>com.taxonomy</groupId>
@@ -46,8 +50,45 @@ MODULE_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
     </dependency>
     {dependency}
   </dependencies>
+  {extra}
 </project>
 """
+EXTERNAL_PARENT = """<parent>
+  <groupId>org.example</groupId>
+  <artifactId>external-parent</artifactId>
+  <version>{version}</version>
+  <relativePath/>
+</parent>"""
+
+
+def module_element(path: str) -> str:
+    return f"<module>{path}</module>"
+
+
+def write_module(
+    root: Path,
+    path: str = "module-a",
+    *,
+    parent_version: str = "1.3.0-SNAPSHOT",
+    artifact_id: str = "module-a",
+    group_id: str = "",
+    version: str = "",
+    dependency: str = "",
+    extra: str = "",
+) -> None:
+    module = root / path
+    module.mkdir(parents=True, exist_ok=True)
+    module.joinpath("pom.xml").write_text(
+        MODULE_TEMPLATE.format(
+            parent_version=parent_version,
+            artifact_id=artifact_id,
+            group_id=f"<groupId>{group_id}</groupId>" if group_id else "",
+            version=f"<version>{version}</version>" if version else "",
+            dependency=dependency,
+            extra=extra,
+        ),
+        encoding="utf-8",
+    )
 
 
 def write_project(
@@ -56,16 +97,51 @@ def write_project(
     external: str = "1.0.0",
     extra: str = "",
     dependency: str = "",
+    parent_version: str = "1.0.0",
+    modules: tuple[str, ...] = ("module-a",),
 ) -> None:
     root.joinpath("pom.xml").write_text(
-        ROOT_TEMPLATE.format(version=version, external=external, extra=extra),
+        ROOT_TEMPLATE.format(
+            parent=EXTERNAL_PARENT.format(version=parent_version),
+            version=version,
+            external=external,
+            modules="".join(module_element(module) for module in modules),
+            extra=extra,
+        ),
         encoding="utf-8",
     )
-    module = root / "module-a"
-    module.mkdir()
-    module.joinpath("pom.xml").write_text(
-        MODULE_TEMPLATE.format(version=version, dependency=dependency),
-        encoding="utf-8",
+    for module in modules:
+        write_module(
+            root,
+            module,
+            parent_version=version,
+            artifact_id=Path(module).name,
+            dependency=dependency if module == "module-a" else "",
+        )
+
+
+def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
+def commit_project(root: Path) -> None:
+    git(root, "init", "-q")
+    git(root, "add", ".")
+    git(
+        root,
+        "-c",
+        "user.name=Release QA",
+        "-c",
+        "user.email=qa@example.invalid",
+        "commit",
+        "-qm",
+        "initial",
     )
 
 
@@ -77,6 +153,8 @@ class ReleasePlanTest(unittest.TestCase):
         release: str = "1.3.0",
         next_version: str = "1.3.1-SNAPSHOT",
         state: str = "development",
+        *,
+        require_clean: bool = False,
     ) -> dict[str, object]:
         return MODULE.validate_release_plan(
             root,
@@ -84,7 +162,7 @@ class ReleasePlanTest(unittest.TestCase):
             release,
             next_version,
             state,
-            require_clean=False,
+            require_clean=require_clean,
         )
 
     def test_development_plan_allows_internal_snapshot_reactor(self) -> None:
@@ -93,6 +171,79 @@ class ReleasePlanTest(unittest.TestCase):
             write_project(root)
             result = self.validate(root)
             self.assertEqual(2, result["pom_count"])
+
+    def test_nested_declared_modules_are_discovered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            aggregator = root / "module-a" / "pom.xml"
+            aggregator.write_text(
+                aggregator.read_text(encoding="utf-8").replace(
+                    "</project>", "<modules><module>nested</module></modules></project>"
+                ),
+                encoding="utf-8",
+            )
+            write_module(
+                root,
+                "module-a/nested",
+                artifact_id="nested",
+                parent_version="1.3.0-SNAPSHOT",
+            )
+            result = self.validate(root)
+            self.assertEqual(3, result["pom_count"])
+
+    def test_unrelated_pom_is_not_part_of_the_reactor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            unrelated = root / "examples"
+            unrelated.mkdir()
+            unrelated.joinpath("pom.xml").write_text(
+                ROOT_TEMPLATE.format(
+                    parent=EXTERNAL_PARENT.format(version="9.0.0-SNAPSHOT"),
+                    version="9.0.0-SNAPSHOT",
+                    external="9.0.0-SNAPSHOT",
+                    modules="",
+                    extra="",
+                ),
+                encoding="utf-8",
+            )
+            result = self.validate(root)
+            self.assertEqual(2, result["pom_count"])
+
+    def test_missing_declared_module_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root, modules=())
+            pom = root / "pom.xml"
+            pom.write_text(
+                pom.read_text(encoding="utf-8").replace(
+                    "<modules></modules>",
+                    "<modules><module>missing</module></modules>",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "does not exist"):
+                self.validate(root)
+
+    def test_module_outside_repository_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repo"
+            root.mkdir()
+            write_project(root, modules=())
+            pom = root / "pom.xml"
+            pom.write_text(
+                pom.read_text(encoding="utf-8").replace(
+                    "<modules></modules>",
+                    "<modules><module>../outside</module></modules>",
+                ),
+                encoding="utf-8",
+            )
+            outside = root.parent / "outside"
+            outside.mkdir()
+            outside.joinpath("pom.xml").write_text("<project/>", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "outside the repository"):
+                self.validate(root)
 
     def test_major_next_version_is_supported(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -124,6 +275,15 @@ class ReleasePlanTest(unittest.TestCase):
             )
             self.assertEqual("advanced", result["state"])
 
+    def test_external_snapshot_parent_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root, parent_version="9.0.0-SNAPSHOT")
+            with self.assertRaisesRegex(
+                ValueError, "external parent org.example:external-parent"
+            ):
+                self.validate(root)
+
     def test_external_snapshot_dependency_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -131,24 +291,47 @@ class ReleasePlanTest(unittest.TestCase):
               <groupId>example</groupId><artifactId>unstable</artifactId>
               <version>${external.version}</version>
             </dependency>"""
-            write_project(
-                root, external="9.0.0-SNAPSHOT", dependency=dependency
-            )
+            write_project(root, external="9.0.0-SNAPSHOT", dependency=dependency)
             with self.assertRaisesRegex(
                 ValueError, "external dependency example:unstable"
             ):
                 self.validate(root)
 
-    def test_reactor_version_mismatch_is_rejected(self) -> None:
+    def test_external_snapshot_plugin_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extra = """<build><plugins><plugin>
+              <groupId>example</groupId><artifactId>unstable-plugin</artifactId>
+              <version>9.0.0-SNAPSHOT</version>
+            </plugin></plugins></build>"""
+            write_project(root, extra=extra)
+            with self.assertRaisesRegex(
+                ValueError, "external plugin example:unstable-plugin"
+            ):
+                self.validate(root)
+
+    def test_external_snapshot_extension_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            extra = """<build><extensions><extension>
+              <groupId>example</groupId><artifactId>unstable-extension</artifactId>
+              <version>9.0.0-SNAPSHOT</version>
+            </extension></extensions></build>"""
+            write_project(root, extra=extra)
+            with self.assertRaisesRegex(
+                ValueError, "external build extension example:unstable-extension"
+            ):
+                self.validate(root)
+
+    def test_reactor_version_mismatch_is_rejected_even_with_another_group(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             write_project(root)
-            module_pom = root / "module-a" / "pom.xml"
-            module_pom.write_text(
-                module_pom.read_text(encoding="utf-8").replace(
-                    "1.3.0-SNAPSHOT", "1.2.9-SNAPSHOT"
-                ),
-                encoding="utf-8",
+            write_module(
+                root,
+                group_id="org.other",
+                version="1.2.9-SNAPSHOT",
+                parent_version="1.3.0-SNAPSHOT",
             )
             with self.assertRaisesRegex(ValueError, "reactor version"):
                 self.validate(root)
@@ -164,6 +347,47 @@ class ReleasePlanTest(unittest.TestCase):
             write_project(root, extra=extra)
             with self.assertRaisesRegex(ValueError, "second SCM release authority"):
                 self.validate(root)
+
+    def test_stale_release_plugin_state_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            root.joinpath("release.properties").write_text("stale", encoding="utf-8")
+            root.joinpath("module-a", "pom.xml.releaseBackup").write_text(
+                "stale", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(ValueError, "stale Maven Release Plugin"):
+                self.validate(root)
+
+    def test_dirty_checkout_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            commit_project(root)
+            root.joinpath("untracked.txt").write_text("dirty", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "clean checkout"):
+                self.validate(root, require_clean=True)
+
+    def test_clean_checkout_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_project(root)
+            commit_project(root)
+            result = self.validate(root, require_clean=True)
+            self.assertEqual(2, result["pom_count"])
+
+    def test_linked_worktree_dirty_state_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source"
+            source.mkdir()
+            write_project(source)
+            commit_project(source)
+            worktree = Path(directory) / "worktree"
+            git(source, "worktree", "add", "-q", "-b", "qa-worktree", str(worktree))
+            self.assertTrue((worktree / ".git").is_file())
+            worktree.joinpath("untracked.txt").write_text("dirty", encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "clean checkout"):
+                self.validate(worktree, require_clean=True)
 
     def test_unresolved_maven_property_reports_missing_argument(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -21,14 +21,18 @@ Run this before starting a release:
 
 The command is non-mutating. It verifies:
 
-1. the current root and reactor versions match `${releaseVersion}-SNAPSHOT`;
+1. the current root and every declared reactor-module version match
+   `${releaseVersion}-SNAPSHOT`;
 2. the release version uses `X.Y.Z` and the next version uses
    `X.Y.Z-SNAPSHOT`;
 3. the next version is numerically newer, including freely selected major or
    minor transitions;
-4. all Taxonomy modules use one consistent reactor version;
-5. no external dependency, plugin or build extension uses a SNAPSHOT version;
-6. the checkout is clean;
+4. the reactor is recursively derived from Maven `<modules>` declarations;
+   missing modules and module paths outside the repository fail closed, while
+   unrelated example POMs are not misclassified as release modules;
+5. no external parent, dependency, plugin or build extension uses a SNAPSHOT
+   version;
+6. the checkout is clean, including linked Git worktrees;
 7. no `release.properties`, `pom.xml.releaseBackup` or
    `maven-release-plugin` configuration introduces a competing release path.
 

--- a/docs/dev/RELEASE_PROCESS.md
+++ b/docs/dev/RELEASE_PROCESS.md
@@ -30,10 +30,12 @@ The command is non-mutating. It verifies:
 4. the reactor is recursively derived from Maven `<modules>` declarations;
    missing modules and module paths outside the repository fail closed, while
    unrelated example POMs are not misclassified as release modules;
-5. no external parent, dependency, plugin or build extension uses a SNAPSHOT
-   version;
-6. the checkout is clean, including linked Git worktrees;
-7. no `release.properties`, `pom.xml.releaseBackup` or
+5. reactor coordinates are unique and version properties inherited through
+   internal parent POMs are resolved with child-over-parent precedence;
+6. no external parent, dependency, plugin or build extension uses a SNAPSHOT
+   version, and no explicit version may retain an unresolved `${...}` property;
+7. the checkout is clean, including linked Git worktrees;
+8. no `release.properties`, `pom.xml.releaseBackup` or
    `maven-release-plugin` configuration introduces a competing release path.
 
 For example, a major transition is valid:


### PR DESCRIPTION
## QA-Befunde

Die umfassende Prüfung des in #543 eingeführten Release-Checks hat sechs relevante Lücken gefunden:

1. Externe Maven-Parents mit SNAPSHOT-Version wurden nicht geprüft.
2. Der Reactor wurde per Dateisuche und gleicher `groupId` angenähert statt aus `<modules>` aufgebaut.
3. `release.sh` nahm mit `pom.xml */pom.xml` nur POMs bis zur ersten Modulebene in Versionscommits auf.
4. Versionsproperties interner Zwischen-Parents wurden in verschachtelten Modulen nicht geerbt.
5. Unaufgelöste Versionsproperties und doppelte Reactor-Koordinaten wurden nicht fail-closed abgelehnt.
6. Nach der korrekten Reactor-Prüfung durchsuchte `release.sh` nochmals alle vorhandenen POMs mit `grep -R SNAPSHOT`; ein nicht zum Reactor gehörendes Beispiel-POM konnte den Release dadurch weiterhin fälschlich blockieren.

## Korrektur

- Reactor-POMs werden rekursiv aus den tatsächlichen `<modules>`-Deklarationen aufgebaut.
- Fehlende beziehungsweise außerhalb des Repositorys liegende Module scheitern geschlossen.
- Jedes Reactor-Modul muss dieselbe Release-Version verwenden, unabhängig von seiner `groupId`.
- Doppelte Maven-Koordinaten werden abgelehnt.
- Properties interner Parent-POMs werden entlang der Parent-Kette mit Child-over-Parent-Priorität vererbt.
- Unaufgelöste Properties in Projekt-, Parent-, Dependency-, Plugin- oder Extension-Versionen blockieren den Release.
- Externe SNAPSHOT-Parents, -Dependencies, -Plugins und -Extensions werden abgelehnt; interne Parent-/Dependency-SNAPSHOTS bleiben nur in den vorgesehenen Entwicklungszuständen zulässig.
- Release- und Folgeversionscommit erfassen alle getrackten POMs einschließlich verschachtelter Module; der vorherige Clean-Check stellt sicher, dass nur die Versionsänderungen gestaged werden.
- Der unpräzise repositoryweite SNAPSHOT-Grep wurde durch den echten Release-State-Validator auf dem deklarierten Reactor ersetzt.
- Der Delivery-Vertrag verhindert die Rückkehr zu beiden fehlerhaften Grobprüfungen.

## Erweiterte QA

Die Validator-Suite wächst von 9 auf 24 Fälle, darunter verschachtelte Parent-Ketten, geerbte stabile und SNAPSHOT-Properties, unaufgelöste Properties, doppelte Koordinaten, fremde Neben-POMs, externe SNAPSHOT-Artefakte, Major-Sprünge sowie normale und verlinkte Git-Worktrees.

Die vollständigen Repository-Gates werden auf dem finalen Head erneut ausgeführt. `Closes #545`.

Closes #545