### PR TITLE
Add verified 1,000-requirement portfolio scale contract

### DIFF
--- a/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/de/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -16,3 +16,19 @@ Eine Wiederholung setzt fehlgeschlagene Einträge sowie ausschließlich solche l
 Ein zu niedriges Timeout kann Arbeit duplizieren, wenn ein Provider legitimerweise länger benötigt. Es sollte oberhalb der längsten erwarteten Providerlaufzeit einschließlich deterministischer Nachverarbeitung liegen. Aktive Worker werden durch eine Wiederholungsanfrage nicht unterbrochen.
 
 Zu große Analyse- oder Importanfragen werden abgelehnt, bevor ein Analysejob oder importierte Anforderungen gespeichert werden. Die Anwendungslimits sollten durch Größenlimits am Ingress, Provider-Rate-Limits und reguläre Datenbanksicherungen ergänzt werden.
+
+## Geprüfter Skalierungsvertrag
+
+Die Größen 100, 1.000 und 10.000 prüfen bewusst unterschiedliche Risiken. Sie dürfen nicht als identische Lasttests interpretiert werden.
+
+| Größe | Nachweis | Verbindliche Aussage |
+|---:|---|---|
+| 100 Anforderungen | `ProjectRequirementListQueryCountTest` legt über den öffentlichen Service ein reales Projekt mit 100 Anforderungen und Versionen an | Das vollständige Listen einschließlich aktueller Versionen benötigt höchstens drei SQL-Statements; die Queryzahl wächst nicht mit der Anzahl der Anforderungen |
+| 1.000 Anforderungen | `ProjectRequirementThousandScaleContractTest` persistiert 1.000 reale Anforderungen und unveränderliche Versionen | Der reine, von der Fixture-Erzeugung getrennte Leseweg benötigt höchstens drei SQL-Statements und muss in der CI-In-Memory-Datenbank innerhalb von 30 Sekunden abschließen |
+| 10.000 Anforderungen | `ProjectPortfolioViewCountTest` simuliert die Aggregatzahlen eines großen Projekts | Eine Projektzusammenfassung lädt keine vollständigen Anforderungs-, Lösungs- oder Konfliktlisten, sondern ausschließlich skalare Datenbankzählungen |
+
+Der 10.000er-Nachweis ist ein **kontrollierter Grenzvertrag für die Zusammenfassung**, kein behaupteter End-to-End-Durchsatztest mit 10.000 vollständig materialisierten Anforderungen. Eine Anforderungsliste überträgt und materialisiert weiterhin proportional zur Ergebnisgröße Daten und Objekte; ihre SQL-Statement-Anzahl ist konstant, Speicherbedarf und Antwortgröße bleiben jedoch `O(n)`.
+
+Das Standardlimit von 100 Anforderungen gilt pro **Analysejob**. Projekte dürfen mehr Anforderungen enthalten; große Bestände werden in mehrere Analysejobs aufgeteilt. Die 1.000er- und 10.000er-Verträge heben daher weder Providerbudgets noch Batchgrenzen auf.
+
+Vor einer produktiven Kapazitätszusage sind zusätzlich umgebungsspezifische Messungen mit der eingesetzten PostgreSQL-Version, realistischen Text-/Snapshotgrößen, Netzwerklatenz, Heapgrenzen und gleichzeitigen Benutzern erforderlich. Die Repositorytests sichern die algorithmische und queryseitige Untergrenze, nicht eine universelle Antwortzeit für jede Infrastruktur.

--- a/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
+++ b/docs/en/PROJECT_PORTFOLIO_OPERATIONS.md
@@ -16,3 +16,19 @@ Retry requests reset failed items and only those running items whose claim is ol
 A low timeout can duplicate work when a provider legitimately needs longer than the timeout. Set it above the longest expected provider call plus deterministic post-processing time. Active workers are not interrupted by a retry request.
 
 Oversized analysis or import requests fail before an analysis job or imported requirement is persisted. Operators should combine these limits with ingress request-body limits, provider rate limits and normal database backups.
+
+## Verified scale contract
+
+The 100, 1,000 and 10,000 sizes deliberately cover different risks. They must not be interpreted as identical load tests.
+
+| Size | Evidence | Enforced statement |
+|---:|---|---|
+| 100 requirements | `ProjectRequirementListQueryCountTest` creates a real project with 100 requirements and versions through the public service | Listing all requirements with their current versions uses at most three SQL statements; the query count does not grow with the requirement count |
+| 1,000 requirements | `ProjectRequirementThousandScaleContractTest` persists 1,000 real requirements and immutable versions | The read path, measured separately from fixture creation, uses at most three SQL statements and must complete within 30 seconds on the CI in-memory database |
+| 10,000 requirements | `ProjectPortfolioViewCountTest` simulates the aggregate counts of a large project | A project summary never loads complete requirement, solution or conflict collections and uses scalar database counts only |
+
+The 10,000-case evidence is a **controlled summary boundary contract**, not a claim that an end-to-end request fully materializes 10,000 requirements at a particular throughput. Requirement-list transfer and object materialization remain proportional to the result size: the SQL statement count is constant, while response size and memory consumption remain `O(n)`.
+
+The default limit of 100 requirements applies to one **analysis job**. Projects may contain more requirements; large portfolios are analysed through multiple jobs. The 1,000- and 10,000-case contracts therefore do not override provider budgets or batch limits.
+
+A production capacity commitment additionally requires environment-specific measurements with the deployed PostgreSQL version, representative text and snapshot sizes, network latency, heap limits and concurrent users. Repository tests secure the algorithmic and query-level lower bound; they do not promise one universal response time for every infrastructure configuration.

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementThousandScaleContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementThousandScaleContractTest.java
@@ -1,0 +1,131 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.model.ArchitectureProject;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.model.ProjectRequirement;
+import com.taxonomy.portfolio.model.ProjectRequirementVersion;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import jakarta.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Controlled 1,000-requirement scale contract for the portfolio list path.
+ * Fixture creation is excluded from the measured read operation.
+ */
+@SpringBootTest(properties = "spring.jpa.properties.hibernate.generate_statistics=true")
+@Transactional
+class ProjectRequirementThousandScaleContractTest {
+
+    private static final int REQUIREMENT_COUNT = 1_000;
+    private static final int MAXIMUM_READ_STATEMENTS = 3;
+    private static final Duration MAXIMUM_READ_DURATION = Duration.ofSeconds(30);
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void listsOneThousandCurrentRequirementVersionsWithConstantDatabaseWork() {
+        WorkspaceContext context = new WorkspaceContext(
+                "scale-thousand-user", "ws-scale-thousand-" + shortId(), "draft");
+        var projectView = projectService.createProject(
+                new CreateProjectRequest(
+                        "P-SCALE-1000-" + shortId(),
+                        "One thousand requirement scale contract",
+                        null,
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                context.username(),
+                context);
+
+        ArchitectureProject project = entityManager.getReference(
+                ArchitectureProject.class, projectView.id());
+        Instant now = Instant.parse("2026-08-03T10:00:00Z");
+        for (int index = 1; index <= REQUIREMENT_COUNT; index++) {
+            ProjectRequirement requirement = new ProjectRequirement(
+                    project,
+                    "REQ-%04d".formatted(index),
+                    "Requirement " + index,
+                    RequirementStatus.APPROVED,
+                    50,
+                    Criticality.MEDIUM,
+                    RequirementType.FUNCTIONAL,
+                    ReviewStatus.CONFIRMED,
+                    context.username(),
+                    now);
+            entityManager.persist(requirement);
+
+            ProjectRequirementVersion version = new ProjectRequirementVersion(
+                    requirement,
+                    1,
+                    "Traceable requirement text " + index,
+                    "%064x".formatted(index),
+                    "Scale fixture",
+                    context.username(),
+                    now,
+                    null,
+                    null,
+                    "[]",
+                    null,
+                    null,
+                    null);
+            entityManager.persist(version);
+            requirement.pointToVersion(version.getId(), now);
+
+            if (index % 100 == 0) {
+                entityManager.flush();
+                entityManager.clear();
+                project = entityManager.getReference(
+                        ArchitectureProject.class, projectView.id());
+            }
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+        Statistics statistics = entityManager.getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+        statistics.clear();
+
+        long startedAt = System.nanoTime();
+        var requirements = projectService.listRequirements(
+                projectView.id(), context.username(), context);
+        Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+        assertThat(requirements).hasSize(REQUIREMENT_COUNT);
+        assertThat(requirements)
+                .allSatisfy(requirement -> assertThat(requirement.currentVersion()).isNotNull());
+        assertThat(statistics.getPrepareStatementCount())
+                .as("project authorization plus current-version list query count")
+                .isLessThanOrEqualTo(MAXIMUM_READ_STATEMENTS);
+        assertThat(elapsed)
+                .as("controlled in-memory database read duration; fixture creation excluded")
+                .isLessThan(MAXIMUM_READ_DURATION);
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementThousandScaleContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectRequirementThousandScaleContractTest.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -122,10 +123,10 @@ class ProjectRequirementThousandScaleContractTest {
                 .isLessThanOrEqualTo(MAXIMUM_READ_STATEMENTS);
         assertThat(elapsed)
                 .as("controlled in-memory database read duration; fixture creation excluded")
-                .isLessThan(MAXIMUM_READ_DURATION);
+                .isLessThanOrEqualTo(MAXIMUM_READ_DURATION);
     }
 
     private static String shortId() {
-        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase(Locale.ROOT);
     }
 }


### PR DESCRIPTION
## Summary

Completes the explicit 100 / 1,000 / 10,000 scaling evidence requested by #549.

- adds a real 1,000-requirement and immutable-version fixture
- measures the list read separately from fixture creation
- enforces a constant query budget of at most three SQL statements
- adds a generous 30-second CI in-memory read boundary to catch catastrophic regressions without pretending to be a production benchmark
- documents precisely what the existing 100, new 1,000 and controlled 10,000 cases prove
- distinguishes constant SQL work from the unavoidable O(n) response and object materialization cost
- clarifies that the default 100 limit is per analysis job, not per project

## Existing and new evidence

- 100: real public-service integration test with current versions
- 1,000: real persistence and list-read scale contract
- 10,000: controlled project-summary contract proving scalar counts instead of loading child collections

The documentation explicitly avoids claiming infrastructure-independent production throughput.

Part of #549.