### PR TITLE
[Portfolio] Eliminate project-summary and requirement-list scaling queries

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
@@ -67,9 +67,17 @@ public class ProjectRequirement {
     @Column(name = "owner_username", nullable = false, length = 160)
     private String ownerUsername;
 
-    /** Points at the immutable current text version without creating a circular FK. */
+    /** Points at the immutable current text version without creating a circular writable FK. */
     @Column(name = "current_version_id")
     private Long currentVersionId;
+
+    /**
+     * Read-only association used by portfolio list queries to fetch the current
+     * immutable version in the same SQL statement as the requirement identity.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_version_id", insertable = false, updatable = false)
+    private ProjectRequirementVersion currentVersion;
 
     /** Points at the immutable current analysis snapshot. */
     @Column(name = "current_snapshot_id", length = 36)
@@ -131,6 +139,7 @@ public class ProjectRequirement {
 
     public void pointToVersion(Long versionId, Instant now) {
         this.currentVersionId = versionId;
+        this.currentVersion = null;
         this.updatedAt = now;
     }
 
@@ -150,6 +159,7 @@ public class ProjectRequirement {
     public ReviewStatus getReviewStatus() { return reviewStatus; }
     public String getOwnerUsername() { return ownerUsername; }
     public Long getCurrentVersionId() { return currentVersionId; }
+    public ProjectRequirementVersion getCurrentVersion() { return currentVersion; }
     public String getCurrentAnalysisSnapshotId() { return currentAnalysisSnapshotId; }
     public Instant getCreatedAt() { return createdAt; }
     public Instant getUpdatedAt() { return updatedAt; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectConflictRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectConflictRepository.java
@@ -1,14 +1,18 @@
 package com.taxonomy.portfolio.repository;
 
+import com.taxonomy.portfolio.model.PortfolioTypes.ConflictStatus;
 import com.taxonomy.portfolio.model.ProjectConflict;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface ProjectConflictRepository extends JpaRepository<ProjectConflict, Long> {
 
     List<ProjectConflict> findByProjectIdOrderByConfidenceDescDetectedAtDesc(Long projectId);
+
+    long countByProjectIdAndStatusNotIn(Long projectId, Collection<ConflictStatus> statuses);
 
     Optional<ProjectConflict> findByIdAndProjectId(Long id, Long projectId);
 

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
@@ -1,6 +1,7 @@
 package com.taxonomy.portfolio.repository;
 
 import com.taxonomy.portfolio.model.ProjectRequirement;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Optional;
 
 public interface ProjectRequirementRepository extends JpaRepository<ProjectRequirement, Long> {
 
+    @EntityGraph(attributePaths = "currentVersion")
     List<ProjectRequirement> findByProjectIdOrderByRequirementKeyAsc(Long projectId);
 
     Optional<ProjectRequirement> findByIdAndProjectId(Long id, Long projectId);

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
@@ -17,5 +17,15 @@ public interface ProjectRequirementVersionRepository extends JpaRepository<Proje
 
     Optional<ProjectRequirementVersion> findByRequirementIdAndContentHash(Long requirementId, String contentHash);
 
-    Optional<ProjectRequirementVersion> findByIdAndRequirementId(Long id, Long requirementId);
+    /**
+     * Uses the first-level persistence cache when the version was fetched with
+     * its requirement list, while retaining the requirement ownership check.
+     */
+    default Optional<ProjectRequirementVersion> findByIdAndRequirementId(Long id, Long requirementId) {
+        if (id == null || requirementId == null) {
+            return Optional.empty();
+        }
+        return findById(id)
+                .filter(version -> requirementId.equals(version.getRequirement().getId()));
+    }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectSolutionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectSolutionRepository.java
@@ -10,6 +10,8 @@ public interface ProjectSolutionRepository extends JpaRepository<ProjectSolution
 
     List<ProjectSolution> findByProjectIdOrderByPriorityDescSolutionTitleAsc(Long projectId);
 
+    long countByProjectId(Long projectId);
+
     Optional<ProjectSolution> findByIdAndProjectId(Long id, Long projectId);
 
     Optional<ProjectSolution> findByProjectIdAndSolutionId(Long projectId, Long solutionId);

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
@@ -41,6 +41,8 @@ public class ProjectPortfolioService {
 
     private static final Pattern BUSINESS_KEY =
             Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]{0,63}");
+    private static final List<ConflictStatus> CLOSED_CONFLICT_STATUSES =
+            List.of(ConflictStatus.REJECTED, ConflictStatus.RESOLVED);
 
     private final ArchitectureProjectRepository projectRepository;
     private final ProjectRequirementRepository requirementRepository;
@@ -324,13 +326,9 @@ public class ProjectPortfolioService {
     @Transactional(readOnly = true)
     public ProjectView toProjectView(ArchitectureProject project) {
         int requirementCount = Math.toIntExact(requirementRepository.countByProjectId(project.getId()));
-        int solutionCount = projectSolutionRepository.findByProjectIdOrderByPriorityDescSolutionTitleAsc(
-                project.getId()).size();
-        int openConflicts = (int) conflictRepository
-                .findByProjectIdOrderByConfidenceDescDetectedAtDesc(project.getId()).stream()
-                .filter(conflict -> conflict.getStatus() != ConflictStatus.REJECTED
-                        && conflict.getStatus() != ConflictStatus.RESOLVED)
-                .count();
+        int solutionCount = Math.toIntExact(projectSolutionRepository.countByProjectId(project.getId()));
+        int openConflicts = Math.toIntExact(conflictRepository.countByProjectIdAndStatusNotIn(
+                project.getId(), CLOSED_CONFLICT_STATUSES));
         return new ProjectView(
                 project.getId(),
                 project.getProjectKey(),

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioViewCountTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioViewCountTest.java
@@ -1,0 +1,93 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.model.ArchitectureProject;
+import com.taxonomy.portfolio.model.PortfolioTypes.ConflictStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.repository.ArchitectureProjectRepository;
+import com.taxonomy.portfolio.repository.ProjectConflictRepository;
+import com.taxonomy.portfolio.repository.ProjectRequirementRepository;
+import com.taxonomy.portfolio.repository.ProjectRequirementVersionRepository;
+import com.taxonomy.portfolio.repository.ProjectSolutionRepository;
+import com.taxonomy.portfolio.service.PortfolioFingerprintService;
+import com.taxonomy.portfolio.service.PortfolioJsonCodec;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectPortfolioViewCountTest {
+
+    @Mock
+    private ArchitectureProjectRepository projectRepository;
+    @Mock
+    private ProjectRequirementRepository requirementRepository;
+    @Mock
+    private ProjectRequirementVersionRepository versionRepository;
+    @Mock
+    private ProjectSolutionRepository solutionRepository;
+    @Mock
+    private ProjectConflictRepository conflictRepository;
+    @Mock
+    private PortfolioFingerprintService fingerprintService;
+    @Mock
+    private PortfolioJsonCodec jsonCodec;
+
+    private ProjectPortfolioService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProjectPortfolioService(
+                projectRepository,
+                requirementRepository,
+                versionRepository,
+                solutionRepository,
+                conflictRepository,
+                fingerprintService,
+                jsonCodec);
+    }
+
+    @Test
+    void createsProjectSummaryFromAggregateCountsWithoutLoadingChildEntities() {
+        ArchitectureProject project = org.mockito.Mockito.mock(ArchitectureProject.class);
+        when(project.getId()).thenReturn(42L);
+        when(project.getProjectKey()).thenReturn("LOAD-TEST");
+        when(project.getTitle()).thenReturn("Large portfolio");
+        when(project.getStatus()).thenReturn(ProjectStatus.ACTIVE);
+        when(project.getOwnerUsername()).thenReturn("load-user");
+        when(project.getCreatedAt()).thenReturn(Instant.EPOCH);
+        when(project.getUpdatedAt()).thenReturn(Instant.EPOCH);
+        when(requirementRepository.countByProjectId(42L)).thenReturn(10_000L);
+        when(solutionRepository.countByProjectId(42L)).thenReturn(1_000L);
+        when(conflictRepository.countByProjectIdAndStatusNotIn(eq(42L), argThat(statuses ->
+                statuses.size() == 2
+                        && statuses.contains(ConflictStatus.REJECTED)
+                        && statuses.contains(ConflictStatus.RESOLVED))))
+                .thenReturn(250L);
+
+        var view = service.toProjectView(project);
+
+        assertThat(view.requirementCount()).isEqualTo(10_000);
+        assertThat(view.solutionCount()).isEqualTo(1_000);
+        assertThat(view.openConflictCount()).isEqualTo(250);
+        verify(solutionRepository).countByProjectId(42L);
+        verify(conflictRepository).countByProjectIdAndStatusNotIn(eq(42L), argThat(statuses ->
+                statuses.contains(ConflictStatus.REJECTED)
+                        && statuses.contains(ConflictStatus.RESOLVED)));
+        verify(solutionRepository, never())
+                .findByProjectIdOrderByPriorityDescSolutionTitleAsc(42L);
+        verify(conflictRepository, never())
+                .findByProjectIdOrderByConfidenceDescDetectedAtDesc(42L);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementListQueryCountTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementListQueryCountTest.java
@@ -1,0 +1,92 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import jakarta.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "spring.jpa.properties.hibernate.generate_statistics=true")
+@Transactional
+class ProjectRequirementListQueryCountTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void listsOneHundredRequirementsWithConstantQueryCount() {
+        WorkspaceContext context = new WorkspaceContext(
+                "scale-user", "ws-scale-" + shortId(), "draft");
+        var project = projectService.createProject(
+                new CreateProjectRequest(
+                        "P-SCALE-" + shortId(),
+                        "Scale query project",
+                        null,
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                context.username(),
+                context);
+
+        for (int index = 1; index <= 100; index++) {
+            String key = "REQ-%04d".formatted(index);
+            projectService.createRequirement(
+                    project.id(),
+                    new CreateRequirementRequest(
+                            key,
+                            "Requirement " + index,
+                            "Traceable requirement text " + index,
+                            RequirementStatus.APPROVED,
+                            50,
+                            Criticality.MEDIUM,
+                            RequirementType.FUNCTIONAL,
+                            ReviewStatus.CONFIRMED,
+                            context.username(),
+                            "Scale fixture",
+                            null),
+                    context.username(),
+                    context);
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+        Statistics statistics = entityManager.getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+        statistics.clear();
+
+        var requirements = projectService.listRequirements(
+                project.id(), context.username(), context);
+
+        assertThat(requirements).hasSize(100);
+        assertThat(requirements)
+                .allSatisfy(requirement -> assertThat(requirement.currentVersion()).isNotNull());
+        assertThat(statistics.getQueryExecutionCount())
+                .as("project lookup plus one joined requirement/current-version query")
+                .isLessThanOrEqualTo(3L);
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementListQueryCountTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementListQueryCountTest.java
@@ -81,8 +81,8 @@ class ProjectRequirementListQueryCountTest {
         assertThat(requirements).hasSize(100);
         assertThat(requirements)
                 .allSatisfy(requirement -> assertThat(requirement.currentVersion()).isNotNull());
-        assertThat(statistics.getQueryExecutionCount())
-                .as("project lookup plus one joined requirement/current-version query")
+        assertThat(statistics.getPrepareStatementCount())
+                .as("all SQL statements for project lookup and joined requirement/current-version loading")
                 .isLessThanOrEqualTo(3L);
     }
 


### PR DESCRIPTION
## What changed
- replace solution-list loading with `countByProjectId`
- replace conflict-list loading and in-memory filtering with a database count excluding resolved/rejected states
- map the immutable `current_version_id` as a read-only association
- fetch requirements and their current versions through one EntityGraph query
- reuse joined versions from the persistence context while retaining requirement ownership validation

## Regression coverage
- a 10,000-requirement project summary verifies that only scalar counts are requested and child entity lists are never loaded
- a real Spring/Hibernate test persists 100 requirements, clears the persistence context and then requires the complete list with a constant query budget of at most three statements

## Why
Issue #549 identified two scaling risks: project summaries loaded complete solution/conflict collections merely to count them, and requirement lists resolved every current version separately. Both paths now have data-volume-independent query counts.

## Verification
The repository CI/CD, Security Scan and CodeQL gates must pass on the final head before merge.

Relates to #549.