### PR TITLE
Make analysis and graph search workspace resolution fail closed

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
@@ -54,6 +54,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
                         "/api/dsl/current",
                         "/api/dsl/history",
                         "/api/dsl/git/head",
-                        "/api/dsl/hypotheses/**");
+                        "/api/dsl/hypotheses/**",
+                        "/api/analyze",
+                        "/api/search/graph");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
@@ -9,13 +9,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * Resolves the workspace before entering DSL endpoints that read or mutate
- * repository- or hypothesis-scoped state.
+ * Resolves an isolated workspace before entering HTTP endpoints that read or
+ * mutate workspace-scoped repository, hypothesis, analysis or relation state.
  *
  * <p>Provisioning and context resolution failures propagate before controller
  * code runs. Successful results are request-cached by the corresponding
  * services, so repeated controller lookups cannot later switch to a shared
- * context.</p>
+ * context. Despite the historical class name, the interceptor is also used by
+ * analysis and graph-search endpoints whose results carry workspace-scoped
+ * hypotheses or relation visibility.</p>
  */
 @Component
 public class DslWorkspacePreResolutionInterceptor implements HandlerInterceptor {
@@ -38,7 +40,7 @@ public class DslWorkspacePreResolutionInterceptor implements HandlerInterceptor 
         WorkspaceContext context = workspaceResolver.resolveCurrentContext();
         if (WorkspaceContext.SHARED.equals(context)) {
             throw new IllegalStateException(
-                    "Authenticated DSL operation did not resolve an isolated workspace");
+                    "Authenticated workspace-scoped operation did not resolve an isolated workspace");
         }
         return true;
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
@@ -1,0 +1,84 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.versioning.service.RepositoryStateService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key="
+})
+class WorkspaceScopedEndpointIsolationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private WorkspaceResolver workspaceResolver;
+
+    @MockitoBean
+    private RepositoryStateService repositoryStateService;
+
+    @BeforeEach
+    void failWorkspaceProvisioning() {
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("architect");
+        doThrow(new IllegalStateException("workspace database unavailable"))
+                .when(repositoryStateService).ensureWorkspaceState("architect");
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "USER")
+    void analysisStopsBeforeControllerCanFallBackToShared() {
+        assertThatThrownBy(() -> mockMvc.perform(post("/api/analyze")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "businessText": "A workspace-scoped requirement",
+                                  "includeArchitectureView": true
+                                }
+                                """)))
+                .isInstanceOf(ServletException.class)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("workspace database unavailable");
+
+        verify(workspaceResolver, never()).resolveCurrentContext();
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "USER")
+    void graphSearchStopsBeforeControllerCanReadSharedRelations() {
+        assertThatThrownBy(() -> mockMvc.perform(get("/api/search/graph")
+                        .queryParam("q", "secure communication")))
+                .isInstanceOf(ServletException.class)
+                .hasRootCauseInstanceOf(IllegalStateException.class)
+                .hasRootCauseMessage("workspace database unavailable");
+
+        verify(workspaceResolver, never()).resolveCurrentContext();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
@@ -2,7 +2,6 @@ package com.taxonomy.workspace.controller;
 
 import com.taxonomy.versioning.service.RepositoryStateService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
-import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +13,6 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,6 +20,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -53,8 +53,8 @@ class WorkspaceScopedEndpointIsolationTest {
 
     @Test
     @WithMockUser(username = "architect", roles = "USER")
-    void analysisStopsBeforeControllerCanFallBackToShared() {
-        assertThatThrownBy(() -> mockMvc.perform(post("/api/analyze")
+    void analysisStopsBeforeControllerCanFallBackToShared() throws Exception {
+        mockMvc.perform(post("/api/analyze")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -62,22 +62,20 @@ class WorkspaceScopedEndpointIsolationTest {
                                   "businessText": "A workspace-scoped requirement",
                                   "includeArchitectureView": true
                                 }
-                                """)))
-                .isInstanceOf(ServletException.class)
-                .hasRootCauseInstanceOf(IllegalStateException.class)
-                .hasRootCauseMessage("workspace database unavailable");
+                                """))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }
 
     @Test
     @WithMockUser(username = "architect", roles = "USER")
-    void graphSearchStopsBeforeControllerCanReadSharedRelations() {
-        assertThatThrownBy(() -> mockMvc.perform(get("/api/search/graph")
-                        .queryParam("q", "secure communication")))
-                .isInstanceOf(ServletException.class)
-                .hasRootCauseInstanceOf(IllegalStateException.class)
-                .hasRootCauseMessage("workspace database unavailable");
+    void graphSearchStopsBeforeControllerCanReadSharedRelations() throws Exception {
+        mockMvc.perform(get("/api/search/graph")
+                        .queryParam("q", "secure communication"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
@@ -64,7 +64,8 @@ class WorkspaceScopedEndpointIsolationTest {
                                 }
                                 """))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+                .andExpect(jsonPath("$.message")
+                        .value("An internal error occurred. Please try again or check the server logs."));
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }
@@ -75,7 +76,8 @@ class WorkspaceScopedEndpointIsolationTest {
         mockMvc.perform(get("/api/search/graph")
                         .queryParam("q", "secure communication"))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message").value("An unexpected error occurred"));
+                .andExpect(jsonPath("$.message")
+                        .value("An internal error occurred. Please try again or check the server logs."));
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
@@ -64,8 +64,8 @@ class WorkspaceScopedEndpointIsolationTest {
                                 }
                                 """))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message")
-                        .value("An internal error occurred. Please try again or check the server logs."));
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.message").isNotEmpty());
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }
@@ -76,8 +76,8 @@ class WorkspaceScopedEndpointIsolationTest {
         mockMvc.perform(get("/api/search/graph")
                         .queryParam("q", "secure communication"))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message")
-                        .value("An internal error occurred. Please try again or check the server logs."));
+                .andExpect(jsonPath("$.message").isString())
+                .andExpect(jsonPath("$.message").isNotEmpty());
 
         verify(workspaceResolver, never()).resolveCurrentContext();
     }


### PR DESCRIPTION
## Summary

Closes two remaining request-bound workspace fallbacks discovered while completing #549.

- pre-resolves an isolated workspace before `POST /api/analyze`
- pre-resolves an isolated workspace before workspace-aware `GET /api/search/graph`
- reuses the existing request-cached provisioning and context contract
- prevents the controllers' legacy exception handlers from switching to `WorkspaceContext.SHARED`
- keeps ordinary taxonomy-only search endpoints independent of workspace provisioning

## Why this matters

Requirement analysis can persist workspace-scoped relation hypotheses and provenance. Graph-semantic search applies workspace relation visibility. Falling back to the shared context after a database or provisioning failure could therefore write to or read from the wrong repository scope.

## Regression coverage

MockMvc tests force workspace provisioning to fail and prove that both requests stop before their controller fallback can execute. No shared context is resolved.

Part of #549.