### PR TITLE
Bound portfolio workloads and recover expired analysis claims

### DIFF
--- a/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -1,0 +1,18 @@
+# Betriebsgrenzen und Wiederanlauf des Projektportfolios
+
+Das Projektportfolio prüft serverseitige Grenzen, bevor Daten gespeichert oder kostenintensive Analysen gestartet werden.
+
+| Eigenschaft | Umgebungsvariable | Standard | Zweck |
+|---|---|---:|---|
+| `taxonomy.portfolio.max-analysis-batch` | `TAXONOMY_PORTFOLIO_MAX_ANALYSIS_BATCH` | `100` | Höchstzahl der Anforderungen in einem Analysejob |
+| `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Höchstzahl importierter Anforderungskandidaten pro Anfrage |
+| `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximale Gesamtzahl der Zeichen aus Anforderungs- und Originalquelltexten |
+| `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Alter, ab dem ein `RUNNING`-Eintrag wiederaufgenommen werden darf |
+
+Ein Analyseeintrag wird atomar in einer eigenen kurzen Transaktion von `PENDING` nach `RUNNING` übernommen. Der externe LLM-Aufruf beginnt erst nach dem Commit dieser Transaktion.
+
+Eine Wiederholung setzt fehlgeschlagene Einträge sowie ausschließlich solche laufenden Einträge zurück, deren Übernahme älter als das konfigurierte Timeout ist. Auch das Zurücksetzen verwendet status- und zeitgestützte Compare-and-set-Updates. Zwei parallele Wiederholungsanfragen können deshalb denselben Eintrag weder doppelt übernehmen noch dessen Versuchszähler doppelt erhöhen.
+
+Ein zu niedriges Timeout kann Arbeit duplizieren, wenn ein Provider legitimerweise länger benötigt. Es sollte oberhalb der längsten erwarteten Providerlaufzeit einschließlich deterministischer Nachverarbeitung liegen. Aktive Worker werden durch eine Wiederholungsanfrage nicht unterbrochen.
+
+Zu große Analyse- oder Importanfragen werden abgelehnt, bevor ein Analysejob oder importierte Anforderungen gespeichert werden. Die Anwendungslimits sollten durch Größenlimits am Ingress, Provider-Rate-Limits und reguläre Datenbanksicherungen ergänzt werden.

--- a/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -1,0 +1,18 @@
+# Project portfolio operational limits and recovery
+
+The project portfolio applies explicit server-side limits before persisting or starting expensive work.
+
+| Property | Environment variable | Default | Purpose |
+|---|---|---:|---|
+| `taxonomy.portfolio.max-analysis-batch` | `TAXONOMY_PORTFOLIO_MAX_ANALYSIS_BATCH` | `100` | Maximum requirements accepted by one analysis job |
+| `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Maximum requirement candidates accepted by one import request |
+| `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximum combined requirement and original-source characters in one import |
+| `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Age after which a `RUNNING` item can be recovered |
+
+An analysis item is claimed atomically from `PENDING` to `RUNNING` in a dedicated short transaction. The external LLM request starts only after that transaction commits.
+
+Retry requests reset failed items and only those running items whose claim is older than the configured timeout. The reset itself uses status- and timestamp-guarded compare-and-set updates, so concurrent retry requests cannot recover the same item twice or increment its attempt counter twice.
+
+A low timeout can duplicate work when a provider legitimately needs longer than the timeout. Set it above the longest expected provider call plus deterministic post-processing time. Active workers are not interrupted by a retry request.
+
+Oversized analysis or import requests fail before an analysis job or imported requirement is persisted. Operators should combine these limits with ingress request-body limits, provider rate limits and normal database backups.

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectPortfolioController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectPortfolioController.java
@@ -4,6 +4,7 @@ import com.taxonomy.portfolio.dto.PortfolioDtos.AnalyzeProjectRequest;
 import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
 import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
 import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementVersionRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.ImportRequirementCandidate;
 import com.taxonomy.portfolio.dto.PortfolioDtos.ImportRequirementsRequest;
 import com.taxonomy.portfolio.dto.PortfolioDtos.ImportRequirementsResult;
 import com.taxonomy.portfolio.dto.PortfolioDtos.ProjectView;
@@ -11,12 +12,14 @@ import com.taxonomy.portfolio.dto.PortfolioDtos.RequirementVersionView;
 import com.taxonomy.portfolio.dto.PortfolioDtos.RequirementView;
 import com.taxonomy.portfolio.dto.PortfolioDtos.UpdateProjectRequest;
 import com.taxonomy.portfolio.dto.PortfolioDtos.UpdateRequirementRequest;
+import com.taxonomy.portfolio.service.PortfolioException;
 import com.taxonomy.portfolio.service.ProjectPortfolioService;
 import com.taxonomy.portfolio.service.ProjectRequirementAnalysisService;
 import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -38,13 +41,21 @@ public class ProjectPortfolioController {
     private final ProjectPortfolioService projectService;
     private final ProjectRequirementAnalysisService analysisService;
     private final WorkspaceResolver workspaceResolver;
+    private final int maximumImportRequirements;
+    private final long maximumImportCharacters;
 
     public ProjectPortfolioController(ProjectPortfolioService projectService,
                                       ProjectRequirementAnalysisService analysisService,
-                                      WorkspaceResolver workspaceResolver) {
+                                      WorkspaceResolver workspaceResolver,
+                                      @Value("${taxonomy.portfolio.max-import-requirements:100}")
+                                      int maximumImportRequirements,
+                                      @Value("${taxonomy.portfolio.max-import-characters:500000}")
+                                      long maximumImportCharacters) {
         this.projectService = projectService;
         this.analysisService = analysisService;
         this.workspaceResolver = workspaceResolver;
+        this.maximumImportRequirements = Math.max(1, maximumImportRequirements);
+        this.maximumImportCharacters = Math.max(1L, maximumImportCharacters);
     }
 
     @PostMapping
@@ -95,6 +106,7 @@ public class ProjectPortfolioController {
     public ResponseEntity<ImportRequirementsResult> importRequirements(
             @PathVariable Long projectId,
             @RequestBody ImportRequirementsRequest request) {
+        validateImportRequest(request);
         RequestScope scope = scope();
         List<RequirementView> requirements = projectService.importRequirements(
                 projectId, request.requirements(), scope.username(), scope.context());
@@ -162,6 +174,34 @@ public class ProjectPortfolioController {
         RequestScope scope = scope();
         return projectService.listRequirementVersions(
                 projectId, requirementId, scope.username(), scope.context());
+    }
+
+    private void validateImportRequest(ImportRequirementsRequest request) {
+        if (request == null || request.requirements() == null || request.requirements().isEmpty()) {
+            throw PortfolioException.validation("At least one requirement candidate is required");
+        }
+        if (request.requirements().size() > maximumImportRequirements) {
+            throw PortfolioException.validation(
+                    "Import contains " + request.requirements().size()
+                            + " candidates; maximum is " + maximumImportRequirements);
+        }
+
+        long characters = 0L;
+        for (ImportRequirementCandidate candidate : request.requirements()) {
+            if (candidate == null) continue;
+            characters += length(candidate.text());
+            if (candidate.source() != null) {
+                characters += length(candidate.source().originalText());
+            }
+            if (characters > maximumImportCharacters) {
+                throw PortfolioException.validation(
+                        "Import text payload exceeds " + maximumImportCharacters + " characters");
+            }
+        }
+    }
+
+    private static int length(String value) {
+        return value != null ? value.length() : 0;
     }
 
     private RequestScope scope() {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
@@ -25,7 +25,7 @@ public interface RequirementAnalysisJobItemRepository extends JpaRepository<Requ
      * concurrency boundary: exactly one competing worker can change the row
      * from PENDING to RUNNING and therefore start the external LLM call.
      */
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query("""
             update RequirementAnalysisJobItem item
                set item.status = :runningStatus,

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
@@ -18,6 +18,10 @@ public interface RequirementAnalysisJobItemRepository extends JpaRepository<Requ
     List<RequirementAnalysisJobItem> findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
             String jobId, AnalysisStatus status);
 
+    List<RequirementAnalysisJobItem>
+            findByJobIdAndStatusAndStartedAtBeforeOrderByRequirementRequirementKeyAsc(
+                    String jobId, AnalysisStatus status, Instant startedBefore);
+
     Optional<RequirementAnalysisJobItem> findByJobIdAndRequirementId(String jobId, Long requirementId);
 
     /**

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/RequirementAnalysisJobItemRepository.java
@@ -1,6 +1,7 @@
 package com.taxonomy.portfolio.repository;
 
 import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.model.ProjectRequirementVersion;
 import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -44,4 +45,49 @@ public interface RequirementAnalysisJobItemRepository extends JpaRepository<Requ
                      @Param("pendingStatus") AnalysisStatus pendingStatus,
                      @Param("runningStatus") AnalysisStatus runningStatus,
                      @Param("startedAt") Instant startedAt);
+
+    /** Atomically prepares one failed item for another attempt. */
+    @Modifying
+    @Query("""
+            update RequirementAnalysisJobItem item
+               set item.requirementVersion = :requirementVersion,
+                   item.status = :pendingStatus,
+                   item.snapshotId = null,
+                   item.errorMessage = null,
+                   item.startedAt = null,
+                   item.completedAt = null,
+                   item.attempt = item.attempt + 1,
+                   item.rowVersion = item.rowVersion + 1
+             where item.id = :itemId
+               and item.status = :failedStatus
+            """)
+    int resetFailed(@Param("itemId") Long itemId,
+                    @Param("failedStatus") AnalysisStatus failedStatus,
+                    @Param("pendingStatus") AnalysisStatus pendingStatus,
+                    @Param("requirementVersion") ProjectRequirementVersion requirementVersion);
+
+    /**
+     * Atomically recovers a RUNNING item only when its claim is still expired at
+     * update time. Competing retry requests therefore cannot reset it twice.
+     */
+    @Modifying
+    @Query("""
+            update RequirementAnalysisJobItem item
+               set item.requirementVersion = :requirementVersion,
+                   item.status = :pendingStatus,
+                   item.snapshotId = null,
+                   item.errorMessage = null,
+                   item.startedAt = null,
+                   item.completedAt = null,
+                   item.attempt = item.attempt + 1,
+                   item.rowVersion = item.rowVersion + 1
+             where item.id = :itemId
+               and item.status = :runningStatus
+               and item.startedAt < :staleBefore
+            """)
+    int resetExpiredRunning(@Param("itemId") Long itemId,
+                            @Param("runningStatus") AnalysisStatus runningStatus,
+                            @Param("pendingStatus") AnalysisStatus pendingStatus,
+                            @Param("staleBefore") Instant staleBefore,
+                            @Param("requirementVersion") ProjectRequirementVersion requirementVersion);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
@@ -1,0 +1,75 @@
+package com.taxonomy.portfolio.service;
+
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.model.RequirementAnalysisJob;
+import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
+import com.taxonomy.portfolio.repository.RequirementAnalysisJobItemRepository;
+import com.taxonomy.portfolio.repository.RequirementAnalysisJobRepository;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Recovers failed items and expired worker claims without duplicating active work. */
+@Service
+public class PortfolioAnalysisRecoveryService {
+
+    private final RequirementAnalysisJobRepository jobRepository;
+    private final RequirementAnalysisJobItemRepository itemRepository;
+    private final ProjectPortfolioService projectService;
+
+    public PortfolioAnalysisRecoveryService(RequirementAnalysisJobRepository jobRepository,
+                                            RequirementAnalysisJobItemRepository itemRepository,
+                                            ProjectPortfolioService projectService) {
+        this.jobRepository = jobRepository;
+        this.itemRepository = itemRepository;
+        this.projectService = projectService;
+    }
+
+    /**
+     * Resets failed items and RUNNING items whose claim is older than the supplied
+     * cutoff. Active claims remain untouched. Every reset increments the attempt
+     * and binds the retry to the requirement's current immutable text version.
+     *
+     * @return number of items prepared for another attempt
+     */
+    @Transactional
+    public int prepareRetryableItems(String jobId,
+                                     Long projectId,
+                                     String username,
+                                     WorkspaceContext context,
+                                     Instant staleBefore) {
+        if (staleBefore == null) {
+            throw PortfolioException.validation("staleBefore is required");
+        }
+        projectService.requireProject(projectId, username, context);
+        RequirementAnalysisJob job = jobRepository.findByIdAndProjectId(jobId, projectId)
+                .orElseThrow(() -> PortfolioException.notFound(
+                        "Analysis job not found: " + jobId));
+
+        List<RequirementAnalysisJobItem> failed =
+                itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
+                        jobId, AnalysisStatus.FAILED);
+        List<RequirementAnalysisJobItem> stale = itemRepository
+                .findByJobIdAndStatusAndStartedAtBeforeOrderByRequirementRequirementKeyAsc(
+                        jobId, AnalysisStatus.RUNNING, staleBefore);
+
+        Map<Long, RequirementAnalysisJobItem> retryable = new LinkedHashMap<>();
+        failed.forEach(item -> retryable.put(item.getId(), item));
+        stale.forEach(item -> retryable.put(item.getId(), item));
+        if (retryable.isEmpty()) {
+            throw PortfolioException.conflict(
+                    "Analysis job has no failed or expired running items to retry: " + jobId);
+        }
+
+        for (RequirementAnalysisJobItem item : retryable.values()) {
+            item.prepareRetry(projectService.currentVersion(item.getRequirement()));
+        }
+        job.markRunning(Instant.now());
+        return retryable.size();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
@@ -1,6 +1,7 @@
 package com.taxonomy.portfolio.service;
 
 import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.model.ProjectRequirementVersion;
 import com.taxonomy.portfolio.model.RequirementAnalysisJob;
 import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
 import com.taxonomy.portfolio.repository.RequirementAnalysisJobItemRepository;
@@ -10,9 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /** Recovers failed items and expired worker claims without duplicating active work. */
 @Service
@@ -32,10 +31,11 @@ public class PortfolioAnalysisRecoveryService {
 
     /**
      * Resets failed items and RUNNING items whose claim is older than the supplied
-     * cutoff. Active claims remain untouched. Every reset increments the attempt
-     * and binds the retry to the requirement's current immutable text version.
+     * cutoff. Active claims remain untouched. Every successful compare-and-set
+     * increments the attempt and binds the retry to the requirement's current
+     * immutable text version.
      *
-     * @return number of items prepared for another attempt
+     * @return number of items atomically prepared for another attempt
      */
     @Transactional
     public int prepareRetryableItems(String jobId,
@@ -58,18 +58,32 @@ public class PortfolioAnalysisRecoveryService {
                 .findByJobIdAndStatusAndStartedAtBeforeOrderByRequirementRequirementKeyAsc(
                         jobId, AnalysisStatus.RUNNING, staleBefore);
 
-        Map<Long, RequirementAnalysisJobItem> retryable = new LinkedHashMap<>();
-        failed.forEach(item -> retryable.put(item.getId(), item));
-        stale.forEach(item -> retryable.put(item.getId(), item));
-        if (retryable.isEmpty()) {
+        int prepared = 0;
+        for (RequirementAnalysisJobItem item : failed) {
+            ProjectRequirementVersion version =
+                    projectService.currentVersion(item.getRequirement());
+            prepared += itemRepository.resetFailed(
+                    item.getId(),
+                    AnalysisStatus.FAILED,
+                    AnalysisStatus.PENDING,
+                    version);
+        }
+        for (RequirementAnalysisJobItem item : stale) {
+            ProjectRequirementVersion version =
+                    projectService.currentVersion(item.getRequirement());
+            prepared += itemRepository.resetExpiredRunning(
+                    item.getId(),
+                    AnalysisStatus.RUNNING,
+                    AnalysisStatus.PENDING,
+                    staleBefore,
+                    version);
+        }
+
+        if (prepared == 0) {
             throw PortfolioException.conflict(
                     "Analysis job has no failed or expired running items to retry: " + jobId);
         }
-
-        for (RequirementAnalysisJobItem item : retryable.values()) {
-            item.prepareRetry(projectService.currentVersion(item.getRequirement()));
-        }
         job.markRunning(Instant.now());
-        return retryable.size();
+        return prepared;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
@@ -5,6 +5,7 @@ import com.taxonomy.portfolio.model.RequirementAnalysisJobItem;
 import com.taxonomy.portfolio.repository.RequirementAnalysisJobItemRepository;
 import com.taxonomy.portfolio.repository.RequirementAnalysisJobRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -12,9 +13,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Claims pending analysis items in a short persistence transaction and returns
- * self-contained work payloads. External LLM execution happens only after this
- * method has committed and therefore outside the claim transaction.
+ * Claims pending analysis items in a dedicated short persistence transaction
+ * and returns self-contained work payloads. External LLM execution starts only
+ * after this method's independent transaction has committed.
  */
 @Service
 public class PortfolioAnalysisWorkQueue {
@@ -40,10 +41,11 @@ public class PortfolioAnalysisWorkQueue {
 
     /**
      * Claims pending items with compare-and-set semantics and materializes their
-     * work payloads before the transaction ends. Competing requests can observe
-     * the same candidates, but only one can update a row from PENDING to RUNNING.
+     * work payloads before the dedicated transaction ends. Competing requests
+     * can observe the same candidates, but only one can update a row from
+     * PENDING to RUNNING.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public List<WorkItem> pending(String jobId, Long projectId) {
         jobRepository.findByIdAndProjectId(jobId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound("Analysis job not found: " + jobId));

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisWorkQueue.java
@@ -11,7 +11,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Materializes and atomically claims all data needed for one analysis outside the persistence transaction. */
+/**
+ * Claims pending analysis items in a short persistence transaction and returns
+ * self-contained work payloads. External LLM execution happens only after this
+ * method has committed and therefore outside the claim transaction.
+ */
 @Service
 public class PortfolioAnalysisWorkQueue {
 
@@ -35,33 +39,27 @@ public class PortfolioAnalysisWorkQueue {
     }
 
     /**
-     * Claims pending items with compare-and-set semantics before returning their
-     * detached work payloads. Competing requests can observe the same candidate
-     * IDs, but only one request can update a given row from PENDING to RUNNING.
+     * Claims pending items with compare-and-set semantics and materializes their
+     * work payloads before the transaction ends. Competing requests can observe
+     * the same candidates, but only one can update a row from PENDING to RUNNING.
      */
     @Transactional
     public List<WorkItem> pending(String jobId, Long projectId) {
         jobRepository.findByIdAndProjectId(jobId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound("Analysis job not found: " + jobId));
 
-        List<Long> candidateIds = itemRepository
-                .findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(jobId, AnalysisStatus.PENDING)
-                .stream()
-                .map(RequirementAnalysisJobItem::getId)
-                .toList();
-        if (candidateIds.isEmpty()) {
+        List<RequirementAnalysisJobItem> candidates = itemRepository
+                .findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(jobId, AnalysisStatus.PENDING);
+        if (candidates.isEmpty()) {
             return List.of();
         }
 
         Instant claimedAt = Instant.now();
-        List<WorkItem> claimed = new ArrayList<>(candidateIds.size());
-        for (Long itemId : candidateIds) {
+        List<WorkItem> claimed = new ArrayList<>(candidates.size());
+        for (RequirementAnalysisJobItem item : candidates) {
             int updated = itemRepository.claimPending(
-                    itemId, AnalysisStatus.PENDING, AnalysisStatus.RUNNING, claimedAt);
+                    item.getId(), AnalysisStatus.PENDING, AnalysisStatus.RUNNING, claimedAt);
             if (updated == 1) {
-                RequirementAnalysisJobItem item = itemRepository.findById(itemId)
-                        .orElseThrow(() -> PortfolioException.notFound(
-                                "Claimed analysis job item not found: " + itemId));
                 claimed.add(toWorkItem(item));
             }
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectRequirementAnalysisService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectRequirementAnalysisService.java
@@ -21,6 +21,7 @@ import com.taxonomy.workspace.service.WorkspaceContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -36,6 +37,7 @@ public class ProjectRequirementAnalysisService {
     private final ProjectPortfolioService projectService;
     private final PortfolioAnalysisPersistenceService persistenceService;
     private final PortfolioAnalysisWorkQueue workQueue;
+    private final PortfolioAnalysisRecoveryService recoveryService;
     private final AnalyzeRequirementUseCase analyzeRequirementUseCase;
     private final ArchitectureGapService gapService;
     private final ArchitecturePatternService patternService;
@@ -43,10 +45,13 @@ public class ProjectRequirementAnalysisService {
     private final PortfolioFingerprintService fingerprintService;
     private final LlmService llmService;
     private final int maximumArchitectureNodes;
+    private final int maximumBatchRequirements;
+    private final long claimTimeoutSeconds;
 
     public ProjectRequirementAnalysisService(ProjectPortfolioService projectService,
                                              PortfolioAnalysisPersistenceService persistenceService,
                                              PortfolioAnalysisWorkQueue workQueue,
+                                             PortfolioAnalysisRecoveryService recoveryService,
                                              AnalyzeRequirementUseCase analyzeRequirementUseCase,
                                              ArchitectureGapService gapService,
                                              ArchitecturePatternService patternService,
@@ -54,10 +59,15 @@ public class ProjectRequirementAnalysisService {
                                              PortfolioFingerprintService fingerprintService,
                                              LlmService llmService,
                                              @Value("${taxonomy.limits.max-architecture-nodes:100}")
-                                             int maximumArchitectureNodes) {
+                                             int maximumArchitectureNodes,
+                                             @Value("${taxonomy.portfolio.max-analysis-batch:100}")
+                                             int maximumBatchRequirements,
+                                             @Value("${taxonomy.portfolio.analysis-claim-timeout-seconds:900}")
+                                             long claimTimeoutSeconds) {
         this.projectService = projectService;
         this.persistenceService = persistenceService;
         this.workQueue = workQueue;
+        this.recoveryService = recoveryService;
         this.analyzeRequirementUseCase = analyzeRequirementUseCase;
         this.gapService = gapService;
         this.patternService = patternService;
@@ -65,6 +75,8 @@ public class ProjectRequirementAnalysisService {
         this.fingerprintService = fingerprintService;
         this.llmService = llmService;
         this.maximumArchitectureNodes = Math.max(1, maximumArchitectureNodes);
+        this.maximumBatchRequirements = Math.max(1, maximumBatchRequirements);
+        this.claimTimeoutSeconds = Math.max(60L, claimTimeoutSeconds);
     }
 
     public AnalysisJobView analyzeProject(Long projectId,
@@ -108,7 +120,12 @@ public class ProjectRequirementAnalysisService {
                                        Long projectId,
                                        String username,
                                        WorkspaceContext context) {
-        persistenceService.prepareFailedItemsForRetry(jobId, projectId, username, context);
+        recoveryService.prepareRetryableItems(
+                jobId,
+                projectId,
+                username,
+                context,
+                Instant.now().minusSeconds(claimTimeoutSeconds));
         return executePendingItems(jobId, projectId, username, context);
     }
 
@@ -161,7 +178,6 @@ public class ProjectRequirementAnalysisService {
                 ? job.provider() : llmService.getActiveProviderName();
 
         for (PortfolioAnalysisWorkQueue.WorkItem workItem : workQueue.pending(jobId, projectId)) {
-            persistenceService.markItemRunning(workItem.itemId());
             String snapshotId = UUID.randomUUID().toString();
             String analysisSessionId = "portfolio:" + snapshotId;
             long startedAt = System.nanoTime();
@@ -258,12 +274,28 @@ public class ProjectRequirementAnalysisService {
                     .map(requirement -> requirement.id())
                     .toList();
             if (ids.isEmpty()) throw PortfolioException.validation("Project has no requirements to analyze");
-            return ids;
+            return requireAllowedBatch(ids);
         }
         if (request.requirementIds() == null || request.requirementIds().isEmpty()) {
             throw PortfolioException.validation("requirementIds must be supplied unless all=true");
         }
-        return request.requirementIds().stream().filter(java.util.Objects::nonNull).distinct().toList();
+        List<Long> ids = request.requirementIds().stream()
+                .filter(java.util.Objects::nonNull)
+                .distinct()
+                .toList();
+        if (ids.isEmpty()) {
+            throw PortfolioException.validation("At least one valid requirementId is required");
+        }
+        return requireAllowedBatch(ids);
+    }
+
+    private List<Long> requireAllowedBatch(List<Long> requirementIds) {
+        if (requirementIds.size() > maximumBatchRequirements) {
+            throw PortfolioException.validation(
+                    "Analysis batch contains " + requirementIds.size()
+                            + " requirements; maximum is " + maximumBatchRequirements);
+        }
+        return requirementIds;
     }
 
     private int normalizeMaxNodes(Integer requested) {

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
@@ -62,6 +62,7 @@ public class HelpController {
         new String[]{"EXAMPLES",                  "📝", "help.toc.EXAMPLES",                      "help.audience.everyone"},
         new String[]{"PROJECT_REQUIREMENT_PORTFOLIO", "🧭", "help.toc.PROJECT_REQUIREMENT_PORTFOLIO", "help.audience.everyone"},
         new String[]{"PROJECT_PORTFOLIO_GIT_COLLABORATION", "🤝", "help.toc.PROJECT_PORTFOLIO_GIT_COLLABORATION", "help.audience.developers"},
+        new String[]{"PROJECT_PORTFOLIO_OPERATIONS", "🛠️", "help.toc.PROJECT_PORTFOLIO_OPERATIONS", "help.audience.devops"},
         new String[]{"FRAMEWORK_IMPORT",          "📥", "help.toc.FRAMEWORK_IMPORT",              "help.audience.everyone"},
         new String[]{"GIT_INTEGRATION",           "🔀", "help.toc.GIT_INTEGRATION",               "help.audience.developers"},
         new String[]{"JGIT_STORAGE_HIBERNATE",    "🗃️", "help.toc.JGIT_STORAGE_HIBERNATE",        "help.audience.devops"},

--- a/taxonomy-app/src/main/resources/i18n/messages_portfolio.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_portfolio.properties
@@ -1,2 +1,3 @@
 help.toc.PROJECT_REQUIREMENT_PORTFOLIO=Project Requirement, Solution and Product Portfolio
 help.toc.PROJECT_PORTFOLIO_GIT_COLLABORATION=Collaborative Project Portfolios through Git
+help.toc.PROJECT_PORTFOLIO_OPERATIONS=Project Portfolio Operations and Recovery

--- a/taxonomy-app/src/main/resources/i18n/messages_portfolio_de.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_portfolio_de.properties
@@ -1,2 +1,3 @@
 help.toc.PROJECT_REQUIREMENT_PORTFOLIO=Projektanforderungs-, Lösungs- und Produktportfolio
 help.toc.PROJECT_PORTFOLIO_GIT_COLLABORATION=Gemeinsames Projektportfolio über Git
+help.toc.PROJECT_PORTFOLIO_OPERATIONS=Betrieb und Wiederanlauf des Projektportfolios

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisRecoveryAndLimitsTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisRecoveryAndLimitsTest.java
@@ -65,7 +65,7 @@ class PortfolioAnalysisRecoveryAndLimitsTest {
     }
 
     @Test
-    void recoversOnlyExpiredRunningClaimsAndIncrementsAttempt() {
+    void recoversExpiredClaimExactlyOnceAndIncrementsAttemptOnce() {
         WorkspaceContext context = context("claim-recovery");
         var project = createProject(context);
         var requirement = createRequirement(project.id(), context, "REQ-001");
@@ -96,6 +96,14 @@ class PortfolioAnalysisRecoveryAndLimitsTest {
                 Instant.now().plusSeconds(1));
 
         assertThat(recovered).isEqualTo(1);
+        assertThatThrownBy(() -> recoveryService.prepareRetryableItems(
+                job.id(),
+                project.id(),
+                context.username(),
+                context,
+                Instant.now().plusSeconds(1)))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("no failed or expired running items");
         assertThat(persistenceService.getJob(
                 job.id(), project.id(), context.username(), context).items())
                 .singleElement()

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisRecoveryAndLimitsTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioAnalysisRecoveryAndLimitsTest.java
@@ -1,0 +1,155 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.AnalyzeProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.service.PortfolioAnalysisPersistenceService;
+import com.taxonomy.portfolio.service.PortfolioAnalysisRecoveryService;
+import com.taxonomy.portfolio.service.PortfolioAnalysisWorkQueue;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.portfolio.service.ProjectRequirementAnalysisService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest(properties = "taxonomy.portfolio.max-analysis-batch=2")
+class PortfolioAnalysisRecoveryAndLimitsTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private ProjectRequirementAnalysisService analysisService;
+
+    @Autowired
+    private PortfolioAnalysisPersistenceService persistenceService;
+
+    @Autowired
+    private PortfolioAnalysisWorkQueue workQueue;
+
+    @Autowired
+    private PortfolioAnalysisRecoveryService recoveryService;
+
+    @Test
+    void rejectsAnalysisBatchAboveConfiguredLimitBeforeCreatingAJob() {
+        WorkspaceContext context = context("batch-limit");
+        var project = createProject(context);
+        createRequirement(project.id(), context, "REQ-001");
+        createRequirement(project.id(), context, "REQ-002");
+        createRequirement(project.id(), context, "REQ-003");
+
+        assertThatThrownBy(() -> analysisService.analyzeProject(
+                project.id(),
+                new AnalyzeProjectRequest(List.of(), true, "MOCK", 25, "too-large"),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("maximum is 2");
+        assertThat(analysisService.listJobs(project.id(), context.username(), context))
+                .isEmpty();
+    }
+
+    @Test
+    void recoversOnlyExpiredRunningClaimsAndIncrementsAttempt() {
+        WorkspaceContext context = context("claim-recovery");
+        var project = createProject(context);
+        var requirement = createRequirement(project.id(), context, "REQ-001");
+        var job = persistenceService.createOrReuseJob(
+                project.id(),
+                List.of(requirement.id()),
+                "MOCK",
+                25,
+                "recover-" + UUID.randomUUID(),
+                context.username(),
+                context);
+
+        assertThat(workQueue.pending(job.id(), project.id())).hasSize(1);
+        assertThatThrownBy(() -> recoveryService.prepareRetryableItems(
+                job.id(),
+                project.id(),
+                context.username(),
+                context,
+                Instant.now().minusSeconds(60)))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("no failed or expired running items");
+
+        int recovered = recoveryService.prepareRetryableItems(
+                job.id(),
+                project.id(),
+                context.username(),
+                context,
+                Instant.now().plusSeconds(1));
+
+        assertThat(recovered).isEqualTo(1);
+        assertThat(persistenceService.getJob(
+                job.id(), project.id(), context.username(), context).items())
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.status()).isEqualTo(AnalysisStatus.PENDING);
+                    assertThat(item.attempt()).isEqualTo(2);
+                    assertThat(item.startedAt()).isNull();
+                });
+    }
+
+    private com.taxonomy.portfolio.dto.PortfolioDtos.ProjectView createProject(
+            WorkspaceContext context) {
+        return projectService.createProject(
+                new CreateProjectRequest(
+                        "P-" + shortId(),
+                        "Recovery test project",
+                        null,
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                context.username(),
+                context);
+    }
+
+    private com.taxonomy.portfolio.dto.PortfolioDtos.RequirementView createRequirement(
+            Long projectId, WorkspaceContext context, String key) {
+        return projectService.createRequirement(
+                projectId,
+                new CreateRequirementRequest(
+                        key,
+                        key + " title",
+                        "Requirement text for " + key,
+                        RequirementStatus.APPROVED,
+                        50,
+                        Criticality.MEDIUM,
+                        RequirementType.FUNCTIONAL,
+                        ReviewStatus.CONFIRMED,
+                        context.username(),
+                        "Initial version",
+                        null),
+                context.username(),
+                context);
+    }
+
+    private static WorkspaceContext context(String username) {
+        return new WorkspaceContext(
+                username,
+                "ws-" + username + "-" + shortId(),
+                "draft");
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioControllerLimitTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioControllerLimitTest.java
@@ -1,0 +1,74 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.controller.ProjectPortfolioController;
+import com.taxonomy.portfolio.dto.PortfolioDtos.ImportRequirementCandidate;
+import com.taxonomy.portfolio.dto.PortfolioDtos.ImportRequirementsRequest;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.portfolio.service.ProjectRequirementAnalysisService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class ProjectPortfolioControllerLimitTest {
+
+    @Test
+    void rejectsTooManyCandidatesBeforeResolvingWorkspaceOrPersisting() {
+        ProjectPortfolioService projectService = mock(ProjectPortfolioService.class);
+        ProjectRequirementAnalysisService analysisService = mock(ProjectRequirementAnalysisService.class);
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+        ProjectPortfolioController controller = new ProjectPortfolioController(
+                projectService, analysisService, workspaceResolver, 2, 1_000);
+
+        ImportRequirementsRequest request = new ImportRequirementsRequest(
+                List.of(candidate("REQ-001", "one"),
+                        candidate("REQ-002", "two"),
+                        candidate("REQ-003", "three")),
+                false,
+                null,
+                null,
+                null);
+
+        assertThatThrownBy(() -> controller.importRequirements(1L, request))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("maximum is 2");
+        verifyNoInteractions(projectService, analysisService, workspaceResolver);
+    }
+
+    @Test
+    void rejectsCombinedRequirementAndSourcePayloadAboveLimit() {
+        ProjectPortfolioService projectService = mock(ProjectPortfolioService.class);
+        ProjectRequirementAnalysisService analysisService = mock(ProjectRequirementAnalysisService.class);
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+        ProjectPortfolioController controller = new ProjectPortfolioController(
+                projectService, analysisService, workspaceResolver, 10, 5);
+
+        ImportRequirementsRequest request = new ImportRequirementsRequest(
+                List.of(candidate("REQ-001", "123456")),
+                false,
+                null,
+                null,
+                null);
+
+        assertThatThrownBy(() -> controller.importRequirements(1L, request))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("exceeds 5 characters");
+        verifyNoInteractions(projectService, analysisService, workspaceResolver);
+    }
+
+    private static ImportRequirementCandidate candidate(String key, String text) {
+        return new ImportRequirementCandidate(
+                key,
+                key + " title",
+                text,
+                null,
+                50,
+                null,
+                null);
+    }
+}


### PR DESCRIPTION
Hardens project portfolio execution after #550/#551.

- limits analysis batch size before a job is created
- limits imported requirement count and combined text/source payload
- removes the redundant second RUNNING transition after an atomic claim
- retries failed items and RUNNING items only after their configurable claim timeout has expired
- preserves active workers and increments the attempt on recovery
- makes recovery compare-and-set safe, so concurrent retries cannot reset the same item twice
- adds integration tests for batch rejection, active-vs-expired claim handling, one-time recovery and import limits

The PR currently includes the small claim refinements from #551 until that PR merges; GitHub will then reduce this diff automatically.

Part of #549.