### PR TITLE
Add portfolio REST and authorization contract tests

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
@@ -105,6 +105,7 @@ class PortfolioApiContractTest {
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.title").value("Portfolio resource not found"))
                 .andExpect(jsonPath("$.type").value("urn:taxonomy:portfolio:not_found"));
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
@@ -13,6 +13,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -81,6 +82,8 @@ class PortfolioApiContractTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
                 .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.title").value("Invalid portfolio request"))
                 .andExpect(jsonPath("$.type").value("urn:taxonomy:portfolio:validation"))
                 .andExpect(jsonPath("$.detail").isNotEmpty());
@@ -100,6 +103,8 @@ class PortfolioApiContractTest {
                                 }
                                 """))
                 .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.type").value("urn:taxonomy:portfolio:not_found"));
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioApiContractTest.java
@@ -1,0 +1,121 @@
+package com.taxonomy.portfolio;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** REST and authorization contracts for the project portfolio API. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "embedding.enabled=false",
+        "llm.mock=true",
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key="
+})
+class PortfolioApiContractTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "reader", roles = "USER")
+    void readerCanListProjectsButCannotCreateOne() throws Exception {
+        mockMvc.perform(get("/api/projects"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/projects")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "projectKey": "P-SECURITY",
+                                  "title": "Forbidden project"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void architectCanCreateAProjectAndReceivesAResourceLocation() throws Exception {
+        mockMvc.perform(post("/api/projects")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "projectKey": "P-API-CONTRACT",
+                                  "title": "API contract project",
+                                  "status": "PLANNING"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", org.hamcrest.Matchers.matchesPattern(
+                        "/api/projects/[0-9]+")))
+                .andExpect(jsonPath("$.projectKey").value("P-API-CONTRACT"))
+                .andExpect(jsonPath("$.title").value("API contract project"));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void invalidPortfolioRequestUsesRfc9457ProblemDetail() throws Exception {
+        mockMvc.perform(post("/api/projects")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.title").value("Invalid portfolio request"))
+                .andExpect(jsonPath("$.type").value("urn:taxonomy:portfolio:validation"))
+                .andExpect(jsonPath("$.detail").isNotEmpty());
+    }
+
+    @Test
+    @WithMockUser(username = "reader", roles = "USER")
+    void readerMayStartAnalysisButProjectIsolationStillReturnsNotFound() throws Exception {
+        mockMvc.perform(post("/api/projects/999999999/analyses")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requirementIds": [1],
+                                  "all": false,
+                                  "provider": "MOCK"
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.type").value("urn:taxonomy:portfolio:not_found"));
+    }
+
+    @Test
+    @WithMockUser(username = "reader", roles = "USER")
+    void readerCannotConfirmGeneratedMappings() throws Exception {
+        mockMvc.perform(patch("/api/projects/1/analysis-mappings/elements/1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "reviewStatus": "CONFIRMED",
+                                  "actionStatus": "REUSE",
+                                  "comment": "reviewed"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
Adds focused MockMvc regression coverage for the new project portfolio API.

The tests verify:

- authenticated readers can list projects but cannot create them
- architects can create projects and receive a stable resource location
- validation failures use the documented RFC 9457 ProblemDetail contract
- USER-role project analysis passes authorization while workspace/project isolation still returns 404
- readers cannot confirm generated taxonomy mappings

This addresses the low controller/security coverage identified in #549 without invoking a real LLM provider.

Part of #549.