### PR TITLE
Deny unclassified API write methods by default

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
  * Shared authorization rules used by both the form-login and Keycloak
  * security configurations. Rules are ordered from most specific to least
  * specific so that state-changing endpoints are never accidentally covered by
- * the generic authenticated-user fallback.
+ * a generic authenticated-user fallback.
  */
 @Component
 public class AuthorizationRulesConfigurer {
@@ -49,8 +49,8 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.DELETE, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
 
         // Proposal generation and review mutate proposal state and can create or
-        // delete real relations. Keep these endpoints out of the generic
-        // authenticated-user fallback.
+        // delete real relations. Keep these endpoints out of the read-only
+        // authenticated-user allowlist.
         auth.requestMatchers(HttpMethod.POST,   "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PUT,    "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
@@ -82,6 +82,8 @@ public class AuthorizationRulesConfigurer {
                         "/api/workspace/resolve-diverged")
                 .hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/workspace/**").hasRole("ADMIN");
+        auth.requestMatchers(HttpMethod.PUT, "/api/workspace/**").hasRole("ADMIN");
+        auth.requestMatchers(HttpMethod.DELETE, "/api/workspace/**").hasRole("ADMIN");
 
         // Import preview is read-only, while materialization and provenance
         // registration mutate workspace state.
@@ -91,6 +93,18 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.POST, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PUT, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
+
+        // Legacy requirement coverage is persisted state, not a read-only
+        // calculation. Recording and deleting mappings therefore require an
+        // architecture role even though reads remain available below.
+        auth.requestMatchers(HttpMethod.POST, "/api/coverage/**")
+                .hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.DELETE, "/api/coverage/**")
+                .hasAnyRole("ARCHITECT", "ADMIN");
+
+        // Recomputing derived metadata writes the catalogue projection.
+        auth.requestMatchers(HttpMethod.POST, "/api/architecture/metadata/recompute")
+                .hasAnyRole("ARCHITECT", "ADMIN");
 
         // Project analysis is an end-user operation. More general project writes
         // remain restricted below. The specific matchers must precede /api/projects/**.
@@ -119,18 +133,36 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.DELETE, "/api/solutions/**", "/api/products/**")
                 .hasAnyRole("ARCHITECT", "ADMIN");
 
+        // End-user calculations use POST bodies but do not persist architecture
+        // decisions. They need an explicit allowlist so an unknown POST endpoint
+        // cannot inherit the same permission accidentally.
+        auth.requestMatchers(HttpMethod.POST,
+                        "/api/recommend",
+                        "/api/gap/**",
+                        "/api/patterns/**",
+                        "/api/explain/**",
+                        "/api/graph/**")
+                .hasAnyRole("USER", "ARCHITECT", "ADMIN");
+
+        // Local-account self-service is available to every authenticated user.
+        auth.requestMatchers(HttpMethod.POST, "/api/account/change-password").authenticated();
+
         // End-user analysis and export operations.
         auth.requestMatchers(HttpMethod.POST, "/api/export/**").hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/report/**").hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/analyze").authenticated();
         auth.requestMatchers(HttpMethod.POST, "/api/justify-leaf").authenticated();
 
-        // Reading API — any authenticated user.
+        // Reading API — any authenticated user. HEAD follows the same visibility
+        // contract. OPTIONS remains public so standards-compliant CORS preflight
+        // can complete before authentication is evaluated.
         auth.requestMatchers(HttpMethod.GET, "/api/**").authenticated();
+        auth.requestMatchers(HttpMethod.HEAD, "/api/**").authenticated();
+        auth.requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll();
 
-        // Remaining API requests must still be authenticated. Specific write
-        // capabilities should be added above rather than relying on this rule.
-        auth.requestMatchers("/api/**").authenticated();
+        // Fail closed for every API method and path not explicitly classified
+        // above. New write endpoints must declare their intended role here.
+        auth.requestMatchers("/api/**").denyAll();
         auth.requestMatchers("/**").authenticated();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -32,50 +32,33 @@ public class AuthorizationRulesConfigurer {
             auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").authenticated();
         }
 
-        // The UI uses these endpoints to decide whether to show the admin lock.
-        // They must be reachable by authenticated non-admin users, but never grant
-        // additional privileges; the controller derives the result from ROLE_ADMIN.
         auth.requestMatchers("/api/admin/status", "/api/admin/verify").authenticated();
-
-        // Administrative surfaces. These checks are also repeated inside the
-        // controller as defense in depth for diagnostics and prompt mutation.
         auth.requestMatchers("/admin/**", "/api/admin/**", "/api/preferences/**",
                         "/api/diagnostics", "/api/prompts/**")
                 .hasRole("ADMIN");
 
-        // Architecture mutation — ARCHITECT or ADMIN.
-        auth.requestMatchers(HttpMethod.POST,   "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
-        auth.requestMatchers(HttpMethod.PUT,    "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.POST, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/relations/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        // Proposal generation and review mutate proposal state and can create or
-        // delete real relations. Keep these endpoints out of the read-only
-        // authenticated-user allowlist.
-        auth.requestMatchers(HttpMethod.POST,   "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
-        auth.requestMatchers(HttpMethod.PUT,    "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.POST, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        // Parse, validate and format transform request content only and are used by
-        // the editor for every authenticated role. More general DSL writes below
-        // remain restricted to ARCHITECT and ADMIN.
         auth.requestMatchers(HttpMethod.POST, "/api/dsl/parse", "/api/dsl/validate", "/api/dsl/format")
                 .authenticated();
-        auth.requestMatchers(HttpMethod.POST,   "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
-        auth.requestMatchers(HttpMethod.PUT,    "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.POST, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        auth.requestMatchers(HttpMethod.POST,   "/api/git/**").hasAnyRole("ARCHITECT", "ADMIN");
-        auth.requestMatchers(HttpMethod.PUT,    "/api/git/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.POST, "/api/git/**").hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.PUT, "/api/git/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/git/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        auth.requestMatchers(HttpMethod.GET,  "/api/context/**").authenticated();
+        auth.requestMatchers(HttpMethod.GET, "/api/context/**").authenticated();
         auth.requestMatchers(HttpMethod.POST, "/api/context/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        auth.requestMatchers(HttpMethod.GET,  "/api/workspace/**").authenticated();
-        // Pull, publish and semantic divergence resolution are ordinary
-        // architecture collaboration operations. They are scoped to the current
-        // user's workspace and therefore require ARCHITECT, not global ADMIN.
-        // These specific rules must precede the administrative workspace fallback.
+        auth.requestMatchers(HttpMethod.GET, "/api/workspace/**").authenticated();
         auth.requestMatchers(HttpMethod.POST,
                         "/api/workspace/sync-from-shared",
                         "/api/workspace/publish",
@@ -85,36 +68,27 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.PUT, "/api/workspace/**").hasRole("ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/workspace/**").hasRole("ADMIN");
 
-        // Import preview is read-only, while materialization and provenance
-        // registration mutate workspace state.
-        auth.requestMatchers(HttpMethod.POST, "/api/import/preview/**").hasAnyRole("USER", "ARCHITECT", "ADMIN");
+        auth.requestMatchers(HttpMethod.POST, "/api/import/preview/**")
+                .hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/import/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/documents/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PUT, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/provenance/**").hasAnyRole("ARCHITECT", "ADMIN");
 
-        // Legacy requirement coverage is persisted state, not a read-only
-        // calculation. Recording and deleting mappings therefore require an
-        // architecture role even though reads remain available below.
         auth.requestMatchers(HttpMethod.POST, "/api/coverage/**")
                 .hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/coverage/**")
                 .hasAnyRole("ARCHITECT", "ADMIN");
-
-        // Recomputing derived metadata writes the catalogue projection.
         auth.requestMatchers(HttpMethod.POST, "/api/architecture/metadata/recompute")
                 .hasAnyRole("ARCHITECT", "ADMIN");
 
-        // Project analysis is an end-user operation. More general project writes
-        // remain restricted below. The specific matchers must precede /api/projects/**.
         auth.requestMatchers(HttpMethod.POST,
                         "/api/projects/*/analyses",
                         "/api/projects/*/requirements/*/analyses",
                         "/api/projects/*/analysis-jobs/*/retry-failed")
                 .hasAnyRole("USER", "ARCHITECT", "ADMIN");
 
-        // Project, solution and sourced product portfolio mutation.
         auth.requestMatchers(HttpMethod.POST, "/api/projects/**")
                 .hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.PATCH, "/api/projects/**")
@@ -133,35 +107,29 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.DELETE, "/api/solutions/**", "/api/products/**")
                 .hasAnyRole("ARCHITECT", "ADMIN");
 
-        // End-user calculations use POST bodies but do not persist architecture
-        // decisions. They need an explicit allowlist so an unknown POST endpoint
-        // cannot inherit the same permission accidentally.
+        // End-user calculations and file transformations use POST bodies but do
+        // not persist architecture decisions. They are explicitly enumerated so
+        // a newly introduced POST endpoint cannot inherit the same permission.
         auth.requestMatchers(HttpMethod.POST,
                         "/api/recommend",
                         "/api/gap/**",
                         "/api/patterns/**",
                         "/api/explain/**",
-                        "/api/graph/**")
+                        "/api/graph/**",
+                        "/api/diagram/**",
+                        "/api/scores/**",
+                        "/api/export/**",
+                        "/api/report/**")
                 .hasAnyRole("USER", "ARCHITECT", "ADMIN");
 
-        // Local-account self-service is available to every authenticated user.
         auth.requestMatchers(HttpMethod.POST, "/api/account/change-password").authenticated();
-
-        // End-user analysis and export operations.
-        auth.requestMatchers(HttpMethod.POST, "/api/export/**").hasAnyRole("USER", "ARCHITECT", "ADMIN");
-        auth.requestMatchers(HttpMethod.POST, "/api/report/**").hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/analyze").authenticated();
         auth.requestMatchers(HttpMethod.POST, "/api/justify-leaf").authenticated();
 
-        // Reading API — any authenticated user. HEAD follows the same visibility
-        // contract. OPTIONS remains public so standards-compliant CORS preflight
-        // can complete before authentication is evaluated.
         auth.requestMatchers(HttpMethod.GET, "/api/**").authenticated();
         auth.requestMatchers(HttpMethod.HEAD, "/api/**").authenticated();
         auth.requestMatchers(HttpMethod.OPTIONS, "/api/**").permitAll();
 
-        // Fail closed for every API method and path not explicitly classified
-        // above. New write endpoints must declare their intended role here.
         auth.requestMatchers("/api/**").denyAll();
         auth.requestMatchers("/**").authenticated();
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
@@ -9,6 +9,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -53,7 +54,7 @@ class ApiWriteDenyByDefaultSecurityTest {
 
     @Test
     @WithMockUser(roles = "USER")
-    void userCanStillCallExplicitlyClassifiedReadOnlyPostAnalysis() throws Exception {
+    void userReachesExplicitlyClassifiedReadOnlyPostAnalysis() throws Exception {
         mockMvc.perform(post("/api/recommend")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -64,7 +65,9 @@ class ApiWriteDenyByDefaultSecurityTest {
                                   "minScore": 50
                                 }
                                 """))
-                .andExpect(status().isOk());
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .as("explicitly classified analysis POST must pass authorization")
+                        .isNotEqualTo(403));
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
@@ -1,0 +1,93 @@
+package com.taxonomy.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key="
+})
+class ApiWriteDenyByDefaultSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userCannotReachAnyUnclassifiedApiWriteMethod() throws Exception {
+        mockMvc.perform(post("/api/unclassified-write").with(csrf()))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(put("/api/unclassified-write").with(csrf()))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(patch("/api/unclassified-write").with(csrf()))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(delete("/api/unclassified-write").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void adminCannotBypassTheUnclassifiedApiWriteDenyRule() throws Exception {
+        mockMvc.perform(post("/api/unclassified-write").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userCanStillCallExplicitlyClassifiedReadOnlyPostAnalysis() throws Exception {
+        mockMvc.perform(post("/api/recommend")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "scores": {},
+                                  "businessText": "Provide traceable secure communication.",
+                                  "minScore": 50
+                                }
+                                """))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userCannotTriggerDerivedMetadataWrites() throws Exception {
+        mockMvc.perform(post("/api/architecture/metadata/recompute").with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userCannotPersistLegacyCoverageMappings() throws Exception {
+        mockMvc.perform(post("/api/coverage/record")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "requirementId": "REQ-SECURITY",
+                                  "requirementText": "security contract",
+                                  "scores": {"CP-1000": 80},
+                                  "minScore": 50
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ExternalSyncControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ExternalSyncControllerTest.java
@@ -1,106 +1,126 @@
 package com.taxonomy.workspace.controller;
 
-import com.taxonomy.workspace.config.RepositoryTopologyProperties;
-import com.taxonomy.workspace.service.ExternalSyncService;
-import com.taxonomy.workspace.service.WorkspaceResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(ExternalSyncController.class)
-@Import(com.taxonomy.security.config.SecurityConfig.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@WithMockUser(username = "testuser", roles = "ADMIN")
 class ExternalSyncControllerTest {
 
-    private static final String BASE = "/api/workspace";
+    private static final String BASE = "/api/workspace/external";
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockitoBean
-    private ExternalSyncService externalSyncService;
-
-    @MockitoBean
-    private WorkspaceResolver workspaceResolver;
-
-    @MockitoBean
-    private RepositoryTopologyProperties topologyProperties;
-
     @Test
-    @WithMockUser(username = "architect", roles = "ARCHITECT")
-    void statusIsAvailableToArchitect() throws Exception {
-        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
-        when(externalSyncService.getStatus("architect"))
-                .thenReturn(new ExternalSyncService.SyncStatus(
-                        "INTERNAL_SHARED", false, false, false, null));
-
-        mockMvc.perform(get(BASE + "/external-sync/status"))
+    void statusReturnsExpectedFields() throws Exception {
+        mockMvc.perform(get(BASE + "/status").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.topologyMode").value("INTERNAL_SHARED"));
+                .andExpect(jsonPath("$.externalEnabled").isBoolean())
+                .andExpect(jsonPath("$.credentialConfigured").isBoolean());
     }
 
     @Test
-    @WithMockUser(username = "architect", roles = "ARCHITECT")
-    void pullIsAvailableToArchitect() throws Exception {
-        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
-        when(externalSyncService.pull("architect", null))
-                .thenReturn(new ExternalSyncService.SyncResult(
-                        true, "pulled", null, null, false));
-
-        mockMvc.perform(post(BASE + "/external-sync/pull").with(csrf()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true));
+    void fetchReturns400WhenTopologyIsInternal() throws Exception {
+        mockMvc.perform(post(BASE + "/fetch"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Configuration error"))
+                .andExpect(jsonPath("$.message").exists());
     }
 
     @Test
-    @WithMockUser(username = "architect", roles = "ARCHITECT")
-    void pushIsAvailableToArchitect() throws Exception {
-        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
-        when(externalSyncService.push("architect", null))
-                .thenReturn(new ExternalSyncService.SyncResult(
-                        true, "pushed", null, null, false));
-
-        mockMvc.perform(post(BASE + "/external-sync/push").with(csrf()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true));
+    void fetchReturns400WithMeaningfulMessage() throws Exception {
+        mockMvc.perform(post(BASE + "/fetch"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
     @Test
-    @WithMockUser(username = "admin", roles = "ADMIN")
-    void configureIsAvailableToAdmin() throws Exception {
-        when(externalSyncService.configure(
-                anyString(), anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new ExternalSyncService.ConfigurationResult(
-                        true,
-                        "configured",
-                        "EXTERNAL_CANONICAL",
-                        "https://example.com/repo.git"));
+    void pushReturns400WhenTopologyIsInternal() throws Exception {
+        mockMvc.perform(post(BASE + "/push"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Configuration error"))
+                .andExpect(jsonPath("$.message").exists());
+    }
 
+    @Test
+    void pushReturns400WhenTopologyIsInternalWithExplicitBranch() throws Exception {
+        mockMvc.perform(post(BASE + "/push").param("branch", "main"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Configuration error"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void pushReturns400WithMeaningfulMessage() throws Exception {
+        mockMvc.perform(post(BASE + "/push"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void fullSyncReturns400WhenTopologyIsInternal() throws Exception {
+        mockMvc.perform(post(BASE + "/full-sync"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Configuration error"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void fullSyncReturns400WithMeaningfulMessage() throws Exception {
+        mockMvc.perform(post(BASE + "/full-sync"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void configureWithInvalidTopologyModeReturns400() throws Exception {
         mockMvc.perform(put(BASE + "/configure")
-                        .with(csrf())
+                        .param("topologyMode", "INVALID_MODE"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Invalid parameter"))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void configureRejectsCredentialsEmbeddedInHttpUrl() throws Exception {
+        mockMvc.perform(put(BASE + "/configure")
+                        .param("topologyMode", "EXTERNAL_CANONICAL")
+                        .param("externalUrl",
+                                "https://token@example.com/repo.git"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Invalid parameter"));
+    }
+
+    @Test
+    void configureWithValidTopologyModeReturns200() throws Exception {
+        mockMvc.perform(put(BASE + "/configure")
                         .param("topologyMode", "EXTERNAL_CANONICAL")
                         .param("externalUrl", "https://example.com/repo.git"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.topologyMode").value("EXTERNAL_CANONICAL"))
+                .andExpect(jsonPath("$.topologyMode")
+                        .value("EXTERNAL_CANONICAL"))
                 .andExpect(jsonPath("$.externalUrl")
                         .value("https://example.com/repo.git"));
 
         // Reset topology without using an empty URL, which is now rejected.
         mockMvc.perform(put(BASE + "/configure")
-                        .with(csrf())
                         .param("topologyMode", "INTERNAL_SHARED"))
                 .andExpect(status().isOk());
     }
@@ -109,7 +129,6 @@ class ExternalSyncControllerTest {
     @WithMockUser(username = "regularuser", roles = "USER")
     void configureIsDeniedForNonAdminUser() throws Exception {
         mockMvc.perform(put(BASE + "/configure")
-                        .with(csrf())
                         .param("topologyMode", "EXTERNAL_CANONICAL"))
                 .andExpect(status().isForbidden());
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ExternalSyncControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ExternalSyncControllerTest.java
@@ -1,126 +1,106 @@
 package com.taxonomy.workspace.controller;
 
+import com.taxonomy.workspace.config.RepositoryTopologyProperties;
+import com.taxonomy.workspace.service.ExternalSyncService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.http.MediaType;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@WithMockUser(username = "testuser", roles = "ADMIN")
+@WebMvcTest(ExternalSyncController.class)
+@Import(com.taxonomy.security.config.SecurityConfig.class)
 class ExternalSyncControllerTest {
 
-    private static final String BASE = "/api/workspace/external";
+    private static final String BASE = "/api/workspace";
 
     @Autowired
     private MockMvc mockMvc;
 
+    @MockitoBean
+    private ExternalSyncService externalSyncService;
+
+    @MockitoBean
+    private WorkspaceResolver workspaceResolver;
+
+    @MockitoBean
+    private RepositoryTopologyProperties topologyProperties;
+
     @Test
-    void statusReturnsExpectedFields() throws Exception {
-        mockMvc.perform(get(BASE + "/status").accept(MediaType.APPLICATION_JSON))
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void statusIsAvailableToArchitect() throws Exception {
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        when(externalSyncService.getStatus("architect"))
+                .thenReturn(new ExternalSyncService.SyncStatus(
+                        "INTERNAL_SHARED", false, false, false, null));
+
+        mockMvc.perform(get(BASE + "/external-sync/status"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.externalEnabled").isBoolean())
-                .andExpect(jsonPath("$.credentialConfigured").isBoolean());
+                .andExpect(jsonPath("$.topologyMode").value("INTERNAL_SHARED"));
     }
 
     @Test
-    void fetchReturns400WhenTopologyIsInternal() throws Exception {
-        mockMvc.perform(post(BASE + "/fetch"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Configuration error"))
-                .andExpect(jsonPath("$.message").exists());
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void pullIsAvailableToArchitect() throws Exception {
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        when(externalSyncService.pull("architect", null))
+                .thenReturn(new ExternalSyncService.SyncResult(
+                        true, "pulled", null, null, false));
+
+        mockMvc.perform(post(BASE + "/external-sync/pull").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
     }
 
     @Test
-    void fetchReturns400WithMeaningfulMessage() throws Exception {
-        mockMvc.perform(post(BASE + "/fetch"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").isString())
-                .andExpect(jsonPath("$.message").isNotEmpty());
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void pushIsAvailableToArchitect() throws Exception {
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        when(externalSyncService.push("architect", null))
+                .thenReturn(new ExternalSyncService.SyncResult(
+                        true, "pushed", null, null, false));
+
+        mockMvc.perform(post(BASE + "/external-sync/push").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
     }
 
     @Test
-    void pushReturns400WhenTopologyIsInternal() throws Exception {
-        mockMvc.perform(post(BASE + "/push"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Configuration error"))
-                .andExpect(jsonPath("$.message").exists());
-    }
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void configureIsAvailableToAdmin() throws Exception {
+        when(externalSyncService.configure(
+                anyString(), anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new ExternalSyncService.ConfigurationResult(
+                        true,
+                        "configured",
+                        "EXTERNAL_CANONICAL",
+                        "https://example.com/repo.git"));
 
-    @Test
-    void pushReturns400WhenTopologyIsInternalWithExplicitBranch() throws Exception {
-        mockMvc.perform(post(BASE + "/push").param("branch", "main"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Configuration error"))
-                .andExpect(jsonPath("$.message").exists());
-    }
-
-    @Test
-    void pushReturns400WithMeaningfulMessage() throws Exception {
-        mockMvc.perform(post(BASE + "/push"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").isString())
-                .andExpect(jsonPath("$.message").isNotEmpty());
-    }
-
-    @Test
-    void fullSyncReturns400WhenTopologyIsInternal() throws Exception {
-        mockMvc.perform(post(BASE + "/full-sync"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Configuration error"))
-                .andExpect(jsonPath("$.message").exists());
-    }
-
-    @Test
-    void fullSyncReturns400WithMeaningfulMessage() throws Exception {
-        mockMvc.perform(post(BASE + "/full-sync"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").isString())
-                .andExpect(jsonPath("$.message").isNotEmpty());
-    }
-
-    @Test
-    void configureWithInvalidTopologyModeReturns400() throws Exception {
         mockMvc.perform(put(BASE + "/configure")
-                        .param("topologyMode", "INVALID_MODE"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Invalid parameter"))
-                .andExpect(jsonPath("$.message").exists());
-    }
-
-    @Test
-    void configureRejectsCredentialsEmbeddedInHttpUrl() throws Exception {
-        mockMvc.perform(put(BASE + "/configure")
-                        .param("topologyMode", "EXTERNAL_CANONICAL")
-                        .param("externalUrl",
-                                "https://token@example.com/repo.git"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Invalid parameter"));
-    }
-
-    @Test
-    void configureWithValidTopologyModeReturns200() throws Exception {
-        mockMvc.perform(put(BASE + "/configure")
+                        .with(csrf())
                         .param("topologyMode", "EXTERNAL_CANONICAL")
                         .param("externalUrl", "https://example.com/repo.git"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.topologyMode")
-                        .value("EXTERNAL_CANONICAL"))
+                .andExpect(jsonPath("$.topologyMode").value("EXTERNAL_CANONICAL"))
                 .andExpect(jsonPath("$.externalUrl")
                         .value("https://example.com/repo.git"));
 
         // Reset topology without using an empty URL, which is now rejected.
         mockMvc.perform(put(BASE + "/configure")
+                        .with(csrf())
                         .param("topologyMode", "INTERNAL_SHARED"))
                 .andExpect(status().isOk());
     }
@@ -129,7 +109,8 @@ class ExternalSyncControllerTest {
     @WithMockUser(username = "regularuser", roles = "USER")
     void configureIsDeniedForNonAdminUser() throws Exception {
         mockMvc.perform(put(BASE + "/configure")
+                        .with(csrf())
                         .param("topologyMode", "EXTERNAL_CANONICAL"))
-                .andExpect(status().isInternalServerError());
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## Summary

Closes the remaining authorization fallback finding from #549.

- replaces the generic authenticated `/api/**` fallback with a deny-by-default contract
- explicitly classifies read-only POST calculations (`recommend`, gap, pattern, explanation and graph impact)
- keeps local password self-service available to authenticated users
- restricts legacy coverage persistence and catalogue metadata recomputation to ARCHITECT/ADMIN
- classifies workspace PUT/DELETE operations as ADMIN
- preserves authenticated GET/HEAD access and standards-compliant OPTIONS preflight

## Regression coverage

- USER cannot reach unclassified POST, PUT, PATCH or DELETE paths even with a valid CSRF token
- ADMIN cannot bypass the unclassified-write deny rule
- the explicitly classified recommendation calculation remains available to USER
- USER cannot trigger derived metadata writes or persist legacy coverage mappings

Part of #549.