### PR TITLE
Add authoritative portfolio browser E2E coverage

### DIFF
--- a/.github/scripts/ui-portfolio-acceptance.mjs
+++ b/.github/scripts/ui-portfolio-acceptance.mjs
@@ -22,7 +22,7 @@ function assert(condition, message) {
 
 async function waitUntilIdle(page) {
   const busy = page.locator('#portfolioBusy');
-  await busy.waitFor({ state: 'hidden', timeout: 120_000 }).catch(() => {});
+  await busy.waitFor({ state: 'hidden', timeout: 120_000 });
 }
 
 async function submitModal(page, modalId, fill, responsePattern) {
@@ -161,11 +161,11 @@ try {
     .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
     .analyze();
   axeViolations = axeResult.violations;
-  const severe = axeViolations.filter(item =>
-    item.impact === 'critical' || item.impact === 'serious');
-  assert(severe.length === 0,
-    `Portfolio accessibility has severe violations: ${severe.map(item => item.id).join(', ')}`);
-  checks.push('portfolio axe audit without serious violations');
+  const blocking = axeViolations.filter(item =>
+    item.impact === 'critical' || item.impact === 'serious' || item.impact === 'moderate');
+  assert(blocking.length === 0,
+    `Portfolio accessibility has blocking violations: ${blocking.map(item => item.id).join(', ')}`);
+  checks.push('portfolio axe audit without moderate, serious or critical violations');
 
   const overflow = await page.evaluate(() => ({
     scrollWidth: document.documentElement.scrollWidth,

--- a/.github/scripts/ui-portfolio-acceptance.mjs
+++ b/.github/scripts/ui-portfolio-acceptance.mjs
@@ -39,6 +39,39 @@ async function submitModal(page, modalId, fill, responsePattern) {
   await waitUntilIdle(page);
 }
 
+async function verifyAnalysisCompletion(page, response) {
+  const submitted = await response.json();
+  assert(submitted.totalItems === 1,
+    `Expected one independently analysed requirement, got ${submitted.totalItems}`);
+
+  const asyncUiEnabled = await page.locator(
+    'script[src*="taxonomy-portfolio-async.js"]').count() > 0;
+  if (asyncUiEnabled) {
+    assert(response.status() === 202,
+      `Asynchronous portfolio UI must receive HTTP 202, got ${response.status()}`);
+    const location = await response.headerValue('location');
+    assert(location, 'Asynchronous analysis response lacks a canonical Location header');
+    await waitUntilIdle(page);
+    const terminal = await page.evaluate(async jobUrl => {
+      const result = await fetch(jobUrl, { headers: { Accept: 'application/json' } });
+      return { status: result.status, body: await result.json() };
+    }, new URL(location, baseUrl).toString());
+    assert(terminal.status === 200,
+      `Terminal analysis job could not be read: HTTP ${terminal.status}`);
+    assert(terminal.body.status === 'SUCCESS' || terminal.body.status === 'PARTIAL',
+      `Analysis job did not finish successfully: ${terminal.body.status}`);
+    assert(terminal.body.successfulItems + terminal.body.partialItems === 1,
+      'Asynchronous analysis did not create a successful or partial snapshot');
+    return;
+  }
+
+  assert(response.status() === 200,
+    `Synchronous compatibility path must receive HTTP 200, got ${response.status()}`);
+  assert(submitted.successfulItems + submitted.partialItems === 1,
+    'Requirement analysis did not create a successful or partial snapshot');
+  await waitUntilIdle(page);
+}
+
 await mkdir(outputDir, { recursive: true });
 const reportPath = path.join(outputDir, 'report.json');
 const screenshotPath = path.join(outputDir, 'screenshot.png');
@@ -143,12 +176,7 @@ try {
   await page.locator('#analyzeAllBtn').click();
   const analysis = await analysisResponse;
   assert(analysis.ok(), `Portfolio analysis failed with HTTP ${analysis.status()}`);
-  await waitUntilIdle(page);
-  const analysisBody = await analysis.json();
-  assert(analysisBody.totalItems === 1,
-    `Expected one independently analysed requirement, got ${analysisBody.totalItems}`);
-  assert(analysisBody.successfulItems + analysisBody.partialItems === 1,
-    'Requirement analysis did not create a successful or partial snapshot');
+  await verifyAnalysisCompletion(page, analysis);
   checks.push('independent mock analysis and persisted snapshot');
 
   await page.locator('#taxonomy-tab').click();

--- a/.github/scripts/ui-portfolio-acceptance.mjs
+++ b/.github/scripts/ui-portfolio-acceptance.mjs
@@ -1,0 +1,194 @@
+import { chromium } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
+const username = process.env.TAXONOMY_UI_USERNAME || 'admin';
+const password = process.env.TAXONOMY_UI_PASSWORD || 'ui-acceptance-password';
+const outputDir = process.env.TAXONOMY_UI_OUTPUT_DIR || '/tmp/taxonomy-portfolio-ui';
+const viewport = { width: 1440, height: 1000 };
+const suffix = `${Date.now().toString(36)}-${process.pid.toString(36)}`.toUpperCase();
+const keys = {
+  project: `P-UI-${suffix}`,
+  requirement: 'REQ-001',
+  solution: `SOL-UI-${suffix}`,
+  product: `PRD-UI-${suffix}`
+};
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function waitUntilIdle(page) {
+  const busy = page.locator('#portfolioBusy');
+  await busy.waitFor({ state: 'hidden', timeout: 120_000 }).catch(() => {});
+}
+
+async function submitModal(page, modalId, fill, responsePattern) {
+  const modal = page.locator(`#${modalId}`);
+  await modal.waitFor({ state: 'visible', timeout: 20_000 });
+  await fill(modal);
+  const response = page.waitForResponse(value =>
+    value.request().method() === 'POST' && responsePattern.test(new URL(value.url()).pathname),
+  { timeout: 120_000 });
+  await modal.locator('button[type="submit"]').click();
+  const result = await response;
+  assert(result.ok(), `${modalId} request failed with HTTP ${result.status()}`);
+  await modal.waitFor({ state: 'hidden', timeout: 30_000 });
+  await waitUntilIdle(page);
+}
+
+await mkdir(outputDir, { recursive: true });
+const reportPath = path.join(outputDir, 'report.json');
+const screenshotPath = path.join(outputDir, 'screenshot.png');
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({ viewport, reducedMotion: 'reduce' });
+const page = await context.newPage();
+const checks = [];
+const consoleErrors = [];
+const externalRequests = [];
+let auditError = null;
+let axeViolations = [];
+
+page.on('console', message => {
+  if (message.type() === 'error') consoleErrors.push(message.text());
+});
+page.on('pageerror', error => consoleErrors.push(error.message));
+page.on('request', request => {
+  const url = request.url();
+  if (url.startsWith('data:') || url.startsWith('blob:')) return;
+  if (new URL(url).origin !== new URL(baseUrl).origin) externalRequests.push(url);
+});
+
+try {
+  await page.goto(`${baseUrl}/login`, { waitUntil: 'networkidle' });
+  await page.locator('input[name="username"]').fill(username);
+  await page.locator('input[name="password"]').fill(password);
+  await Promise.all([
+    page.waitForURL(url => !url.pathname.endsWith('/login'), { timeout: 30_000 }),
+    page.locator('button[type="submit"], input[type="submit"]').first().click()
+  ]);
+  await page.locator('#taxonomyTree [role="treeitem"]').first()
+    .waitFor({ state: 'visible', timeout: 120_000 });
+  checks.push('authenticated application readiness');
+
+  await page.goto(`${baseUrl}/projects`, { waitUntil: 'networkidle' });
+  await page.locator('#portfolioMain').waitFor({ state: 'visible', timeout: 30_000 });
+  assert(await page.locator('#projectList').getAttribute('role') === 'listbox',
+    'Project list lacks listbox semantics');
+  checks.push('portfolio page and project list semantics');
+
+  const skipLink = page.locator('.skip-link');
+  await skipLink.focus();
+  await page.keyboard.press('Enter');
+  assert(await page.evaluate(() => document.activeElement?.id === 'portfolioMain'),
+    'Portfolio skip link did not move focus to the main region');
+  checks.push('skip link and keyboard focus');
+
+  await page.locator('[data-bs-target="#projectModal"]').click();
+  await submitModal(page, 'projectModal', async modal => {
+    await modal.locator('#projectKey').fill(keys.project);
+    await modal.locator('#projectTitle').fill('Portfolio browser acceptance');
+    await modal.locator('#projectDescription').fill('Created by the authoritative UI verification suite.');
+  }, /^\/api\/projects$/);
+  await page.locator('#selectedProjectKey').filter({ hasText: keys.project })
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  checks.push('project creation through UI');
+
+  await page.locator('[data-bs-target="#requirementModal"]').click();
+  await submitModal(page, 'requirementModal', async modal => {
+    await modal.locator('#requirementKey').fill(keys.requirement);
+    await modal.locator('#requirementTitle').fill('Secure portfolio analysis');
+    await modal.locator('#requirementType').selectOption('SECURITY');
+    await modal.locator('#requirementText').fill(
+      'Provide traceable secure communication, resilient data exchange and auditable architecture decisions.');
+  }, /^\/api\/projects\/\d+\/requirements$/);
+  await page.locator('#requirementsTable tbody').getByText(keys.requirement)
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  checks.push('separate requirement creation through UI');
+
+  await page.locator('#solutions-tab').click();
+  await page.locator('[data-bs-target="#solutionModal"]').click();
+  await submitModal(page, 'solutionModal', async modal => {
+    await modal.locator('#solutionKey').fill(keys.solution);
+    await modal.locator('#solutionTitle').fill('Secure communication service');
+    await modal.locator('#solutionType').selectOption('SERVICE');
+    await modal.locator('#solutionOperatingModel').selectOption('PRIVATE_CLOUD');
+    await modal.locator('#solutionDescription').fill('Reusable solution created by UI acceptance.');
+  }, /^\/api\/solutions$/);
+  await page.locator('#solutionsList').getByText('Secure communication service')
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  checks.push('solution creation and project assignment through UI');
+
+  await page.locator('#products-tab').click();
+  await page.locator('[data-bs-target="#productModal"]').click();
+  await submitModal(page, 'productModal', async modal => {
+    await modal.locator('#productKey').fill(keys.product);
+    await modal.locator('#productManufacturer').fill('Acceptance Vendor');
+    await modal.locator('#productName').fill('Acceptance Product');
+    await modal.locator('#productVersion').fill('1.0');
+    await modal.locator('#productOperatingModel').selectOption('PRIVATE_CLOUD');
+    await modal.locator('#productSource').fill('UI acceptance catalogue reference, version 1.0');
+  }, /^\/api\/products$/);
+  await page.locator('#productsList').getByText('Acceptance Product')
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  checks.push('sourced product creation through UI');
+
+  await page.locator('#requirements-tab').click();
+  const analysisResponse = page.waitForResponse(value =>
+    value.request().method() === 'POST'
+      && /^\/api\/projects\/\d+\/analyses$/.test(new URL(value.url()).pathname),
+  { timeout: 180_000 });
+  await page.locator('#analyzeAllBtn').click();
+  const analysis = await analysisResponse;
+  assert(analysis.ok(), `Portfolio analysis failed with HTTP ${analysis.status()}`);
+  await waitUntilIdle(page);
+  const analysisBody = await analysis.json();
+  assert(analysisBody.totalItems === 1,
+    `Expected one independently analysed requirement, got ${analysisBody.totalItems}`);
+  assert(analysisBody.successfulItems + analysisBody.partialItems === 1,
+    'Requirement analysis did not create a successful or partial snapshot');
+  checks.push('independent mock analysis and persisted snapshot');
+
+  await page.locator('#taxonomy-tab').click();
+  await page.locator('#taxonomyPane').waitFor({ state: 'visible' });
+  await page.locator('#snapshots-tab').click();
+  await page.locator('#snapshotsPane').waitFor({ state: 'visible' });
+  checks.push('portfolio tab navigation and result surfaces');
+
+  const axeResult = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  axeViolations = axeResult.violations;
+  const severe = axeViolations.filter(item =>
+    item.impact === 'critical' || item.impact === 'serious');
+  assert(severe.length === 0,
+    `Portfolio accessibility has severe violations: ${severe.map(item => item.id).join(', ')}`);
+  checks.push('portfolio axe audit without serious violations');
+
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth
+  }));
+  assert(overflow.scrollWidth <= overflow.clientWidth + 2,
+    `Portfolio overflows desktop viewport: ${overflow.scrollWidth} > ${overflow.clientWidth}`);
+  assert(externalRequests.length === 0,
+    `Portfolio made external browser requests: ${externalRequests.join(', ')}`);
+  assert(consoleErrors.length === 0,
+    `Portfolio browser console errors: ${consoleErrors.join(' | ')}`);
+  checks.push('reflow, local assets and clean console');
+} catch (error) {
+  auditError = error?.stack || String(error);
+  process.exitCode = 1;
+} finally {
+  await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+  await writeFile(reportPath, `${JSON.stringify({
+    keys, viewport, checks, consoleErrors, externalRequests, axeViolations, auditError
+  }, null, 2)}\n`, 'utf8');
+  await context.close();
+  await browser.close();
+}
+
+if (auditError) throw new Error(auditError);
+console.log(`Portfolio UI acceptance passed: ${checks.join(', ')}`);

--- a/.github/scripts/ui-primary-portfolio-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-workflows.mjs
@@ -24,6 +24,40 @@ async function submitModal(page, modalId, fill, responsePattern) {
   await waitUntilIdle(page);
 }
 
+async function verifyAnalysisCompletion(page, response, baseUrl, evidence) {
+  const submitted = await response.json();
+  evidence.assert(submitted.totalItems === 1,
+    `Expected one independently analysed requirement, got ${submitted.totalItems}`);
+
+  const asyncUiEnabled = await page.locator(
+    'script[src*="taxonomy-portfolio-async.js"]').count() > 0;
+  if (asyncUiEnabled) {
+    evidence.assert(response.status() === 202,
+      `Asynchronous portfolio UI must receive HTTP 202, got ${response.status()}`);
+    const location = await response.headerValue('location');
+    evidence.assert(location,
+      'Asynchronous analysis response lacks a canonical Location header');
+    await waitUntilIdle(page);
+    const terminal = await page.evaluate(async jobUrl => {
+      const result = await fetch(jobUrl, { headers: { Accept: 'application/json' } });
+      return { status: result.status, body: await result.json() };
+    }, new URL(location, baseUrl).toString());
+    evidence.assert(terminal.status === 200,
+      `Terminal analysis job could not be read: HTTP ${terminal.status}`);
+    evidence.assert(terminal.body.status === 'SUCCESS' || terminal.body.status === 'PARTIAL',
+      `Analysis job did not finish successfully: ${terminal.body.status}`);
+    evidence.assert(terminal.body.successfulItems + terminal.body.partialItems === 1,
+      'Asynchronous analysis did not create a successful or partial snapshot');
+    return;
+  }
+
+  evidence.assert(response.status() === 200,
+    `Synchronous compatibility path must receive HTTP 200, got ${response.status()}`);
+  evidence.assert(submitted.successfulItems + submitted.partialItems === 1,
+    'Portfolio analysis did not create a successful or partial snapshot');
+  await waitUntilIdle(page);
+}
+
 /** End-to-end portfolio workflow for the authoritative ADMIN browser profile. */
 export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   const suffix = uniqueSuffix();
@@ -106,12 +140,7 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   const analysisResponse = await responsePromise;
   evidence.assert(analysisResponse.ok(),
     `Portfolio analysis failed with HTTP ${analysisResponse.status()}`);
-  const job = await analysisResponse.json();
-  evidence.assert(job.totalItems === 1,
-    `Expected one independently analysed requirement, got ${job.totalItems}`);
-  evidence.assert(job.successfulItems + job.partialItems === 1,
-    'Portfolio analysis did not create a successful or partial snapshot');
-  await waitUntilIdle(page);
+  await verifyAnalysisCompletion(page, analysisResponse, baseUrl, evidence);
   evidence.passed('portfolio independent mock analysis');
 
   await page.locator('#taxonomy-tab').click();

--- a/.github/scripts/ui-primary-portfolio-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-workflows.mjs
@@ -41,9 +41,13 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   const skipLink = page.locator('.skip-link');
   await skipLink.focus();
   await page.keyboard.press('Enter');
-  evidence.assert(await page.evaluate(() => document.activeElement?.id === 'portfolioMain'),
-    'Portfolio skip link did not move focus to the main region');
-  evidence.passed('portfolio skip link focus');
+  await page.waitForFunction(() => window.location.hash === '#portfolioMain');
+  await page.keyboard.press('Tab');
+  evidence.assert(await page.evaluate(() => {
+    const main = document.querySelector('#portfolioMain');
+    return Boolean(main && document.activeElement && main.contains(document.activeElement));
+  }), 'Portfolio skip link did not bypass navigation into the main region');
+  evidence.passed('portfolio skip link keyboard bypass');
 
   await page.locator('[data-bs-target="#projectModal"]').click();
   await submitModal(page, 'projectModal', async modal => {

--- a/.github/scripts/ui-primary-portfolio-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-workflows.mjs
@@ -1,0 +1,129 @@
+function uniqueSuffix() {
+  return `${Date.now().toString(36)}-${process.pid.toString(36)}`.toUpperCase();
+}
+
+async function waitUntilIdle(page) {
+  await page.locator('#portfolioBusy')
+    .waitFor({ state: 'hidden', timeout: 120_000 })
+    .catch(() => undefined);
+}
+
+async function submitModal(page, modalId, fill, responsePattern) {
+  const modal = page.locator(`#${modalId}`);
+  await modal.waitFor({ state: 'visible', timeout: 20_000 });
+  await fill(modal);
+  const responsePromise = page.waitForResponse(response =>
+    response.request().method() === 'POST'
+      && responsePattern.test(new URL(response.url()).pathname),
+  { timeout: 120_000 });
+  await modal.locator('button[type="submit"]').click();
+  const response = await responsePromise;
+  if (!response.ok()) {
+    throw new Error(`${modalId} request failed with HTTP ${response.status()}`);
+  }
+  await modal.waitFor({ state: 'hidden', timeout: 30_000 });
+  await waitUntilIdle(page);
+}
+
+/** End-to-end portfolio workflow for the authoritative ADMIN browser profile. */
+export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
+  const suffix = uniqueSuffix();
+  const projectKey = `P-UI-${suffix}`;
+  const solutionKey = `SOL-UI-${suffix}`;
+  const productKey = `PRD-UI-${suffix}`;
+
+  await page.goto(`${baseUrl}/projects`, { waitUntil: 'networkidle' });
+  await page.locator('#portfolioMain').waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.assert(await page.locator('#projectList').getAttribute('role') === 'listbox',
+    'Project portfolio list lacks listbox semantics');
+  evidence.passed('portfolio page and project list semantics');
+
+  const skipLink = page.locator('.skip-link');
+  await skipLink.focus();
+  await page.keyboard.press('Enter');
+  evidence.assert(await page.evaluate(() => document.activeElement?.id === 'portfolioMain'),
+    'Portfolio skip link did not move focus to the main region');
+  evidence.passed('portfolio skip link focus');
+
+  await page.locator('[data-bs-target="#projectModal"]').click();
+  await submitModal(page, 'projectModal', async modal => {
+    await modal.locator('#projectKey').fill(projectKey);
+    await modal.locator('#projectTitle').fill('Portfolio primary acceptance');
+    await modal.locator('#projectDescription').fill(
+      'Created by the authoritative primary workflow suite.');
+  }, /^\/api\/projects$/);
+  await page.locator('#selectedProjectKey').filter({ hasText: projectKey })
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.passed('portfolio project creation');
+
+  await page.locator('[data-bs-target="#requirementModal"]').click();
+  await submitModal(page, 'requirementModal', async modal => {
+    await modal.locator('#requirementKey').fill('REQ-001');
+    await modal.locator('#requirementTitle').fill('Secure portfolio analysis');
+    await modal.locator('#requirementType').selectOption('SECURITY');
+    await modal.locator('#requirementText').fill(
+      'Provide traceable secure communication, resilient data exchange and auditable architecture decisions.');
+  }, /^\/api\/projects\/\d+\/requirements$/);
+  await page.locator('#requirementsTable tbody').getByText('REQ-001')
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.passed('portfolio requirement creation');
+
+  await page.locator('#solutions-tab').click();
+  await page.locator('[data-bs-target="#solutionModal"]').click();
+  await submitModal(page, 'solutionModal', async modal => {
+    await modal.locator('#solutionKey').fill(solutionKey);
+    await modal.locator('#solutionTitle').fill('Secure communication service');
+    await modal.locator('#solutionType').selectOption('SERVICE');
+    await modal.locator('#solutionOperatingModel').selectOption('PRIVATE_CLOUD');
+  }, /^\/api\/solutions$/);
+  await page.locator('#solutionsList').getByText('Secure communication service')
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.passed('portfolio solution creation');
+
+  await page.locator('#products-tab').click();
+  await page.locator('[data-bs-target="#productModal"]').click();
+  await submitModal(page, 'productModal', async modal => {
+    await modal.locator('#productKey').fill(productKey);
+    await modal.locator('#productManufacturer').fill('Acceptance Vendor');
+    await modal.locator('#productName').fill('Acceptance Product');
+    await modal.locator('#productVersion').fill('1.0');
+    await modal.locator('#productOperatingModel').selectOption('PRIVATE_CLOUD');
+    await modal.locator('#productSource').fill('Primary UI acceptance catalogue reference 1.0');
+  }, /^\/api\/products$/);
+  await page.locator('#productsList').getByText('Acceptance Product')
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.passed('portfolio sourced product creation');
+
+  await page.locator('#requirements-tab').click();
+  const responsePromise = page.waitForResponse(response =>
+    response.request().method() === 'POST'
+      && /^\/api\/projects\/\d+\/analyses$/.test(new URL(response.url()).pathname),
+  { timeout: 180_000 });
+  await page.locator('#analyzeAllBtn').click();
+  const analysisResponse = await responsePromise;
+  evidence.assert(analysisResponse.ok(),
+    `Portfolio analysis failed with HTTP ${analysisResponse.status()}`);
+  const job = await analysisResponse.json();
+  evidence.assert(job.totalItems === 1,
+    `Expected one independently analysed requirement, got ${job.totalItems}`);
+  evidence.assert(job.successfulItems + job.partialItems === 1,
+    'Portfolio analysis did not create a successful or partial snapshot');
+  await waitUntilIdle(page);
+  evidence.passed('portfolio independent mock analysis');
+
+  await page.locator('#taxonomy-tab').click();
+  await page.locator('#taxonomyPane').waitFor({ state: 'visible' });
+  await page.locator('#snapshots-tab').click();
+  await page.locator('#snapshotsPane').waitFor({ state: 'visible' });
+  evidence.passed('portfolio result tab navigation');
+
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth
+  }));
+  evidence.assert(overflow.scrollWidth <= overflow.clientWidth + 2,
+    `Portfolio overflows viewport: ${overflow.scrollWidth} > ${overflow.clientWidth}`);
+  await evidence.axeState('portfolio-complete', '#portfolioMain');
+  await evidence.saveState('portfolio-complete', '#portfolioMain');
+  evidence.passed('portfolio reflow and evidence');
+}

--- a/.github/scripts/ui-primary-portfolio-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-workflows.mjs
@@ -4,8 +4,7 @@ function uniqueSuffix() {
 
 async function waitUntilIdle(page) {
   await page.locator('#portfolioBusy')
-    .waitFor({ state: 'hidden', timeout: 120_000 })
-    .catch(() => undefined);
+    .waitFor({ state: 'hidden', timeout: 120_000 });
 }
 
 async function submitModal(page, modalId, fill, responsePattern) {

--- a/.github/scripts/ui-primary-workflow-acceptance.mjs
+++ b/.github/scripts/ui-primary-workflow-acceptance.mjs
@@ -7,6 +7,7 @@ import { runBasicWorkflows } from './ui-primary-basic-workflows.mjs';
 import { runProposalWorkflows } from './ui-primary-proposal-workflows.mjs';
 import { runRelationWorkflows } from './ui-primary-relation-workflows.mjs';
 import { runImportWorkflows } from './ui-primary-import-workflows.mjs';
+import { runPortfolioWorkflows } from './ui-primary-portfolio-workflows.mjs';
 import { runPasswordWorkflows, runWorkspaceSyncWorkflows,
   verifyUserMutationDenied } from './ui-primary-account-workflows.mjs';
 
@@ -42,7 +43,10 @@ try {
   } else {
     await verifyUserMutationDenied(workflow);
   }
-  if (role === 'ADMIN') await runWorkspaceSyncWorkflows(workflow);
+  if (role === 'ADMIN') {
+    await runWorkspaceSyncWorkflows(workflow);
+    await runPortfolioWorkflows(workflow);
+  }
   if (role === 'USER') await runPasswordWorkflows(workflow);
 } catch (error) {
   auditError = error?.stack || String(error);

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-portfolio.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-portfolio.css
@@ -27,6 +27,11 @@
     border-left-color: var(--bs-primary);
 }
 
+#projectList .list-group-item.active .opacity-75 {
+    color: var(--bs-white);
+    opacity: 1 !important;
+}
+
 .portfolio-actions .btn {
     white-space: nowrap;
 }
@@ -38,6 +43,10 @@
 
 .portfolio-tabs .nav-link {
     white-space: nowrap;
+}
+
+.portfolio-tabs .nav-link:not(.active) {
+    color: var(--bs-primary-text-emphasis);
 }
 
 .portfolio-metric {


### PR DESCRIPTION
Adds the project portfolio to the Maven-owned browser evidence suite.

The ADMIN primary workflow now verifies through the real UI:

- portfolio navigation and listbox semantics
- keyboard skip-link focus
- project creation
- separate requirement creation
- reusable solution creation and project assignment
- sourced product creation
- independent mock-provider analysis and snapshot creation
- taxonomy/snapshot tab navigation
- viewport reflow
- axe audit with no moderate, serious or critical findings
- curated screenshot, HTML and ARIA evidence

Unique project/solution/product keys keep repeated CI runs isolated. The workflow uses the existing application process, role fixtures, evidence policy and report publication rather than a standalone ad-hoc test.

Part of #549.