### PR TITLE
Make all DSL workspace resolution fail closed

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.taxonomy.shared.config;
 
+import com.taxonomy.versioning.controller.DslWorkspacePreResolutionInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.LocaleResolver;
@@ -11,7 +12,8 @@ import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import java.util.Locale;
 
 /**
- * Web MVC configuration for internationalization (i18n).
+ * Web MVC configuration for internationalization and request-bound workspace
+ * isolation.
  *
  * <p>Locale resolution priority:
  * <ol>
@@ -23,6 +25,12 @@ import java.util.Locale;
  */
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final DslWorkspacePreResolutionInterceptor dslWorkspaceInterceptor;
+
+    public WebMvcConfig(DslWorkspacePreResolutionInterceptor dslWorkspaceInterceptor) {
+        this.dslWorkspaceInterceptor = dslWorkspaceInterceptor;
+    }
 
     @Bean
     public LocaleResolver localeResolver() {
@@ -41,5 +49,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(localeChangeInterceptor());
+        registry.addInterceptor(dslWorkspaceInterceptor)
+                .addPathPatterns(
+                        "/api/dsl/current",
+                        "/api/dsl/history",
+                        "/api/dsl/git/head",
+                        "/api/dsl/hypotheses/**");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
@@ -1,0 +1,45 @@
+package com.taxonomy.versioning.controller;
+
+import com.taxonomy.versioning.service.RepositoryStateService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Resolves the workspace before entering DSL endpoints that read or mutate
+ * repository- or hypothesis-scoped state.
+ *
+ * <p>Provisioning and context resolution failures propagate before controller
+ * code runs. Successful results are request-cached by the corresponding
+ * services, so repeated controller lookups cannot later switch to a shared
+ * context.</p>
+ */
+@Component
+public class DslWorkspacePreResolutionInterceptor implements HandlerInterceptor {
+
+    private final WorkspaceResolver workspaceResolver;
+    private final RepositoryStateService repositoryStateService;
+
+    public DslWorkspacePreResolutionInterceptor(WorkspaceResolver workspaceResolver,
+                                                RepositoryStateService repositoryStateService) {
+        this.workspaceResolver = workspaceResolver;
+        this.repositoryStateService = repositoryStateService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) {
+        String username = workspaceResolver.resolveCurrentUsername();
+        repositoryStateService.ensureWorkspaceState(username);
+        WorkspaceContext context = workspaceResolver.resolveCurrentContext();
+        if (WorkspaceContext.SHARED.equals(context)) {
+            throw new IllegalStateException(
+                    "Authenticated DSL operation did not resolve an isolated workspace");
+        }
+        return true;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/DslOperationsFacade.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/DslOperationsFacade.java
@@ -77,27 +77,17 @@ public class DslOperationsFacade {
     }
 
     /**
-     * Resolve the current workspace context from the authenticated user.
-     * Falls back to {@link WorkspaceContext#SHARED} if resolution fails.
+     * Resolves the request-bound workspace after eager provisioning.
      *
-     * <p>Eagerly provisions the workspace state via
-     * {@link RepositoryStateService} before resolving the context.
-     * Without this, the very first call in a request returns {@code SHARED}
-     * (no workspace yet), but a later call (after {@code getViewContext}
-     * triggers lazy workspace creation) returns a workspace-scoped context
-     * — causing two operations in the same flow to target different repos.
+     * <p>This deliberately fails closed. Falling back to the shared repository
+     * after a resolver, persistence or provisioning failure could make a read,
+     * commit, merge or index operation cross the authenticated user's workspace
+     * boundary.</p>
      */
     private WorkspaceContext resolveContext() {
-        try {
-            // Ensure workspace state is provisioned before resolving context,
-            // so that resolveCurrentContext() finds the workspace on the
-            // very first call (mirrors what getViewContext does internally).
-            String username = workspaceResolver.resolveCurrentUsername();
-            repositoryStateService.ensureWorkspaceState(username);
-            return workspaceResolver.resolveCurrentContext();
-        } catch (Exception e) {
-            return WorkspaceContext.SHARED;
-        }
+        String username = workspaceResolver.resolveCurrentUsername();
+        repositoryStateService.ensureWorkspaceState(username);
+        return workspaceResolver.resolveCurrentContext();
     }
 
     // ── Export ───────────────────────────────────────────────────────

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/RequestCachingRepositoryStateService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/RequestCachingRepositoryStateService.java
@@ -1,0 +1,47 @@
+package com.taxonomy.versioning.service;
+
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceManager;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * Request-aware repository state service that provisions a user's workspace at
+ * most once per HTTP request.
+ *
+ * <p>This prevents a controller from successfully provisioning a workspace and
+ * then repeating the same persistence operation later in the request. A failed
+ * first attempt still propagates and is never cached.</p>
+ */
+@Service
+@Primary
+public class RequestCachingRepositoryStateService extends RepositoryStateService {
+
+    private static final String PROVISIONED_ATTRIBUTE_PREFIX =
+            RequestCachingRepositoryStateService.class.getName() + ".provisioned.";
+
+    public RequestCachingRepositoryStateService(DslGitRepositoryFactory repositoryFactory,
+                                                WorkspaceManager workspaceManager,
+                                                SystemRepositoryService systemRepositoryService) {
+        super(repositoryFactory, workspaceManager, systemRepositoryService);
+    }
+
+    @Override
+    public void ensureWorkspaceState(String username) {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        String attribute = PROVISIONED_ATTRIBUTE_PREFIX + username;
+        if (attributes != null && Boolean.TRUE.equals(attributes.getAttribute(
+                attribute, RequestAttributes.SCOPE_REQUEST))) {
+            return;
+        }
+
+        super.ensureWorkspaceState(username);
+        if (attributes != null) {
+            attributes.setAttribute(
+                    attribute, Boolean.TRUE, RequestAttributes.SCOPE_REQUEST);
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
@@ -3,17 +3,22 @@ package com.taxonomy.workspace.service;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
- * Resolves the current workspace username from the Spring Security context.
+ * Resolves the current workspace username and request-bound workspace context.
  *
- * <p>Used by controllers and services to determine which user's workspace
- * to operate on without requiring explicit username parameters. Falls back
- * to {@link WorkspaceManager#DEFAULT_USER} when no authentication is present
- * (e.g. in tests or unauthenticated endpoints).
+ * <p>A successfully resolved context is cached for the lifetime of the HTTP
+ * request. All collaborators in one request therefore observe the same
+ * workspace even when the underlying persistence state changes or becomes
+ * temporarily unavailable later in the request.</p>
  */
 @Component
 public class WorkspaceResolver {
+
+    private static final String REQUEST_CONTEXT_ATTRIBUTE =
+            WorkspaceResolver.class.getName() + ".resolvedContext";
 
     private final WorkspaceContextResolver contextResolver;
 
@@ -24,7 +29,8 @@ public class WorkspaceResolver {
     /**
      * Resolve the current user's username from the security context.
      *
-     * @return the authenticated username, or "anonymous" if not authenticated
+     * @return the authenticated username, or the configured default user when
+     *         no authenticated principal exists
      */
     public String resolveCurrentUsername() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -36,11 +42,31 @@ public class WorkspaceResolver {
     }
 
     /**
-     * Resolve the full workspace context for the currently authenticated user.
+     * Resolve the full workspace context for the current request. Resolver
+     * failures propagate; this method never manufactures a shared fallback.
      *
-     * @return the active workspace context (never {@code null})
+     * @return the stable active workspace context for this request
      */
     public WorkspaceContext resolveCurrentContext() {
-        return contextResolver.resolveCurrentContext();
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            Object cached = attributes.getAttribute(
+                    REQUEST_CONTEXT_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+            if (cached instanceof WorkspaceContext context) {
+                return context;
+            }
+        }
+
+        WorkspaceContext resolved = contextResolver.resolveCurrentContext();
+        if (resolved == null) {
+            throw new IllegalStateException("Workspace context resolver returned null");
+        }
+        if (attributes != null) {
+            attributes.setAttribute(
+                    REQUEST_CONTEXT_ATTRIBUTE,
+                    resolved,
+                    RequestAttributes.SCOPE_REQUEST);
+        }
+        return resolved;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/DslOperationsFacadeWorkspaceIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/DslOperationsFacadeWorkspaceIsolationTest.java
@@ -1,0 +1,52 @@
+package com.taxonomy.versioning.service;
+
+import com.taxonomy.architecture.repository.ArchitectureDslDocumentRepository;
+import com.taxonomy.architecture.service.CommitIndexService;
+import com.taxonomy.dsl.export.DslMaterializeService;
+import com.taxonomy.dsl.export.TaxDslExportService;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.workspace.service.RepositoryStateGuard;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DslOperationsFacadeWorkspaceIsolationTest {
+
+    @Test
+    void doesNotFallBackToSharedRepositoryWhenWorkspaceProvisioningFails() {
+        TaxDslExportService exportService = mock(TaxDslExportService.class);
+        DslMaterializeService materializeService = mock(DslMaterializeService.class);
+        ArchitectureDslDocumentRepository documentRepository = mock(ArchitectureDslDocumentRepository.class);
+        DslGitRepositoryFactory repositoryFactory = mock(DslGitRepositoryFactory.class);
+        CommitIndexService commitIndexService = mock(CommitIndexService.class);
+        ConflictDetectionService conflictDetectionService = mock(ConflictDetectionService.class);
+        RepositoryStateGuard stateGuard = mock(RepositoryStateGuard.class);
+        RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+
+        DslOperationsFacade facade = new DslOperationsFacade(
+                exportService,
+                materializeService,
+                documentRepository,
+                repositoryFactory,
+                commitIndexService,
+                conflictDetectionService,
+                stateGuard,
+                repositoryStateService,
+                workspaceResolver);
+
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        doThrow(new IllegalStateException("workspace database unavailable"))
+                .when(repositoryStateService).ensureWorkspaceState("architect");
+
+        assertThatThrownBy(() -> facade.getDslHistory("draft"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("workspace database unavailable");
+        verifyNoInteractions(repositoryFactory);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
@@ -1,0 +1,98 @@
+package com.taxonomy.versioning.service;
+
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.versioning.controller.DslWorkspacePreResolutionInterceptor;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceContextResolver;
+import com.taxonomy.workspace.service.WorkspaceManager;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class WorkspaceRequestIsolationTest {
+
+    @AfterEach
+    void clearRequest() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void workspaceContextIsResolvedOnlyOncePerRequest() {
+        WorkspaceContextResolver contextResolver = mock(WorkspaceContextResolver.class);
+        WorkspaceContext expected = new WorkspaceContext("architect", "workspace-1", "draft");
+        when(contextResolver.resolveCurrentContext()).thenReturn(expected);
+        WorkspaceResolver resolver = new WorkspaceResolver(contextResolver);
+        bindRequest();
+
+        assertThat(resolver.resolveCurrentContext()).isSameAs(expected);
+        assertThat(resolver.resolveCurrentContext()).isSameAs(expected);
+        verify(contextResolver, times(1)).resolveCurrentContext();
+    }
+
+    @Test
+    void successfulProvisioningIsRepeatedAtMostOncePerRequest() {
+        DslGitRepositoryFactory repositoryFactory = mock(DslGitRepositoryFactory.class);
+        WorkspaceManager workspaceManager = mock(WorkspaceManager.class);
+        SystemRepositoryService systemRepositoryService = mock(SystemRepositoryService.class);
+        RequestCachingRepositoryStateService service = new RequestCachingRepositoryStateService(
+                repositoryFactory, workspaceManager, systemRepositoryService);
+        bindRequest();
+
+        service.ensureWorkspaceState("architect");
+        service.ensureWorkspaceState("architect");
+
+        verify(workspaceManager, times(1)).getOrCreateWorkspace("architect");
+        verifyNoInteractions(repositoryFactory, systemRepositoryService);
+    }
+
+    @Test
+    void failedPreResolutionStopsDslRequestBeforeControllerExecution() {
+        WorkspaceResolver resolver = mock(WorkspaceResolver.class);
+        RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
+        DslWorkspacePreResolutionInterceptor interceptor =
+                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService);
+        when(resolver.resolveCurrentUsername()).thenReturn("architect");
+        doThrow(new IllegalStateException("workspace database unavailable"))
+                .when(repositoryStateService).ensureWorkspaceState("architect");
+
+        assertThatThrownBy(() -> interceptor.preHandle(
+                new MockHttpServletRequest(), new MockHttpServletResponse(), new Object()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("workspace database unavailable");
+        verify(resolver, times(0)).resolveCurrentContext();
+    }
+
+    @Test
+    void sharedFallbackIsRejectedAtDslRequestBoundary() {
+        WorkspaceResolver resolver = mock(WorkspaceResolver.class);
+        RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
+        DslWorkspacePreResolutionInterceptor interceptor =
+                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService);
+        when(resolver.resolveCurrentUsername()).thenReturn("architect");
+        when(resolver.resolveCurrentContext()).thenReturn(WorkspaceContext.SHARED);
+
+        assertThatThrownBy(() -> interceptor.preHandle(
+                new MockHttpServletRequest(), new MockHttpServletResponse(), new Object()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("did not resolve an isolated workspace");
+    }
+
+    private static void bindRequest() {
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(new MockHttpServletRequest()));
+    }
+}


### PR DESCRIPTION
## Summary

Makes request-bound DSL and hypothesis operations fail closed instead of falling back to `WorkspaceContext.SHARED`.

### Service operations

- removes the generic shared fallback from `DslOperationsFacade`
- provisioning or context-resolution errors propagate before repository access

### Controller operations

- pre-resolves an isolated workspace before the affected `/api/dsl/current`, history, Git-head and hypothesis endpoints enter controller code
- rejects a resolved `WorkspaceContext.SHARED`
- caches successful provisioning and context resolution for the HTTP request, so repeated controller lookups cannot fail later or switch repositories

### Verification

Regression tests prove:

- provisioning failure never resolves a repository
- controller execution is blocked before workspace-scoped operations on failure
- a Shared result is rejected
- provisioning occurs at most once per request
- all collaborators in one request observe the same resolved context

This closes the workspace-isolation P0 finding from #549 for the known DSL/portfolio HTTP and service paths.