### PR TITLE
Separate metrics authentication and make last-admin protection atomic

### DIFF
--- a/deploy/helm/taxonomy/values.yaml
+++ b/deploy/helm/taxonomy/values.yaml
@@ -96,10 +96,6 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
 
-# The default policy permits application access only from the same namespace.
-# When ingress is enabled, add the ingress-controller namespace/pod selectors to
-# ingressFrom. Egress remains open because PostgreSQL, LLM and optional model
-# endpoints are deployment-specific; replace it with explicit rules as required.
 networkPolicy:
   enabled: true
   allowSameNamespace: true
@@ -123,6 +119,9 @@ secretEnv:
   ADMIN_PASSWORD:
     key: ADMIN_PASSWORD
     optional: false
+  TAXONOMY_METRICS_TOKEN:
+    key: TAXONOMY_METRICS_TOKEN
+    optional: true
   GEMINI_API_KEY:
     key: GEMINI_API_KEY
     optional: true
@@ -156,10 +155,11 @@ config:
   TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
   TAXONOMY_EMBEDDING_ENABLED: "false"
   TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
+  TAXONOMY_METRICS_ALLOW_UNAUTHENTICATED: "false"
   JAVA_OPTS: -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=20.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp
 
-# Prometheus Operator integration. The application accepts the ADMIN_PASSWORD as
-# a Bearer token for /actuator/prometheus; the ServiceMonitor reads it from a Secret.
+# Prometheus Operator integration. The application uses a dedicated metrics-only
+# token; the ServiceMonitor reads it from a Secret and never receives ADMIN_PASSWORD.
 serviceMonitor:
   enabled: false
   additionalLabels: {}
@@ -168,7 +168,7 @@ serviceMonitor:
   authorization:
     enabled: true
     secretName: ""
-    secretKey: ADMIN_PASSWORD
+    secretKey: TAXONOMY_METRICS_TOKEN
   relabelings: []
   metricRelabelings: []
 

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
@@ -13,78 +13,67 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
-/**
- * Protects sensitive Actuator endpoints (/actuator/metrics, /actuator/prometheus, etc.)
- * using the existing admin password mechanism.
- *
- * <ul>
- *   <li>{@code /actuator/health} and {@code /actuator/health/**} are PUBLIC (needed for platform probes)</li>
- *   <li>{@code /actuator/info} is PUBLIC (non-sensitive)</li>
- *   <li>All other {@code /actuator/**} endpoints require either the legacy
- *       {@code X-Admin-Token} header or an Authorization header in the form
- *       {@code Authorization: Bearer ADMIN_PASSWORD_VALUE}, where the Bearer
- *       value matches the {@code ADMIN_PASSWORD} environment variable.</li>
- *   <li>If no {@code ADMIN_PASSWORD} is configured, all endpoints are accessible (backward compatible).</li>
- * </ul>
- */
+/** Protects non-public Actuator endpoints with a dedicated metrics credential. */
 @Component
 public class ActuatorSecurityFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
 
-    @Value("${admin.token:}")
-    private String adminPassword;
+    @Value("${taxonomy.metrics.token:}")
+    private String metricsToken;
+
+    @Value("${taxonomy.metrics.allow-unauthenticated:false}")
+    private boolean allowUnauthenticated;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String path = request.getRequestURI();
-
-        // Only filter actuator paths
         if (!path.startsWith("/actuator/")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Public endpoints: health and info
         if (path.equals("/actuator/health") || path.startsWith("/actuator/health/")
                 || path.equals("/actuator/info")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // If no admin password configured, allow all
-        if (adminPassword == null || adminPassword.isBlank()) {
+        if ((metricsToken == null || metricsToken.isBlank()) && allowUnauthenticated) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        if (matchesToken(request.getHeader("X-Admin-Token"))
-                || matchesBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION))) {
+        if (metricsToken != null && !metricsToken.isBlank()
+                && (matchesToken(request.getHeader("X-Metrics-Token"))
+                || matchesBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION)))) {
             filterChain.doFilter(request, response);
             return;
         }
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.getWriter().write("{\"error\":\"Admin authentication required for actuator endpoints\"}");
+        response.setContentType("application/problem+json");
+        response.getWriter().write("{\"title\":\"Metrics authentication required\","
+                + "\"status\":401,\"detail\":\"A valid metrics credential is required.\"}");
     }
 
     private boolean matchesBearerToken(String authorization) {
         if (authorization == null
-                || !authorization.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+                || !authorization.regionMatches(
+                        true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
             return false;
         }
         return matchesToken(authorization.substring(BEARER_PREFIX.length()).trim());
     }
 
     private boolean matchesToken(String candidate) {
-        if (candidate == null) {
+        if (candidate == null || metricsToken == null) {
             return false;
         }
         return MessageDigest.isEqual(
-                adminPassword.getBytes(StandardCharsets.UTF_8),
+                metricsToken.getBytes(StandardCharsets.UTF_8),
                 candidate.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/MetricsSecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/MetricsSecurityConfig.java
@@ -1,0 +1,34 @@
+package com.taxonomy.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Gives the Prometheus endpoint a dedicated least-privilege security chain.
+ * Authentication is performed by {@link ActuatorSecurityFilter}; this chain
+ * prevents form-login or resource-server redirects from overriding that
+ * machine-to-machine contract.
+ */
+@Configuration
+public class MetricsSecurityConfig {
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain metricsSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/actuator/prometheus")
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable)
+                .requestCache(AbstractHttpConfigurer::disable)
+                .securityContext(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable);
+        return http.build();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/repository/UserRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/repository/UserRepository.java
@@ -1,13 +1,33 @@
 package com.taxonomy.security.repository;
 
 import com.taxonomy.security.model.AppUser;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<AppUser, Long> {
 
     Optional<AppUser> findByUsername(String username);
+
+    /**
+     * Serializes operations that may remove local administrative access. The
+     * user rows are locked in stable ID order so concurrent disable/role-change
+     * transactions re-evaluate the invariant after the preceding commit.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select distinct user
+            from AppUser user
+            join user.roles role
+            where user.enabled = true
+              and role.name = 'ROLE_ADMIN'
+            order by user.id
+            """)
+    List<AppUser> lockEnabledAdministrators();
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
@@ -100,7 +100,8 @@ public class UserManagementService {
         if (body.containsKey("enabled")) {
             boolean enabled = Boolean.TRUE.equals(body.get("enabled"));
             if (!enabled) {
-                assertAdministrativeAccessRemains(user);
+                assertAdministrativeAccessRemains(
+                        user, "Cannot disable the last admin user.");
             }
             user.setEnabled(enabled);
         }
@@ -109,7 +110,8 @@ public class UserManagementService {
             boolean removingAdmin = hasRole(user, "ROLE_ADMIN")
                     && newRoles.stream().noneMatch(role -> "ROLE_ADMIN".equals(role.getName()));
             if (removingAdmin) {
-                assertAdministrativeAccessRemains(user);
+                assertAdministrativeAccessRemains(
+                        user, "Cannot remove ADMIN role from the last admin user.");
             }
             user.setRoles(newRoles);
         }
@@ -131,14 +133,15 @@ public class UserManagementService {
 
     public String disableUser(Long id, String actor) {
         AppUser user = requireUser(id);
-        assertAdministrativeAccessRemains(user);
+        assertAdministrativeAccessRemains(
+                user, "Cannot disable the last admin user.");
         user.setEnabled(false);
         userRepository.save(user);
         log.info("USER_DISABLED user={} by={}", user.getUsername(), actor);
         return user.getUsername();
     }
 
-    private void assertAdministrativeAccessRemains(AppUser user) {
+    private void assertAdministrativeAccessRemains(AppUser user, String violationMessage) {
         if (!user.isEnabled() || !hasRole(user, "ROLE_ADMIN")) {
             return;
         }
@@ -146,7 +149,7 @@ public class UserManagementService {
         boolean targetIsLockedAdmin = lockedAdministrators.stream()
                 .anyMatch(candidate -> candidate.getId().equals(user.getId()));
         if (targetIsLockedAdmin && lockedAdministrators.size() <= 1) {
-            throw new ValidationException("Cannot disable or demote the last admin user.");
+            throw new ValidationException(violationMessage);
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/service/UserManagementService.java
@@ -58,10 +58,10 @@ public class UserManagementService {
     }
 
     public Map<String, Object> createUser(Map<String, Object> body, String actor) {
-        String username = stringValue(body.get("username"));
+        String username = bounded(stringValue(body.get("username")), 160, "Username");
         String password = stringValue(body.get("password"));
-        String displayName = stringValue(body.get("displayName"));
-        String email = stringValue(body.get("email"));
+        String displayName = bounded(stringValue(body.get("displayName")), 240, "Display name");
+        String email = bounded(stringValue(body.get("email")), 320, "Email");
         List<String> roles = stringList(body.get("roles"));
 
         if (username == null || username.isBlank()) {
@@ -91,15 +91,16 @@ public class UserManagementService {
         AppUser user = requireUser(id);
 
         if (body.containsKey("displayName")) {
-            user.setDisplayName(stringValue(body.get("displayName")));
+            user.setDisplayName(bounded(
+                    stringValue(body.get("displayName")), 240, "Display name"));
         }
         if (body.containsKey("email")) {
-            user.setEmail(stringValue(body.get("email")));
+            user.setEmail(bounded(stringValue(body.get("email")), 320, "Email"));
         }
         if (body.containsKey("enabled")) {
             boolean enabled = Boolean.TRUE.equals(body.get("enabled"));
-            if (!enabled && isLastAdmin(user)) {
-                throw new ValidationException("Cannot disable the last admin user.");
+            if (!enabled) {
+                assertAdministrativeAccessRemains(user);
             }
             user.setEnabled(enabled);
         }
@@ -107,8 +108,8 @@ public class UserManagementService {
             Set<AppRole> newRoles = resolveRoles(stringList(body.get("roles")));
             boolean removingAdmin = hasRole(user, "ROLE_ADMIN")
                     && newRoles.stream().noneMatch(role -> "ROLE_ADMIN".equals(role.getName()));
-            if (removingAdmin && isLastAdmin(user)) {
-                throw new ValidationException("Cannot remove ADMIN role from the last admin user.");
+            if (removingAdmin) {
+                assertAdministrativeAccessRemains(user);
             }
             user.setRoles(newRoles);
         }
@@ -130,13 +131,23 @@ public class UserManagementService {
 
     public String disableUser(Long id, String actor) {
         AppUser user = requireUser(id);
-        if (isLastAdmin(user)) {
-            throw new ValidationException("Cannot disable the last admin user.");
-        }
+        assertAdministrativeAccessRemains(user);
         user.setEnabled(false);
         userRepository.save(user);
         log.info("USER_DISABLED user={} by={}", user.getUsername(), actor);
         return user.getUsername();
+    }
+
+    private void assertAdministrativeAccessRemains(AppUser user) {
+        if (!user.isEnabled() || !hasRole(user, "ROLE_ADMIN")) {
+            return;
+        }
+        List<AppUser> lockedAdministrators = userRepository.lockEnabledAdministrators();
+        boolean targetIsLockedAdmin = lockedAdministrators.stream()
+                .anyMatch(candidate -> candidate.getId().equals(user.getId()));
+        if (targetIsLockedAdmin && lockedAdministrators.size() <= 1) {
+            throw new ValidationException("Cannot disable or demote the last admin user.");
+        }
     }
 
     private AppUser requireUser(Long id) {
@@ -149,17 +160,9 @@ public class UserManagementService {
             throw new ValidationException(
                     "Password must be at least " + MIN_PASSWORD_LENGTH + " characters.");
         }
-    }
-
-    private boolean isLastAdmin(AppUser user) {
-        if (!hasRole(user, "ROLE_ADMIN")) {
-            return false;
+        if (password.length() > 1024) {
+            throw new ValidationException("Password is too long.");
         }
-        long enabledAdmins = userRepository.findAll().stream()
-                .filter(AppUser::isEnabled)
-                .filter(candidate -> hasRole(candidate, "ROLE_ADMIN"))
-                .count();
-        return enabledAdmins <= 1;
     }
 
     private boolean hasRole(AppUser user, String roleName) {
@@ -169,6 +172,9 @@ public class UserManagementService {
     private Set<AppRole> resolveRoles(List<String> roleNames) {
         if (roleNames == null || roleNames.isEmpty()) {
             return roleRepository.findByName("ROLE_USER").map(Set::of).orElse(Set.of());
+        }
+        if (roleNames.size() > 20) {
+            throw new ValidationException("Too many roles were supplied.");
         }
         Set<AppRole> roles = new HashSet<>();
         for (String roleName : roleNames) {
@@ -194,6 +200,13 @@ public class UserManagementService {
         map.put("mustChangePassword", user.isMustChangePassword());
         map.put("roles", user.getRoles().stream().map(AppRole::getName).sorted().toList());
         return map;
+    }
+
+    private String bounded(String value, int maximum, String field) {
+        if (value != null && value.length() > maximum) {
+            throw new ValidationException(field + " exceeds " + maximum + " characters.");
+        }
+        return value;
     }
 
     private String stringValue(Object value) {

--- a/taxonomy-app/src/main/resources/application-hsqldb.properties
+++ b/taxonomy-app/src/main/resources/application-hsqldb.properties
@@ -21,8 +21,12 @@ spring.datasource.hikari.minimum-idle=${TAXONOMY_DB_MIN_IDLE:1}
 spring.datasource.hikari.maximum-pool-size=${TAXONOMY_DB_MAX_POOL_SIZE:4}
 spring.datasource.hikari.connection-timeout=${TAXONOMY_DB_CONNECTION_TIMEOUT_MS:30000}
 spring.datasource.hikari.pool-name=taxonomy-hsqldb
-# Explicit dialect keeps startup deterministic for both in-memory and file URLs.
 spring.jpa.database-platform=org.hibernate.dialect.HSQLDialect
+
+# Local development may expose metrics without a token. Production profiles do
+# not inherit this opt-in and therefore fail closed when no metrics token exists.
+taxonomy.metrics.allow-unauthenticated=${TAXONOMY_METRICS_ALLOW_UNAUTHENTICATED:true}
+taxonomy.metrics.token=${TAXONOMY_METRICS_TOKEN:}
 
 # jgit-storage-hibernate owns git_packs, git_reflog, git_repository_lock and
 # git_pack_chunks through its released Flyway migration stream. Hibernate still

--- a/taxonomy-app/src/main/resources/application-kubernetes.properties
+++ b/taxonomy-app/src/main/resources/application-kubernetes.properties
@@ -23,6 +23,11 @@ springdoc.swagger-ui.enabled=${TAXONOMY_SPRINGDOC_ENABLED:false}
 taxonomy.security.swagger-public=false
 taxonomy.security.audit-logging=${TAXONOMY_AUDIT_LOGGING:true}
 
+# Metrics are machine-to-machine traffic and must use their own least-privilege
+# credential. They never reuse the interactive administrator password.
+taxonomy.metrics.token=${TAXONOMY_METRICS_TOKEN:}
+taxonomy.metrics.allow-unauthenticated=false
+
 # Persistent deployments must not recreate their schema on every pod start.
 spring.jpa.hibernate.ddl-auto=${TAXONOMY_DDL_AUTO:validate}
 

--- a/taxonomy-app/src/test/java/com/taxonomy/security/UserManagementServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/UserManagementServiceTest.java
@@ -106,7 +106,7 @@ class UserManagementServiceTest {
     void lastAdminCannotBeDisabledOrLoseAdminRole() {
         AppUser admin = user(1L, "admin", true, Set.of(adminRole, userRole));
         when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
-        when(userRepository.findAll()).thenReturn(List.of(admin));
+        when(userRepository.lockEnabledAdministrators()).thenReturn(List.of(admin));
 
         assertThatThrownBy(() -> service.disableUser(1L, "admin"))
                 .isInstanceOf(UserManagementService.ValidationException.class)
@@ -116,6 +116,8 @@ class UserManagementServiceTest {
                 java.util.Map.of("roles", List.of("USER")), "admin"))
                 .isInstanceOf(UserManagementService.ValidationException.class)
                 .hasMessageContaining("last admin");
+
+        verify(userRepository, org.mockito.Mockito.times(2)).lockEnabledAdministrators();
     }
 
     @Test
@@ -123,11 +125,25 @@ class UserManagementServiceTest {
         AppUser first = user(1L, "admin-one", true, Set.of(adminRole));
         AppUser second = user(2L, "admin-two", true, Set.of(adminRole));
         when(userRepository.findById(1L)).thenReturn(Optional.of(first));
-        when(userRepository.findAll()).thenReturn(List.of(first, second));
+        when(userRepository.lockEnabledAdministrators()).thenReturn(List.of(first, second));
         when(userRepository.save(first)).thenReturn(first);
 
         assertThat(service.disableUser(1L, "admin-two")).isEqualTo("admin-one");
         assertThat(first.isEnabled()).isFalse();
+    }
+
+    @Test
+    void fieldAndRoleBoundsAreEnforced() {
+        assertThatThrownBy(() -> service.createUser(java.util.Map.of(
+                "username", "x".repeat(161),
+                "password", "StrongPassword!2026"), "admin"))
+                .isInstanceOf(UserManagementService.ValidationException.class);
+
+        assertThatThrownBy(() -> service.createUser(java.util.Map.of(
+                "username", "alice",
+                "password", "StrongPassword!2026",
+                "roles", java.util.Collections.nCopies(21, "USER")), "admin"))
+                .isInstanceOf(UserManagementService.ValidationException.class);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
@@ -12,62 +12,66 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ActuatorSecurityFilterTest {
 
-    private static final String ADMIN_TOKEN = "test-admin-token";
+    private static final String METRICS_TOKEN = "test-metrics-token";
 
     private ActuatorSecurityFilter filter;
 
     @BeforeEach
     void setUp() {
         filter = new ActuatorSecurityFilter();
-        ReflectionTestUtils.setField(filter, "adminPassword", ADMIN_TOKEN);
+        ReflectionTestUtils.setField(filter, "metricsToken", METRICS_TOKEN);
+        ReflectionTestUtils.setField(filter, "allowUnauthenticated", false);
     }
 
     @Test
     void healthEndpointsRemainPublicForPlatformProbes() throws Exception {
-        MockHttpServletResponse response = invoke("/actuator/health/readiness", null, null);
-
-        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(invoke("/actuator/health/readiness", null, null).getStatus())
+                .isEqualTo(200);
     }
 
     @Test
     void sensitiveEndpointRejectsMissingCredentials() throws Exception {
         MockHttpServletResponse response = invoke("/actuator/prometheus", null, null);
-
         assertThat(response.getStatus()).isEqualTo(401);
-        assertThat(response.getContentAsString()).contains("Admin authentication required");
+        assertThat(response.getContentType()).contains("application/problem+json");
     }
 
     @Test
-    void sensitiveEndpointAcceptsLegacyAdminHeader() throws Exception {
-        MockHttpServletResponse response = invoke(
-                "/actuator/prometheus", "X-Admin-Token", ADMIN_TOKEN);
-
-        assertThat(response.getStatus()).isEqualTo(200);
+    void sensitiveEndpointAcceptsDedicatedHeader() throws Exception {
+        assertThat(invoke(
+                "/actuator/prometheus", "X-Metrics-Token", METRICS_TOKEN).getStatus())
+                .isEqualTo(200);
     }
 
     @Test
-    void sensitiveEndpointAcceptsBearerTokenForPrometheusOperator() throws Exception {
-        MockHttpServletResponse response = invoke(
-                "/actuator/prometheus", HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN);
-
-        assertThat(response.getStatus()).isEqualTo(200);
+    void sensitiveEndpointAcceptsBearerMetricsToken() throws Exception {
+        assertThat(invoke(
+                "/actuator/prometheus", HttpHeaders.AUTHORIZATION,
+                "Bearer " + METRICS_TOKEN).getStatus())
+                .isEqualTo(200);
     }
 
     @Test
     void sensitiveEndpointRejectsIncorrectBearerToken() throws Exception {
-        MockHttpServletResponse response = invoke(
-                "/actuator/prometheus", HttpHeaders.AUTHORIZATION, "Bearer wrong-token");
-
-        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(invoke(
+                "/actuator/prometheus", HttpHeaders.AUTHORIZATION,
+                "Bearer wrong-token").getStatus())
+                .isEqualTo(401);
     }
 
     @Test
-    void blankAdminTokenPreservesDevelopmentCompatibility() throws Exception {
-        ReflectionTestUtils.setField(filter, "adminPassword", "");
+    void blankTokenFailsClosedByDefault() throws Exception {
+        ReflectionTestUtils.setField(filter, "metricsToken", "");
+        assertThat(invoke("/actuator/prometheus", null, null).getStatus())
+                .isEqualTo(401);
+    }
 
-        MockHttpServletResponse response = invoke("/actuator/prometheus", null, null);
-
-        assertThat(response.getStatus()).isEqualTo(200);
+    @Test
+    void developmentCompatibilityMustBeExplicit() throws Exception {
+        ReflectionTestUtils.setField(filter, "metricsToken", "");
+        ReflectionTestUtils.setField(filter, "allowUnauthenticated", true);
+        assertThat(invoke("/actuator/prometheus", null, null).getStatus())
+                .isEqualTo(200);
     }
 
     private MockHttpServletResponse invoke(String path, String header, String value)

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityIntegrationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "taxonomy.metrics.token=integration-metrics-token",
+        "taxonomy.metrics.allow-unauthenticated=false",
+        "management.endpoints.web.exposure.include=health,info,prometheus",
+        "management.endpoint.prometheus.enabled=true",
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key="
+})
+class ActuatorSecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void serviceMonitorBearerTokenReachesPrometheusEndpoint() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION,
+                                "Bearer integration-metrics-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/plain"));
+    }
+
+    @Test
+    void missingMetricsTokenReturnsMachineReadableUnauthorized() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith("application/problem+json"));
+    }
+
+    @Test
+    void invalidMetricsTokenDoesNotRedirectToLogin() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer wrong"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary

Implements #582 and #583.

### Metrics security

- replaces reuse of `ADMIN_PASSWORD` with a dedicated `TAXONOMY_METRICS_TOKEN`
- adds a dedicated `/actuator/prometheus` security chain so machine requests never redirect to form login or depend on an interactive admin identity
- fails closed when no token is configured outside explicitly opted-in HSQL development
- returns RFC-style problem JSON for unauthorized scrapes
- updates Helm secret mappings and ServiceMonitor to use the metrics-only key
- adds full MockMvc security-chain tests, not only isolated filter tests

### Administrator invariant

- adds a pessimistic write-lock query for all enabled local administrators
- serializes disable and ADMIN-role-removal decisions inside the existing transaction
- ensures the second concurrent mutation re-evaluates the committed administrator set
- adds input bounds for local user administration
- updates service tests to verify the locking contract

Closes #582
Closes #583