### PR TITLE
Prevent sensitive LLM prompts from entering logs

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/shared/logging/SensitiveLlmPromptTurboFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/logging/SensitiveLlmPromptTurboFilter.java
@@ -1,0 +1,63 @@
+package com.taxonomy.shared.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.springframework.stereotype.Component;
+
+/**
+ * Prevents rendered LLM prompts from entering application logs.
+ *
+ * <p>Rendered prompts can contain requirement text, document excerpts and other
+ * project data. The filter is deliberately independent of the configured log
+ * level so enabling DEBUG for diagnostics cannot expose those values. Structured
+ * request metadata and provider diagnostics remain available.</p>
+ */
+@Component
+public final class SensitiveLlmPromptTurboFilter extends TurboFilter {
+
+    static final String LLM_SERVICE_LOGGER = "com.taxonomy.analysis.service.LlmService";
+    static final String FULL_PROMPT_MESSAGE_PREFIX = "Full LLM prompt:";
+
+    private LoggerContext loggerContext;
+
+    @PostConstruct
+    void install() {
+        if (LoggerFactory.getILoggerFactory() instanceof LoggerContext context) {
+            loggerContext = context;
+            start();
+            context.addTurboFilter(this);
+        }
+    }
+
+    @PreDestroy
+    void uninstall() {
+        if (loggerContext != null) {
+            loggerContext.getTurboFilterList().remove(this);
+            stop();
+            loggerContext = null;
+        }
+    }
+
+    @Override
+    public FilterReply decide(Marker marker,
+                              Logger logger,
+                              Level level,
+                              String format,
+                              Object[] parameters,
+                              Throwable throwable) {
+        if (logger != null
+                && LLM_SERVICE_LOGGER.equals(logger.getName())
+                && format != null
+                && format.startsWith(FULL_PROMPT_MESSAGE_PREFIX)) {
+            return FilterReply.DENY;
+        }
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/logging/SensitiveLlmPromptTurboFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/logging/SensitiveLlmPromptTurboFilterTest.java
@@ -1,0 +1,60 @@
+package com.taxonomy.shared.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.spi.FilterReply;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveLlmPromptTurboFilterTest {
+
+    private final LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+    private final SensitiveLlmPromptTurboFilter filter = new SensitiveLlmPromptTurboFilter();
+
+    @Test
+    void deniesRenderedPromptEvenAtDebugLevel() {
+        var logger = context.getLogger(SensitiveLlmPromptTurboFilter.LLM_SERVICE_LOGGER);
+
+        FilterReply reply = filter.decide(
+                null,
+                logger,
+                Level.DEBUG,
+                "Full LLM prompt:\n{}",
+                new Object[]{"sensitive requirement text"},
+                null);
+
+        assertThat(reply).isEqualTo(FilterReply.DENY);
+    }
+
+    @Test
+    void preservesNonSensitiveLlmDiagnostics() {
+        var logger = context.getLogger(SensitiveLlmPromptTurboFilter.LLM_SERVICE_LOGGER);
+
+        FilterReply reply = filter.decide(
+                null,
+                logger,
+                Level.INFO,
+                "LLM Request [{}] — sending prompt for {} nodes",
+                new Object[]{"GEMINI", 3},
+                null);
+
+        assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+    }
+
+    @Test
+    void doesNotSuppressMessagesFromOtherLoggers() {
+        var logger = context.getLogger("com.taxonomy.other.Service");
+
+        FilterReply reply = filter.decide(
+                null,
+                logger,
+                Level.DEBUG,
+                "Full LLM prompt:\n{}",
+                new Object[]{"not emitted by LlmService"},
+                null);
+
+        assertThat(reply).isEqualTo(FilterReply.NEUTRAL);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the sensitive prompt logging finding from #549.

- installs a Logback `TurboFilter` during application startup
- denies rendered `LlmService` full-prompt events independently of the configured log level
- prevents requirement text, source excerpts and other rendered prompt data from appearing even when DEBUG is enabled
- preserves provider, node-count and other non-sensitive diagnostics
- removes the filter cleanly when an application context shuts down

## Regression coverage

- full rendered prompts from `LlmService` are denied at DEBUG
- ordinary LLM request metadata remains loggable
- similarly worded events from unrelated loggers are not suppressed

Part of #549.