### PR TITLE
Run portfolio analysis as persisted asynchronous jobs

### DIFF
--- a/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -8,10 +8,11 @@ Das Projektportfolio prüft serverseitige Grenzen, bevor Daten gespeichert oder 
 | `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Höchstzahl importierter Anforderungskandidaten pro Anfrage |
 | `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximale Gesamtzahl der Zeichen aus Anforderungs- und Originalquelltexten |
 | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Alter, ab dem ein `RUNNING`-Eintrag wiederaufgenommen werden darf |
-| `taxonomy.portfolio.analysis-worker-core-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CORE_POOL_SIZE` | `1` | Ständig verfügbare Hintergrund-Worker |
-| `taxonomy.portfolio.analysis-worker-max-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_MAX_POOL_SIZE` | `4` | Maximale Zahl gleichzeitig arbeitender Hintergrund-Worker |
+| `taxonomy.portfolio.analysis-worker-concurrency` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY` | `1` | Feste Zahl gleichzeitig ausgeführter Analysejobs |
 | `taxonomy.portfolio.analysis-worker-queue-capacity` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `100` | Persistierte Jobs, die in der prozessinternen Dispatch-Warteschlange warten dürfen |
 | `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `30` | Graceful-Shutdown-Frist für aktive Worker |
+
+Die Standardparallelität von eins ist bewusst konservativ: Bereits die Analyse einer einzigen Anforderung kann beim Durchlaufen der Taxonomie mehrere Provideraufrufe auslösen. Sie sollte nur zusammen mit Provider-Rate-Limits, Datenbankkapazität und einem beobachteten Latenz-/Fehlerbudget erhöht werden. Anders als bei einem Core-/Max-Pool mit großer Warteschlange entspricht dieser feste Wert der tatsächlichen dauerhaften Parallelität.
 
 ## HTTP-Jobvertrag
 

--- a/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -8,11 +8,31 @@ Das Projektportfolio prüft serverseitige Grenzen, bevor Daten gespeichert oder 
 | `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Höchstzahl importierter Anforderungskandidaten pro Anfrage |
 | `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximale Gesamtzahl der Zeichen aus Anforderungs- und Originalquelltexten |
 | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Alter, ab dem ein `RUNNING`-Eintrag wiederaufgenommen werden darf |
+| `taxonomy.portfolio.analysis-worker-core-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CORE_POOL_SIZE` | `1` | Ständig verfügbare Hintergrund-Worker |
+| `taxonomy.portfolio.analysis-worker-max-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_MAX_POOL_SIZE` | `4` | Maximale Zahl gleichzeitig arbeitender Hintergrund-Worker |
+| `taxonomy.portfolio.analysis-worker-queue-capacity` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `100` | Persistierte Jobs, die in der prozessinternen Dispatch-Warteschlange warten dürfen |
+| `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `30` | Graceful-Shutdown-Frist für aktive Worker |
+
+## HTTP-Jobvertrag
+
+Analyseaufträge werden gespeichert, bevor Providerarbeit beginnt. `POST /api/projects/{projectId}/analyses`, die Einzelanforderungsanalyse und Wiederholungsanfragen liefern `202 Accepted` mit einem `AnalysisJobView` sowie einem kanonischen `Location`-Header:
+
+```text
+/api/projects/{projectId}/analysis-jobs/{jobId}
+```
+
+Clients fragen diese Ressource ab, bis der Job `SUCCESS`, `PARTIAL`, `FAILED` oder `CANCELLED` erreicht. Die Portfolio-Oberfläche erledigt dieses Polling automatisch. Der ursprüngliche HTTP-Request bleibt daher nicht mehr für die Dauer eines oder mehrerer LLM-Aufrufe geöffnet.
+
+Der Executor ist begrenzt. Sind alle Worker und Warteschlangenplätze belegt, liefert die API ein RFC-9457-Problem mit `503 Service Unavailable`. Der Job ist zu diesem Zeitpunkt bereits gespeichert und seine Kennung steht im Problemtext. Derselbe idempotente Auftrag kann deshalb erneut gesendet werden, ohne doppelte Arbeit anzulegen.
+
+## Übernahme und Wiederanlauf
 
 Ein Analyseeintrag wird atomar in einer eigenen kurzen Transaktion von `PENDING` nach `RUNNING` übernommen. Der externe LLM-Aufruf beginnt erst nach dem Commit dieser Transaktion.
 
-Eine Wiederholung setzt fehlgeschlagene Einträge sowie ausschließlich solche laufenden Einträge zurück, deren Übernahme älter als das konfigurierte Timeout ist. Auch das Zurücksetzen verwendet status- und zeitgestützte Compare-and-set-Updates. Zwei parallele Wiederholungsanfragen können deshalb denselben Eintrag weder doppelt übernehmen noch dessen Versuchszähler doppelt erhöhen.
+Eine Wiederholung setzt fehlgeschlagene Einträge sowie ausschließlich solche laufenden Einträge zurück, deren Übernahme älter als das konfigurierte Timeout ist. Auch das Zurücksetzen verwendet status- und zeitgestützte Compare-and-set-Updates. Zwei parallele Wiederholungsanfragen können deshalb denselben Eintrag weder doppelt übernehmen noch dessen Versuchszähler doppelt erhöhen. Ein gespeicherter `PENDING`-Job, dessen prozessinterner Dispatch beim Herunterfahren verloren ging, kann über denselben Wiederholungsendpunkt erneut eingeplant werden.
 
 Ein zu niedriges Timeout kann Arbeit duplizieren, wenn ein Provider legitimerweise länger benötigt. Es sollte oberhalb der längsten erwarteten Providerlaufzeit einschließlich deterministischer Nachverarbeitung liegen. Aktive Worker werden durch eine Wiederholungsanfrage nicht unterbrochen.
+
+Beim geordneten Herunterfahren erhalten aktive Worker die konfigurierte Abschlussfrist. Stoppt der Prozess vorher, wird die persistierte `RUNNING`-Übernahme nach Ablauf des Timeouts wiederaufnahmefähig; die prozessinterne Warteschlange ist niemals die führende Datenquelle.
 
 Zu große Analyse- oder Importanfragen werden abgelehnt, bevor ein Analysejob oder importierte Anforderungen gespeichert werden. Die Anwendungslimits sollten durch Größenlimits am Ingress, Provider-Rate-Limits und reguläre Datenbanksicherungen ergänzt werden.

--- a/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -8,11 +8,31 @@ The project portfolio applies explicit server-side limits before persisting or s
 | `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Maximum requirement candidates accepted by one import request |
 | `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximum combined requirement and original-source characters in one import |
 | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Age after which a `RUNNING` item can be recovered |
+| `taxonomy.portfolio.analysis-worker-core-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CORE_POOL_SIZE` | `1` | Always available background analysis workers |
+| `taxonomy.portfolio.analysis-worker-max-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_MAX_POOL_SIZE` | `4` | Maximum concurrent background analysis workers |
+| `taxonomy.portfolio.analysis-worker-queue-capacity` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `100` | Persisted jobs that may wait in the in-process dispatch queue |
+| `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `30` | Graceful shutdown period for active workers |
+
+## HTTP job contract
+
+Analysis submissions are persisted before provider work begins. `POST /api/projects/{projectId}/analyses`, the single-requirement analysis endpoint and retry requests return `202 Accepted` with an `AnalysisJobView` body and a canonical `Location` header:
+
+```text
+/api/projects/{projectId}/analysis-jobs/{jobId}
+```
+
+Clients poll that resource until the job reaches `SUCCESS`, `PARTIAL`, `FAILED` or `CANCELLED`. The portfolio browser performs this polling automatically. The original HTTP request therefore does not remain open for the duration of one or more LLM calls.
+
+The executor is bounded. When all workers and queue slots are occupied, the API returns an RFC 9457 `503 Service Unavailable` problem. The job is already persisted and its identifier is included in the problem detail, so the same idempotent submission can be sent again instead of creating duplicate work.
+
+## Claiming and recovery
 
 An analysis item is claimed atomically from `PENDING` to `RUNNING` in a dedicated short transaction. The external LLM request starts only after that transaction commits.
 
-Retry requests reset failed items and only those running items whose claim is older than the configured timeout. The reset itself uses status- and timestamp-guarded compare-and-set updates, so concurrent retry requests cannot recover the same item twice or increment its attempt counter twice.
+Retry requests reset failed items and only those running items whose claim is older than the configured timeout. The reset itself uses status- and timestamp-guarded compare-and-set updates, so concurrent retry requests cannot recover the same item twice or increment its attempt counter twice. A persisted `PENDING` job whose in-process dispatch was lost during shutdown can also be dispatched again through the retry endpoint.
 
 A low timeout can duplicate work when a provider legitimately needs longer than the timeout. Set it above the longest expected provider call plus deterministic post-processing time. Active workers are not interrupted by a retry request.
+
+During graceful shutdown, active workers receive the configured completion period. If a process stops before an item finishes, its persisted `RUNNING` claim becomes eligible for recovery after the timeout; no in-memory queue is treated as the source of truth.
 
 Oversized analysis or import requests fail before an analysis job or imported requirement is persisted. Operators should combine these limits with ingress request-body limits, provider rate limits and normal database backups.

--- a/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -8,10 +8,11 @@ The project portfolio applies explicit server-side limits before persisting or s
 | `taxonomy.portfolio.max-import-requirements` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `100` | Maximum requirement candidates accepted by one import request |
 | `taxonomy.portfolio.max-import-characters` | `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `500000` | Maximum combined requirement and original-source characters in one import |
 | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `900` | Age after which a `RUNNING` item can be recovered |
-| `taxonomy.portfolio.analysis-worker-core-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CORE_POOL_SIZE` | `1` | Always available background analysis workers |
-| `taxonomy.portfolio.analysis-worker-max-pool-size` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_MAX_POOL_SIZE` | `4` | Maximum concurrent background analysis workers |
+| `taxonomy.portfolio.analysis-worker-concurrency` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY` | `1` | Fixed number of concurrently dispatched analysis jobs |
 | `taxonomy.portfolio.analysis-worker-queue-capacity` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `100` | Persisted jobs that may wait in the in-process dispatch queue |
 | `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `30` | Graceful shutdown period for active workers |
+
+The default concurrency of one is deliberately conservative because one requirement analysis can issue several provider calls while traversing the taxonomy. Increase it only together with provider rate limits, database capacity and an observed latency/error budget. Unlike a core/max pool with a large queue, this fixed value is the actual steady-state concurrency.
 
 ## HTTP job contract
 

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
@@ -1,0 +1,34 @@
+package com.taxonomy.portfolio.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/** Bounded, lifecycle-managed executor for persisted portfolio analysis jobs. */
+@Configuration(proxyBeanMethods = false)
+public class PortfolioAnalysisExecutorConfiguration {
+
+    @Bean(name = "portfolioAnalysisExecutor")
+    public AsyncTaskExecutor portfolioAnalysisExecutor(
+            @Value("${taxonomy.portfolio.analysis-worker-core-pool-size:1}") int configuredCorePoolSize,
+            @Value("${taxonomy.portfolio.analysis-worker-max-pool-size:4}") int configuredMaxPoolSize,
+            @Value("${taxonomy.portfolio.analysis-worker-queue-capacity:100}") int configuredQueueCapacity,
+            @Value("${taxonomy.portfolio.analysis-worker-shutdown-seconds:30}") int configuredShutdownSeconds) {
+        int corePoolSize = Math.max(1, configuredCorePoolSize);
+        int maxPoolSize = Math.max(corePoolSize, configuredMaxPoolSize);
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("portfolio-analysis-");
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(Math.max(0, configuredQueueCapacity));
+        executor.setKeepAliveSeconds(60);
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(Math.max(0, configuredShutdownSeconds));
+        executor.initialize();
+        return executor;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
@@ -28,7 +28,6 @@ public class PortfolioAnalysisExecutorConfiguration {
         executor.setAllowCoreThreadTimeOut(true);
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(Math.max(0, configuredShutdownSeconds));
-        executor.initialize();
         return executor;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/config/PortfolioAnalysisExecutorConfiguration.java
@@ -12,20 +12,16 @@ public class PortfolioAnalysisExecutorConfiguration {
 
     @Bean(name = "portfolioAnalysisExecutor")
     public AsyncTaskExecutor portfolioAnalysisExecutor(
-            @Value("${taxonomy.portfolio.analysis-worker-core-pool-size:1}") int configuredCorePoolSize,
-            @Value("${taxonomy.portfolio.analysis-worker-max-pool-size:4}") int configuredMaxPoolSize,
+            @Value("${taxonomy.portfolio.analysis-worker-concurrency:1}") int configuredConcurrency,
             @Value("${taxonomy.portfolio.analysis-worker-queue-capacity:100}") int configuredQueueCapacity,
             @Value("${taxonomy.portfolio.analysis-worker-shutdown-seconds:30}") int configuredShutdownSeconds) {
-        int corePoolSize = Math.max(1, configuredCorePoolSize);
-        int maxPoolSize = Math.max(corePoolSize, configuredMaxPoolSize);
+        int concurrency = Math.max(1, configuredConcurrency);
 
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setThreadNamePrefix("portfolio-analysis-");
-        executor.setCorePoolSize(corePoolSize);
-        executor.setMaxPoolSize(maxPoolSize);
+        executor.setCorePoolSize(concurrency);
+        executor.setMaxPoolSize(concurrency);
         executor.setQueueCapacity(Math.max(0, configuredQueueCapacity));
-        executor.setKeepAliveSeconds(60);
-        executor.setAllowCoreThreadTimeOut(true);
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(Math.max(0, configuredShutdownSeconds));
         return executor;

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioExceptionHandler.java
@@ -21,6 +21,7 @@ public class PortfolioExceptionHandler {
             case CONFLICT -> HttpStatus.CONFLICT;
             case VALIDATION -> HttpStatus.BAD_REQUEST;
             case ANALYSIS_FAILED -> HttpStatus.UNPROCESSABLE_ENTITY;
+            case UNAVAILABLE -> HttpStatus.SERVICE_UNAVAILABLE;
         };
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(status, exception.getMessage());
         problem.setTitle(switch (exception.getKind()) {
@@ -28,6 +29,7 @@ public class PortfolioExceptionHandler {
             case CONFLICT -> "Portfolio state conflict";
             case VALIDATION -> "Invalid portfolio request";
             case ANALYSIS_FAILED -> "Portfolio analysis payload failure";
+            case UNAVAILABLE -> "Portfolio analysis capacity unavailable";
         });
         problem.setType(URI.create("urn:taxonomy:portfolio:" + exception.getKind().name().toLowerCase()));
         return ResponseEntity.status(status).body(problem);

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectAnalysisController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectAnalysisController.java
@@ -15,6 +15,7 @@ import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.net.URI;
 import java.util.List;
 
 /** Requirement-separated analysis jobs and immutable snapshot history. */
@@ -45,23 +47,25 @@ public class ProjectAnalysisController {
     }
 
     @PostMapping("/analyses")
-    @Operation(summary = "Analyze selected or all requirements independently")
-    public AnalysisJobView analyzeProject(@PathVariable Long projectId,
-                                          @RequestBody AnalyzeProjectRequest request) {
+    @Operation(summary = "Queue independent analyses for selected or all requirements")
+    public ResponseEntity<AnalysisJobView> analyzeProject(@PathVariable Long projectId,
+                                                          @RequestBody AnalyzeProjectRequest request) {
         RequestScope scope = scope();
-        return analysisService.analyzeProject(projectId, request, scope.username(), scope.context());
+        AnalysisJobView job = analysisService.enqueueProject(
+                projectId, request, scope.username(), scope.context());
+        return accepted(projectId, job);
     }
 
     @PostMapping("/requirements/{requirementId}/analyses")
-    @Operation(summary = "Analyze one requirement and create an immutable snapshot")
-    public AnalysisJobView analyzeRequirement(
+    @Operation(summary = "Queue one requirement analysis and immutable snapshot")
+    public ResponseEntity<AnalysisJobView> analyzeRequirement(
             @PathVariable Long projectId,
             @PathVariable Long requirementId,
             @RequestBody(required = false) AnalyzeProjectRequest request) {
         RequestScope scope = scope();
         AnalyzeProjectRequest effective = request != null
                 ? request : new AnalyzeProjectRequest(List.of(requirementId), false, null, null, null);
-        return analysisService.analyzeRequirement(
+        AnalysisJobView job = analysisService.enqueueRequirement(
                 projectId,
                 requirementId,
                 effective.provider(),
@@ -69,6 +73,7 @@ public class ProjectAnalysisController {
                 effective.idempotencyKey(),
                 scope.username(),
                 scope.context());
+        return accepted(projectId, job);
     }
 
     @GetMapping("/analysis-jobs")
@@ -87,11 +92,13 @@ public class ProjectAnalysisController {
     }
 
     @PostMapping("/analysis-jobs/{jobId}/retry-failed")
-    @Operation(summary = "Retry only failed requirement analyses using their current versions")
-    public AnalysisJobView retryFailed(@PathVariable Long projectId,
-                                       @PathVariable String jobId) {
+    @Operation(summary = "Queue failed or expired requirement analyses for retry")
+    public ResponseEntity<AnalysisJobView> retryFailed(@PathVariable Long projectId,
+                                                       @PathVariable String jobId) {
         RequestScope scope = scope();
-        return analysisService.retryFailed(jobId, projectId, scope.username(), scope.context());
+        AnalysisJobView job = analysisService.enqueueRetryFailed(
+                jobId, projectId, scope.username(), scope.context());
+        return accepted(projectId, job);
     }
 
     @GetMapping("/requirements/{requirementId}/snapshots")
@@ -141,6 +148,12 @@ public class ProjectAnalysisController {
         RequestScope scope = scope();
         return persistenceService.reviewRelationMapping(
                 projectId, mappingId, request, scope.username(), scope.context());
+    }
+
+    private static ResponseEntity<AnalysisJobView> accepted(Long projectId, AnalysisJobView job) {
+        URI location = URI.create(
+                "/api/projects/" + projectId + "/analysis-jobs/" + job.id());
+        return ResponseEntity.accepted().location(location).body(job);
     }
 
     private RequestScope scope() {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectPortfolioController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/ProjectPortfolioController.java
@@ -102,7 +102,7 @@ public class ProjectPortfolioController {
     }
 
     @PostMapping("/{projectId}/requirements/import")
-    @Operation(summary = "Import candidates as separate requirements, optionally analyze them")
+    @Operation(summary = "Import candidates as separate requirements, optionally queue their analysis")
     public ResponseEntity<ImportRequirementsResult> importRequirements(
             @PathVariable Long projectId,
             @RequestBody ImportRequirementsRequest request) {
@@ -111,7 +111,7 @@ public class ProjectPortfolioController {
         List<RequirementView> requirements = projectService.importRequirements(
                 projectId, request.requirements(), scope.username(), scope.context());
         var job = request.analyzeAfterImport()
-                ? analysisService.analyzeProject(
+                ? analysisService.enqueueProject(
                         projectId,
                         new AnalyzeProjectRequest(
                                 requirements.stream().map(RequirementView::id).toList(),

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
@@ -133,8 +133,12 @@ public class RequirementAnalysisJob {
         if (completedItems < totalItems) {
             // Another worker may still own RUNNING items. Never expose a
             // premature SUCCESS state merely because this request claimed no
-            // additional work.
+            // additional work. Preserve an existing start time, but enforce
+            // the invariant that every externally visible RUNNING job has one.
             this.status = AnalysisStatus.RUNNING;
+            if (this.startedAt == null) {
+                this.startedAt = now;
+            }
             this.completedAt = null;
             return;
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/RequirementAnalysisJob.java
@@ -105,6 +105,13 @@ public class RequirementAnalysisJob {
         this.createdAt = createdAt;
     }
 
+    public void markPending() {
+        this.status = AnalysisStatus.PENDING;
+        this.startedAt = null;
+        this.completedAt = null;
+        this.errorSummary = null;
+    }
+
     public void markRunning(Instant now) {
         this.status = AnalysisStatus.RUNNING;
         this.startedAt = now;

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
@@ -30,12 +30,13 @@ public class PortfolioAnalysisRecoveryService {
     }
 
     /**
-     * Resets failed items and RUNNING items whose claim is older than the supplied
-     * cutoff. Active claims remain untouched. Every successful compare-and-set
-     * increments the attempt and binds the retry to the requirement's current
-     * immutable text version.
+     * Keeps already pending items dispatchable and resets failed items plus RUNNING
+     * items whose claim is older than the supplied cutoff. Active claims remain
+     * untouched. Every successful reset increments the attempt and binds the retry
+     * to the requirement's current immutable text version; merely redispatching an
+     * existing PENDING item does not increment it.
      *
-     * @return number of items atomically prepared for another attempt
+     * @return number of pending or atomically reset items available for another dispatch
      */
     @Transactional
     public int prepareRetryableItems(String jobId,
@@ -51,6 +52,9 @@ public class PortfolioAnalysisRecoveryService {
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Analysis job not found: " + jobId));
 
+        List<RequirementAnalysisJobItem> pending =
+                itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
+                        jobId, AnalysisStatus.PENDING);
         List<RequirementAnalysisJobItem> failed =
                 itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
                         jobId, AnalysisStatus.FAILED);
@@ -58,7 +62,7 @@ public class PortfolioAnalysisRecoveryService {
                 .findByJobIdAndStatusAndStartedAtBeforeOrderByRequirementRequirementKeyAsc(
                         jobId, AnalysisStatus.RUNNING, staleBefore);
 
-        int prepared = 0;
+        int prepared = pending.size();
         for (RequirementAnalysisJobItem item : failed) {
             ProjectRequirementVersion version =
                     projectService.currentVersion(item.getRequirement());
@@ -81,7 +85,7 @@ public class PortfolioAnalysisRecoveryService {
 
         if (prepared == 0) {
             throw PortfolioException.conflict(
-                    "Analysis job has no failed or expired running items to retry: " + jobId);
+                    "Analysis job has no pending, failed or expired running items to retry: " + jobId);
         }
         job.markRunning(Instant.now());
         return prepared;

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioAnalysisRecoveryService.java
@@ -30,13 +30,13 @@ public class PortfolioAnalysisRecoveryService {
     }
 
     /**
-     * Keeps already pending items dispatchable and resets failed items plus RUNNING
-     * items whose claim is older than the supplied cutoff. Active claims remain
-     * untouched. Every successful reset increments the attempt and binds the retry
-     * to the requirement's current immutable text version; merely redispatching an
-     * existing PENDING item does not increment it.
+     * Resets failed items and RUNNING items whose claim is older than the supplied
+     * cutoff. Active claims remain untouched. Every successful compare-and-set
+     * increments the attempt and binds the retry to the requirement's current
+     * immutable text version. The job remains PENDING until a worker actually
+     * claims its prepared items, so a lost or rejected dispatch can be retried.
      *
-     * @return number of pending or atomically reset items available for another dispatch
+     * @return number of items atomically prepared for another attempt
      */
     @Transactional
     public int prepareRetryableItems(String jobId,
@@ -52,9 +52,6 @@ public class PortfolioAnalysisRecoveryService {
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Analysis job not found: " + jobId));
 
-        List<RequirementAnalysisJobItem> pending =
-                itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
-                        jobId, AnalysisStatus.PENDING);
         List<RequirementAnalysisJobItem> failed =
                 itemRepository.findByJobIdAndStatusOrderByRequirementRequirementKeyAsc(
                         jobId, AnalysisStatus.FAILED);
@@ -62,7 +59,7 @@ public class PortfolioAnalysisRecoveryService {
                 .findByJobIdAndStatusAndStartedAtBeforeOrderByRequirementRequirementKeyAsc(
                         jobId, AnalysisStatus.RUNNING, staleBefore);
 
-        int prepared = pending.size();
+        int prepared = 0;
         for (RequirementAnalysisJobItem item : failed) {
             ProjectRequirementVersion version =
                     projectService.currentVersion(item.getRequirement());
@@ -85,9 +82,9 @@ public class PortfolioAnalysisRecoveryService {
 
         if (prepared == 0) {
             throw PortfolioException.conflict(
-                    "Analysis job has no pending, failed or expired running items to retry: " + jobId);
+                    "Analysis job has no failed or expired running items to retry: " + jobId);
         }
-        job.markRunning(Instant.now());
+        job.markPending();
         return prepared;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioException.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioException.java
@@ -7,7 +7,8 @@ public class PortfolioException extends RuntimeException {
         NOT_FOUND,
         CONFLICT,
         VALIDATION,
-        ANALYSIS_FAILED
+        ANALYSIS_FAILED,
+        UNAVAILABLE
     }
 
     private final Kind kind;
@@ -40,5 +41,9 @@ public class PortfolioException extends RuntimeException {
 
     public static PortfolioException analysisFailed(String message, Throwable cause) {
         return new PortfolioException(Kind.ANALYSIS_FAILED, message, cause);
+    }
+
+    public static PortfolioException unavailable(String message, Throwable cause) {
+        return new PortfolioException(Kind.UNAVAILABLE, message, cause);
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectRequirementAnalysisService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectRequirementAnalysisService.java
@@ -18,7 +18,12 @@ import com.taxonomy.portfolio.dto.PortfolioDtos.SnapshotDiff;
 import com.taxonomy.portfolio.dto.PortfolioDtos.SnapshotSummary;
 import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
 import com.taxonomy.workspace.service.WorkspaceContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -31,6 +36,7 @@ import java.util.UUID;
 @Service
 public class ProjectRequirementAnalysisService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProjectRequirementAnalysisService.class);
     private static final int DEFAULT_ARCHITECTURE_NODES = 25;
     private static final int INTELLIGENCE_MIN_SCORE = 50;
 
@@ -44,6 +50,7 @@ public class ProjectRequirementAnalysisService {
     private final ArchitectureRecommendationService recommendationService;
     private final PortfolioFingerprintService fingerprintService;
     private final LlmService llmService;
+    private final AsyncTaskExecutor analysisExecutor;
     private final int maximumArchitectureNodes;
     private final int maximumBatchRequirements;
     private final long claimTimeoutSeconds;
@@ -58,6 +65,8 @@ public class ProjectRequirementAnalysisService {
                                              ArchitectureRecommendationService recommendationService,
                                              PortfolioFingerprintService fingerprintService,
                                              LlmService llmService,
+                                             @Qualifier("portfolioAnalysisExecutor")
+                                             AsyncTaskExecutor analysisExecutor,
                                              @Value("${taxonomy.limits.max-architecture-nodes:100}")
                                              int maximumArchitectureNodes,
                                              @Value("${taxonomy.portfolio.max-analysis-batch:100}")
@@ -74,32 +83,34 @@ public class ProjectRequirementAnalysisService {
         this.recommendationService = recommendationService;
         this.fingerprintService = fingerprintService;
         this.llmService = llmService;
+        this.analysisExecutor = analysisExecutor;
         this.maximumArchitectureNodes = Math.max(1, maximumArchitectureNodes);
         this.maximumBatchRequirements = Math.max(1, maximumBatchRequirements);
         this.claimTimeoutSeconds = Math.max(60L, claimTimeoutSeconds);
     }
 
+    /** Executes a persisted job in the caller thread. Kept for internal batch use and deterministic tests. */
     public AnalysisJobView analyzeProject(Long projectId,
                                           AnalyzeProjectRequest request,
                                           String username,
                                           WorkspaceContext context) {
-        if (request == null) throw PortfolioException.validation("analysis request is required");
-        projectService.requireProject(projectId, username, context);
-
-        List<Long> requirementIds = selectRequirementIds(projectId, request, username, context);
-        int maxNodes = normalizeMaxNodes(request.maxArchitectureNodes());
-        AnalysisJobView job = persistenceService.createOrReuseJob(
-                projectId,
-                requirementIds,
-                normalizeProvider(request.provider()),
-                maxNodes,
-                request.idempotencyKey(),
-                username,
-                context);
+        AnalysisJobView job = prepareJob(projectId, request, username, context);
         if (job.status() != AnalysisStatus.PENDING) {
             return job;
         }
         return executePendingItems(job.id(), projectId, username, context);
+    }
+
+    /** Persists and dispatches a job, returning before any LLM request is made. */
+    public AnalysisJobView enqueueProject(Long projectId,
+                                          AnalyzeProjectRequest request,
+                                          String username,
+                                          WorkspaceContext context) {
+        AnalysisJobView job = prepareJob(projectId, request, username, context);
+        if (job.status() == AnalysisStatus.PENDING) {
+            dispatch(job.id(), projectId, username, context);
+        }
+        return job;
     }
 
     public AnalysisJobView analyzeRequirement(Long projectId,
@@ -110,8 +121,20 @@ public class ProjectRequirementAnalysisService {
                                               String username,
                                               WorkspaceContext context) {
         return analyzeProject(projectId,
-                new AnalyzeProjectRequest(
-                        List.of(requirementId), false, provider, maxArchitectureNodes, idempotencyKey),
+                requestForRequirement(requirementId, provider, maxArchitectureNodes, idempotencyKey),
+                username,
+                context);
+    }
+
+    public AnalysisJobView enqueueRequirement(Long projectId,
+                                              Long requirementId,
+                                              String provider,
+                                              Integer maxArchitectureNodes,
+                                              String idempotencyKey,
+                                              String username,
+                                              WorkspaceContext context) {
+        return enqueueProject(projectId,
+                requestForRequirement(requirementId, provider, maxArchitectureNodes, idempotencyKey),
                 username,
                 context);
     }
@@ -127,6 +150,25 @@ public class ProjectRequirementAnalysisService {
                 context,
                 Instant.now().minusSeconds(claimTimeoutSeconds));
         return executePendingItems(jobId, projectId, username, context);
+    }
+
+    /** Re-dispatches pending jobs or recovers failed/expired claims without holding the HTTP request. */
+    public AnalysisJobView enqueueRetryFailed(String jobId,
+                                              Long projectId,
+                                              String username,
+                                              WorkspaceContext context) {
+        AnalysisJobView job = persistenceService.getJob(jobId, projectId, username, context);
+        if (job.status() != AnalysisStatus.PENDING) {
+            recoveryService.prepareRetryableItems(
+                    jobId,
+                    projectId,
+                    username,
+                    context,
+                    Instant.now().minusSeconds(claimTimeoutSeconds));
+            job = persistenceService.getJob(jobId, projectId, username, context);
+        }
+        dispatch(jobId, projectId, username, context);
+        return job;
     }
 
     public AnalysisJobView getJob(String jobId,
@@ -166,18 +208,71 @@ public class ProjectRequirementAnalysisService {
                 projectId, olderSnapshotId, newerSnapshotId, username, context);
     }
 
+    private AnalysisJobView prepareJob(Long projectId,
+                                       AnalyzeProjectRequest request,
+                                       String username,
+                                       WorkspaceContext context) {
+        if (request == null) throw PortfolioException.validation("analysis request is required");
+        projectService.requireProject(projectId, username, context);
+
+        List<Long> requirementIds = selectRequirementIds(projectId, request, username, context);
+        int maxNodes = normalizeMaxNodes(request.maxArchitectureNodes());
+        return persistenceService.createOrReuseJob(
+                projectId,
+                requirementIds,
+                normalizeProvider(request.provider()),
+                maxNodes,
+                request.idempotencyKey(),
+                username,
+                context);
+    }
+
+    private static AnalyzeProjectRequest requestForRequirement(Long requirementId,
+                                                               String provider,
+                                                               Integer maxArchitectureNodes,
+                                                               String idempotencyKey) {
+        return new AnalyzeProjectRequest(
+                List.of(requirementId), false, provider, maxArchitectureNodes, idempotencyKey);
+    }
+
+    private void dispatch(String jobId,
+                          Long projectId,
+                          String username,
+                          WorkspaceContext context) {
+        try {
+            analysisExecutor.execute(() -> {
+                try {
+                    executePendingItems(jobId, projectId, username, context);
+                } catch (RuntimeException failure) {
+                    LOGGER.error("Asynchronous portfolio analysis job {} for project {} stopped unexpectedly",
+                            jobId, projectId, failure);
+                }
+            });
+        } catch (TaskRejectedException rejected) {
+            throw PortfolioException.unavailable(
+                    "Portfolio analysis capacity is currently exhausted; persisted job "
+                            + jobId + " can be submitted again",
+                    rejected);
+        }
+    }
+
     private AnalysisJobView executePendingItems(String jobId,
                                                 Long projectId,
                                                 String username,
                                                 WorkspaceContext context) {
-        persistenceService.markJobRunning(jobId, projectId);
         AnalysisJobView job = persistenceService.getJob(jobId, projectId, username, context);
         String taxonomyFingerprint = fingerprintService.taxonomyFingerprint();
         String promptFingerprint = fingerprintService.promptFingerprint();
         String effectiveProvider = job.provider() != null
                 ? job.provider() : llmService.getActiveProviderName();
 
-        for (PortfolioAnalysisWorkQueue.WorkItem workItem : workQueue.pending(jobId, projectId)) {
+        List<PortfolioAnalysisWorkQueue.WorkItem> workItems = workQueue.pending(jobId, projectId);
+        if (workItems.isEmpty()) {
+            return persistenceService.completeJob(jobId, projectId);
+        }
+        persistenceService.markJobRunning(jobId, projectId);
+
+        for (PortfolioAnalysisWorkQueue.WorkItem workItem : workItems) {
             String snapshotId = UUID.randomUUID().toString();
             String analysisSessionId = "portfolio:" + snapshotId;
             long startedAt = System.nanoTime();

--- a/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
+++ b/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
@@ -13,7 +13,8 @@
 
     window.fetch = async function portfolioAwareFetch(input, init) {
         const response = await originalFetch(input, init);
-        const method = String((init && init.method) || 'GET').toUpperCase();
+        const method = String((init && init.method)
+            || (input instanceof Request ? input.method : 'GET')).toUpperCase();
         const requestUrl = resolveUrl(input);
         if (method !== 'POST' || response.status !== 202 || !isAnalysisSubmission(requestUrl)) {
             return response;
@@ -74,13 +75,21 @@
                 reject(new DOMException('The operation was aborted.', 'AbortError'));
                 return;
             }
-            const timeout = window.setTimeout(resolve, milliseconds);
-            if (signal) {
-                signal.addEventListener('abort', function onAbort() {
-                    window.clearTimeout(timeout);
-                    reject(new DOMException('The operation was aborted.', 'AbortError'));
-                }, { once: true });
-            }
+
+            let settled = false;
+            const onAbort = function () {
+                if (settled) return;
+                settled = true;
+                window.clearTimeout(timeout);
+                reject(new DOMException('The operation was aborted.', 'AbortError'));
+            };
+            const timeout = window.setTimeout(function () {
+                if (settled) return;
+                settled = true;
+                if (signal) signal.removeEventListener('abort', onAbort);
+                resolve();
+            }, milliseconds);
+            if (signal) signal.addEventListener('abort', onAbort, { once: true });
         });
     }
 })();

--- a/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
+++ b/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
@@ -1,0 +1,86 @@
+/*
+ * Keeps the portfolio UI compatible with the asynchronous analysis API.
+ * POST requests return 202 immediately; this page-local fetch adapter polls the
+ * persisted job resource and resolves the existing UI call with its terminal view.
+ */
+(function () {
+    'use strict';
+
+    const originalFetch = window.fetch.bind(window);
+    const terminalStatuses = new Set(['SUCCESS', 'PARTIAL', 'FAILED', 'CANCELLED']);
+    const pollIntervalMs = 400;
+    const pollTimeoutMs = 10 * 60 * 1000;
+
+    window.fetch = async function portfolioAwareFetch(input, init) {
+        const response = await originalFetch(input, init);
+        const method = String((init && init.method) || 'GET').toUpperCase();
+        const requestUrl = resolveUrl(input);
+        if (method !== 'POST' || response.status !== 202 || !isAnalysisSubmission(requestUrl)) {
+            return response;
+        }
+
+        const initialJob = await response.clone().json().catch(function () { return null; });
+        const location = response.headers.get('Location');
+        if (!initialJob || !initialJob.id || !location || terminalStatuses.has(initialJob.status)) {
+            return response;
+        }
+
+        const completedJob = await pollJob(location, init && init.signal);
+        const headers = new Headers(response.headers);
+        headers.set('Content-Type', 'application/json');
+        return new Response(JSON.stringify(completedJob), {
+            status: 200,
+            statusText: 'OK',
+            headers: headers
+        });
+    };
+
+    function resolveUrl(input) {
+        const value = input instanceof Request ? input.url : String(input);
+        return new URL(value, window.location.href);
+    }
+
+    function isAnalysisSubmission(url) {
+        return url.origin === window.location.origin
+            && url.pathname.startsWith('/api/projects/')
+            && (url.pathname.endsWith('/analyses') || url.pathname.endsWith('/retry-failed'));
+    }
+
+    async function pollJob(location, signal) {
+        const startedAt = Date.now();
+        const jobUrl = new URL(location, window.location.href).toString();
+        while (Date.now() - startedAt < pollTimeoutMs) {
+            await delay(pollIntervalMs, signal);
+            const response = await originalFetch(jobUrl, {
+                method: 'GET',
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+                cache: 'no-store',
+                signal: signal
+            });
+            if (!response.ok) {
+                throw new Error('Unable to read the queued portfolio analysis job (HTTP '
+                    + response.status + ').');
+            }
+            const job = await response.json();
+            if (job && terminalStatuses.has(job.status)) return job;
+        }
+        throw new Error('The queued portfolio analysis did not finish within ten minutes.');
+    }
+
+    function delay(milliseconds, signal) {
+        return new Promise(function (resolve, reject) {
+            if (signal && signal.aborted) {
+                reject(new DOMException('The operation was aborted.', 'AbortError'));
+                return;
+            }
+            const timeout = window.setTimeout(resolve, milliseconds);
+            if (signal) {
+                signal.addEventListener('abort', function onAbort() {
+                    window.clearTimeout(timeout);
+                    reject(new DOMException('The operation was aborted.', 'AbortError'));
+                }, { once: true });
+            }
+        });
+    }
+})();

--- a/taxonomy-app/src/main/resources/templates/projects.html
+++ b/taxonomy-app/src/main/resources/templates/projects.html
@@ -465,6 +465,7 @@
 </div>
 
 <script th:src="@{/webjars/bootstrap/5.3.8/dist/js/bootstrap.bundle.min.js}"></script>
+<script th:src="@{/js/portfolio/taxonomy-portfolio-async.js}"></script>
 <script th:src="@{/js/portfolio/taxonomy-portfolio.js}"></script>
 </body>
 </html>

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectAnalysisControllerAsyncContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectAnalysisControllerAsyncContractTest.java
@@ -1,0 +1,99 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.controller.ProjectAnalysisController;
+import com.taxonomy.portfolio.dto.PortfolioDtos.AnalysisJobView;
+import com.taxonomy.portfolio.dto.PortfolioDtos.AnalyzeProjectRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.service.PortfolioAnalysisPersistenceService;
+import com.taxonomy.portfolio.service.ProjectRequirementAnalysisService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectAnalysisControllerAsyncContractTest {
+
+    @Mock private ProjectRequirementAnalysisService analysisService;
+    @Mock private PortfolioAnalysisPersistenceService persistenceService;
+    @Mock private WorkspaceResolver workspaceResolver;
+
+    private ProjectAnalysisController controller;
+    private final WorkspaceContext context = new WorkspaceContext("architect", "ws-architect", "draft");
+
+    @BeforeEach
+    void setUp() {
+        controller = new ProjectAnalysisController(
+                analysisService, persistenceService, workspaceResolver);
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn(context.username());
+        when(workspaceResolver.resolveCurrentContext()).thenReturn(context);
+    }
+
+    @Test
+    void projectAnalysisReturnsAcceptedAndCanonicalJobLocation() {
+        AnalysisJobView job = pendingJob();
+        AnalyzeProjectRequest request = new AnalyzeProjectRequest(
+                List.of(7L), false, "MOCK", 25, "client-key");
+        when(analysisService.enqueueProject(
+                eq(41L), eq(request), eq(context.username()), eq(context)))
+                .thenReturn(job);
+
+        var response = controller.analyzeProject(41L, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getLocation())
+                .hasToString("/api/projects/41/analysis-jobs/job-1");
+        assertThat(response.getBody()).isSameAs(job);
+    }
+
+    @Test
+    void singleRequirementAnalysisAlsoUsesThePersistedJobResource() {
+        AnalysisJobView job = pendingJob();
+        when(analysisService.enqueueRequirement(
+                eq(41L), eq(7L), eq("MOCK"), eq(25), eq("single-key"),
+                eq(context.username()), eq(context)))
+                .thenReturn(job);
+
+        var response = controller.analyzeRequirement(
+                41L,
+                7L,
+                new AnalyzeProjectRequest(List.of(), false, "MOCK", 25, "single-key"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getLocation())
+                .hasToString("/api/projects/41/analysis-jobs/job-1");
+    }
+
+    private AnalysisJobView pendingJob() {
+        return new AnalysisJobView(
+                "job-1",
+                41L,
+                AnalysisStatus.PENDING,
+                "client-key",
+                "MOCK",
+                25,
+                context.username(),
+                context.workspaceId(),
+                Instant.now(),
+                null,
+                null,
+                1,
+                0,
+                0,
+                0,
+                null,
+                List.of());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectAnalysisControllerAsyncContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectAnalysisControllerAsyncContractTest.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementAnalysisAsyncDispatchTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementAnalysisAsyncDispatchTest.java
@@ -35,6 +35,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -74,9 +76,9 @@ class ProjectRequirementAnalysisAsyncDispatchTest {
                 100,
                 100,
                 900);
-        when(persistenceService.createOrReuseJob(
+        lenient().when(persistenceService.createOrReuseJob(
                 anyLong(), anyList(), anyString(), anyInt(), anyString(), anyString(), any()))
-                .thenReturn(pendingJob());
+                .thenReturn(job(AnalysisStatus.PENDING));
     }
 
     @Test
@@ -110,11 +112,36 @@ class ProjectRequirementAnalysisAsyncDispatchTest {
         verifyNoInteractions(analyzeRequirementUseCase);
     }
 
-    private AnalysisJobView pendingJob() {
+    @Test
+    void rejectedRecoveredJobCanBeSubmittedAgainWithoutAnotherRecovery() {
+        when(persistenceService.getJob(
+                "job-1", 41L, context.username(), context))
+                .thenReturn(job(AnalysisStatus.FAILED), job(AnalysisStatus.PENDING),
+                        job(AnalysisStatus.PENDING));
+        doThrow(new TaskRejectedException("worker queue full"))
+                .doNothing()
+                .when(analysisExecutor).execute(any(Runnable.class));
+
+        assertThatThrownBy(() -> service.enqueueRetryFailed(
+                "job-1", 41L, context.username(), context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("persisted job job-1");
+
+        AnalysisJobView redispatched = service.enqueueRetryFailed(
+                "job-1", 41L, context.username(), context);
+
+        assertThat(redispatched.status()).isEqualTo(AnalysisStatus.PENDING);
+        verify(recoveryService, times(1)).prepareRetryableItems(
+                anyString(), anyLong(), anyString(), any(), any());
+        verify(analysisExecutor, times(2)).execute(any(Runnable.class));
+        verifyNoInteractions(analyzeRequirementUseCase);
+    }
+
+    private AnalysisJobView job(AnalysisStatus status) {
         return new AnalysisJobView(
                 "job-1",
                 41L,
-                AnalysisStatus.PENDING,
+                status,
                 "client-key",
                 "MOCK",
                 25,
@@ -124,9 +151,9 @@ class ProjectRequirementAnalysisAsyncDispatchTest {
                 null,
                 null,
                 1,
+                status == AnalysisStatus.SUCCESS ? 1 : 0,
                 0,
-                0,
-                0,
+                status == AnalysisStatus.FAILED ? 1 : 0,
                 null,
                 List.of());
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementAnalysisAsyncDispatchTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementAnalysisAsyncDispatchTest.java
@@ -1,0 +1,133 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.analysis.service.LlmService;
+import com.taxonomy.analysis.usecase.AnalyzeRequirementUseCase;
+import com.taxonomy.architecture.service.ArchitectureGapService;
+import com.taxonomy.architecture.service.ArchitecturePatternService;
+import com.taxonomy.architecture.service.ArchitectureRecommendationService;
+import com.taxonomy.portfolio.dto.PortfolioDtos.AnalysisJobView;
+import com.taxonomy.portfolio.dto.PortfolioDtos.AnalyzeProjectRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import com.taxonomy.portfolio.service.PortfolioAnalysisPersistenceService;
+import com.taxonomy.portfolio.service.PortfolioAnalysisRecoveryService;
+import com.taxonomy.portfolio.service.PortfolioAnalysisWorkQueue;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.PortfolioFingerprintService;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.portfolio.service.ProjectRequirementAnalysisService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectRequirementAnalysisAsyncDispatchTest {
+
+    @Mock private ProjectPortfolioService projectService;
+    @Mock private PortfolioAnalysisPersistenceService persistenceService;
+    @Mock private PortfolioAnalysisWorkQueue workQueue;
+    @Mock private PortfolioAnalysisRecoveryService recoveryService;
+    @Mock private AnalyzeRequirementUseCase analyzeRequirementUseCase;
+    @Mock private ArchitectureGapService gapService;
+    @Mock private ArchitecturePatternService patternService;
+    @Mock private ArchitectureRecommendationService recommendationService;
+    @Mock private PortfolioFingerprintService fingerprintService;
+    @Mock private LlmService llmService;
+    @Mock private AsyncTaskExecutor analysisExecutor;
+
+    private ProjectRequirementAnalysisService service;
+    private final WorkspaceContext context = new WorkspaceContext("architect", "ws-architect", "draft");
+
+    @BeforeEach
+    void setUp() {
+        service = new ProjectRequirementAnalysisService(
+                projectService,
+                persistenceService,
+                workQueue,
+                recoveryService,
+                analyzeRequirementUseCase,
+                gapService,
+                patternService,
+                recommendationService,
+                fingerprintService,
+                llmService,
+                analysisExecutor,
+                100,
+                100,
+                900);
+        when(persistenceService.createOrReuseJob(
+                anyLong(), anyList(), anyString(), anyInt(), anyString(), anyString(), any()))
+                .thenReturn(pendingJob());
+    }
+
+    @Test
+    void enqueueReturnsPersistedJobWithoutCallingTheProviderInTheRequestThread() {
+        AnalysisJobView job = service.enqueueProject(
+                41L,
+                new AnalyzeProjectRequest(List.of(7L), false, "mock", 25, "client-key"),
+                context.username(),
+                context);
+
+        assertThat(job.status()).isEqualTo(AnalysisStatus.PENDING);
+        verify(analysisExecutor).execute(any(Runnable.class));
+        verifyNoInteractions(analyzeRequirementUseCase);
+    }
+
+    @Test
+    void saturatedExecutorReturnsTypedServiceUnavailableFailureAndKeepsTheJobPersisted() {
+        doThrow(new TaskRejectedException("worker queue full"))
+                .when(analysisExecutor).execute(any(Runnable.class));
+
+        assertThatThrownBy(() -> service.enqueueProject(
+                41L,
+                new AnalyzeProjectRequest(List.of(7L), false, "MOCK", 25, "client-key"),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .satisfies(failure -> assertThat(((PortfolioException) failure).getKind())
+                        .isEqualTo(PortfolioException.Kind.UNAVAILABLE))
+                .hasMessageContaining("persisted job job-1");
+
+        verifyNoInteractions(analyzeRequirementUseCase);
+    }
+
+    private AnalysisJobView pendingJob() {
+        return new AnalysisJobView(
+                "job-1",
+                41L,
+                AnalysisStatus.PENDING,
+                "client-key",
+                "MOCK",
+                25,
+                context.username(),
+                context.workspaceId(),
+                Instant.now(),
+                null,
+                null,
+                1,
+                0,
+                0,
+                0,
+                null,
+                List.of());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/model/RequirementAnalysisJobTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/model/RequirementAnalysisJobTest.java
@@ -1,0 +1,51 @@
+package com.taxonomy.portfolio.model;
+
+import com.taxonomy.portfolio.model.PortfolioTypes.AnalysisStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequirementAnalysisJobTest {
+
+    @Test
+    void incompleteCompletionAddsStartedAtWhenACompetingWorkerOwnsTheItems() {
+        Instant createdAt = Instant.parse("2026-08-03T08:00:00Z");
+        Instant completionAttempt = Instant.parse("2026-08-03T08:01:00Z");
+        RequirementAnalysisJob job = job(createdAt);
+
+        job.complete(0, 0, 0, null, completionAttempt);
+
+        assertThat(job.getStatus()).isEqualTo(AnalysisStatus.RUNNING);
+        assertThat(job.getStartedAt()).isEqualTo(completionAttempt);
+        assertThat(job.getCompletedAt()).isNull();
+    }
+
+    @Test
+    void incompleteCompletionPreservesTheOriginalWorkerStartTime() {
+        Instant createdAt = Instant.parse("2026-08-03T08:00:00Z");
+        Instant workerStartedAt = Instant.parse("2026-08-03T08:00:30Z");
+        RequirementAnalysisJob job = job(createdAt);
+        job.markRunning(workerStartedAt);
+
+        job.complete(0, 0, 0, null, Instant.parse("2026-08-03T08:01:00Z"));
+
+        assertThat(job.getStatus()).isEqualTo(AnalysisStatus.RUNNING);
+        assertThat(job.getStartedAt()).isEqualTo(workerStartedAt);
+        assertThat(job.getCompletedAt()).isNull();
+    }
+
+    private static RequirementAnalysisJob job(Instant createdAt) {
+        return new RequirementAnalysisJob(
+                "job-1",
+                null,
+                "client-key",
+                "MOCK",
+                25,
+                "architect",
+                "ws-architect",
+                1,
+                createdAt);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining synchronous-request part of #549 for project portfolio analyses.

- persists analysis jobs before provider work starts
- returns `202 Accepted` and a canonical job `Location` from project, single-requirement and retry endpoints
- dispatches work through a bounded, lifecycle-managed executor
- preserves atomic item claiming and expired-claim recovery
- lets persisted `PENDING` jobs be dispatched again after an interrupted shutdown
- returns RFC 9457 `503 Service Unavailable` when worker and queue capacity are exhausted
- adds page-local polling so the existing portfolio UI waits for the terminal persisted job instead of keeping the POST request open
- queues optional analysis after requirement import
- documents worker sizing, shutdown and recovery in German and English

## Verification

- unit contract: analysis enqueue returns without invoking the provider on the request thread
- unit contract: executor saturation produces typed `UNAVAILABLE`
- controller contract: analysis submissions return `202` with `/api/projects/{projectId}/analysis-jobs/{jobId}`
- existing synchronous service-level integration tests remain available for deterministic domain verification
- the authoritative portfolio browser E2E exercises the asynchronous HTTP path and client polling

Part of #549.