### PR TITLE
Fix portfolio workspace isolation and duplicate analysis claims

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioGitController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioGitController.java
@@ -98,14 +98,15 @@ public class PortfolioGitController {
                 true, outcome.commitId(), outcome.semanticFallback(), List.of(), materialized));
     }
 
+    /**
+     * Resolves the authenticated user's workspace and deliberately fails closed.
+     * Falling back to the shared repository after a provisioning or persistence
+     * error could mutate another collaboration scope.
+     */
     private RequestContext context() {
         String username = workspaceResolver.resolveCurrentUsername();
-        try {
-            repositoryStateService.ensureWorkspaceState(username);
-            return new RequestContext(username, workspaceResolver.resolveCurrentContext());
-        } catch (RuntimeException exception) {
-            return new RequestContext(username, WorkspaceContext.SHARED);
-        }
+        repositoryStateService.ensureWorkspaceState(username);
+        return new RequestContext(username, workspaceResolver.resolveCurrentContext());
     }
 
     private static boolean blank(String value) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
@@ -121,6 +121,17 @@ public class RequirementAnalysisJob {
         this.partialItems = partialItems;
         this.failedItems = failedItems;
         this.errorSummary = errorSummary;
+
+        int completedItems = successfulItems + partialItems + failedItems;
+        if (completedItems < totalItems) {
+            // Another worker may still own RUNNING items. Never expose a
+            // premature SUCCESS state merely because this request claimed no
+            // additional work.
+            this.status = AnalysisStatus.RUNNING;
+            this.completedAt = null;
+            return;
+        }
+
         this.completedAt = now;
         if (failedItems == totalItems && totalItems > 0) {
             this.status = AnalysisStatus.FAILED;

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
@@ -3,7 +3,11 @@ package com.taxonomy.portfolio.repository;
 import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
 import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +19,25 @@ public interface RequirementAnalysisJobItemRepository extends JpaRepository<Requ
             String jobId, AnalysisStatus status);
 
     Optional<RequirementAnalysisJobItem> findByJobIdAndRequirementId(String jobId, Long requirementId);
+
+    /**
+     * Atomically claims one pending work item. The status predicate is the
+     * concurrency boundary: exactly one competing worker can change the row
+     * from PENDING to RUNNING and therefore start the external LLM call.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update RequirementAnalysisJobItem item
+               set item.status = :runningStatus,
+                   item.startedAt = :startedAt,
+                   item.completedAt = null,
+                   item.errorMessage = null,
+                   item.rowVersion = item.rowVersion + 1
+             where item.id = :itemId
+               and item.status = :pendingStatus
+            """)
+    int claimPending(@Param("itemId") Long itemId,
+                     @Param("pendingStatus") AnalysisStatus pendingStatus,
+                     @Param("runningStatus") AnalysisStatus runningStatus,
+                     @Param("startedAt") Instant startedAt);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
@@ -7,9 +7,11 @@ import com.taxonomy.portfolio.repository.RequirementAnalysisJobRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
-/** Materializes all data needed for one analysis outside the persistence transaction. */
+/** Materializes and atomically claims all data needed for one analysis outside the persistence transaction. */
 @Service
 public class PortfolioAnalysisWorkQueue {
 
@@ -32,14 +34,38 @@ public class PortfolioAnalysisWorkQueue {
         this.itemRepository = itemRepository;
     }
 
-    @Transactional(readOnly = true)
+    /**
+     * Claims pending items with compare-and-set semantics before returning their
+     * detached work payloads. Competing requests can observe the same candidate
+     * IDs, but only one request can update a given row from PENDING to RUNNING.
+     */
+    @Transactional
     public List<WorkItem> pending(String jobId, Long projectId) {
         jobRepository.findByIdAndProjectId(jobId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound("Analysis job not found: " + jobId));
-        return itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
-                        jobId, AnalysisStatus.PENDING).stream()
-                .map(this::toWorkItem)
+
+        List<Long> candidateIds = itemRepository
+                .findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(jobId, AnalysisStatus.PENDING)
+                .stream()
+                .map(RequirementAnalysisJobItem::getId)
                 .toList();
+        if (candidateIds.isEmpty()) {
+            return List.of();
+        }
+
+        Instant claimedAt = Instant.now();
+        List<WorkItem> claimed = new ArrayList<>(candidateIds.size());
+        for (Long itemId : candidateIds) {
+            int updated = itemRepository.claimPending(
+                    itemId, AnalysisStatus.PENDING, AnalysisStatus.RUNNING, claimedAt);
+            if (updated == 1) {
+                RequirementAnalysisJobItem item = itemRepository.findById(itemId)
+                        .orElseThrow(() -> PortfolioException.notFound(
+                                "Claimed analysis job item not found: " + itemId));
+                claimed.add(toWorkItem(item));
+            }
+        }
+        return List.copyOf(claimed);
     }
 
     private WorkItem toWorkItem(RequirementAnalysisJobItem item) {

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/SemanticDslOperationsFacade.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/SemanticDslOperationsFacade.java
@@ -58,13 +58,14 @@ public class SemanticDslOperationsFacade extends DslOperationsFacade {
         return outcome.commitId();
     }
 
+    /**
+     * Resolves the request-bound workspace and fails closed when provisioning or
+     * context lookup fails. A silent shared fallback would make a semantic merge
+     * cross the user's repository boundary.
+     */
     private WorkspaceContext resolveContext() {
-        try {
-            String username = workspaceResolver.resolveCurrentUsername();
-            repositoryStateService.ensureWorkspaceState(username);
-            return workspaceResolver.resolveCurrentContext();
-        } catch (RuntimeException exception) {
-            return WorkspaceContext.SHARED;
-        }
+        String username = workspaceResolver.resolveCurrentUsername();
+        repositoryStateService.ensureWorkspaceState(username);
+        return workspaceResolver.resolveCurrentContext();
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisWorkQueueClaimTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisWorkQueueClaimTest.java
@@ -34,7 +34,7 @@ class PortfolioAnalysisWorkQueueClaimTest {
     private PortfolioAnalysisWorkQueue workQueue;
 
     @Test
-    void pendingWorkItemCanBeClaimedOnlyOnce() {
+    void pendingWorkItemCanBeClaimedOnlyOnceWithoutPrematureJobCompletion() {
         String suffix = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
         WorkspaceContext context = new WorkspaceContext(
                 "claim-" + suffix.toLowerCase(), "ws-claim-" + suffix, "draft");
@@ -76,11 +76,14 @@ class PortfolioAnalysisWorkQueueClaimTest {
                 context);
 
         var firstClaim = workQueue.pending(job.id(), project.id());
+        var prematureCompletion = persistenceService.completeJob(job.id(), project.id());
         var secondClaim = workQueue.pending(job.id(), project.id());
 
         assertThat(firstClaim).singleElement()
                 .satisfies(item -> assertThat(item.requirementId()).isEqualTo(requirement.id()));
         assertThat(secondClaim).isEmpty();
+        assertThat(prematureCompletion.status()).isEqualTo(AnalysisStatus.RUNNING);
+        assertThat(prematureCompletion.completedAt()).isNull();
         assertThat(persistenceService.getJob(
                 job.id(), project.id(), context.username(), context).items())
                 .singleElement()

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisWorkQueueClaimTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisWorkQueueClaimTest.java
@@ -1,0 +1,89 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.service.PortfolioAnalysisPersistenceService;
+import com.taxonomy.portfolio.service.PortfolioAnalysisWorkQueue;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PortfolioAnalysisWorkQueueClaimTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private PortfolioAnalysisPersistenceService persistenceService;
+
+    @Autowired
+    private PortfolioAnalysisWorkQueue workQueue;
+
+    @Test
+    void pendingWorkItemCanBeClaimedOnlyOnce() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        WorkspaceContext context = new WorkspaceContext(
+                "claim-" + suffix.toLowerCase(), "ws-claim-" + suffix, "draft");
+        var project = projectService.createProject(
+                new CreateProjectRequest(
+                        "P-" + suffix,
+                        "Atomic claim project",
+                        null,
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                context.username(),
+                context);
+        var requirement = projectService.createRequirement(
+                project.id(),
+                new CreateRequirementRequest(
+                        "REQ-001",
+                        "Atomic claim requirement",
+                        "The requirement must be processed by exactly one worker.",
+                        RequirementStatus.APPROVED,
+                        50,
+                        Criticality.MEDIUM,
+                        RequirementType.FUNCTIONAL,
+                        ReviewStatus.CONFIRMED,
+                        context.username(),
+                        "Initial version",
+                        null),
+                context.username(),
+                context);
+        var job = persistenceService.createOrReuseJob(
+                project.id(),
+                List.of(requirement.id()),
+                "MOCK",
+                25,
+                "claim-" + suffix,
+                context.username(),
+                context);
+
+        var firstClaim = workQueue.pending(job.id(), project.id());
+        var secondClaim = workQueue.pending(job.id(), project.id());
+
+        assertThat(firstClaim).singleElement()
+                .satisfies(item -> assertThat(item.requirementId()).isEqualTo(requirement.id()));
+        assertThat(secondClaim).isEmpty();
+        assertThat(persistenceService.getJob(
+                job.id(), project.id(), context.username(), context).items())
+                .singleElement()
+                .satisfies(item -> assertThat(item.status()).isEqualTo(AnalysisStatus.RUNNING));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioGitControllerWorkspaceIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioGitControllerWorkspaceIsolationTest.java
@@ -1,0 +1,42 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.portfolio.controller.PortfolioGitController;
+import com.taxonomy.portfolio.service.PortfolioGitService;
+import com.taxonomy.versioning.service.RepositoryStateService;
+import com.taxonomy.versioning.service.SemanticGitMergeService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PortfolioGitControllerWorkspaceIsolationTest {
+
+    @Test
+    void doesNotFallBackToSharedRepositoryWhenWorkspaceProvisioningFails() {
+        PortfolioGitService portfolioGitService = mock(PortfolioGitService.class);
+        SemanticGitMergeService semanticGitMergeService = mock(SemanticGitMergeService.class);
+        DslGitRepositoryFactory repositoryFactory = mock(DslGitRepositoryFactory.class);
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+        RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
+        PortfolioGitController controller = new PortfolioGitController(
+                portfolioGitService,
+                semanticGitMergeService,
+                repositoryFactory,
+                workspaceResolver,
+                repositoryStateService);
+
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        doThrow(new IllegalStateException("workspace database unavailable"))
+                .when(repositoryStateService).ensureWorkspaceState("architect");
+
+        assertThatThrownBy(controller::exportPortfolio)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("workspace database unavailable");
+        verifyNoInteractions(portfolioGitService, semanticGitMergeService, repositoryFactory);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the first isolated fixes from QA blocker #549.

### Workspace isolation

- removes the silent `WorkspaceContext.SHARED` fallback from portfolio Git operations
- removes the same fallback from semantic DSL merges
- makes provisioning/context resolution fail closed before repository access
- adds a regression test proving no shared-repository dependency is invoked after provisioning failure

### Analysis concurrency

- adds an atomic compare-and-set claim for analysis items (`PENDING -> RUNNING`)
- increments the optimistic row version in the claim update
- returns work only to the request that successfully claimed the row
- prevents a second request from marking a job `SUCCESS` while claimed items are still `RUNNING`
- adds an integration test for one-time claiming and in-flight job state

## Why

Two simultaneous analysis requests could previously execute the same expensive LLM work and persist competing snapshots. A competing request could additionally complete the job prematurely after finding no remaining pending items. Separately, a transient workspace-resolution failure could redirect Git mutations to the shared repository. These behaviours violate the portfolio's isolation, cost-control and provenance contracts.

## Verification

The new tests cover:

- repeat claim returns no second work item
- claimed item is persisted as `RUNNING`
- an in-flight item keeps the parent job in `RUNNING`
- workspace provisioning failure propagates and does not touch portfolio/shared Git services

Part of #549. The database migration/Helm blocker, crash recovery and full UI/API test coverage remain deliberately separate follow-up work.