### PR TITLE
Harden portfolio versioning and persisted input boundaries

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
@@ -1,8 +1,12 @@
 package com.taxonomy.portfolio.repository;
 
 import com.taxonomy.portfolio.model.ProjectRequirement;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +17,12 @@ public interface ProjectRequirementRepository extends JpaRepository<ProjectRequi
     List<ProjectRequirement> findByProjectIdOrderByRequirementKeyAsc(Long projectId);
 
     Optional<ProjectRequirement> findByIdAndProjectId(Long id, Long projectId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select requirement from ProjectRequirement requirement "
+            + "where requirement.id = :id and requirement.project.id = :projectId")
+    Optional<ProjectRequirement> findByIdAndProjectIdForUpdate(@Param("id") Long id,
+                                                               @Param("projectId") Long projectId);
 
     Optional<ProjectRequirement> findByProjectIdAndRequirementKeyIgnoreCase(Long projectId, String requirementKey);
 

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioValueValidator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioValueValidator.java
@@ -1,0 +1,109 @@
+package com.taxonomy.portfolio.service;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Currency;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Shared validation for persisted portfolio values whose database constraints are not descriptive enough. */
+final class PortfolioValueValidator {
+
+    static final int MAX_SOURCE_FRAGMENT_IDS = 1_000;
+    static final int MAX_ORIGINAL_TEXT_CHARACTERS = 100_000;
+    static final int MAX_EXTENSION_ATTRIBUTES = 100;
+    static final int MAX_EXTENSION_KEY_CHARACTERS = 120;
+    static final int MAX_EXTENSION_VALUE_CHARACTERS = 1_000;
+    static final Duration MAX_VERIFICATION_CLOCK_SKEW = Duration.ofMinutes(5);
+
+    private static final int MONEY_INTEGER_DIGITS = 17;
+    private static final int MONEY_SCALE = 2;
+
+    private PortfolioValueValidator() {
+    }
+
+    static BigDecimal money(BigDecimal value, String field) {
+        if (value == null) return null;
+        if (value.signum() < 0) {
+            throw PortfolioException.validation(field + " must not be negative");
+        }
+
+        BigDecimal normalized = value.stripTrailingZeros();
+        if (normalized.scale() < 0) normalized = normalized.setScale(0);
+        if (normalized.scale() > MONEY_SCALE) {
+            throw PortfolioException.validation(field + " supports at most " + MONEY_SCALE + " decimal places");
+        }
+        int integerDigits = Math.max(0, normalized.precision() - normalized.scale());
+        if (integerDigits > MONEY_INTEGER_DIGITS) {
+            throw PortfolioException.validation(
+                    field + " supports at most " + MONEY_INTEGER_DIGITS + " integer digits");
+        }
+        return normalized;
+    }
+
+    static String currency(String value, String field) {
+        if (value == null || value.isBlank()) return null;
+        String normalized = value.strip().toUpperCase(Locale.ROOT);
+        try {
+            return Currency.getInstance(normalized).getCurrencyCode();
+        } catch (IllegalArgumentException failure) {
+            throw PortfolioException.validation(field + " must be a registered ISO 4217 currency code");
+        }
+    }
+
+    static void requireMoneyPair(BigDecimal amount,
+                                 String currency,
+                                 String amountField,
+                                 String currencyField) {
+        if ((amount == null) != (currency == null)) {
+            throw PortfolioException.validation(
+                    amountField + " and " + currencyField + " must be supplied together");
+        }
+    }
+
+    static Instant verifiedAt(Instant value, Instant now, boolean required) {
+        if (value == null) {
+            if (required) throw PortfolioException.validation("verifiedAt is required for product claims");
+            return null;
+        }
+        Instant latestPlausible = now.plus(MAX_VERIFICATION_CLOCK_SKEW);
+        if (value.isAfter(latestPlausible)) {
+            throw PortfolioException.validation(
+                    "verifiedAt must not be more than five minutes in the future");
+        }
+        return value;
+    }
+
+    static Integer nonNegativeDays(Integer value, String field) {
+        if (value == null) return null;
+        if (value < 0 || value > 36_500) {
+            throw PortfolioException.validation(field + " must be between 0 and 36500 days");
+        }
+        return value;
+    }
+
+    static Map<String, String> extensionAttributes(Map<String, String> attributes) {
+        if (attributes == null) return null;
+        if (attributes.size() > MAX_EXTENSION_ATTRIBUTES) {
+            throw PortfolioException.validation(
+                    "extensionAttributes contains more than " + MAX_EXTENSION_ATTRIBUTES + " entries");
+        }
+
+        Map<String, String> normalized = new LinkedHashMap<>();
+        attributes.forEach((key, value) -> {
+            String normalizedKey = ProjectPortfolioService.requireText(
+                    key, "extensionAttributes key", MAX_EXTENSION_KEY_CHARACTERS);
+            String normalizedValue = ProjectPortfolioService.limited(
+                    value, MAX_EXTENSION_VALUE_CHARACTERS,
+                    "extensionAttributes[" + normalizedKey + "]");
+            if (normalizedValue == null) {
+                throw PortfolioException.validation(
+                        "extensionAttributes[" + normalizedKey + "] must not be null");
+            }
+            normalized.put(normalizedKey, normalizedValue);
+        });
+        return Map.copyOf(normalized);
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProductCatalogService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProductCatalogService.java
@@ -69,10 +69,13 @@ public class ProductCatalogService {
         }
         String source = ProjectPortfolioService.requireText(
                 request.sourceReference(), "sourceReference", 100_000);
-        if (request.verifiedAt() == null) {
-            throw PortfolioException.validation("verifiedAt is required for product claims");
-        }
         Instant now = Instant.now();
+        var costAmount = PortfolioValueValidator.money(request.costAmount(), "costAmount");
+        String costCurrency = normalizeCurrency(request.costCurrency());
+        PortfolioValueValidator.requireMoneyPair(
+                costAmount, costCurrency, "costAmount", "costCurrency");
+        Instant verifiedAt = PortfolioValueValidator.verifiedAt(request.verifiedAt(), now, true);
+
         ProductCatalogEntry product = new ProductCatalogEntry(
                 scopeKey,
                 PortfolioScope.workspaceId(context),
@@ -88,11 +91,11 @@ public class ProductCatalogService {
                 ProjectPortfolioService.limited(request.supportedPlatforms(), 2000, "supportedPlatforms"),
                 ProjectPortfolioService.limited(request.securityFeatures(), 4000, "securityFeatures"),
                 ProjectPortfolioService.limited(request.complianceFeatures(), 4000, "complianceFeatures"),
-                request.costAmount(),
-                normalizeCurrency(request.costCurrency()),
+                costAmount,
+                costCurrency,
                 ProjectPortfolioService.limited(request.costBasis(), 500, "costBasis"),
                 source,
-                request.verifiedAt(),
+                verifiedAt,
                 PortfolioScope.username(username, context),
                 now);
         return toProductView(productRepository.save(product));
@@ -117,6 +120,20 @@ public class ProductCatalogService {
                                      WorkspaceContext context) {
         if (request == null) throw PortfolioException.validation("product update is required");
         ProductCatalogEntry product = requireProduct(productId, username, context);
+        Instant now = Instant.now();
+        var requestedAmount = request.costAmount() != null
+                ? PortfolioValueValidator.money(request.costAmount(), "costAmount") : null;
+        String requestedCurrency = request.costCurrency() != null
+                ? normalizeCurrency(request.costCurrency()) : null;
+        var effectiveAmount = request.costAmount() != null
+                ? requestedAmount : product.getCostAmount();
+        String effectiveCurrency = request.costCurrency() != null
+                ? requestedCurrency : product.getCostCurrency();
+        PortfolioValueValidator.requireMoneyPair(
+                effectiveAmount, effectiveCurrency, "costAmount", "costCurrency");
+        Instant verifiedAt = request.verifiedAt() != null
+                ? PortfolioValueValidator.verifiedAt(request.verifiedAt(), now, false) : null;
+
         product.update(
                 request.manufacturer() != null
                         ? ProjectPortfolioService.requireText(request.manufacturer(), "manufacturer", 240) : null,
@@ -131,14 +148,14 @@ public class ProductCatalogService {
                 ProjectPortfolioService.limited(request.supportedPlatforms(), 2000, "supportedPlatforms"),
                 ProjectPortfolioService.limited(request.securityFeatures(), 4000, "securityFeatures"),
                 ProjectPortfolioService.limited(request.complianceFeatures(), 4000, "complianceFeatures"),
-                request.costAmount(),
-                normalizeCurrency(request.costCurrency()),
+                requestedAmount,
+                requestedCurrency,
                 ProjectPortfolioService.limited(request.costBasis(), 500, "costBasis"),
                 request.sourceReference() != null
                         ? ProjectPortfolioService.requireText(
                                 request.sourceReference(), "sourceReference", 100_000) : null,
-                request.verifiedAt(),
-                Instant.now());
+                verifiedAt,
+                now);
         return toProductView(product);
     }
 
@@ -349,11 +366,6 @@ public class ProductCatalogService {
     }
 
     private static String normalizeCurrency(String value) {
-        if (value == null || value.isBlank()) return null;
-        String normalized = value.strip().toUpperCase(Locale.ROOT);
-        if (!normalized.matches("[A-Z]{3}")) {
-            throw PortfolioException.validation("costCurrency must be a three-letter ISO currency code");
-        }
-        return normalized;
+        return PortfolioValueValidator.currency(value, "costCurrency");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
@@ -80,6 +80,11 @@ public class ProjectPortfolioService {
             throw PortfolioException.conflict("Project key already exists in this workspace: " + projectKey);
         }
 
+        var budgetAmount = PortfolioValueValidator.money(request.budgetAmount(), "budgetAmount");
+        String budgetCurrency = normalizeCurrency(request.budgetCurrency());
+        PortfolioValueValidator.requireMoneyPair(
+                budgetAmount, budgetCurrency, "budgetAmount", "budgetCurrency");
+
         Instant now = Instant.now();
         ArchitectureProject project = new ArchitectureProject(
                 scopeKey,
@@ -96,8 +101,8 @@ public class ProjectPortfolioService {
                 null,
                 limited(request.targetArchitecture(), 4000, "targetArchitecture"),
                 request.targetDate(),
-                request.budgetAmount(),
-                normalizeCurrency(request.budgetCurrency()),
+                budgetAmount,
+                budgetCurrency,
                 now);
         return toProjectView(projectRepository.save(project));
     }
@@ -120,14 +125,25 @@ public class ProjectPortfolioService {
                                      WorkspaceContext context) {
         requireNonNull(request, "project update");
         ArchitectureProject project = requireProject(projectId, username, context);
+        var requestedAmount = request.budgetAmount() != null
+                ? PortfolioValueValidator.money(request.budgetAmount(), "budgetAmount") : null;
+        String requestedCurrency = request.budgetCurrency() != null
+                ? normalizeCurrency(request.budgetCurrency()) : null;
+        var effectiveAmount = request.budgetAmount() != null
+                ? requestedAmount : project.getBudgetAmount();
+        String effectiveCurrency = request.budgetCurrency() != null
+                ? requestedCurrency : project.getBudgetCurrency();
+        PortfolioValueValidator.requireMoneyPair(
+                effectiveAmount, effectiveCurrency, "budgetAmount", "budgetCurrency");
+
         project.update(
                 request.title() != null ? requireText(request.title(), "title", 240) : null,
                 limited(request.description(), 4000, "description"),
                 request.status(),
                 limited(request.targetArchitecture(), 4000, "targetArchitecture"),
                 request.targetDate(),
-                request.budgetAmount(),
-                normalizeCurrency(request.budgetCurrency()),
+                requestedAmount,
+                requestedCurrency,
                 Instant.now());
         return toProjectView(project);
     }
@@ -157,7 +173,8 @@ public class ProjectPortfolioService {
                 request.requirementType() != null ? request.requirementType() : RequirementType.FUNCTIONAL,
                 request.reviewStatus() != null ? request.reviewStatus() : ReviewStatus.PROPOSED,
                 request.ownerUsername() != null && !request.ownerUsername().isBlank()
-                        ? request.ownerUsername().strip() : PortfolioScope.username(username, context),
+                        ? requireText(request.ownerUsername(), "ownerUsername", 160)
+                        : PortfolioScope.username(username, context),
                 now);
         requirementRepository.save(requirement);
         ProjectRequirementVersion version = createVersionEntity(
@@ -238,7 +255,7 @@ public class ProjectPortfolioService {
                 request.requirementType(),
                 request.reviewStatus(),
                 request.ownerUsername() != null && !request.ownerUsername().isBlank()
-                        ? request.ownerUsername().strip() : null,
+                        ? requireText(request.ownerUsername(), "ownerUsername", 160) : null,
                 Instant.now());
         return toRequirementView(requirement, currentVersion(requirement));
     }
@@ -250,7 +267,8 @@ public class ProjectPortfolioService {
                                                         String username,
                                                         WorkspaceContext context) {
         requireNonNull(request, "requirement version request");
-        ProjectRequirement requirement = requireRequirement(projectId, requirementId, username, context);
+        ProjectRequirement requirement = requireRequirementForUpdate(
+                projectId, requirementId, username, context);
         String text = requireText(request.text(), "text", 100_000);
         String contentHash = fingerprintService.contentFingerprint(text);
         ProjectRequirementVersion existing = versionRepository
@@ -305,6 +323,17 @@ public class ProjectPortfolioService {
         requireProject(projectId, username, context);
         if (requirementId == null) throw PortfolioException.validation("requirementId is required");
         return requirementRepository.findByIdAndProjectId(requirementId, projectId)
+                .orElseThrow(() -> PortfolioException.notFound(
+                        "Requirement " + requirementId + " was not found in project " + projectId));
+    }
+
+    private ProjectRequirement requireRequirementForUpdate(Long projectId,
+                                                           Long requirementId,
+                                                           String username,
+                                                           WorkspaceContext context) {
+        requireProject(projectId, username, context);
+        if (requirementId == null) throw PortfolioException.validation("requirementId is required");
+        return requirementRepository.findByIdAndProjectIdForUpdate(requirementId, projectId)
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Requirement " + requirementId + " was not found in project " + projectId));
     }
@@ -393,9 +422,12 @@ public class ProjectPortfolioService {
                                                            String createdBy,
                                                            int versionNumber,
                                                            Instant now) {
-        List<Long> fragmentIds = source != null && source.sourceFragmentIds() != null
-                ? source.sourceFragmentIds().stream().filter(Objects::nonNull).distinct().toList()
-                : List.of();
+        List<Long> fragmentIds = sourceFragmentIds(source);
+        Long sourceArtifactId = source != null
+                ? positiveIdentifier(source.sourceArtifactId(), "sourceArtifactId") : null;
+        Long sourceVersionId = source != null
+                ? positiveIdentifier(source.sourceVersionId(), "sourceVersionId") : null;
+        Integer pageNumber = source != null ? positivePageNumber(source.pageNumber()) : null;
         return new ProjectRequirementVersion(
                 requirement,
                 versionNumber,
@@ -404,12 +436,47 @@ public class ProjectPortfolioService {
                 limited(changeReason, 1000, "changeReason"),
                 createdBy,
                 now,
-                source != null ? source.sourceArtifactId() : null,
-                source != null ? source.sourceVersionId() : null,
+                sourceArtifactId,
+                sourceVersionId,
                 jsonCodec.write(fragmentIds),
                 source != null ? limited(source.sectionReference(), 500, "sectionReference") : null,
-                source != null ? source.pageNumber() : null,
-                source != null ? source.originalText() : null);
+                pageNumber,
+                source != null
+                        ? limited(source.originalText(),
+                                PortfolioValueValidator.MAX_ORIGINAL_TEXT_CHARACTERS,
+                                "originalText")
+                        : null);
+    }
+
+    private static List<Long> sourceFragmentIds(SourceReference source) {
+        if (source == null || source.sourceFragmentIds() == null) return List.of();
+        if (source.sourceFragmentIds().size() > PortfolioValueValidator.MAX_SOURCE_FRAGMENT_IDS) {
+            throw PortfolioException.validation(
+                    "sourceFragmentIds contains more than "
+                            + PortfolioValueValidator.MAX_SOURCE_FRAGMENT_IDS + " entries");
+        }
+        List<Long> fragmentIds = source.sourceFragmentIds().stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (fragmentIds.stream().anyMatch(id -> id <= 0)) {
+            throw PortfolioException.validation("sourceFragmentIds must contain only positive identifiers");
+        }
+        return fragmentIds;
+    }
+
+    private static Long positiveIdentifier(Long value, String field) {
+        if (value != null && value <= 0) {
+            throw PortfolioException.validation(field + " must be a positive identifier");
+        }
+        return value;
+    }
+
+    private static Integer positivePageNumber(Integer value) {
+        if (value != null && value < 1) {
+            throw PortfolioException.validation("pageNumber must be positive");
+        }
+        return value;
     }
 
     private static int normalizePriority(Integer priority) {
@@ -430,12 +497,7 @@ public class ProjectPortfolioService {
     }
 
     private static String normalizeCurrency(String currency) {
-        if (currency == null || currency.isBlank()) return null;
-        String normalized = currency.strip().toUpperCase(Locale.ROOT);
-        if (!normalized.matches("[A-Z]{3}")) {
-            throw PortfolioException.validation("budgetCurrency must be a three-letter ISO currency code");
-        }
-        return normalized;
+        return PortfolioValueValidator.currency(currency, "budgetCurrency");
     }
 
     static String requireText(String value, String field, int maximumLength) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/SolutionPortfolioService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/SolutionPortfolioService.java
@@ -98,6 +98,17 @@ public class SolutionPortfolioService {
             throw PortfolioException.conflict("Solution key already exists in this workspace: " + solutionKey);
         }
         int maturity = normalizeMaturity(request.maturityLevel());
+        var costAmount = PortfolioValueValidator.money(request.costAmount(), "costAmount");
+        String costCurrency = normalizeCurrency(request.costCurrency());
+        PortfolioValueValidator.requireMoneyPair(
+                costAmount, costCurrency, "costAmount", "costCurrency");
+        Integer leadTimeDays = PortfolioValueValidator.nonNegativeDays(
+                request.leadTimeDays(), "leadTimeDays");
+        Map<String, String> extensionAttributes = PortfolioValueValidator.extensionAttributes(
+                request.extensionAttributes() != null ? request.extensionAttributes() : Map.of());
+        String extensionAttributesJson = ProjectPortfolioService.limited(
+                jsonCodec.write(extensionAttributes), 4000, "extensionAttributes");
+
         Instant now = Instant.now();
         SolutionDefinition solution = new SolutionDefinition(
                 scopeKey,
@@ -122,12 +133,11 @@ public class SolutionPortfolioService {
                 null,
                 null,
                 null,
-                request.costAmount(),
-                normalizeCurrency(request.costCurrency()),
+                costAmount,
+                costCurrency,
                 ProjectPortfolioService.limited(request.riskNotes(), 2000, "riskNotes"),
-                request.leadTimeDays(),
-                jsonCodec.write(request.extensionAttributes() != null
-                        ? request.extensionAttributes() : Map.of()),
+                leadTimeDays,
+                extensionAttributesJson,
                 now);
         return toSolutionView(solutionRepository.save(solution));
     }
@@ -150,6 +160,26 @@ public class SolutionPortfolioService {
                                        WorkspaceContext context) {
         if (request == null) throw PortfolioException.validation("solution update is required");
         SolutionDefinition solution = requireSolution(solutionId, username, context);
+        var requestedAmount = request.costAmount() != null
+                ? PortfolioValueValidator.money(request.costAmount(), "costAmount") : null;
+        String requestedCurrency = request.costCurrency() != null
+                ? normalizeCurrency(request.costCurrency()) : null;
+        var effectiveAmount = request.costAmount() != null
+                ? requestedAmount : solution.getCostAmount();
+        String effectiveCurrency = request.costCurrency() != null
+                ? requestedCurrency : solution.getCostCurrency();
+        PortfolioValueValidator.requireMoneyPair(
+                effectiveAmount, effectiveCurrency, "costAmount", "costCurrency");
+        Integer leadTimeDays = request.leadTimeDays() != null
+                ? PortfolioValueValidator.nonNegativeDays(request.leadTimeDays(), "leadTimeDays") : null;
+        String extensionAttributesJson = null;
+        if (request.extensionAttributes() != null) {
+            extensionAttributesJson = ProjectPortfolioService.limited(
+                    jsonCodec.write(PortfolioValueValidator.extensionAttributes(request.extensionAttributes())),
+                    4000,
+                    "extensionAttributes");
+        }
+
         solution.update(
                 request.title() != null
                         ? ProjectPortfolioService.requireText(request.title(), "title", 240) : null,
@@ -159,14 +189,14 @@ public class SolutionPortfolioService {
                 request.lifecycleStatus(),
                 request.maturityLevel() != null ? normalizeMaturity(request.maturityLevel()) : null,
                 request.ownerUsername() != null && !request.ownerUsername().isBlank()
-                        ? request.ownerUsername().strip() : null,
+                        ? ProjectPortfolioService.requireText(request.ownerUsername(), "ownerUsername", 160) : null,
                 ProjectPortfolioService.limited(
                         request.responsibleOrganization(), 240, "responsibleOrganization"),
-                request.costAmount(),
-                normalizeCurrency(request.costCurrency()),
+                requestedAmount,
+                requestedCurrency,
                 ProjectPortfolioService.limited(request.riskNotes(), 2000, "riskNotes"),
-                request.leadTimeDays(),
-                request.extensionAttributes() != null ? jsonCodec.write(request.extensionAttributes()) : null,
+                leadTimeDays,
+                extensionAttributesJson,
                 Instant.now());
         return toSolutionView(solution);
     }
@@ -517,11 +547,6 @@ public class SolutionPortfolioService {
     }
 
     private static String normalizeCurrency(String value) {
-        if (value == null || value.isBlank()) return null;
-        String normalized = value.strip().toUpperCase(Locale.ROOT);
-        if (!normalized.matches("[A-Z]{3}")) {
-            throw PortfolioException.validation("costCurrency must be a three-letter ISO currency code");
-        }
-        return normalized;
+        return PortfolioValueValidator.currency(value, "costCurrency");
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioInputValidationIntegrationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioInputValidationIntegrationTest.java
@@ -1,0 +1,160 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProductRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateSolutionRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.SourceReference;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.LifecycleStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.OperatingModel;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProductStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.SolutionType;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.ProductCatalogService;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.portfolio.service.SolutionPortfolioService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class PortfolioInputValidationIntegrationTest {
+
+    @Autowired private ProjectPortfolioService projectService;
+    @Autowired private ProductCatalogService productService;
+    @Autowired private SolutionPortfolioService solutionService;
+
+    @Test
+    void rejectsUnregisteredProjectCurrencyAndUnpairedBudget() {
+        WorkspaceContext context = context("budget-validation");
+
+        assertThatThrownBy(() -> projectService.createProject(
+                projectRequest(new BigDecimal("100.00"), "ZZZ"),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("ISO 4217");
+        assertThatThrownBy(() -> projectService.createProject(
+                projectRequest(new BigDecimal("100.00"), null),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("must be supplied together");
+    }
+
+    @Test
+    void rejectsFutureProductVerificationAndNegativeSolutionCost() {
+        WorkspaceContext context = context("catalog-validation");
+
+        assertThatThrownBy(() -> productService.createProduct(
+                new CreateProductRequest(
+                        "PRD-" + shortId(),
+                        "Example Manufacturer",
+                        null,
+                        "Example Product",
+                        "1.0",
+                        ProductStatus.CANDIDATE,
+                        null,
+                        null,
+                        OperatingModel.SAAS,
+                        null,
+                        null,
+                        null,
+                        new BigDecimal("10.00"),
+                        "EUR",
+                        "per month",
+                        "Vendor documentation",
+                        Instant.now().plusSeconds(600)),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("five minutes");
+
+        assertThatThrownBy(() -> solutionService.createSolution(
+                new CreateSolutionRequest(
+                        "SOL-" + shortId(),
+                        "Example solution",
+                        null,
+                        SolutionType.SERVICE,
+                        OperatingModel.SAAS,
+                        LifecycleStatus.PLANNED,
+                        1,
+                        null,
+                        new BigDecimal("-1.00"),
+                        "EUR",
+                        null,
+                        30,
+                        Map.of()),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("must not be negative");
+    }
+
+    @Test
+    void boundsRequirementSourceFragmentListsBeforeSerialization() {
+        WorkspaceContext context = context("source-validation");
+        var project = projectService.createProject(
+                projectRequest(null, null), context.username(), context);
+        SourceReference source = new SourceReference(
+                1L,
+                1L,
+                Collections.nCopies(1_001, 1L),
+                "section",
+                1,
+                "source text");
+
+        assertThatThrownBy(() -> projectService.createRequirement(
+                project.id(),
+                new CreateRequirementRequest(
+                        "REQ-001",
+                        "Sourced requirement",
+                        "Requirement text",
+                        RequirementStatus.DRAFT,
+                        50,
+                        Criticality.MEDIUM,
+                        RequirementType.FUNCTIONAL,
+                        ReviewStatus.PROPOSED,
+                        context.username(),
+                        null,
+                        source),
+                context.username(),
+                context))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("more than 1000 entries");
+    }
+
+    private static CreateProjectRequest projectRequest(BigDecimal amount, String currency) {
+        return new CreateProjectRequest(
+                "P-" + shortId(),
+                "Validation project",
+                null,
+                ProjectStatus.ACTIVE,
+                null,
+                null,
+                amount,
+                currency);
+    }
+
+    private static WorkspaceContext context(String username) {
+        return new WorkspaceContext(username, "ws-" + username + "-" + shortId(), "draft");
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementVersionConcurrencyTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementVersionConcurrencyTest.java
@@ -1,0 +1,116 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementVersionRequest;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ProjectRequirementVersionConcurrencyTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Test
+    void allocatesMonotonicUniqueVersionNumbersUnderConcurrentWriters() throws Exception {
+        WorkspaceContext context = new WorkspaceContext(
+                "version-writer", "ws-version-" + shortId(), "draft");
+        var project = projectService.createProject(
+                new CreateProjectRequest(
+                        "P-" + shortId(),
+                        "Concurrent version project",
+                        null,
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                context.username(),
+                context);
+        var requirement = projectService.createRequirement(
+                project.id(),
+                new CreateRequirementRequest(
+                        "REQ-001",
+                        "Concurrent requirement",
+                        "Initial immutable text",
+                        RequirementStatus.APPROVED,
+                        50,
+                        Criticality.MEDIUM,
+                        RequirementType.FUNCTIONAL,
+                        ReviewStatus.CONFIRMED,
+                        context.username(),
+                        "Initial version",
+                        null),
+                context.username(),
+                context);
+
+        int writers = 8;
+        CountDownLatch ready = new CountDownLatch(writers);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(writers);
+        try {
+            List<Future<Integer>> futures = new ArrayList<>();
+            for (int index = 0; index < writers; index++) {
+                int writer = index;
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    if (!start.await(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Concurrent writers did not start together");
+                    }
+                    return projectService.addRequirementVersion(
+                            project.id(),
+                            requirement.id(),
+                            new CreateRequirementVersionRequest(
+                                    "Immutable text from writer " + writer,
+                                    "Concurrent update " + writer,
+                                    null),
+                            context.username(),
+                            context).versionNumber();
+                }));
+            }
+
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            List<Integer> allocated = new ArrayList<>();
+            for (Future<Integer> future : futures) {
+                allocated.add(future.get(30, TimeUnit.SECONDS));
+            }
+
+            assertThat(allocated)
+                    .doesNotHaveDuplicates()
+                    .containsExactlyInAnyOrder(2, 3, 4, 5, 6, 7, 8, 9);
+            assertThat(projectService.listRequirementVersions(
+                    project.id(), requirement.id(), context.username(), context))
+                    .extracting(version -> version.versionNumber())
+                    .containsExactly(9, 8, 7, 6, 5, 4, 3, 2, 1);
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/service/PortfolioValueValidatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/service/PortfolioValueValidatorTest.java
@@ -1,0 +1,77 @@
+package com.taxonomy.portfolio.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PortfolioValueValidatorTest {
+
+    @Test
+    void normalizesDatabaseCompatibleMoneyAndRejectsInvalidValues() {
+        assertThat(PortfolioValueValidator.money(new BigDecimal("123.4500"), "amount"))
+                .isEqualByComparingTo("123.45");
+        assertThat(PortfolioValueValidator.money(BigDecimal.ZERO, "amount"))
+                .isEqualByComparingTo(BigDecimal.ZERO);
+
+        assertThatThrownBy(() -> PortfolioValueValidator.money(
+                new BigDecimal("-0.01"), "amount"))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("must not be negative");
+        assertThatThrownBy(() -> PortfolioValueValidator.money(
+                new BigDecimal("1.001"), "amount"))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("at most 2 decimal places");
+        assertThatThrownBy(() -> PortfolioValueValidator.money(
+                new BigDecimal("100000000000000000"), "amount"))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("17 integer digits");
+    }
+
+    @Test
+    void acceptsRegisteredIsoCurrencyCodesOnly() {
+        assertThat(PortfolioValueValidator.currency(" eur ", "currency")).isEqualTo("EUR");
+        assertThatThrownBy(() -> PortfolioValueValidator.currency("AAA", "currency"))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("ISO 4217");
+        assertThatThrownBy(() -> PortfolioValueValidator.requireMoneyPair(
+                BigDecimal.ONE, null, "amount", "currency"))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("must be supplied together");
+    }
+
+    @Test
+    void rejectsVerificationDatesBeyondClockSkew() {
+        Instant now = Instant.parse("2026-08-03T06:00:00Z");
+        assertThat(PortfolioValueValidator.verifiedAt(now.plusSeconds(300), now, true))
+                .isEqualTo(now.plusSeconds(300));
+        assertThatThrownBy(() -> PortfolioValueValidator.verifiedAt(
+                now.plusSeconds(301), now, true))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("five minutes");
+    }
+
+    @Test
+    void boundsExtensionAttributeCountKeysAndValues() {
+        Map<String, String> normalized = PortfolioValueValidator.extensionAttributes(
+                Map.of(" owner ", " architecture "));
+        assertThat(normalized).containsEntry("owner", "architecture");
+
+        Map<String, String> tooMany = new LinkedHashMap<>();
+        for (int index = 0; index <= PortfolioValueValidator.MAX_EXTENSION_ATTRIBUTES; index++) {
+            tooMany.put("key-" + index, "value");
+        }
+        assertThatThrownBy(() -> PortfolioValueValidator.extensionAttributes(tooMany))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("more than 100 entries");
+        assertThatThrownBy(() -> PortfolioValueValidator.extensionAttributes(
+                Map.of("key", "x".repeat(PortfolioValueValidator.MAX_EXTENSION_VALUE_CHARACTERS + 1))))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("exceeds 1000 characters");
+    }
+}


### PR DESCRIPTION
## Summary

Addresses the remaining P2 data-integrity and input-boundary findings from #549.

- serializes requirement version allocation with a database write lock, eliminating the concurrent `max + 1` race
- validates project, solution and product money against the persisted `DECIMAL(19,2)` shape
- requires amount and currency together and accepts registered ISO 4217 codes instead of a three-letter regex
- rejects product verification timestamps more than five minutes in the future
- bounds solution lead times and extension-attribute count, key/value size and serialized JSON size
- bounds source fragment lists and original source text; rejects non-positive provenance identifiers and page numbers
- bounds owner usernames consistently
- adds a simultaneous eight-writer version regression plus focused unit and integration validation tests

## Verification

- concurrent writers must allocate exactly versions 2 through 9 without duplicates
- invalid currency, unpaired money, negative/over-precise/oversized money and future verification timestamps fail as typed portfolio validation errors
- oversized provenance lists fail before JSON persistence
- extension attributes are normalized and bounded before serialization

Part of #549.