### PR TITLE
Fail closed across workspace paths and block unsafe releases

### DIFF
--- a/.github/scripts/check-release-blockers.py
+++ b/.github/scripts/check-release-blockers.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fail closed when open release-blocker issues or pull requests exist."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", ""),
+        help="GitHub repository in owner/name form",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN", ""),
+    )
+    parser.add_argument(
+        "--input-file",
+        type=Path,
+        help="Read a GitHub search response from a fixture instead of the API",
+    )
+    return parser.parse_args()
+
+
+def load_response(args: argparse.Namespace) -> dict[str, Any]:
+    if args.input_file:
+        return json.loads(args.input_file.read_text(encoding="utf-8"))
+    if not args.repository or "/" not in args.repository:
+        raise RuntimeError("GITHUB_REPOSITORY or --repository must be owner/name")
+    if not args.token:
+        raise RuntimeError("GH_TOKEN or GITHUB_TOKEN is required")
+
+    query = f'repo:{args.repository} is:open label:"release-blocker"'
+    url = f"{args.api_url.rstrip('/')}/search/issues?q={urllib.parse.quote(query)}&per_page=100"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {args.token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "taxonomy-release-blocker-check",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"GitHub blocker query failed with HTTP {error.code}: {detail}") from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(f"GitHub blocker query failed: {error.reason}") from error
+
+
+def blocker_rows(payload: dict[str, Any]) -> list[tuple[int, str, str, str]]:
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise RuntimeError("GitHub response does not contain an items array")
+
+    rows: list[tuple[int, str, str, str]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise RuntimeError("GitHub response contains a non-object item")
+        number = item.get("number")
+        title = item.get("title")
+        url = item.get("html_url")
+        if not isinstance(number, int) or not isinstance(title, str) or not isinstance(url, str):
+            raise RuntimeError("GitHub blocker item is missing number, title or html_url")
+        kind = "PR" if isinstance(item.get("pull_request"), dict) else "Issue"
+        rows.append((number, kind, title, url))
+    return sorted(rows)
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        rows = blocker_rows(load_response(args))
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"::error::Release blocker check failed closed: {error}", file=sys.stderr)
+        return 2
+
+    if rows:
+        print("::error::Release publication is blocked by open release-blocker items", file=sys.stderr)
+        for number, kind, title, url in rows:
+            print(f"- {kind} #{number}: {title} ({url})", file=sys.stderr)
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary:
+            with Path(summary).open("a", encoding="utf-8") as output:
+                output.write("## Release blocked\n\n")
+                for number, kind, title, url in rows:
+                    output.write(f"- [{kind} #{number}: {title}]({url})\n")
+        return 1
+
+    print("No open release-blocker issues or pull requests were found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test-check-release-blockers.py
+++ b/.github/scripts/test-check-release-blockers.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Contract tests for check-release-blockers.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check-release-blockers.py")
+
+
+def run(payload: object) -> subprocess.CompletedProcess[str]:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as fixture:
+        json.dump(payload, fixture)
+        path = Path(fixture.name)
+    try:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--input-file", str(path)],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    clear = run({"total_count": 0, "items": []})
+    require(clear.returncode == 0, clear.stderr)
+
+    blocked = run({
+        "total_count": 2,
+        "items": [
+            {
+                "number": 574,
+                "title": "Workspace isolation",
+                "html_url": "https://example.invalid/issues/574",
+            },
+            {
+                "number": 575,
+                "title": "Release guard",
+                "html_url": "https://example.invalid/pull/575",
+                "pull_request": {},
+            },
+        ],
+    })
+    require(blocked.returncode == 1, blocked.stderr)
+    require("Issue #574" in blocked.stderr, blocked.stderr)
+    require("PR #575" in blocked.stderr, blocked.stderr)
+
+    malformed = run({"total_count": 1})
+    require(malformed.returncode == 2, malformed.stderr)
+    require("failed closed" in malformed.stderr, malformed.stderr)
+
+    print("Release blocker preflight tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -66,6 +66,12 @@ jobs:
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: python3 .github/scripts/resolve-release-parameters.py
 
+      - name: Reject open release blockers before mutation
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/check-release-blockers.py
+
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
@@ -109,6 +115,7 @@ jobs:
           set -euo pipefail
           python3 .github/scripts/test-resolve-release-parameters.py
           python3 .github/scripts/test-check-version-state.py
+          python3 .github/scripts/test-check-release-blockers.py
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
@@ -331,6 +338,12 @@ jobs:
             exit 1
           fi
           gh run watch "$run_id" --exit-status
+
+      - name: Re-check release blockers before publication
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/check-release-blockers.py
 
       - name: Publish complete release and trigger deployment
         if: steps.release_parameters.outputs.dry_run != 'true'

--- a/taxonomy-app/src/main/java/com/taxonomy/search/controller/SearchApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/search/controller/SearchApiController.java
@@ -3,14 +3,11 @@ package com.taxonomy.search.controller;
 import com.taxonomy.dto.GraphSearchResult;
 import com.taxonomy.dto.TaxonomyNodeDto;
 import com.taxonomy.search.service.SearchFacade;
-import com.taxonomy.versioning.service.RepositoryStateService;
 import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.ResponseEntity;
@@ -29,81 +26,78 @@ import java.util.Map;
 @Tag(name = "Search")
 public class SearchApiController {
 
-    private static final Logger log = LoggerFactory.getLogger(SearchApiController.class);
-
     private final SearchFacade searchFacade;
     private final MessageSource messageSource;
     private final WorkspaceResolver workspaceResolver;
-    private final RepositoryStateService repositoryStateService;
 
     public SearchApiController(SearchFacade searchFacade,
                                MessageSource messageSource,
-                               WorkspaceResolver workspaceResolver,
-                               RepositoryStateService repositoryStateService) {
+                               WorkspaceResolver workspaceResolver) {
         this.searchFacade = searchFacade;
         this.messageSource = messageSource;
         this.workspaceResolver = workspaceResolver;
-        this.repositoryStateService = repositoryStateService;
     }
 
-    @Operation(summary = "Full-text search", description = "Search taxonomy nodes using full-text Lucene search", tags = {"Search"})
+    @Operation(summary = "Full-text search", tags = {"Search"})
     @GetMapping("/search")
     public ResponseEntity<List<TaxonomyNodeDto>> search(
             @Parameter(description = "Search query") @RequestParam String q,
-            @Parameter(description = "Maximum number of results") @RequestParam(defaultValue = "50") int maxResults) {
+            @Parameter(description = "Maximum number of results")
+            @RequestParam(defaultValue = "50") int maxResults) {
         ResponseEntity<List<TaxonomyNodeDto>> guard = checkInitialized();
         if (guard != null) return guard;
         if (q == null || q.isBlank()) return ResponseEntity.badRequest().build();
         return ResponseEntity.ok(searchFacade.fullTextSearch(q, maxResults));
     }
 
-    @Operation(summary = "Semantic search", description = "Search taxonomy nodes using embedding similarity (KNN). Requires LOCAL_ONNX or embedding enabled.", tags = {"Search"})
+    @Operation(summary = "Semantic search", tags = {"Search"})
     @GetMapping("/search/semantic")
     public ResponseEntity<List<TaxonomyNodeDto>> semanticSearch(
-            @Parameter(description = "Natural-language query") @RequestParam String q,
-            @Parameter(description = "Maximum number of results") @RequestParam(defaultValue = "20") int maxResults) {
+            @RequestParam String q,
+            @RequestParam(defaultValue = "20") int maxResults) {
         ResponseEntity<List<TaxonomyNodeDto>> guard = checkInitialized();
         if (guard != null) return guard;
         if (q == null || q.isBlank()) return ResponseEntity.badRequest().build();
         return ResponseEntity.ok(searchFacade.semanticSearch(q, maxResults));
     }
 
-    @Operation(summary = "Hybrid search", description = "Combines full-text Lucene and semantic KNN results via Reciprocal Rank Fusion. Falls back to full-text only when embedding is unavailable.", tags = {"Search"})
+    @Operation(summary = "Hybrid search", tags = {"Search"})
     @GetMapping("/search/hybrid")
     public ResponseEntity<List<TaxonomyNodeDto>> hybridSearch(
-            @Parameter(description = "Natural-language query") @RequestParam String q,
-            @Parameter(description = "Maximum number of results") @RequestParam(defaultValue = "20") int maxResults) {
+            @RequestParam String q,
+            @RequestParam(defaultValue = "20") int maxResults) {
         ResponseEntity<List<TaxonomyNodeDto>> guard = checkInitialized();
         if (guard != null) return guard;
         if (q == null || q.isBlank()) return ResponseEntity.badRequest().build();
         return ResponseEntity.ok(searchFacade.hybridSearch(q, maxResults));
     }
 
-    @Operation(summary = "Find similar nodes", description = "Find taxonomy nodes semantically similar to a given node", tags = {"Search"})
+    @Operation(summary = "Find similar nodes", tags = {"Search"})
     @GetMapping("/search/similar/{code}")
     public ResponseEntity<List<TaxonomyNodeDto>> findSimilar(
-            @Parameter(description = "Taxonomy node code") @PathVariable String code,
-            @Parameter(description = "Maximum number of similar nodes") @RequestParam(defaultValue = "10") int topK) {
+            @PathVariable String code,
+            @RequestParam(defaultValue = "10") int topK) {
         ResponseEntity<List<TaxonomyNodeDto>> guard = checkInitialized();
         if (guard != null) return guard;
         return ResponseEntity.ok(searchFacade.findSimilarNodes(code, topK));
     }
 
-    @Operation(summary = "Embedding model status", description = "Returns the current status of the local embedding model", tags = {"Embedding"})
+    @Operation(summary = "Embedding model status", tags = {"Embedding"})
     @GetMapping("/embedding/status")
     public ResponseEntity<Map<String, Object>> embeddingStatus() {
         return ResponseEntity.ok(searchFacade.getEmbeddingStatus());
     }
 
-    @Operation(summary = "Graph-semantic search", description = "Combines node and relation KNN queries with explicit workspace relation visibility.", tags = {"Search"})
+    @Operation(summary = "Graph-semantic search", tags = {"Search"})
     @GetMapping("/search/graph")
     public ResponseEntity<GraphSearchResult> graphSearch(
-            @Parameter(description = "Natural-language query") @RequestParam String q,
-            @Parameter(description = "Maximum number of node results") @RequestParam(defaultValue = "20") int maxResults) {
+            @RequestParam String q,
+            @RequestParam(defaultValue = "20") int maxResults) {
         ResponseEntity<GraphSearchResult> guard = checkInitialized();
         if (guard != null) return guard;
         if (q == null || q.isBlank()) return ResponseEntity.badRequest().build();
-        return ResponseEntity.ok(searchFacade.graphSearch(q, maxResults, currentWorkspaceContext()));
+        WorkspaceContext context = workspaceResolver.resolveCurrentContext();
+        return ResponseEntity.ok(searchFacade.graphSearch(q, maxResults, context));
     }
 
     @SuppressWarnings("unchecked")
@@ -111,23 +105,11 @@ public class SearchApiController {
         if (!searchFacade.isInitialized()) {
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("error", messageSource.getMessage("error.loading", null,
-                    "Taxonomy data is still loading. Please wait.", LocaleContextHolder.getLocale()));
+                    "Taxonomy data is still loading. Please wait.",
+                    LocaleContextHolder.getLocale()));
             body.put("status", searchFacade.getInitStatus());
             return (ResponseEntity<T>) ResponseEntity.status(503).body(body);
         }
         return null;
-    }
-
-    private WorkspaceContext currentWorkspaceContext() {
-        String username = workspaceResolver.resolveCurrentUsername();
-        try {
-            repositoryStateService.ensureWorkspaceState(username);
-            WorkspaceContext context = workspaceResolver.resolveCurrentContext();
-            return context != null ? context : WorkspaceContext.SHARED;
-        } catch (Exception error) {
-            log.warn("Falling back to shared search context for user '{}': {}",
-                    username, error.toString());
-            return WorkspaceContext.SHARED;
-        }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/WebMvcConfig.java
@@ -11,25 +11,14 @@ import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 
 import java.util.Locale;
 
-/**
- * Web MVC configuration for internationalization and request-bound workspace
- * isolation.
- *
- * <p>Locale resolution priority:
- * <ol>
- *   <li>{@code ?lang=de} query parameter (persisted to cookie)</li>
- *   <li>{@code lang} cookie</li>
- *   <li>{@code Accept-Language} header</li>
- *   <li>Fallback: English</li>
- * </ol>
- */
+/** Web MVC configuration for internationalization and workspace isolation. */
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final DslWorkspacePreResolutionInterceptor dslWorkspaceInterceptor;
+    private final DslWorkspacePreResolutionInterceptor workspaceInterceptor;
 
-    public WebMvcConfig(DslWorkspacePreResolutionInterceptor dslWorkspaceInterceptor) {
-        this.dslWorkspaceInterceptor = dslWorkspaceInterceptor;
+    public WebMvcConfig(DslWorkspacePreResolutionInterceptor workspaceInterceptor) {
+        this.workspaceInterceptor = workspaceInterceptor;
     }
 
     @Bean
@@ -49,13 +38,21 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(localeChangeInterceptor());
-        registry.addInterceptor(dslWorkspaceInterceptor)
+        registry.addInterceptor(workspaceInterceptor)
                 .addPathPatterns(
-                        "/api/dsl/current",
-                        "/api/dsl/history",
-                        "/api/dsl/git/head",
-                        "/api/dsl/hypotheses/**",
+                        "/api/dsl/**",
                         "/api/analyze",
-                        "/api/search/graph");
+                        "/api/search/graph",
+                        "/api/relations/**",
+                        "/api/node/*/relations",
+                        "/api/proposals/**",
+                        "/api/node/*/proposals",
+                        "/api/import/**",
+                        "/api/context/**",
+                        "/api/report/**",
+                        "/api/projects/**",
+                        "/api/solutions/**",
+                        "/api/products/**",
+                        "/api/coverage/**");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/ContextNavigationController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/ContextNavigationController.java
@@ -16,7 +16,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -24,17 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * REST API for architecture context navigation.
- *
- * <p>Provides browser-like navigation through architecture versions:
- * open read-only snapshots, switch branches, compare contexts, and
- * selectively transfer elements between versions.
- *
- * <p>All navigation state is isolated per authenticated user via the
- * workspace manager. Each user has their own context, history, and
- * navigation trail.
- */
+/** REST API for workspace-isolated architecture context navigation. */
 @RestController
 @RequestMapping("/api/context")
 @Tag(name = "Context Navigation")
@@ -57,32 +52,19 @@ public class ContextNavigationController {
         this.workspaceResolver = workspaceResolver;
     }
 
-    /**
-     * Resolve the current workspace context from the authenticated user.
-     * Falls back to {@link WorkspaceContext#SHARED} if resolution fails.
-     */
     private WorkspaceContext resolveContext() {
-        try {
-            return workspaceResolver.resolveCurrentContext();
-        } catch (Exception e) {
-            return WorkspaceContext.SHARED;
-        }
+        return workspaceResolver.resolveCurrentContext();
     }
 
-    // ── Phase 1: Context Navigation ─────────────────────────────────
-
     @GetMapping("/current")
-    @Operation(summary = "Get the current architecture context",
-            description = "Returns the active context including branch, commit, mode, and origin info.")
+    @Operation(summary = "Get the current architecture context")
     public ResponseEntity<ContextRef> getCurrentContext() {
-        String user = workspaceResolver.resolveCurrentUsername();
-        return ResponseEntity.ok(navigationService.getCurrentContext(user));
+        return ResponseEntity.ok(navigationService.getCurrentContext(
+                workspaceResolver.resolveCurrentUsername()));
     }
 
     @PostMapping("/open")
-    @Operation(summary = "Open a context (read-only or editable)",
-            description = "Opens a specific branch/commit as a new context. " +
-                    "If readOnly is true, write operations will be blocked.")
+    @Operation(summary = "Open a context (read-only or editable)")
     public ResponseEntity<ContextRef> openContext(
             @RequestParam(defaultValue = "draft") String branch,
             @RequestParam(required = false) String commitId,
@@ -90,66 +72,56 @@ public class ContextNavigationController {
             @RequestParam(required = false) String searchQuery,
             @RequestParam(required = false) String elementId) {
         String user = workspaceResolver.resolveCurrentUsername();
-        WorkspaceContext ctx = resolveContext();
+        WorkspaceContext context = resolveContext();
         if (readOnly) {
-            return ResponseEntity.ok(
-                    navigationService.openReadOnly(user, branch, commitId, ctx, searchQuery, elementId));
-        } else {
-            return ResponseEntity.ok(
-                    navigationService.switchContext(user, branch, commitId, ctx));
+            return ResponseEntity.ok(navigationService.openReadOnly(
+                    user, branch, commitId, context, searchQuery, elementId));
         }
+        return ResponseEntity.ok(navigationService.switchContext(
+                user, branch, commitId, context));
     }
 
     @PostMapping("/return-to-origin")
-    @Operation(summary = "Return to the origin context",
-            description = "Navigates back to the context from which the current context was opened.")
+    @Operation(summary = "Return to the origin context")
     public ResponseEntity<ContextRef> returnToOrigin() {
-        String user = workspaceResolver.resolveCurrentUsername();
-        return ResponseEntity.ok(navigationService.returnToOrigin(user));
+        return ResponseEntity.ok(navigationService.returnToOrigin(
+                workspaceResolver.resolveCurrentUsername()));
     }
 
     @PostMapping("/back")
-    @Operation(summary = "Go one step back in navigation history",
-            description = "Like the browser back button — returns to the previous context.")
+    @Operation(summary = "Go one step back in navigation history")
     public ResponseEntity<ContextRef> back() {
-        String user = workspaceResolver.resolveCurrentUsername();
-        return ResponseEntity.ok(navigationService.back(user));
+        return ResponseEntity.ok(navigationService.back(
+                workspaceResolver.resolveCurrentUsername()));
     }
 
     @GetMapping("/history")
-    @Operation(summary = "Get the navigation history",
-            description = "Returns the list of context navigations (newest last).")
+    @Operation(summary = "Get the navigation history")
     public ResponseEntity<List<ContextHistoryEntry>> getHistory() {
-        String user = workspaceResolver.resolveCurrentUsername();
-        return ResponseEntity.ok(navigationService.getHistory(user));
+        return ResponseEntity.ok(navigationService.getHistory(
+                workspaceResolver.resolveCurrentUsername()));
     }
 
     @PostMapping("/variant")
-    @Operation(summary = "Create a new branch variant from the current context",
-            description = "Creates a new Git branch from the current context and switches to it.")
-    public ResponseEntity<Map<String, Object>> createVariant(
-            @RequestParam String name) {
+    @Operation(summary = "Create a new branch variant from the current context")
+    public ResponseEntity<Map<String, Object>> createVariant(@RequestParam String name) {
         try {
             String user = workspaceResolver.resolveCurrentUsername();
-            ContextRef variant = navigationService.createVariantFromCurrent(user, name, resolveContext());
+            ContextRef variant = navigationService.createVariantFromCurrent(
+                    user, name, resolveContext());
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("context", variant);
             result.put("branch", variant.branch());
             return ResponseEntity.ok(result);
-        } catch (IOException e) {
-            log.error("Failed to create variant '{}'", name, e);
+        } catch (IOException error) {
+            log.error("Failed to create variant '{}'", name, error);
             return ResponseEntity.internalServerError().body(
-                    Map.of("error", "Failed to create variant: " + e.getMessage()));
+                    Map.of("error", "Failed to create variant"));
         }
     }
 
-    // ── Phase 3: Compare ────────────────────────────────────────────
-
     @GetMapping("/compare")
-    @Operation(summary = "Compare two architecture contexts",
-            description = "Returns a semantic diff between two contexts identified by " +
-                    "branch/commit pairs. Includes summary counts, individual changes, " +
-                    "and optional raw DSL diff.")
+    @Operation(summary = "Compare two architecture contexts")
     public ResponseEntity<ContextComparison> compare(
             @RequestParam String leftBranch,
             @RequestParam(required = false) String leftCommit,
@@ -163,74 +135,71 @@ public class ContextNavigationController {
             ContextRef right = new ContextRef(
                     null, rightBranch, rightCommit, null, null,
                     null, null, null, null, null, false);
-
-            ContextComparison comparison;
-            if (leftCommit != null || rightCommit != null) {
-                comparison = compareService.compareContexts(left, right, resolveContext());
-            } else {
-                comparison = compareService.compareBranches(left, right, resolveContext());
-            }
+            ContextComparison comparison = leftCommit != null || rightCommit != null
+                    ? compareService.compareContexts(left, right, resolveContext())
+                    : compareService.compareBranches(left, right, resolveContext());
             return ResponseEntity.ok(applyFilter(comparison, filter));
-        } catch (IOException e) {
-            log.error("Compare failed", e);
+        } catch (IOException error) {
+            log.error("Compare failed", error);
             return ResponseEntity.internalServerError().build();
         }
     }
 
-    // ── Phase 4: Selective Transfer ─────────────────────────────────
-
     @PostMapping("/copy-back/preview")
-    @Operation(summary = "Preview a selective transfer",
-            description = "Shows what would happen if the selected elements and relations " +
-                    "were transferred from source to target context, including conflicts.")
+    @Operation(summary = "Preview a selective transfer")
     public ResponseEntity<Map<String, Object>> previewTransfer(
             @RequestBody TransferSelection selection) {
         try {
-            List<TransferConflict> conflicts = transferService.previewTransfer(selection, resolveContext());
+            List<TransferConflict> conflicts = transferService.previewTransfer(
+                    selection, resolveContext());
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("conflicts", conflicts);
             result.put("hasConflicts", !conflicts.isEmpty());
             result.put("selectedElements", selection.selectedElementIds().size());
             result.put("selectedRelations", selection.selectedRelationIds().size());
+            result.put("expectedTargetHead", selection.targetContextId());
+            result.put("mode", selection.mode());
             return ResponseEntity.ok(result);
-        } catch (IOException e) {
-            log.error("Transfer preview failed", e);
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().body(Map.of("error", error.getMessage()));
+        } catch (IOException error) {
+            log.error("Transfer preview failed", error);
             return ResponseEntity.internalServerError().body(
-                    Map.of("error", "Transfer preview failed: " + e.getMessage()));
+                    Map.of("error", "Transfer preview failed"));
         }
     }
 
     @PostMapping("/copy-back/apply")
-    @Operation(summary = "Apply a selective transfer",
-            description = "Transfers the selected elements and relations from the source " +
-                    "context into the target context, creating a new commit.")
+    @Operation(summary = "Apply a selective transfer")
     public ResponseEntity<Map<String, Object>> applyTransfer(
             @RequestBody TransferSelection selection) {
         try {
+            String previousHead = selection.targetContextId();
             String commitId = transferService.applyTransfer(selection);
             Map<String, Object> result = new LinkedHashMap<>();
             result.put("commitId", commitId);
+            result.put("previousHead", previousHead);
+            result.put("mode", selection.mode());
             result.put("success", true);
             return ResponseEntity.ok(result);
-        } catch (IOException e) {
-            log.error("Transfer failed", e);
+        } catch (java.util.ConcurrentModificationException error) {
+            return ResponseEntity.status(409).body(Map.of("error", error.getMessage()));
+        } catch (IllegalArgumentException | IllegalStateException error) {
+            return ResponseEntity.badRequest().body(Map.of("error", error.getMessage()));
+        } catch (IOException error) {
+            log.error("Transfer failed", error);
             return ResponseEntity.internalServerError().body(
-                    Map.of("error", "Transfer failed: " + e.getMessage()));
+                    Map.of("error", "Transfer failed"));
         }
     }
-
-    // ── Internal helpers ────────────────────────────────────────────
 
     private ContextComparison applyFilter(ContextComparison comparison, Set<String> filter) {
         if (filter == null || filter.isEmpty()) {
             return comparison;
         }
         List<SemanticChange> filtered = comparison.changes().stream()
-                .filter(c -> {
-                    if (filter.contains("elements") && "ELEMENT".equals(c.category())) return true;
-                    if (filter.contains("relations") && "RELATION".equals(c.category())) return true;
-                    return false;
-                })
+                .filter(change -> (filter.contains("elements") && "ELEMENT".equals(change.category()))
+                        || (filter.contains("relations") && "RELATION".equals(change.category())))
                 .toList();
         return new ContextComparison(comparison.left(), comparison.right(),
                 comparison.summary(), filtered, comparison.rawDslDiff());

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/controller/DslWorkspacePreResolutionInterceptor.java
@@ -5,30 +5,29 @@ import com.taxonomy.workspace.service.WorkspaceContext;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 /**
- * Resolves an isolated workspace before entering HTTP endpoints that read or
- * mutate workspace-scoped repository, hypothesis, analysis or relation state.
- *
- * <p>Provisioning and context resolution failures propagate before controller
- * code runs. Successful results are request-cached by the corresponding
- * services, so repeated controller lookups cannot later switch to a shared
- * context. Despite the historical class name, the interceptor is also used by
- * analysis and graph-search endpoints whose results carry workspace-scoped
- * hypotheses or relation visibility.</p>
+ * Resolves a stable workspace before entering workspace-scoped HTTP endpoints.
+ * Provisioning and resolution failures propagate before controller code runs.
  */
 @Component
 public class DslWorkspacePreResolutionInterceptor implements HandlerInterceptor {
 
     private final WorkspaceResolver workspaceResolver;
     private final RepositoryStateService repositoryStateService;
+    private final boolean sharedModeEnabled;
 
-    public DslWorkspacePreResolutionInterceptor(WorkspaceResolver workspaceResolver,
-                                                RepositoryStateService repositoryStateService) {
+    public DslWorkspacePreResolutionInterceptor(
+            WorkspaceResolver workspaceResolver,
+            RepositoryStateService repositoryStateService,
+            @Value("${taxonomy.workspace.shared-mode-enabled:true}")
+            boolean sharedModeEnabled) {
         this.workspaceResolver = workspaceResolver;
         this.repositoryStateService = repositoryStateService;
+        this.sharedModeEnabled = sharedModeEnabled;
     }
 
     @Override
@@ -38,7 +37,7 @@ public class DslWorkspacePreResolutionInterceptor implements HandlerInterceptor 
         String username = workspaceResolver.resolveCurrentUsername();
         repositoryStateService.ensureWorkspaceState(username);
         WorkspaceContext context = workspaceResolver.resolveCurrentContext();
-        if (WorkspaceContext.SHARED.equals(context)) {
+        if (WorkspaceContext.SHARED.equals(context) && !sharedModeEnabled) {
             throw new IllegalStateException(
                     "Authenticated workspace-scoped operation did not resolve an isolated workspace");
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/ConditionalDslCommitter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/ConditionalDslCommitter.java
@@ -1,0 +1,81 @@
+package com.taxonomy.versioning.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import org.eclipse.jgit.lib.CommitBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.TreeFormatter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ConcurrentModificationException;
+import java.util.Objects;
+
+/** Creates a DSL commit only when the target branch still has the expected HEAD. */
+final class ConditionalDslCommitter {
+
+    private static final String DSL_FILENAME = "architecture.taxdsl";
+
+    String commit(DslGitRepository repository,
+                  String branch,
+                  String expectedHead,
+                  String dsl,
+                  String author,
+                  String message) throws IOException {
+        Objects.requireNonNull(repository, "repository");
+        Objects.requireNonNull(branch, "branch");
+        Objects.requireNonNull(expectedHead, "expectedHead");
+        Objects.requireNonNull(dsl, "dsl");
+
+        Repository git = repository.getGitRepository();
+        String refName = Constants.R_HEADS + branch;
+        Ref ref = git.getRefDatabase().exactRef(refName);
+        String actualHead = ref != null && ref.getObjectId() != null
+                ? ref.getObjectId().name() : null;
+        if (!expectedHead.equals(actualHead)) {
+            throw new ConcurrentModificationException(
+                    "Target branch '" + branch + "' moved from " + expectedHead
+                            + " to " + actualHead);
+        }
+
+        PersonIdent actor = new PersonIdent(
+                author != null && !author.isBlank() ? author : "taxonomy",
+                author != null && !author.isBlank() ? author : "taxonomy@system");
+        try (ObjectInserter inserter = git.newObjectInserter()) {
+            ObjectId blob = inserter.insert(
+                    Constants.OBJ_BLOB, dsl.getBytes(StandardCharsets.UTF_8));
+            TreeFormatter tree = new TreeFormatter();
+            tree.append(DSL_FILENAME, FileMode.REGULAR_FILE, blob);
+            ObjectId treeId = inserter.insert(tree);
+
+            CommitBuilder commit = new CommitBuilder();
+            commit.setTreeId(treeId);
+            commit.setParentId(ref.getObjectId());
+            commit.setAuthor(actor);
+            commit.setCommitter(actor);
+            commit.setMessage(message != null ? message : "Selective transfer");
+            ObjectId commitId = inserter.insert(commit);
+            inserter.flush();
+
+            RefUpdate update = git.updateRef(refName);
+            update.setNewObjectId(commitId);
+            update.setExpectedOldObjectId(ObjectId.fromString(expectedHead));
+            update.setRefLogIdent(actor);
+            update.setRefLogMessage("selective-transfer: " + commit.getMessage(), true);
+            RefUpdate.Result result = update.update();
+            if (result != RefUpdate.Result.FAST_FORWARD
+                    && result != RefUpdate.Result.NEW
+                    && result != RefUpdate.Result.NO_CHANGE) {
+                throw new ConcurrentModificationException(
+                        "Target branch '" + branch + "' changed during transfer: " + result);
+            }
+            return commitId.name();
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/ConditionalDslCommitter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/ConditionalDslCommitter.java
@@ -44,6 +44,7 @@ final class ConditionalDslCommitter {
                             + " to " + actualHead);
         }
 
+        String commitMessage = message != null ? message : "Selective transfer";
         PersonIdent actor = new PersonIdent(
                 author != null && !author.isBlank() ? author : "taxonomy",
                 author != null && !author.isBlank() ? author : "taxonomy@system");
@@ -59,7 +60,7 @@ final class ConditionalDslCommitter {
             commit.setParentId(ref.getObjectId());
             commit.setAuthor(actor);
             commit.setCommitter(actor);
-            commit.setMessage(message != null ? message : "Selective transfer");
+            commit.setMessage(commitMessage);
             ObjectId commitId = inserter.insert(commit);
             inserter.flush();
 
@@ -67,7 +68,7 @@ final class ConditionalDslCommitter {
             update.setNewObjectId(commitId);
             update.setExpectedOldObjectId(ObjectId.fromString(expectedHead));
             update.setRefLogIdent(actor);
-            update.setRefLogMessage("selective-transfer: " + commit.getMessage(), true);
+            update.setRefLogMessage("selective-transfer: " + commitMessage, true);
             RefUpdate.Result result = update.update();
             if (result != RefUpdate.Result.FAST_FORWARD
                     && result != RefUpdate.Result.NEW

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/SelectiveTransferService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/SelectiveTransferService.java
@@ -12,26 +12,22 @@ import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
 import com.taxonomy.dto.TransferConflict;
 import com.taxonomy.dto.TransferSelection;
 import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import com.taxonomy.workspace.service.WorkspaceResolver;
 
-/**
- * Performs selective element/relation transfers between architecture contexts.
- *
- * <p>Unlike a full Git merge or cherry-pick, this service allows the user to
- * pick individual elements and relations from one version and apply them to
- * another. Conflict detection and preview are provided before any changes
- * are committed.
- */
+/** Performs safe selective element/relation transfers between architecture commits. */
 @Service
 public class SelectiveTransferService {
 
@@ -40,6 +36,7 @@ public class SelectiveTransferService {
     private final DslGitRepositoryFactory repositoryFactory;
     private final ContextNavigationService contextNavigationService;
     private final WorkspaceResolver workspaceResolver;
+    private final ConditionalDslCommitter conditionalCommitter = new ConditionalDslCommitter();
     private final TaxDslParser parser = new TaxDslParser();
     private final AstToModelMapper astMapper = new AstToModelMapper();
     private final ModelToAstMapper modelToAstMapper = new ModelToAstMapper();
@@ -53,205 +50,203 @@ public class SelectiveTransferService {
         this.workspaceResolver = workspaceResolver;
     }
 
-    /**
-     * Resolve the Git repository for the given workspace context.
-     *
-     * @param ctx the workspace context (use {@link WorkspaceContext#SHARED}
-     *            for the system repository)
-     * @return the resolved DslGitRepository
-     */
-    private DslGitRepository resolveRepository(WorkspaceContext ctx) {
-        return repositoryFactory.resolveRepository(ctx);
+    private DslGitRepository resolveRepository(WorkspaceContext context) {
+        return repositoryFactory.resolveRepository(Objects.requireNonNull(context, "context"));
+    }
+
+    /** Preview in the explicitly supplied workspace without modifying data. */
+    public List<TransferConflict> previewTransfer(TransferSelection selection,
+                                                  WorkspaceContext context) throws IOException {
+        validateSelection(selection);
+        DslGitRepository repository = resolveRepository(context);
+        CanonicalArchitectureModel source = loadModel(repository, selection.sourceContextId());
+        CanonicalArchitectureModel target = loadModel(repository, selection.targetContextId());
+        return detectConflicts(source, target, selection);
     }
 
     /**
-     * Resolve the current workspace context from the authenticated user.
-     * Falls back to {@link WorkspaceContext#SHARED} if resolution fails.
-     */
-    private WorkspaceContext resolveContext() {
-        try {
-            return workspaceResolver.resolveCurrentContext();
-        } catch (Exception e) {
-            return WorkspaceContext.SHARED;
-        }
-    }
-
-    /**
-     * Preview a selective transfer without modifying any data.
-     *
-     * <p>Uses the system repository (SHARED context). Use
-     * {@link #previewTransfer(TransferSelection, WorkspaceContext)} for workspace-aware resolution.
-     *
-     * @param selection the transfer selection
-     * @return list of conflicts (empty if no conflicts)
-     * @throws IOException if Git operations fail
+     * Backward-compatible preview for explicit non-request callers. Request code
+     * must use the overload with a validated context.
      */
     public List<TransferConflict> previewTransfer(TransferSelection selection) throws IOException {
-        return previewTransfer(selection, WorkspaceContext.SHARED);
+        return previewTransfer(selection, workspaceResolver.resolveCurrentContext());
     }
 
     /**
-     * Preview a selective transfer without modifying any data.
-     *
-     * @param selection the transfer selection
-     * @param ctx       the workspace context for repository resolution
-     * @return list of conflicts (empty if no conflicts)
-     * @throws IOException if Git operations fail
-     */
-    public List<TransferConflict> previewTransfer(TransferSelection selection,
-                                                  WorkspaceContext ctx) throws IOException {
-        DslGitRepository repo = resolveRepository(ctx);
-        CanonicalArchitectureModel sourceModel = loadModel(repo, selection.sourceContextId());
-        CanonicalArchitectureModel targetModel = loadModel(repo, selection.targetContextId());
-
-        return detectConflicts(sourceModel, targetModel, selection);
-    }
-
-    /**
-     * Apply a selective transfer, merging selected elements and relations
-     * from the source context into the target context.
-     *
-     * <p>This is a request-bound operation — it resolves the current workspace
-     * context from the authenticated user via {@code WorkspaceResolver}.
-     *
-     * @param selection the transfer selection
-     * @return the commit ID of the resulting commit
-     * @throws IOException if Git operations fail
+     * Apply the selected subset to the current branch only when its HEAD still
+     * equals {@code targetContextId}. This makes preview/apply fail closed under
+     * concurrent changes.
      */
     public String applyTransfer(TransferSelection selection) throws IOException {
-        WorkspaceContext ctx = resolveContext();
-        DslGitRepository repo = resolveRepository(ctx);
-        CanonicalArchitectureModel sourceModel = loadModel(repo, selection.sourceContextId());
-        CanonicalArchitectureModel targetModel = loadModel(repo, selection.targetContextId());
-
-        // Merge selected elements
-        Map<String, ArchitectureElement> targetElements = targetModel.getElements().stream()
-                .collect(Collectors.toMap(ArchitectureElement::getId, Function.identity()));
-
-        for (ArchitectureElement sourceEl : sourceModel.getElements()) {
-            if (selection.selectedElementIds().contains(sourceEl.getId())) {
-                targetElements.put(sourceEl.getId(), sourceEl);
-            }
+        validateSelection(selection);
+        WorkspaceContext context = workspaceResolver.resolveCurrentContext();
+        DslGitRepository repository = resolveRepository(context);
+        String username = workspaceResolver.resolveCurrentUsername();
+        String targetBranch = contextNavigationService.getCurrentContext(username).branch();
+        if (targetBranch == null || targetBranch.isBlank()) {
+            throw new IllegalStateException("No explicit target branch is active");
         }
 
-        // Merge selected relations
-        Map<String, ArchitectureRelation> targetRelations = targetModel.getRelations().stream()
-                .collect(Collectors.toMap(this::relationKey, Function.identity()));
-
-        for (ArchitectureRelation sourceRel : sourceModel.getRelations()) {
-            String key = relationKey(sourceRel);
-            if (selection.selectedRelationIds().contains(key)) {
-                targetRelations.put(key, sourceRel);
-            }
+        String actualHead = repository.getHeadCommit(targetBranch);
+        if (!selection.targetContextId().equals(actualHead)) {
+            throw new ConcurrentModificationException(
+                    "Target branch '" + targetBranch + "' moved from "
+                            + selection.targetContextId() + " to " + actualHead);
         }
 
-        // Build merged model
-        targetModel.getElements().clear();
-        targetModel.getElements().addAll(targetElements.values());
-        targetModel.getRelations().clear();
-        targetModel.getRelations().addAll(targetRelations.values());
+        CanonicalArchitectureModel source = loadModel(repository, selection.sourceContextId());
+        CanonicalArchitectureModel target = loadModel(repository, selection.targetContextId());
+        List<TransferConflict> conflicts = detectConflicts(source, target, selection);
+        if (selection.mode() == TransferSelection.TransferMode.MERGE_SELECTED
+                && !conflicts.isEmpty()) {
+            throw new IllegalStateException(
+                    "MERGE_SELECTED requires conflict resolution before apply");
+        }
 
-        // Serialize merged model back to DSL and commit
-        String targetDsl = repo.getDslAtCommit(selection.targetContextId());
-        var originalDoc = parser.parse(targetDsl);
-        String namespace = originalDoc.getMeta() != null
-                ? originalDoc.getMeta().namespace() : "default";
-        var mergedDoc = modelToAstMapper.toDocument(targetModel, namespace);
-        String mergedDsl = serializer.serialize(mergedDoc);
+        mergeSelected(source, target, selection);
+        String targetDsl = repository.getDslAtCommit(selection.targetContextId());
+        var originalDocument = parser.parse(targetDsl);
+        String namespace = originalDocument.getMeta() != null
+                ? originalDocument.getMeta().namespace() : "default";
+        String mergedDsl = serializer.serialize(modelToAstMapper.toDocument(target, namespace));
 
-        String targetBranch = contextNavigationService.getCurrentContext(
-                workspaceResolver.resolveCurrentUsername()).branch();
-        String commitId = repo.commitDsl(
-                targetBranch, mergedDsl, "system",
-                "Selective transfer: " + selection.selectedElementIds().size() + " elements, "
+        String commitId = conditionalCommitter.commit(
+                repository,
+                targetBranch,
+                selection.targetContextId(),
+                mergedDsl,
+                context.username(),
+                "Selective " + selection.mode() + ": "
+                        + selection.selectedElementIds().size() + " elements, "
                         + selection.selectedRelationIds().size() + " relations");
 
-        log.info("Selective transfer applied: {} elements, {} relations → commit '{}'",
-                selection.selectedElementIds().size(),
-                selection.selectedRelationIds().size(),
+        log.info("Selective transfer applied by '{}' in workspace '{}': mode={}, branch={}, commit={}",
+                context.username(), context.workspaceId(), selection.mode(), targetBranch,
                 commitId.substring(0, Math.min(7, commitId.length())));
-
         return commitId;
     }
 
-    // ── Internal helpers ────────────────────────────────────────────
+    private void mergeSelected(CanonicalArchitectureModel source,
+                               CanonicalArchitectureModel target,
+                               TransferSelection selection) {
+        Map<String, ArchitectureElement> targetElements = target.getElements().stream()
+                .collect(Collectors.toMap(ArchitectureElement::getId, Function.identity()));
+        for (ArchitectureElement element : source.getElements()) {
+            if (selection.selectedElementIds().contains(element.getId())) {
+                targetElements.put(element.getId(), element);
+            }
+        }
 
-    private CanonicalArchitectureModel loadModel(DslGitRepository repo, String commitId) throws IOException {
-        String dsl = repo.getDslAtCommit(commitId);
+        Map<String, ArchitectureRelation> targetRelations = target.getRelations().stream()
+                .collect(Collectors.toMap(this::relationKey, Function.identity()));
+        for (ArchitectureRelation relation : source.getRelations()) {
+            String key = relationKey(relation);
+            if (selection.selectedRelationIds().contains(key)) {
+                targetRelations.put(key, relation);
+            }
+        }
+
+        target.getElements().clear();
+        target.getElements().addAll(targetElements.values());
+        target.getRelations().clear();
+        target.getRelations().addAll(targetRelations.values());
+    }
+
+    private void validateSelection(TransferSelection selection) {
+        if (selection == null) {
+            throw new IllegalArgumentException("Transfer selection is required");
+        }
+        if (selection.sourceContextId() == null || selection.sourceContextId().isBlank()
+                || selection.targetContextId() == null || selection.targetContextId().isBlank()) {
+            throw new IllegalArgumentException("Source and target commit IDs are required");
+        }
+        if (selection.sourceContextId().equals(selection.targetContextId())) {
+            throw new IllegalArgumentException("Source and target commits must differ");
+        }
+        if (selection.mode() == null) {
+            throw new IllegalArgumentException("Transfer mode is required");
+        }
+        Set<String> elementIds = selection.selectedElementIds();
+        Set<String> relationIds = selection.selectedRelationIds();
+        if (elementIds == null || relationIds == null) {
+            throw new IllegalArgumentException("Selected ID sets are required");
+        }
+        if (elementIds.isEmpty() && relationIds.isEmpty()) {
+            throw new IllegalArgumentException("At least one element or relation must be selected");
+        }
+    }
+
+    private CanonicalArchitectureModel loadModel(DslGitRepository repository, String commitId)
+            throws IOException {
+        String dsl = repository.getDslAtCommit(commitId);
         if (dsl == null) {
             throw new IOException("No DSL content at commit: " + commitId);
         }
-        var doc = parser.parse(dsl);
-        return astMapper.map(doc);
+        return astMapper.map(parser.parse(dsl));
     }
 
     List<TransferConflict> detectConflicts(
             CanonicalArchitectureModel sourceModel,
             CanonicalArchitectureModel targetModel,
             TransferSelection selection) {
-
         List<TransferConflict> conflicts = new ArrayList<>();
 
         Map<String, ArchitectureElement> targetElements = targetModel.getElements().stream()
                 .collect(Collectors.toMap(ArchitectureElement::getId, Function.identity()));
-
-        for (ArchitectureElement sourceEl : sourceModel.getElements()) {
-            if (!selection.selectedElementIds().contains(sourceEl.getId())) {
+        for (ArchitectureElement sourceElement : sourceModel.getElements()) {
+            if (!selection.selectedElementIds().contains(sourceElement.getId())) {
                 continue;
             }
-            ArchitectureElement existing = targetElements.get(sourceEl.getId());
-            if (existing != null && !elementsEqual(existing, sourceEl)) {
+            ArchitectureElement existing = targetElements.get(sourceElement.getId());
+            if (existing != null && !elementsEqual(existing, sourceElement)) {
                 conflicts.add(new TransferConflict(
-                        sourceEl.getId(),
+                        sourceElement.getId(),
                         existing.getTitle(),
-                        sourceEl.getTitle(),
-                        findViewsReferencing(targetModel, sourceEl.getId())));
+                        sourceElement.getTitle(),
+                        findViewsReferencing(targetModel, sourceElement.getId())));
             }
         }
 
         Map<String, ArchitectureRelation> targetRelations = targetModel.getRelations().stream()
                 .collect(Collectors.toMap(this::relationKey, Function.identity()));
-
-        for (ArchitectureRelation sourceRel : sourceModel.getRelations()) {
-            String key = relationKey(sourceRel);
+        for (ArchitectureRelation sourceRelation : sourceModel.getRelations()) {
+            String key = relationKey(sourceRelation);
             if (!selection.selectedRelationIds().contains(key)) {
                 continue;
             }
             ArchitectureRelation existing = targetRelations.get(key);
-            if (existing != null && !relationsEqual(existing, sourceRel)) {
+            if (existing != null && !relationsEqual(existing, sourceRelation)) {
                 conflicts.add(new TransferConflict(
                         key,
                         existing.getStatus(),
-                        sourceRel.getStatus(),
+                        sourceRelation.getStatus(),
                         List.of()));
             }
         }
-
         return conflicts;
     }
 
-    private boolean elementsEqual(ArchitectureElement a, ArchitectureElement b) {
-        return java.util.Objects.equals(a.getTitle(), b.getTitle())
-            && java.util.Objects.equals(a.getDescription(), b.getDescription())
-            && java.util.Objects.equals(a.getType(), b.getType());
+    private boolean elementsEqual(ArchitectureElement left, ArchitectureElement right) {
+        return Objects.equals(left.getTitle(), right.getTitle())
+                && Objects.equals(left.getDescription(), right.getDescription())
+                && Objects.equals(left.getType(), right.getType());
     }
 
-    private boolean relationsEqual(ArchitectureRelation a, ArchitectureRelation b) {
-        return java.util.Objects.equals(a.getStatus(), b.getStatus())
-            && java.util.Objects.equals(a.getConfidence(), b.getConfidence());
+    private boolean relationsEqual(ArchitectureRelation left, ArchitectureRelation right) {
+        return Objects.equals(left.getStatus(), right.getStatus())
+                && Objects.equals(left.getConfidence(), right.getConfidence());
     }
 
-    private String relationKey(ArchitectureRelation rel) {
-        return rel.getSourceId() + " " + rel.getRelationType() + " " + rel.getTargetId();
+    private String relationKey(ArchitectureRelation relation) {
+        return relation.getSourceId() + " " + relation.getRelationType() + " "
+                + relation.getTargetId();
     }
 
     private List<String> findViewsReferencing(CanonicalArchitectureModel model, String elementId) {
         return model.getViews().stream()
-                .filter(v -> {
-                    List<String> includes = v.getIncludes();
-                    return includes != null && includes.contains(elementId);
-                })
-                .map(v -> v.getTitle())
+                .filter(view -> view.getIncludes() != null
+                        && view.getIncludes().contains(elementId))
+                .map(view -> view.getTitle())
                 .limit(5)
                 .toList();
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
@@ -3,6 +3,7 @@ package com.taxonomy.workspace.service;
 import com.taxonomy.workspace.model.UserWorkspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -11,13 +12,10 @@ import org.springframework.stereotype.Service;
  * Resolves the current {@link WorkspaceContext} from the security context
  * and the persistent workspace metadata.
  *
- * <p>Combines the username (from Spring Security) with the
- * workspace metadata (from {@link WorkspaceManager}) to produce a
- * consistent context value that downstream services can use for
- * data isolation (workspace-scoped relations, hypotheses, proposals, etc.).
- *
- * <p>Falls back to {@link WorkspaceContext#SHARED} when no provisioned
- * workspace exists for the current user.
+ * <p>Authenticated users are isolated by default. A shared context is returned
+ * only for the configured default/system user or when the operator has
+ * explicitly enabled shared workspace mode. Missing or inconsistent workspace
+ * metadata therefore fails closed in multi-user deployments.</p>
  */
 @Service
 public class WorkspaceContextResolver {
@@ -26,33 +24,29 @@ public class WorkspaceContextResolver {
 
     private final WorkspaceManager workspaceManager;
     private final SystemRepositoryService systemRepositoryService;
+    private final boolean sharedModeEnabled;
 
     public WorkspaceContextResolver(WorkspaceManager workspaceManager,
-                                     SystemRepositoryService systemRepositoryService) {
+                                    SystemRepositoryService systemRepositoryService,
+                                    @Value("${taxonomy.workspace.shared-mode-enabled:true}")
+                                    boolean sharedModeEnabled) {
         this.workspaceManager = workspaceManager;
         this.systemRepositoryService = systemRepositoryService;
+        this.sharedModeEnabled = sharedModeEnabled;
     }
 
-    /**
-     * Resolve the workspace context for the currently authenticated user.
-     *
-     * @return the active workspace context (never {@code null})
-     */
+    /** Resolve the workspace context for the currently authenticated user. */
     public WorkspaceContext resolveCurrentContext() {
-        String username = resolveUsername();
-        return resolveForUser(username);
+        return resolveForUser(resolveUsername());
     }
 
     /**
      * Resolve the workspace context for a specific user.
      *
-     * <p>Only users with an explicitly provisioned persistent workspace
-     * receive a workspace-scoped context. Users with only a default
-     * in-memory workspace state receive the {@link WorkspaceContext#SHARED}
-     * fallback (backward-compatible, no data isolation).
-     *
-     * @param username the username to resolve context for
-     * @return the workspace context (never {@code null})
+     * @return an isolated context, or the explicit shared context when shared
+     *         mode is enabled
+     * @throws IllegalStateException when an authenticated user has no isolated
+     *         workspace and shared mode is disabled
      */
     public WorkspaceContext resolveForUser(String username) {
         if (username == null || username.isBlank()
@@ -60,31 +54,37 @@ public class WorkspaceContextResolver {
             return WorkspaceContext.SHARED;
         }
 
-        // Try active workspace first (multi-workspace aware)
-        UserWorkspace ws = workspaceManager.findActiveWorkspace(username);
-        if (ws == null) {
-            // Fall back to legacy single-workspace lookup for backward compatibility
-            ws = workspaceManager.findUserWorkspace(username);
+        UserWorkspace workspace = workspaceManager.findActiveWorkspace(username);
+        if (workspace == null) {
+            workspace = workspaceManager.findUserWorkspace(username);
         }
 
-        if (ws != null && ws.getWorkspaceId() != null) {
-            String branch = ws.getCurrentBranch() != null
-                    ? ws.getCurrentBranch()
+        if (workspace != null && workspace.getWorkspaceId() != null
+                && !workspace.getWorkspaceId().isBlank()) {
+            String branch = workspace.getCurrentBranch() != null
+                    && !workspace.getCurrentBranch().isBlank()
+                    ? workspace.getCurrentBranch()
                     : systemRepositoryService.getSharedBranch();
             log.debug("Resolved workspace context for user '{}': workspace={}, branch={}",
-                    username, ws.getWorkspaceId(), branch);
-            return new WorkspaceContext(username, ws.getWorkspaceId(), branch);
+                    username, workspace.getWorkspaceId(), branch);
+            return new WorkspaceContext(username, workspace.getWorkspaceId(), branch);
         }
 
-        log.debug("No provisioned workspace for user '{}'; falling back to SHARED", username);
-        return WorkspaceContext.SHARED;
+        if (sharedModeEnabled) {
+            log.warn("Explicit shared workspace mode is active for user '{}'; no data isolation applies",
+                    username);
+            return WorkspaceContext.SHARED;
+        }
+
+        throw new IllegalStateException(
+                "No isolated workspace is provisioned for authenticated user '" + username + "'");
     }
 
     private String resolveUsername() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.isAuthenticated()
-                && !"anonymousUser".equals(auth.getPrincipal())) {
-            return auth.getName();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal())) {
+            return authentication.getName();
         }
         return WorkspaceManager.DEFAULT_USER;
     }

--- a/taxonomy-app/src/main/resources/application-kubernetes.properties
+++ b/taxonomy-app/src/main/resources/application-kubernetes.properties
@@ -23,6 +23,10 @@ springdoc.swagger-ui.enabled=${TAXONOMY_SPRINGDOC_ENABLED:false}
 taxonomy.security.swagger-public=false
 taxonomy.security.audit-logging=${TAXONOMY_AUDIT_LOGGING:true}
 
+# Authenticated users must resolve to an isolated workspace. Shared mode remains
+# available only as an explicit operator decision for single-user/legacy setups.
+taxonomy.workspace.shared-mode-enabled=${TAXONOMY_WORKSPACE_SHARED_MODE_ENABLED:false}
+
 # Persistent deployments must not recreate their schema on every pod start.
 spring.jpa.hibernate.ddl-auto=${TAXONOMY_DDL_AUTO:validate}
 

--- a/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
@@ -1,19 +1,24 @@
 package com.taxonomy;
 
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.repository.RelationProposalRepository;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
+import com.taxonomy.relations.service.RelationCandidateService;
+import com.taxonomy.relations.service.RelationCompatibilityMatrix;
 import com.taxonomy.relations.service.RelationProposalService;
-import com.taxonomy.workspace.service.WorkspaceContext;
+import com.taxonomy.relations.service.RelationReviewService;
+import com.taxonomy.relations.service.RelationValidationService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -21,13 +26,10 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import org.springframework.security.test.context.support.WithMockUser;
-import com.taxonomy.relations.service.RelationCandidateService;
-import com.taxonomy.relations.service.RelationCompatibilityMatrix;
-import com.taxonomy.relations.service.RelationReviewService;
-import com.taxonomy.relations.service.RelationValidationService;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /** Tests for the relation proposal pipeline and REST API. */
 @SpringBootTest
@@ -43,6 +45,7 @@ class RelationProposalTests {
     @Autowired private RelationCompatibilityMatrix compatibilityMatrix;
     @Autowired private RelationProposalRepository proposalRepository;
     @Autowired private TaxonomyRelationRepository relationRepository;
+    @Autowired private WorkspaceResolver workspaceResolver;
 
     @BeforeEach
     void clean() {
@@ -142,7 +145,7 @@ class RelationProposalTests {
         if (!proposals.isEmpty()) {
             Long proposalId = proposals.get(0).getId();
             TaxonomyRelationDto relation = reviewService.acceptProposal(
-                    proposalId, WorkspaceContext.SHARED);
+                    proposalId, workspaceResolver.resolveCurrentContext());
             assertThat(relation).isNotNull();
             assertThat(relation.getSourceCode()).isEqualTo("BP");
             assertThat(relation.getRelationType()).isEqualTo("RELATED_TO");
@@ -160,7 +163,7 @@ class RelationProposalTests {
         if (!proposals.isEmpty()) {
             Long proposalId = proposals.get(0).getId();
             RelationProposalDto rejected = reviewService.rejectProposal(
-                    proposalId, WorkspaceContext.SHARED);
+                    proposalId, workspaceResolver.resolveCurrentContext());
             assertThat(rejected.getStatus()).isEqualTo("REJECTED");
             var updated = proposalRepository.findById(proposalId).orElseThrow();
             assertThat(updated.getStatus()).isEqualTo(ProposalStatus.REJECTED);
@@ -171,14 +174,14 @@ class RelationProposalTests {
     @Test
     void acceptNonExistentProposalThrows() {
         assertThatThrownBy(() -> reviewService.acceptProposal(
-                999L, WorkspaceContext.SHARED))
+                999L, workspaceResolver.resolveCurrentContext()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void rejectNonExistentProposalThrows() {
         assertThatThrownBy(() -> reviewService.rejectProposal(
-                999L, WorkspaceContext.SHARED))
+                999L, workspaceResolver.resolveCurrentContext()))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/controller/ContextNavigationControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/controller/ContextNavigationControllerTest.java
@@ -14,11 +14,10 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * Integration tests for {@link ContextNavigationController}.
- */
+/** Integration tests for {@link ContextNavigationController}. */
 @SpringBootTest
 @AutoConfigureMockMvc
 @WithMockUser(roles = "ADMIN")
@@ -41,29 +40,16 @@ class ContextNavigationControllerTest {
             }
             """;
 
-    /**
-     * Ensure at least one commit exists on the {@code draft} branch so
-     * that the current context's {@code commitId} is non-null.
-     *
-     * <p>In production there is always at least one taxonomy-import commit.
-     * Without this setup, the current context's {@code commitId} would be
-     * {@code null}, causing compare and transfer tests to fail.
-     *
-     * <p>The commit is made through the API to ensure it lands in whatever
-     * repository the current user's workspace context resolves to.
-     */
     @BeforeEach
     void ensureInitialCommit() throws Exception {
-        // Check if there's already a commit (from a previous test in this class)
-        MvcResult ctx = mockMvc.perform(get("/api/context/current"))
+        MvcResult context = mockMvc.perform(get("/api/context/current"))
                 .andExpect(status().isOk())
                 .andReturn();
-        JsonNode json = objectMapper.readTree(ctx.getResponse().getContentAsString());
+        JsonNode json = objectMapper.readTree(context.getResponse().getContentAsString());
         if (!json.get("commitId").isNull()) {
-            return; // Already have a commit
+            return;
         }
 
-        // Commit through the API so it lands in the correct repo for the user
         mockMvc.perform(post("/api/dsl/commit")
                         .contentType(MediaType.TEXT_PLAIN)
                         .content(SAMPLE_DSL)
@@ -72,7 +58,6 @@ class ContextNavigationControllerTest {
                         .param("message", "initial test import"))
                 .andExpect(status().isOk());
 
-        // Refresh the user's navigation context so commitId is non-null
         mockMvc.perform(post("/api/context/open")
                         .param("branch", "draft")
                         .param("readOnly", "false"))
@@ -131,8 +116,6 @@ class ContextNavigationControllerTest {
 
     @Test
     void contextEndpointsRequireAuthentication() throws Exception {
-        // This test verifies the security config works — @WithMockUser is used
-        // at class level so all other tests are authenticated
         mockMvc.perform(get("/api/context/current"))
                 .andExpect(status().isOk());
     }
@@ -166,10 +149,10 @@ class ContextNavigationControllerTest {
 
     @Test
     void compareWithCommitIds_returnsOk() throws Exception {
-        MvcResult ctx = mockMvc.perform(get("/api/context/current"))
+        MvcResult context = mockMvc.perform(get("/api/context/current"))
                 .andExpect(status().isOk())
                 .andReturn();
-        JsonNode json = objectMapper.readTree(ctx.getResponse().getContentAsString());
+        JsonNode json = objectMapper.readTree(context.getResponse().getContentAsString());
         String commitId = json.get("commitId").asText();
 
         mockMvc.perform(get("/api/context/compare")
@@ -192,13 +175,8 @@ class ContextNavigationControllerTest {
     }
 
     @Test
-    void previewTransfer_returnsOk() throws Exception {
-        MvcResult ctx = mockMvc.perform(get("/api/context/current"))
-                .andExpect(status().isOk())
-                .andReturn();
-        JsonNode json = objectMapper.readTree(ctx.getResponse().getContentAsString());
-        String commitId = json.get("commitId").asText();
-
+    void previewTransferRejectsEmptyNoOpSelection() throws Exception {
+        String commitId = currentCommitId();
         String body = """
                 {
                     "sourceContextId": "%s",
@@ -208,23 +186,17 @@ class ContextNavigationControllerTest {
                     "mode": "COPY"
                 }
                 """.formatted(commitId, commitId);
+
         mockMvc.perform(post("/api/context/copy-back/preview")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.hasConflicts").value(false))
-                .andExpect(jsonPath("$.selectedElements").value(0))
-                .andExpect(jsonPath("$.selectedRelations").value(0));
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").isNotEmpty());
     }
 
     @Test
-    void applyTransfer_returnsOk() throws Exception {
-        MvcResult ctx = mockMvc.perform(get("/api/context/current"))
-                .andExpect(status().isOk())
-                .andReturn();
-        JsonNode json = objectMapper.readTree(ctx.getResponse().getContentAsString());
-        String commitId = json.get("commitId").asText();
-
+    void applyTransferRejectsEmptyNoOpSelection() throws Exception {
+        String commitId = currentCommitId();
         String body = """
                 {
                     "sourceContextId": "%s",
@@ -234,10 +206,19 @@ class ContextNavigationControllerTest {
                     "mode": "COPY"
                 }
                 """.formatted(commitId, commitId);
+
         mockMvc.perform(post("/api/context/copy-back/apply")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").isNotEmpty());
+    }
+
+    private String currentCommitId() throws Exception {
+        MvcResult context = mockMvc.perform(get("/api/context/current"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.success").value(true));
+                .andReturn();
+        return objectMapper.readTree(context.getResponse().getContentAsString())
+                .get("commitId").asText();
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/ConditionalDslCommitterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/ConditionalDslCommitterTest.java
@@ -1,0 +1,49 @@
+package com.taxonomy.versioning.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.ConcurrentModificationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConditionalDslCommitterTest {
+
+    private static final String DSL = """
+            meta {
+              language: "taxdsl";
+              version: "2.0";
+              namespace: "test";
+            }
+            """;
+
+    @Test
+    void commitsOnlyOnExpectedHeadAndPreservesActor() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            String initial = repository.commitDsl("draft", DSL, "bootstrap", "Initial");
+            ConditionalDslCommitter committer = new ConditionalDslCommitter();
+
+            String next = committer.commit(
+                    repository, "draft", initial, DSL, "architect", "Selective COPY");
+
+            assertThat(repository.getHeadCommit("draft")).isEqualTo(next);
+            assertThat(repository.getHeadCommitInfo("draft").author()).isEqualTo("architect");
+        }
+    }
+
+    @Test
+    void staleExpectedHeadFailsWithoutMovingBranch() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            String initial = repository.commitDsl("draft", DSL, "bootstrap", "Initial");
+            String concurrent = repository.commitDsl("draft", DSL, "other", "Concurrent");
+            ConditionalDslCommitter committer = new ConditionalDslCommitter();
+
+            assertThatThrownBy(() -> committer.commit(
+                    repository, "draft", initial, DSL, "architect", "Stale transfer"))
+                    .isInstanceOf(ConcurrentModificationException.class)
+                    .hasMessageContaining("moved");
+            assertThat(repository.getHeadCommit("draft")).isEqualTo(concurrent);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
@@ -60,11 +60,11 @@ class WorkspaceRequestIsolationTest {
     }
 
     @Test
-    void failedPreResolutionStopsDslRequestBeforeControllerExecution() {
+    void failedPreResolutionStopsRequestBeforeControllerExecution() {
         WorkspaceResolver resolver = mock(WorkspaceResolver.class);
         RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
         DslWorkspacePreResolutionInterceptor interceptor =
-                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService);
+                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService, false);
         when(resolver.resolveCurrentUsername()).thenReturn("architect");
         doThrow(new IllegalStateException("workspace database unavailable"))
                 .when(repositoryStateService).ensureWorkspaceState("architect");
@@ -77,11 +77,11 @@ class WorkspaceRequestIsolationTest {
     }
 
     @Test
-    void sharedFallbackIsRejectedAtDslRequestBoundary() {
+    void sharedFallbackIsRejectedWhenSharedModeIsDisabled() {
         WorkspaceResolver resolver = mock(WorkspaceResolver.class);
         RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
         DslWorkspacePreResolutionInterceptor interceptor =
-                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService);
+                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService, false);
         when(resolver.resolveCurrentUsername()).thenReturn("architect");
         when(resolver.resolveCurrentContext()).thenReturn(WorkspaceContext.SHARED);
 
@@ -89,6 +89,20 @@ class WorkspaceRequestIsolationTest {
                 new MockHttpServletRequest(), new MockHttpServletResponse(), new Object()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("did not resolve an isolated workspace");
+    }
+
+    @Test
+    void sharedContextIsAllowedOnlyInExplicitSharedMode() {
+        WorkspaceResolver resolver = mock(WorkspaceResolver.class);
+        RepositoryStateService repositoryStateService = mock(RepositoryStateService.class);
+        DslWorkspacePreResolutionInterceptor interceptor =
+                new DslWorkspacePreResolutionInterceptor(resolver, repositoryStateService, true);
+        when(resolver.resolveCurrentUsername()).thenReturn("architect");
+        when(resolver.resolveCurrentContext()).thenReturn(WorkspaceContext.SHARED);
+
+        assertThat(interceptor.preHandle(
+                new MockHttpServletRequest(), new MockHttpServletResponse(), new Object()))
+                .isTrue();
     }
 
     private static void bindRequest() {

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceScopedEndpointIsolationTest.java
@@ -8,10 +8,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -19,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,7 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "deepseek.api.key=",
         "qwen.api.key=",
         "llama.api.key=",
-        "mistral.api.key="
+        "mistral.api.key=",
+        "taxonomy.workspace.shared-mode-enabled=false"
 })
 class WorkspaceScopedEndpointIsolationTest {
 
@@ -54,27 +58,85 @@ class WorkspaceScopedEndpointIsolationTest {
     @Test
     @WithMockUser(username = "architect", roles = "USER")
     void analysisStopsBeforeControllerCanFallBackToShared() throws Exception {
-        mockMvc.perform(post("/api/analyze")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "businessText": "A workspace-scoped requirement",
-                                  "includeArchitectureView": true
-                                }
-                                """))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.message").isString())
-                .andExpect(jsonPath("$.message").isNotEmpty());
-
-        verify(workspaceResolver, never()).resolveCurrentContext();
+        assertGuarded(post("/api/analyze")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "businessText": "A workspace-scoped requirement",
+                          "includeArchitectureView": true
+                        }
+                        """));
     }
 
     @Test
     @WithMockUser(username = "architect", roles = "USER")
     void graphSearchStopsBeforeControllerCanReadSharedRelations() throws Exception {
-        mockMvc.perform(get("/api/search/graph")
-                        .queryParam("q", "secure communication"))
+        assertGuarded(get("/api/search/graph")
+                .queryParam("q", "secure communication"));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void relationMutationStopsBeforeSharedWrite() throws Exception {
+        assertGuarded(post("/api/relations")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void proposalMutationStopsBeforeSharedWrite() throws Exception {
+        assertGuarded(post("/api/proposals/propose")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void archimateImportStopsBeforeSharedWrite() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "model.xml", MediaType.APPLICATION_XML_VALUE, "<model/>".getBytes());
+        assertGuarded(multipart("/api/import/archimate")
+                .file(file)
+                .with(csrf()));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void contextVariantStopsBeforeSystemRepositoryMutation() throws Exception {
+        assertGuarded(post("/api/context/variant")
+                .with(csrf())
+                .queryParam("name", "unsafe-fallback"));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "ARCHITECT")
+    void selectiveTransferStopsBeforeSystemRepositoryMutation() throws Exception {
+        assertGuarded(post("/api/context/copy-back/apply")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "sourceContextId": "source",
+                          "targetContextId": "target",
+                          "selectedElementIds": [],
+                          "selectedRelationIds": [],
+                          "mode": "COPY"
+                        }
+                        """));
+    }
+
+    @Test
+    @WithMockUser(username = "architect", roles = "USER")
+    void portfolioReadStopsBeforeSharedScopeIsUsed() throws Exception {
+        assertGuarded(get("/api/products"));
+    }
+
+    private void assertGuarded(RequestBuilder request) throws Exception {
+        mockMvc.perform(request)
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.message").isString())
                 .andExpect(jsonPath("$.message").isNotEmpty());

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceContextResolverTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceContextResolverTest.java
@@ -1,18 +1,16 @@
 package com.taxonomy.workspace.service;
 
 import com.taxonomy.workspace.model.UserWorkspace;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-/**
- * Unit tests for {@link WorkspaceContextResolver}.
- */
+/** Unit tests for {@link WorkspaceContextResolver}. */
 @ExtendWith(MockitoExtension.class)
 class WorkspaceContextResolverTest {
 
@@ -22,90 +20,94 @@ class WorkspaceContextResolverTest {
     @Mock
     private SystemRepositoryService systemRepositoryService;
 
-    private WorkspaceContextResolver resolver;
-
-    @BeforeEach
-    void setUp() {
-        resolver = new WorkspaceContextResolver(workspaceManager, systemRepositoryService);
-    }
-
     @Test
-    void nullUsernameReturnsSHARED() {
+    void nullBlankAndDefaultUsersReturnSharedContext() {
+        WorkspaceContextResolver resolver = resolver(false);
+
         assertThat(resolver.resolveForUser(null)).isEqualTo(WorkspaceContext.SHARED);
-    }
-
-    @Test
-    void blankUsernameReturnsSHARED() {
         assertThat(resolver.resolveForUser("")).isEqualTo(WorkspaceContext.SHARED);
         assertThat(resolver.resolveForUser("  ")).isEqualTo(WorkspaceContext.SHARED);
+        assertThat(resolver.resolveForUser(WorkspaceManager.DEFAULT_USER))
+                .isEqualTo(WorkspaceContext.SHARED);
     }
 
     @Test
-    void anonymousUserReturnsSHARED() {
-        assertThat(resolver.resolveForUser("anonymous")).isEqualTo(WorkspaceContext.SHARED);
-    }
-
-    @Test
-    void userWithoutProvisionedWorkspaceReturnsSHARED() {
+    void authenticatedUserWithoutWorkspaceFailsClosed() {
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(null);
         when(workspaceManager.findUserWorkspace("alice")).thenReturn(null);
-        assertThat(resolver.resolveForUser("alice")).isEqualTo(WorkspaceContext.SHARED);
+
+        assertThatThrownBy(() -> resolver(false).resolveForUser("alice"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No isolated workspace")
+                .hasMessageContaining("alice");
+    }
+
+    @Test
+    void explicitSharedModeAllowsLegacySharedScope() {
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(null);
+        when(workspaceManager.findUserWorkspace("alice")).thenReturn(null);
+
+        assertThat(resolver(true).resolveForUser("alice"))
+                .isEqualTo(WorkspaceContext.SHARED);
     }
 
     @Test
     void userWithProvisionedWorkspaceReturnsContext() {
-        UserWorkspace ws = new UserWorkspace();
-        ws.setUsername("alice");
-        ws.setWorkspaceId("alice-ws-123");
-        ws.setCurrentBranch("alice/workspace");
+        UserWorkspace workspace = workspace("alice", "alice-ws-123", "alice/workspace");
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(workspace);
 
-        when(workspaceManager.findUserWorkspace("alice")).thenReturn(ws);
+        WorkspaceContext context = resolver(false).resolveForUser("alice");
 
-        WorkspaceContext ctx = resolver.resolveForUser("alice");
-        assertThat(ctx.username()).isEqualTo("alice");
-        assertThat(ctx.workspaceId()).isEqualTo("alice-ws-123");
-        assertThat(ctx.currentBranch()).isEqualTo("alice/workspace");
+        assertThat(context.username()).isEqualTo("alice");
+        assertThat(context.workspaceId()).isEqualTo("alice-ws-123");
+        assertThat(context.currentBranch()).isEqualTo("alice/workspace");
     }
 
     @Test
-    void provisionedWorkspaceWithNullBranchFallsBackToSharedBranch() {
-        UserWorkspace ws = new UserWorkspace();
-        ws.setUsername("bob");
-        ws.setWorkspaceId("bob-ws");
-        ws.setCurrentBranch(null);
+    void legacyWorkspaceLookupRemainsSupported() {
+        UserWorkspace workspace = workspace("alice", "alice-ws-123", "alice/workspace");
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(null);
+        when(workspaceManager.findUserWorkspace("alice")).thenReturn(workspace);
 
-        when(workspaceManager.findUserWorkspace("bob")).thenReturn(ws);
+        assertThat(resolver(false).resolveForUser("alice").workspaceId())
+                .isEqualTo("alice-ws-123");
+    }
+
+    @Test
+    void provisionedWorkspaceWithNullBranchUsesConfiguredSharedBranchName() {
+        UserWorkspace workspace = workspace("bob", "bob-ws", null);
+        when(workspaceManager.findActiveWorkspace("bob")).thenReturn(workspace);
         when(systemRepositoryService.getSharedBranch()).thenReturn("draft");
 
-        WorkspaceContext ctx = resolver.resolveForUser("bob");
-        assertThat(ctx.currentBranch()).isEqualTo("draft");
-    }
-
-    @Test
-    void sharedContextHasNullWorkspaceId() {
-        assertThat(WorkspaceContext.SHARED.username()).isEqualTo("system");
-        assertThat(WorkspaceContext.SHARED.workspaceId()).isNull();
-        assertThat(WorkspaceContext.SHARED.currentBranch()).isEqualTo("draft");
+        assertThat(resolver(false).resolveForUser("bob").currentBranch())
+                .isEqualTo("draft");
     }
 
     @Test
     void differentWorkspacesAreIsolated() {
-        UserWorkspace aliceWs = new UserWorkspace();
-        aliceWs.setUsername("alice");
-        aliceWs.setWorkspaceId("alice-ws");
-        aliceWs.setCurrentBranch("alice/workspace");
+        when(workspaceManager.findActiveWorkspace("alice"))
+                .thenReturn(workspace("alice", "alice-ws", "alice/workspace"));
+        when(workspaceManager.findActiveWorkspace("bob"))
+                .thenReturn(workspace("bob", "bob-ws", "bob/workspace"));
 
-        UserWorkspace bobWs = new UserWorkspace();
-        bobWs.setUsername("bob");
-        bobWs.setWorkspaceId("bob-ws");
-        bobWs.setCurrentBranch("bob/workspace");
+        WorkspaceContextResolver resolver = resolver(false);
+        WorkspaceContext alice = resolver.resolveForUser("alice");
+        WorkspaceContext bob = resolver.resolveForUser("bob");
 
-        when(workspaceManager.findUserWorkspace("alice")).thenReturn(aliceWs);
-        when(workspaceManager.findUserWorkspace("bob")).thenReturn(bobWs);
+        assertThat(alice.workspaceId()).isNotEqualTo(bob.workspaceId());
+        assertThat(alice.currentBranch()).isNotEqualTo(bob.currentBranch());
+    }
 
-        WorkspaceContext aliceCtx = resolver.resolveForUser("alice");
-        WorkspaceContext bobCtx = resolver.resolveForUser("bob");
+    private WorkspaceContextResolver resolver(boolean sharedModeEnabled) {
+        return new WorkspaceContextResolver(
+                workspaceManager, systemRepositoryService, sharedModeEnabled);
+    }
 
-        assertThat(aliceCtx.workspaceId()).isNotEqualTo(bobCtx.workspaceId());
-        assertThat(aliceCtx.currentBranch()).isNotEqualTo(bobCtx.currentBranch());
+    private UserWorkspace workspace(String username, String workspaceId, String branch) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setUsername(username);
+        workspace.setWorkspaceId(workspaceId);
+        workspace.setCurrentBranch(branch);
+        return workspace;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceDataIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceDataIsolationTest.java
@@ -34,8 +34,6 @@ class WorkspaceDataIsolationTest {
 
     @BeforeEach
     void setUp() {
-        // This suite deliberately verifies the explicitly enabled legacy/shared
-        // mode. Production isolation is covered by WorkspaceContextResolverTest.
         resolver = new WorkspaceContextResolver(
                 workspaceManager, systemRepositoryService, true);
     }
@@ -158,6 +156,7 @@ class WorkspaceDataIsolationTest {
             UserWorkspace workspace = new UserWorkspace();
             workspace.setUsername("eve");
             workspace.setWorkspaceId("eve-ws");
+            workspace.setCurrentBranch("");
             when(workspaceManager.findActiveWorkspace("eve")).thenReturn(workspace);
             when(systemRepositoryService.getSharedBranch()).thenReturn("draft");
 

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceDataIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceDataIsolationTest.java
@@ -1,14 +1,8 @@
 package com.taxonomy.workspace.service;
 
-import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.RelationType;
 import com.taxonomy.catalog.model.TaxonomyRelation;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
-import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.relations.model.RelationHypothesis;
 import com.taxonomy.relations.model.RelationProposal;
-import com.taxonomy.relations.repository.RelationHypothesisRepository;
-import com.taxonomy.relations.repository.RelationProposalRepository;
 import com.taxonomy.workspace.model.UserWorkspace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,24 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for workspace-level data isolation of relations, hypotheses,
- * and proposals across multiple workspaces.
- *
- * <p>Verifies that:
- * <ul>
- *   <li>Relations created in workspace A are not visible to workspace B</li>
- *   <li>Shared/legacy relations (workspace_id=NULL) are visible to all</li>
- *   <li>Delete operations respect workspace ownership</li>
- *   <li>WorkspaceContext resolves correctly for different users</li>
- * </ul>
+ * Unit tests for workspace-level data isolation metadata and explicit legacy
+ * shared-mode resolution.
  */
 @ExtendWith(MockitoExtension.class)
 class WorkspaceDataIsolationTest {
@@ -50,10 +34,11 @@ class WorkspaceDataIsolationTest {
 
     @BeforeEach
     void setUp() {
-        resolver = new WorkspaceContextResolver(workspaceManager, systemRepositoryService);
+        // This suite deliberately verifies the explicitly enabled legacy/shared
+        // mode. Production isolation is covered by WorkspaceContextResolverTest.
+        resolver = new WorkspaceContextResolver(
+                workspaceManager, systemRepositoryService, true);
     }
-
-    // ── WorkspaceContext resolution ────────────────────────────────────
 
     @Nested
     @DisplayName("WorkspaceContext resolution")
@@ -74,12 +59,13 @@ class WorkspaceDataIsolationTest {
         }
 
         @Test
-        void unprovisionedUserGetsSHARED() {
+        void explicitlySharedUnprovisionedUserGetsSharedContext() {
+            when(workspaceManager.findActiveWorkspace("charlie")).thenReturn(null);
             when(workspaceManager.findUserWorkspace("charlie")).thenReturn(null);
 
-            WorkspaceContext ctx = resolver.resolveForUser("charlie");
-            assertThat(ctx).isEqualTo(WorkspaceContext.SHARED);
-            assertThat(ctx.workspaceId()).isNull();
+            WorkspaceContext context = resolver.resolveForUser("charlie");
+            assertThat(context).isEqualTo(WorkspaceContext.SHARED);
+            assertThat(context.workspaceId()).isNull();
         }
 
         @Test
@@ -90,22 +76,21 @@ class WorkspaceDataIsolationTest {
         }
 
         @Test
-        void nullWorkspaceIdReturnsSHARED() {
-            UserWorkspace ws = new UserWorkspace();
-            ws.setUsername("dave");
-            ws.setWorkspaceId(null); // not provisioned
-            when(workspaceManager.findUserWorkspace("dave")).thenReturn(ws);
+        void nullWorkspaceIdUsesExplicitSharedMode() {
+            UserWorkspace workspace = new UserWorkspace();
+            workspace.setUsername("dave");
+            workspace.setWorkspaceId(null);
+            when(workspaceManager.findActiveWorkspace("dave")).thenReturn(null);
+            when(workspaceManager.findUserWorkspace("dave")).thenReturn(workspace);
 
-            WorkspaceContext ctx = resolver.resolveForUser("dave");
-            assertThat(ctx).isEqualTo(WorkspaceContext.SHARED);
+            assertThat(resolver.resolveForUser("dave"))
+                    .isEqualTo(WorkspaceContext.SHARED);
         }
     }
 
-    // ── Relation workspace isolation ──────────────────────────────────
-
     @Nested
-    @DisplayName("TaxonomyRelation workspace scoping")
-    class RelationIsolation {
+    @DisplayName("Workspace-scoped entity metadata")
+    class EntityMetadata {
 
         @Test
         void relationCarriesWorkspaceMetadata() {
@@ -119,18 +104,8 @@ class WorkspaceDataIsolationTest {
 
         @Test
         void sharedRelationHasNullWorkspaceId() {
-            TaxonomyRelation relation = new TaxonomyRelation();
-            // Not set = shared/legacy
-            assertThat(relation.getWorkspaceId()).isNull();
-            assertThat(relation.getOwnerUsername()).isNull();
+            assertThat(new TaxonomyRelation().getWorkspaceId()).isNull();
         }
-    }
-
-    // ── Hypothesis workspace isolation ────────────────────────────────
-
-    @Nested
-    @DisplayName("RelationHypothesis workspace scoping")
-    class HypothesisIsolation {
 
         @Test
         void hypothesisCarriesWorkspaceMetadata() {
@@ -143,19 +118,6 @@ class WorkspaceDataIsolationTest {
         }
 
         @Test
-        void sharedHypothesisHasNullWorkspace() {
-            RelationHypothesis hypothesis = new RelationHypothesis();
-            assertThat(hypothesis.getWorkspaceId()).isNull();
-        }
-    }
-
-    // ── Proposal workspace isolation ─────────────────────────────────
-
-    @Nested
-    @DisplayName("RelationProposal workspace scoping")
-    class ProposalIsolation {
-
-        @Test
         void proposalCarriesWorkspaceMetadata() {
             RelationProposal proposal = new RelationProposal();
             proposal.setWorkspaceId("carol-ws");
@@ -164,93 +126,51 @@ class WorkspaceDataIsolationTest {
             assertThat(proposal.getWorkspaceId()).isEqualTo("carol-ws");
             assertThat(proposal.getOwnerUsername()).isEqualTo("carol");
         }
-
-        @Test
-        void sharedProposalHasNullWorkspace() {
-            RelationProposal proposal = new RelationProposal();
-            assertThat(proposal.getWorkspaceId()).isNull();
-        }
     }
 
-    // ── Context equality ─────────────────────────────────────────────
-
     @Nested
-    @DisplayName("WorkspaceContext equality")
-    class ContextEquality {
+    @DisplayName("WorkspaceContext equality and branches")
+    class ContextEqualityAndBranches {
 
         @Test
         void sameValuesAreEqual() {
-            WorkspaceContext a = new WorkspaceContext("alice", "ws-1", "main");
-            WorkspaceContext b = new WorkspaceContext("alice", "ws-1", "main");
-            assertThat(a).isEqualTo(b);
+            WorkspaceContext left = new WorkspaceContext("alice", "ws-1", "main");
+            WorkspaceContext right = new WorkspaceContext("alice", "ws-1", "main");
+            assertThat(left).isEqualTo(right);
         }
 
         @Test
         void differentWorkspacesAreNotEqual() {
-            WorkspaceContext a = new WorkspaceContext("alice", "ws-1", "main");
-            WorkspaceContext b = new WorkspaceContext("alice", "ws-2", "main");
-            assertThat(a).isNotEqualTo(b);
+            WorkspaceContext left = new WorkspaceContext("alice", "ws-1", "main");
+            WorkspaceContext right = new WorkspaceContext("alice", "ws-2", "main");
+            assertThat(left).isNotEqualTo(right);
         }
 
         @Test
-        void sharedIsNotEqualToProvisioned() {
+        void provisionedUserGetsWorkspaceBranch() {
             provisionWorkspace("alice", "alice-ws", "feature-a");
-            WorkspaceContext ctx = resolver.resolveForUser("alice");
-            assertThat(ctx).isNotEqualTo(WorkspaceContext.SHARED);
+            assertThat(resolver.resolveForUser("alice").currentBranch())
+                    .isEqualTo("feature-a");
         }
 
         @Test
-        void sharedHasNullWorkspaceId() {
-            assertThat(WorkspaceContext.SHARED.workspaceId()).isNull();
-        }
-    }
-
-    // ── Workspace branch resolution ──────────────────────────────────
-
-    @Nested
-    @DisplayName("Workspace branch resolution")
-    class BranchResolution {
-
-        @Test
-        void provisionedUserGetsBranchFromWorkspace() {
-            provisionWorkspace("alice", "alice-ws", "feature-a");
-            WorkspaceContext ctx = resolver.resolveForUser("alice");
-            assertThat(ctx.currentBranch()).isEqualTo("feature-a");
-        }
-
-        @Test
-        void unprovisionedUserGetsDraftBranch() {
-            when(workspaceManager.findUserWorkspace("charlie")).thenReturn(null);
-            WorkspaceContext ctx = resolver.resolveForUser("charlie");
-            assertThat(ctx.currentBranch()).isEqualTo("draft");
-        }
-
-        @Test
-        void sharedContextAlwaysUsesDraft() {
-            assertThat(WorkspaceContext.SHARED.currentBranch()).isEqualTo("draft");
-        }
-
-        @Test
-        void provisionedWorkspaceWithNullBranchUsesSharedBranch() {
-            UserWorkspace ws = new UserWorkspace();
-            ws.setUsername("eve");
-            ws.setWorkspaceId("eve-ws");
-            ws.setCurrentBranch(null);
-            when(workspaceManager.findUserWorkspace("eve")).thenReturn(ws);
+        void workspaceWithoutBranchUsesConfiguredSharedBranchName() {
+            UserWorkspace workspace = new UserWorkspace();
+            workspace.setUsername("eve");
+            workspace.setWorkspaceId("eve-ws");
+            when(workspaceManager.findActiveWorkspace("eve")).thenReturn(workspace);
             when(systemRepositoryService.getSharedBranch()).thenReturn("draft");
 
-            WorkspaceContext ctx = resolver.resolveForUser("eve");
-            assertThat(ctx.currentBranch()).isEqualTo("draft");
+            assertThat(resolver.resolveForUser("eve").currentBranch())
+                    .isEqualTo("draft");
         }
     }
 
-    // ── Helper ────────────────────────────────────────────────────────
-
-    private void provisionWorkspace(String username, String wsId, String branch) {
-        UserWorkspace ws = new UserWorkspace();
-        ws.setUsername(username);
-        ws.setWorkspaceId(wsId);
-        ws.setCurrentBranch(branch);
-        when(workspaceManager.findUserWorkspace(username)).thenReturn(ws);
+    private void provisionWorkspace(String username, String workspaceId, String branch) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setUsername(username);
+        workspace.setWorkspaceId(workspaceId);
+        workspace.setCurrentBranch(branch);
+        when(workspaceManager.findActiveWorkspace(username)).thenReturn(workspace);
     }
 }

--- a/taxonomy-domain/src/main/java/com/taxonomy/dto/TransferSelection.java
+++ b/taxonomy-domain/src/main/java/com/taxonomy/dto/TransferSelection.java
@@ -3,13 +3,13 @@ package com.taxonomy.dto;
 import java.util.Set;
 
 /**
- * Selection of elements and relations to transfer between contexts.
+ * Selection of elements and relations to transfer between two exact commits.
  *
- * @param sourceContextId     the context to copy from
- * @param targetContextId     the context to copy into
- * @param selectedElementIds  which elements to transfer
- * @param selectedRelationIds which relations to transfer
- * @param mode                how to perform the transfer
+ * @param sourceContextId     source commit SHA
+ * @param targetContextId     expected target branch HEAD SHA
+ * @param selectedElementIds  elements to transfer
+ * @param selectedRelationIds relations to transfer
+ * @param mode                conflict handling for the selected items
  */
 public record TransferSelection(
     String sourceContextId,
@@ -19,15 +19,11 @@ public record TransferSelection(
     TransferMode mode
 ) {
 
-    /**
-     * How the selective transfer is performed.
-     */
+    /** How conflicts in the selected subset are handled. */
     public enum TransferMode {
-        /** Copy selected items into the target, overwriting any conflicts. */
+        /** Copy selected items into the target and overwrite selected conflicts. */
         COPY,
-        /** Cherry-pick the commit containing the selected items. */
-        CHERRY_PICK,
-        /** Merge only the selected items from the source. */
+        /** Merge only conflict-free selected items; conflicts abort without mutation. */
         MERGE_SELECTED
     }
 }


### PR DESCRIPTION
## Summary

Implements the critical QA findings from #574, #575 and #576.

- makes shared workspace use an explicit operator mode and disables it by default in the Kubernetes profile
- expands pre-resolution to relations, proposals, imports, context navigation, reports and the complete portfolio API
- removes controller/service catch-all fallbacks to `WorkspaceContext.SHARED`
- adds negative MockMvc coverage proving controllers are not entered on provisioning failures
- adds a release-blocker preflight before any release mutation and repeats it immediately before publication
- tests fail-closed blocker API handling with fixtures
- removes the unsupported selective `CHERRY_PICK` mode
- gives `COPY` and `MERGE_SELECTED` distinct conflict semantics
- binds selective apply to an expected target HEAD using an atomic ref compare-and-set
- attributes transfer commits to the authenticated user and returns HTTP 409 for stale previews

## Verification

- workspace resolver and request-bound isolation unit tests
- relation/import/context/portfolio negative endpoint tests
- release blocker contract tests
- conditional Git commit race tests

Closes #574
Closes #575
Closes #576