### PR TITLE
Tighten portfolio analysis claim transaction

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
@@ -25,7 +25,7 @@ public interface RequirementAnalysisJobItemRepository extends JpaRepository<Requ
      * concurrency boundary: exactly one competing worker can change the row
      * from PENDING to RUNNING and therefore start the external LLM call.
      */
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("""
             update RequirementAnalysisJobItem item
                set item.status = :runningStatus,

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
@@ -5,6 +5,7 @@ import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
 import com.taxonomy.portfolio.repository.RequirementAnalysisJobItemRepository;
 import com.taxonomy.portfolio.repository.RequirementAnalysisJobRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -12,9 +13,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Claims pending analysis items in a short persistence transaction and returns
- * self-contained work payloads. External LLM execution happens only after this
- * method has committed and therefore outside the claim transaction.
+ * Claims pending analysis items in a dedicated short persistence transaction
+ * and returns self-contained work payloads. External LLM execution starts only
+ * after this method's independent transaction has committed.
  */
 @Service
 public class PortfolioAnalysisWorkQueue {
@@ -40,10 +41,11 @@ public class PortfolioAnalysisWorkQueue {
 
     /**
      * Claims pending items with compare-and-set semantics and materializes their
-     * work payloads before the transaction ends. Competing requests can observe
-     * the same candidates, but only one can update a row from PENDING to RUNNING.
+     * work payloads before the dedicated transaction ends. Competing requests
+     * can observe the same candidates, but only one can update a row from
+     * PENDING to RUNNING.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<WorkItem> pending(String jobId, Long projectId) {
         jobRepository.findByIdAndProjectId(jobId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound("Analysis job not found: " + jobId));

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
@@ -11,7 +11,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Materializes and atomically claims all data needed for one analysis outside the persistence transaction. */
+/**
+ * Claims pending analysis items in a short persistence transaction and returns
+ * self-contained work payloads. External LLM execution happens only after this
+ * method has committed and therefore outside the claim transaction.
+ */
 @Service
 public class PortfolioAnalysisWorkQueue {
 
@@ -35,33 +39,27 @@ public class PortfolioAnalysisWorkQueue {
     }
 
     /**
-     * Claims pending items with compare-and-set semantics before returning their
-     * detached work payloads. Competing requests can observe the same candidate
-     * IDs, but only one request can update a given row from PENDING to RUNNING.
+     * Claims pending items with compare-and-set semantics and materializes their
+     * work payloads before the transaction ends. Competing requests can observe
+     * the same candidates, but only one can update a row from PENDING to RUNNING.
      */
     @Transactional
     public List<WorkItem> pending(String jobId, Long projectId) {
         jobRepository.findByIdAndProjectId(jobId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound("Analysis job not found: " + jobId));
 
-        List<Long> candidateIds = itemRepository
-                .findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(jobId, AnalysisStatus.PENDING)
-                .stream()
-                .map(RequirementAnalysisJobItem::getId)
-                .toList();
-        if (candidateIds.isEmpty()) {
+        List<RequirementAnalysisJobItem> candidates = itemRepository
+                .findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(jobId, AnalysisStatus.PENDING);
+        if (candidates.isEmpty()) {
             return List.of();
         }
 
         Instant claimedAt = Instant.now();
-        List<WorkItem> claimed = new ArrayList<>(candidateIds.size());
-        for (Long itemId : candidateIds) {
+        List<WorkItem> claimed = new ArrayList<>(candidates.size());
+        for (RequirementAnalysisJobItem item : candidates) {
             int updated = itemRepository.claimPending(
-                    itemId, AnalysisStatus.PENDING, AnalysisStatus.RUNNING, claimedAt);
+                    item.getId(), AnalysisStatus.PENDING, AnalysisStatus.RUNNING, claimedAt);
             if (updated == 1) {
-                RequirementAnalysisJobItem item = itemRepository.findById(itemId)
-                        .orElseThrow(() -> PortfolioException.notFound(
-                                "Claimed analysis job item not found: " + itemId));
                 claimed.add(toWorkItem(item));
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #550 and its review.

- removes the per-item `EntityManager` flush/clear caused by `@Modifying(clearAutomatically = true, flushAutomatically = true)`
- reuses the already loaded candidate entities instead of issuing one additional `findById` query per claimed item
- documents the actual boundary correctly: the database claim is transactional; the external LLM call runs after commit

The atomic `PENDING -> RUNNING` compare-and-set contract remains unchanged.

Part of #549.