### PR TITLE
Add shareable requirement details and interactive portfolio matrices

### DIFF
--- a/.github/scripts/ui-primary-portfolio-detail-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-detail-workflows.mjs
@@ -1,0 +1,65 @@
+/** Browser acceptance for the shareable requirement and matrix workspaces. */
+export async function runPortfolioDetailWorkflows({ page, baseUrl, evidence }) {
+  const context = await page.evaluate(async () => {
+    const projectId = Number(localStorage.getItem('taxonomy.portfolio.projectId'));
+    const response = await fetch(`/api/projects/${projectId}/requirements`, {
+      headers: { Accept: 'application/json' }
+    });
+    return { projectId, requirements: await response.json() };
+  });
+  evidence.assert(context.projectId > 0, 'Portfolio project selection was not retained');
+  evidence.assert(context.requirements.length >= 3,
+    'Detail acceptance requires the three portfolio requirements');
+  const requirement = context.requirements[0];
+
+  await page.goto(`${baseUrl}/projects/${context.projectId}/requirements/${requirement.id}?lang=en`,
+    { waitUntil: 'networkidle' });
+  await page.locator('#requirementHeading').filter({ hasText: requirement.title })
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.assert(await page.locator('#currentText').innerText() === requirement.currentVersion.text,
+    'Requirement detail does not show the current immutable text');
+  evidence.assert(await page.locator('#versionList [data-version-id]').count() >= 1,
+    'Requirement detail does not expose version history');
+  evidence.assert(await page.locator('#snapshotList [data-snapshot-id]').count() >= 1,
+    'Requirement detail does not expose analysis snapshots');
+
+  await page.locator('#analyses-tab').click();
+  await page.locator('#snapshotList [data-snapshot-id]').first().click();
+  await page.locator('#snapshotDetail').getByText(/Provider/).waitFor({ state: 'visible' });
+  await page.locator('#architecture-tab').click();
+  evidence.assert(await page.locator('#mappingTable tbody tr').count() >= 1,
+    'Requirement architecture detail does not expose taxonomy mappings');
+  await page.locator('#decisions-tab').click();
+  evidence.assert(await page.locator('#decisionList article').count() >= 1,
+    'Requirement detail does not expose human decision provenance');
+  await evidence.axeState('portfolio-requirement-detail', '#requirementMain');
+  await evidence.saveState('portfolio-requirement-detail', '#requirementMain');
+  evidence.passed('shareable requirement detail, provenance and history');
+
+  await page.goto(`${baseUrl}/projects/${context.projectId}/matrices?lang=en`,
+    { waitUntil: 'networkidle' });
+  await page.locator('#taxonomyMatrix .matrix-drilldown').first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  const initialCells = await page.locator('#taxonomyMatrix .matrix-drilldown').count();
+  evidence.assert(initialCells > 0, 'Interactive taxonomy matrix contains no cells');
+
+  await page.locator('#matrixSearch').fill('REQ-001');
+  const filteredCells = await page.locator('#taxonomyMatrix .matrix-drilldown').count();
+  evidence.assert(filteredCells > 0 && filteredCells <= initialCells,
+    'Matrix search did not constrain the visible relationships');
+  await page.locator('#taxonomyMatrix .matrix-drilldown').first().click();
+  await page.locator('#cellDetail').waitFor({ state: 'visible', timeout: 20_000 });
+  evidence.assert(await page.locator('#cellDetailBody dt').count() >= 3,
+    'Matrix cell drill-down lacks relationship metadata');
+  await page.locator('#cellDetail .btn-close').click();
+
+  await page.locator('#solutionMatrixTab').click();
+  await page.locator('#solutionMatrix .matrix-drilldown').first()
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await page.locator('#productMatrixTab').click();
+  await page.locator('#productMatrix .matrix-drilldown').first()
+    .waitFor({ state: 'visible', timeout: 20_000 });
+  await evidence.axeState('portfolio-matrices', '#matrixMain');
+  await evidence.saveState('portfolio-matrices', '#matrixMain');
+  evidence.passed('filterable matrices, keyboard buttons and cell drill-down');
+}

--- a/.github/scripts/ui-primary-portfolio-workflows.mjs
+++ b/.github/scripts/ui-primary-portfolio-workflows.mjs
@@ -2,9 +2,8 @@ function uniqueSuffix() {
   return `${Date.now().toString(36)}-${process.pid.toString(36)}`.toUpperCase();
 }
 
-async function waitUntilIdle(page) {
-  await page.locator('#portfolioBusy')
-    .waitFor({ state: 'hidden', timeout: 120_000 });
+async function waitUntilIdle(page, timeout = 30_000) {
+  await page.locator('#portfolioBusy').waitFor({ state: 'hidden', timeout });
 }
 
 async function submitModal(page, modalId, fill, responsePattern) {
@@ -22,40 +21,43 @@ async function submitModal(page, modalId, fill, responsePattern) {
   }
   await modal.waitFor({ state: 'hidden', timeout: 30_000 });
   await waitUntilIdle(page);
+  return response;
 }
 
-async function verifyAnalysisCompletion(page, response, baseUrl, evidence) {
-  const submitted = await response.json();
-  evidence.assert(submitted.totalItems === 1,
-    `Expected one independently analysed requirement, got ${submitted.totalItems}`);
-
-  const asyncUiEnabled = await page.locator(
-    'script[src*="taxonomy-portfolio-async.js"]').count() > 0;
-  if (asyncUiEnabled) {
-    evidence.assert(response.status() === 202,
-      `Asynchronous portfolio UI must receive HTTP 202, got ${response.status()}`);
-    const location = await response.headerValue('location');
-    evidence.assert(location,
-      'Asynchronous analysis response lacks a canonical Location header');
-    await waitUntilIdle(page);
-    const terminal = await page.evaluate(async jobUrl => {
-      const result = await fetch(jobUrl, { headers: { Accept: 'application/json' } });
-      return { status: result.status, body: await result.json() };
-    }, new URL(location, baseUrl).toString());
-    evidence.assert(terminal.status === 200,
-      `Terminal analysis job could not be read: HTTP ${terminal.status}`);
-    evidence.assert(terminal.body.status === 'SUCCESS' || terminal.body.status === 'PARTIAL',
-      `Analysis job did not finish successfully: ${terminal.body.status}`);
-    evidence.assert(terminal.body.successfulItems + terminal.body.partialItems === 1,
-      'Asynchronous analysis did not create a successful or partial snapshot');
-    return;
-  }
-
-  evidence.assert(response.status() === 200,
-    `Synchronous compatibility path must receive HTTP 200, got ${response.status()}`);
-  evidence.assert(submitted.successfulItems + submitted.partialItems === 1,
-    'Portfolio analysis did not create a successful or partial snapshot');
+async function completeDecisionDialog(page, evidence, comment = '') {
+  const modal = page.locator('#portfolioDecisionDialog');
+  await modal.waitFor({ state: 'visible', timeout: 20_000 });
+  await modal.locator('#portfolioDecisionEvidence').fill(evidence);
+  if (comment) await modal.locator('#portfolioDecisionComment').fill(comment);
+  await modal.locator('#portfolioDecisionSave').click();
+  await modal.waitFor({ state: 'hidden', timeout: 30_000 });
   await waitUntilIdle(page);
+}
+
+async function readTerminalJob(page, location, baseUrl) {
+  const jobUrl = new URL(location, baseUrl).toString();
+  await page.waitForFunction(async url => {
+    const response = await fetch(url, { headers: { Accept: 'application/json' } });
+    if (!response.ok) return false;
+    const job = await response.json();
+    return ['SUCCESS', 'PARTIAL', 'FAILED', 'CANCELLED'].includes(job.status);
+  }, jobUrl, { timeout: 180_000, polling: 500 });
+  return page.evaluate(async url => {
+    const response = await fetch(url, { headers: { Accept: 'application/json' } });
+    return { status: response.status, body: await response.json() };
+  }, jobUrl);
+}
+
+async function createRequirement(page, key, title, text) {
+  await page.locator('[data-bs-target="#requirementModal"]').click();
+  await submitModal(page, 'requirementModal', async modal => {
+    await modal.locator('#requirementKey').fill(key);
+    await modal.locator('#requirementTitle').fill(title);
+    await modal.locator('#requirementType').selectOption('SECURITY');
+    await modal.locator('#requirementText').fill(text);
+  }, /^\/api\/projects\/\d+\/requirements$/);
+  await page.locator('#requirementsTable tbody').getByText(key)
+    .waitFor({ state: 'visible', timeout: 30_000 });
 }
 
 /** End-to-end portfolio workflow for the authoritative ADMIN browser profile. */
@@ -67,9 +69,11 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
 
   await page.goto(`${baseUrl}/projects`, { waitUntil: 'networkidle' });
   await page.locator('#portfolioMain').waitFor({ state: 'visible', timeout: 30_000 });
-  evidence.assert(await page.locator('#projectList').getAttribute('role') === 'listbox',
-    'Project portfolio list lacks listbox semantics');
-  evidence.passed('portfolio page and project list semantics');
+  evidence.assert(await page.locator('#projectList').getAttribute('role') !== 'listbox',
+    'Project navigation must not claim an incomplete ARIA listbox pattern');
+  evidence.assert(await page.locator('#projectList button').count() >= 0,
+    'Project navigation must use native interactive controls');
+  evidence.passed('portfolio page and native project navigation semantics');
 
   const skipLink = page.locator('.skip-link');
   await skipLink.focus();
@@ -93,17 +97,13 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
     .waitFor({ state: 'visible', timeout: 30_000 });
   evidence.passed('portfolio project creation');
 
-  await page.locator('[data-bs-target="#requirementModal"]').click();
-  await submitModal(page, 'requirementModal', async modal => {
-    await modal.locator('#requirementKey').fill('REQ-001');
-    await modal.locator('#requirementTitle').fill('Secure portfolio analysis');
-    await modal.locator('#requirementType').selectOption('SECURITY');
-    await modal.locator('#requirementText').fill(
-      'Provide traceable secure communication, resilient data exchange and auditable architecture decisions.');
-  }, /^\/api\/projects\/\d+\/requirements$/);
-  await page.locator('#requirementsTable tbody').getByText('REQ-001')
-    .waitFor({ state: 'visible', timeout: 30_000 });
-  evidence.passed('portfolio requirement creation');
+  await createRequirement(page, 'REQ-001', 'Secure communication',
+    'Provide traceable secure communication and auditable architecture decisions.');
+  await createRequirement(page, 'REQ-002', 'Resilient exchange',
+    'Provide resilient secure data exchange with auditable architecture decisions.');
+  await createRequirement(page, 'REQ-003', 'Controlled operation',
+    'Provide controlled operation and secure communication with human review.');
+  evidence.passed('three independent portfolio requirements');
 
   await page.locator('#solutions-tab').click();
   await page.locator('[data-bs-target="#solutionModal"]').click();
@@ -115,7 +115,6 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   }, /^\/api\/solutions$/);
   await page.locator('#solutionsList').getByText('Secure communication service')
     .waitFor({ state: 'visible', timeout: 30_000 });
-  evidence.passed('portfolio solution creation');
 
   await page.locator('#products-tab').click();
   await page.locator('[data-bs-target="#productModal"]').click();
@@ -129,7 +128,7 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   }, /^\/api\/products$/);
   await page.locator('#productsList').getByText('Acceptance Product')
     .waitFor({ state: 'visible', timeout: 30_000 });
-  evidence.passed('portfolio sourced product creation');
+  evidence.passed('portfolio solution and sourced product creation');
 
   await page.locator('#requirements-tab').click();
   const responsePromise = page.waitForResponse(response =>
@@ -138,24 +137,120 @@ export async function runPortfolioWorkflows({ page, baseUrl, evidence }) {
   { timeout: 180_000 });
   await page.locator('#analyzeAllBtn').click();
   const analysisResponse = await responsePromise;
-  evidence.assert(analysisResponse.ok(),
-    `Portfolio analysis failed with HTTP ${analysisResponse.status()}`);
-  await verifyAnalysisCompletion(page, analysisResponse, baseUrl, evidence);
-  evidence.passed('portfolio independent mock analysis');
+  evidence.assert(analysisResponse.status() === 202,
+    `Portfolio analysis must be accepted asynchronously, got HTTP ${analysisResponse.status()}`);
+  const location = await analysisResponse.headerValue('location');
+  evidence.assert(location, 'Asynchronous analysis response lacks a canonical Location header');
 
-  await page.locator('#taxonomy-tab').click();
-  await page.locator('#taxonomyPane').waitFor({ state: 'visible' });
-  await page.locator('#snapshots-tab').click();
-  await page.locator('#snapshotsPane').waitFor({ state: 'visible' });
-  evidence.passed('portfolio result tab navigation');
+  await waitUntilIdle(page, 30_000);
+  await page.locator('#portfolioJobCenter').waitFor({ state: 'visible', timeout: 20_000 });
+  evidence.assert(await page.locator('#portfolioJobList .portfolio-job').count() >= 1,
+    'Accepted analysis was not registered in the persistent job center');
 
-  const overflow = await page.evaluate(() => ({
+  // Prove that the application remains navigable while the persisted job is
+  // running instead of holding a full-page busy overlay for up to ten minutes.
+  await page.locator('#products-tab').click();
+  await page.locator('#productsPane').waitFor({ state: 'visible' });
+  evidence.passed('non-blocking analysis navigation and visible job center');
+
+  const terminal = await readTerminalJob(page, location, baseUrl);
+  evidence.assert(terminal.status === 200,
+    `Terminal analysis job could not be read: HTTP ${terminal.status}`);
+  evidence.assert(['SUCCESS', 'PARTIAL'].includes(terminal.body.status),
+    `Analysis job did not finish successfully: ${terminal.body.status}`);
+  evidence.assert(terminal.body.totalItems === 3,
+    `Expected three independently analysed requirements, got ${terminal.body.totalItems}`);
+  evidence.assert(terminal.body.successfulItems + terminal.body.partialItems === 3,
+    'Not all three requirements created a successful or partial snapshot');
+  await page.locator('#portfolioJobList').getByText(/Successful|Erfolgreich/)
+    .first().waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.passed('terminal job state and per-requirement persistence');
+
+  // Reload proves that the job list is persisted independently of one page life.
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.locator('#portfolioJobCenter').waitFor({ state: 'visible', timeout: 30_000 });
+  evidence.assert(await page.locator('#portfolioJobList .portfolio-job').count() >= 1,
+    'Analysis job was lost after browser reload');
+  evidence.passed('analysis job recovery after reload');
+
+  await page.locator('#requirements-tab').click();
+  const firstRow = page.locator('#requirementsTable tbody tr').filter({ hasText: 'REQ-001' });
+  await firstRow.locator('.requirement-snapshots').click();
+  await page.locator('#snapshotDetail .mapping-list tbody tr').first()
+    .waitFor({ state: 'visible', timeout: 30_000 });
+  const nodeCode = await page.locator('#snapshotDetail .mapping-list tbody tr').first()
+    .locator('code').innerText();
+  evidence.assert(Boolean(nodeCode), 'Snapshot did not expose a taxonomy mapping');
+
+  const mappingRow = page.locator('#snapshotDetail .mapping-list tbody tr').first();
+  await mappingRow.locator('.mapping-action-select').selectOption('REUSE');
+  await mappingRow.locator('.mapping-review').click();
+  await completeDecisionDialog(page,
+    'Acceptance reviewer verified the requirement text and taxonomy mapping.',
+    'Browser acceptance review');
+  evidence.passed('snapshot detail and evidence-backed mapping review');
+
+  await page.locator('#solutions-tab').click();
+  const solutionCard = page.locator('#solutionsList .portfolio-solution-card')
+    .filter({ hasText: 'Secure communication service' });
+  const coverageDetails = solutionCard.locator('details').first();
+  await coverageDetails.locator('summary').click();
+  await solutionCard.locator('.solution-node-code').fill(nodeCode);
+  await solutionCard.locator('.solution-node-coverage').fill('90');
+  await solutionCard.locator('.solution-node-review').selectOption('CONFIRMED');
+  await solutionCard.locator('.add-solution-coverage').click();
+  await completeDecisionDialog(page,
+    'Solution catalogue evidence confirms coverage of the selected taxonomy node.');
+
+  await page.locator('#proposeSolutionsBtn').click();
+  await waitUntilIdle(page);
+  const confirmLink = page.locator('.confirm-requirement-link').first();
+  await confirmLink.waitFor({ state: 'visible', timeout: 30_000 });
+  await confirmLink.click();
+  await completeDecisionDialog(page,
+    'Reviewer confirmed this reusable solution for the analysed requirement snapshot.');
+  evidence.passed('confirmed requirement-to-solution decision');
+
+  const refreshedSolution = page.locator('#solutionsList .portfolio-solution-card')
+    .filter({ hasText: 'Secure communication service' });
+  await refreshedSolution.locator('.solution-product-select').selectOption({ index: 1 });
+  await refreshedSolution.locator('.solution-product-coverage').fill('85');
+  await refreshedSolution.locator('.add-product-candidate').click();
+  await waitUntilIdle(page);
+  await page.locator('.product-candidate-review[data-status="SHORTLISTED"]').first().click();
+  await waitUntilIdle(page);
+  await page.locator('.product-candidate-review[data-status="SELECTED"]').first().click();
+  await waitUntilIdle(page);
+  evidence.passed('reviewed and selected solution product candidate');
+
+  evidence.assert(await page.locator(
+    '#requirementSolutionMatrix .matrix-cell[data-value]:not([data-value="0"])').count() > 0,
+  'Requirement-to-solution matrix did not reflect the confirmed decision');
+  evidence.assert(await page.locator(
+    '#solutionProductMatrix .matrix-cell[data-value]:not([data-value="0"])').count() > 0,
+  'Solution-to-product matrix did not reflect the selected candidate');
+  evidence.passed('portfolio matrix values match persisted decisions');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.locator('#portfolioMain').waitFor({ state: 'visible' });
+  const mobileOverflow = await page.evaluate(() => ({
     scrollWidth: document.documentElement.scrollWidth,
     clientWidth: document.documentElement.clientWidth
   }));
-  evidence.assert(overflow.scrollWidth <= overflow.clientWidth + 2,
-    `Portfolio overflows viewport: ${overflow.scrollWidth} > ${overflow.clientWidth}`);
+  evidence.assert(mobileOverflow.scrollWidth <= mobileOverflow.clientWidth + 2,
+    `Portfolio overflows mobile viewport: ${mobileOverflow.scrollWidth} > ${mobileOverflow.clientWidth}`);
+
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.evaluate(() => { document.documentElement.style.fontSize = '200%'; });
+  const zoomOverflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth
+  }));
+  evidence.assert(zoomOverflow.scrollWidth <= zoomOverflow.clientWidth + 2,
+    `Portfolio overflows at 200% text zoom: ${zoomOverflow.scrollWidth} > ${zoomOverflow.clientWidth}`);
+  await page.evaluate(() => { document.documentElement.style.fontSize = ''; });
+
   await evidence.axeState('portfolio-complete', '#portfolioMain');
   await evidence.saveState('portfolio-complete', '#portfolioMain');
-  evidence.passed('portfolio reflow and evidence');
+  evidence.passed('portfolio mobile, zoom, accessibility and evidence');
 }

--- a/.github/scripts/ui-primary-workflow-acceptance.mjs
+++ b/.github/scripts/ui-primary-workflow-acceptance.mjs
@@ -8,6 +8,7 @@ import { runProposalWorkflows } from './ui-primary-proposal-workflows.mjs';
 import { runRelationWorkflows } from './ui-primary-relation-workflows.mjs';
 import { runImportWorkflows } from './ui-primary-import-workflows.mjs';
 import { runPortfolioWorkflows } from './ui-primary-portfolio-workflows.mjs';
+import { runPortfolioDetailWorkflows } from './ui-primary-portfolio-detail-workflows.mjs';
 import { runPasswordWorkflows, runWorkspaceSyncWorkflows,
   verifyUserMutationDenied } from './ui-primary-account-workflows.mjs';
 
@@ -46,6 +47,7 @@ try {
   if (role === 'ADMIN') {
     await runWorkspaceSyncWorkflows(workflow);
     await runPortfolioWorkflows(workflow);
+    await runPortfolioDetailWorkflows(workflow);
   }
   if (role === 'USER') await runPasswordWorkflows(workflow);
 } catch (error) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioPageController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/controller/PortfolioPageController.java
@@ -2,13 +2,25 @@ package com.taxonomy.portfolio.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
-/** Dedicated GUI entry point for project requirement and solution portfolio work. */
+/** Dedicated GUI entry points for project portfolio work. */
 @Controller
 public class PortfolioPageController {
 
     @GetMapping({"/projects", "/portfolio"})
     public String projects() {
         return "projects";
+    }
+
+    @GetMapping("/projects/{projectId}/requirements/{requirementId}")
+    public String requirementDetail(@PathVariable Long projectId,
+                                    @PathVariable Long requirementId) {
+        return "requirement-detail";
+    }
+
+    @GetMapping("/projects/{projectId}/matrices")
+    public String matrices(@PathVariable Long projectId) {
+        return "portfolio-matrices";
     }
 }

--- a/taxonomy-app/src/main/resources/static/js/portfolio/portfolio-matrices.js
+++ b/taxonomy-app/src/main/resources/static/js/portfolio/portfolio-matrices.js
@@ -1,0 +1,233 @@
+(function () {
+    'use strict';
+
+    const match = window.location.pathname.match(/^\/projects\/(\d+)\/matrices$/);
+    if (!match) return;
+    const projectId = Number(match[1]);
+    const locale = (new URLSearchParams(window.location.search).get('lang')
+        || document.documentElement.lang || 'en').toLowerCase().startsWith('de') ? 'de' : 'en';
+    const state = { project: null, portfolio: null, activeType: 'taxonomy' };
+    const matrixDefinitions = {
+        taxonomy: { target: 'taxonomyMatrix', property: 'requirementTaxonomyMatrix', title: 'Requirements × taxonomy' },
+        solution: { target: 'solutionMatrix', property: 'requirementSolutionMatrix', title: 'Requirements × solutions' },
+        product: { target: 'productMatrix', property: 'solutionProductMatrix', title: 'Solutions × products' }
+    };
+
+    const labels = {
+        en: { title: 'Portfolio matrices', portfolio: 'Portfolio', filters: 'Filters', search: 'Search rows and columns', minimum: 'Minimum coverage', relationship: 'Relationship', all: 'All', related: 'Related', empty: 'Empty', reset: 'Reset', exportCsv: 'Export filtered CSV', exportJson: 'Export filtered JSON', taxonomy: 'Requirements × taxonomy', solution: 'Requirements × solutions', product: 'Solutions × products', detail: 'Relationship detail', noData: 'No relationships match the active filters.', row: 'Row', column: 'Column', value: 'Coverage', relationAbsent: 'No stored relationship exists. This is not an explicit zero score.', openRequirement: 'Open requirement detail', review: 'Review status', evidence: 'Evidence', source: 'Source', selected: 'Selection', filtersActive: 'Active filters', none: 'none', failed: 'The matrix could not be loaded.' },
+        de: { title: 'Portfolio-Matrizen', portfolio: 'Portfolio', filters: 'Filter', search: 'Zeilen und Spalten durchsuchen', minimum: 'Mindestabdeckung', relationship: 'Beziehung', all: 'Alle', related: 'Verknüpft', empty: 'Leer', reset: 'Zurücksetzen', exportCsv: 'Gefiltertes CSV exportieren', exportJson: 'Gefiltertes JSON exportieren', taxonomy: 'Anforderungen × Taxonomie', solution: 'Anforderungen × Lösungen', product: 'Lösungen × Produkte', detail: 'Beziehungsdetails', noData: 'Keine Beziehungen entsprechen den aktiven Filtern.', row: 'Zeile', column: 'Spalte', value: 'Abdeckung', relationAbsent: 'Es ist keine Beziehung gespeichert. Dies ist kein expliziter Null-Score.', openRequirement: 'Anforderungsdetails öffnen', review: 'Prüfstatus', evidence: 'Evidenz', source: 'Quelle', selected: 'Auswahl', filtersActive: 'Aktive Filter', none: 'keine', failed: 'Die Matrix konnte nicht geladen werden.' }
+    };
+
+    document.addEventListener('DOMContentLoaded', initialize);
+    function l(key) { return labels[locale][key] || labels.en[key] || key; }
+
+    async function initialize() {
+        translateSurface();
+        wireEvents();
+        setBusy(true);
+        try {
+            [state.project, state.portfolio] = await Promise.all([
+                api(`/api/projects/${projectId}`), api(`/api/projects/${projectId}/portfolio`)
+            ]);
+            document.getElementById('matrixProject').textContent = `${state.project.projectKey} — ${state.project.title}`;
+            renderAll();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function translateSurface() {
+        document.documentElement.lang = locale;
+        document.title = `${l('title')} — Taxonomy`;
+        document.querySelector('.skip-link').textContent = locale === 'de' ? 'Zu den Matrizen springen' : 'Skip to matrices';
+        document.getElementById('matrixPageTitle').textContent = l('title');
+        document.getElementById('matrixHeading').textContent = l('title');
+        document.getElementById('portfolioBack').textContent = l('portfolio');
+        document.getElementById('portfolioBack').href = `/projects?lang=${locale}`;
+        document.getElementById('filterHeading').textContent = l('filters');
+        document.querySelector('label[for="matrixSearch"]').textContent = l('search');
+        document.querySelector('label[for="minimumValue"]').textContent = l('minimum');
+        document.querySelector('label[for="relationState"]').textContent = l('relationship');
+        const relation = document.getElementById('relationState');
+        relation.options[0].textContent = l('all'); relation.options[1].textContent = l('related'); relation.options[2].textContent = l('empty');
+        document.getElementById('resetFilters').textContent = l('reset');
+        document.getElementById('exportCsv').textContent = l('exportCsv');
+        document.getElementById('exportJson').textContent = l('exportJson');
+        document.getElementById('taxonomyMatrixTab').textContent = l('taxonomy');
+        document.getElementById('solutionMatrixTab').textContent = l('solution');
+        document.getElementById('productMatrixTab').textContent = l('product');
+        document.getElementById('cellDetailTitle').textContent = l('detail');
+    }
+
+    function wireEvents() {
+        ['matrixSearch', 'minimumValue', 'relationState'].forEach(id => document.getElementById(id).addEventListener('input', renderAll));
+        document.getElementById('resetFilters').addEventListener('click', () => {
+            document.getElementById('matrixSearch').value = '';
+            document.getElementById('minimumValue').value = '0';
+            document.getElementById('relationState').value = 'all';
+            renderAll();
+        });
+        document.getElementById('exportCsv').addEventListener('click', () => exportCurrent('csv'));
+        document.getElementById('exportJson').addEventListener('click', () => exportCurrent('json'));
+        document.querySelectorAll('[data-bs-toggle="tab"]').forEach(button => button.addEventListener('shown.bs.tab', event => {
+            if (event.target.id === 'taxonomyMatrixTab') state.activeType = 'taxonomy';
+            if (event.target.id === 'solutionMatrixTab') state.activeType = 'solution';
+            if (event.target.id === 'productMatrixTab') state.activeType = 'product';
+        }));
+        document.getElementById('matrixMain').addEventListener('click', event => {
+            const cell = event.target.closest('.matrix-drilldown');
+            if (cell) openCellDetail(cell.dataset.matrixType, cell.dataset.row, cell.dataset.column, Number(cell.dataset.value));
+        });
+    }
+
+    function renderAll() {
+        Object.entries(matrixDefinitions).forEach(([type, definition]) => renderMatrix(type, definition));
+        const search = document.getElementById('matrixSearch').value.trim();
+        const minimum = Number(document.getElementById('minimumValue').value || 0);
+        const relation = document.getElementById('relationState').value;
+        document.getElementById('activeFilters').textContent = `${l('filtersActive')}: `
+            + ([search && `“${search}”`, minimum > 0 && `≥ ${minimum}%`, relation !== 'all' && l(relation)]
+                .filter(Boolean).join(' · ') || l('none'));
+    }
+
+    function filteredMatrix(type) {
+        const definition = matrixDefinitions[type];
+        const matrix = state.portfolio && state.portfolio[definition.property];
+        if (!matrix || !Array.isArray(matrix.rows) || !Array.isArray(matrix.columns)) return { rows: [], columns: [], values: {} };
+        const search = document.getElementById('matrixSearch').value.trim().toLowerCase();
+        const minimum = Number(document.getElementById('minimumValue').value || 0);
+        const relation = document.getElementById('relationState').value;
+        const rowMatches = row => !search || row.toLowerCase().includes(search)
+            || matrix.columns.some(column => column.toLowerCase().includes(search) && cellVisible(valueAt(matrix, row, column), minimum, relation));
+        const columnMatches = column => !search || column.toLowerCase().includes(search)
+            || matrix.rows.some(row => row.toLowerCase().includes(search) && cellVisible(valueAt(matrix, row, column), minimum, relation));
+        const rows = matrix.rows.filter(rowMatches).filter(row => matrix.columns.some(column => cellVisible(valueAt(matrix, row, column), minimum, relation)));
+        const columns = matrix.columns.filter(columnMatches).filter(column => rows.some(row => cellVisible(valueAt(matrix, row, column), minimum, relation)));
+        const values = {};
+        rows.forEach(row => {
+            values[row] = {};
+            columns.forEach(column => {
+                const value = valueAt(matrix, row, column);
+                if (cellVisible(value, minimum, relation)) values[row][column] = value;
+            });
+        });
+        return { rows, columns, values };
+    }
+
+    function cellVisible(value, minimum, relation) {
+        if (relation === 'related' && value <= 0) return false;
+        if (relation === 'empty' && value > 0) return false;
+        return value >= minimum;
+    }
+
+    function valueAt(matrix, row, column) { return Number(matrix.values && matrix.values[row] && matrix.values[row][column] || 0); }
+
+    function renderMatrix(type, definition) {
+        const target = document.getElementById(definition.target);
+        const matrix = filteredMatrix(type);
+        target.textContent = '';
+        if (!matrix.rows.length || !matrix.columns.length) {
+            const empty = document.createElement('p'); empty.className = 'p-4 text-body-secondary mb-0'; empty.textContent = l('noData'); target.appendChild(empty); return;
+        }
+        const table = document.createElement('table'); table.className = 'table table-sm table-bordered align-middle mb-0';
+        const caption = document.createElement('caption'); caption.className = 'visually-hidden'; caption.textContent = definition.title; table.appendChild(caption);
+        const thead = document.createElement('thead'); const header = document.createElement('tr');
+        const corner = document.createElement('th'); corner.scope = 'col'; corner.textContent = ''; header.appendChild(corner);
+        matrix.columns.forEach(column => { const th = document.createElement('th'); th.scope = 'col'; th.textContent = column; th.title = column; header.appendChild(th); });
+        thead.appendChild(header); table.appendChild(thead);
+        const tbody = document.createElement('tbody');
+        matrix.rows.forEach(rowName => {
+            const row = document.createElement('tr'); const th = document.createElement('th'); th.scope = 'row'; th.textContent = rowName; row.appendChild(th);
+            matrix.columns.forEach(column => {
+                const value = Number(matrix.values[rowName] && matrix.values[rowName][column] || 0);
+                const td = document.createElement('td'); td.className = 'matrix-cell'; td.dataset.value = String(value);
+                const button = document.createElement('button'); button.type = 'button'; button.className = 'btn btn-sm w-100 matrix-drilldown ' + (value > 0 ? 'btn-outline-primary' : 'btn-link text-body-secondary');
+                button.dataset.matrixType = type; button.dataset.row = rowName; button.dataset.column = column; button.dataset.value = String(value);
+                button.textContent = value > 0 ? `${value}%` : '·';
+                button.setAttribute('aria-label', `${rowName}, ${column}: ${value > 0 ? value + '%' : l('empty')}`);
+                td.appendChild(button); row.appendChild(td);
+            });
+            tbody.appendChild(row);
+        });
+        table.appendChild(tbody); target.appendChild(table);
+        addAlternativeList(target, type, matrix);
+    }
+
+    function addAlternativeList(target, type, matrix) {
+        const details = document.createElement('details'); details.className = 'matrix-alternative mt-3 p-2 border rounded';
+        const summary = document.createElement('summary'); summary.className = 'fw-semibold'; summary.textContent = locale === 'de' ? 'Alternative Listenansicht' : 'Alternative list view'; details.appendChild(summary);
+        const list = document.createElement('div'); list.className = 'list-group list-group-flush mt-2';
+        matrix.rows.forEach(row => matrix.columns.forEach(column => {
+            const value = Number(matrix.values[row] && matrix.values[row][column] || 0);
+            const button = document.createElement('button'); button.type = 'button'; button.className = 'list-group-item list-group-item-action matrix-drilldown';
+            button.dataset.matrixType = type; button.dataset.row = row; button.dataset.column = column; button.dataset.value = String(value);
+            button.innerHTML = `<div class="d-flex justify-content-between gap-2"><span>${escapeHtml(row)} → ${escapeHtml(column)}</span><strong>${value > 0 ? value + '%' : '—'}</strong></div>`;
+            list.appendChild(button);
+        }));
+        details.appendChild(list); target.appendChild(details);
+    }
+
+    function openCellDetail(type, row, column, value) {
+        const detail = describeRelationship(type, row, column, value);
+        const body = document.getElementById('cellDetailBody'); body.textContent = '';
+        const dl = document.createElement('dl'); dl.className = 'portfolio-card-meta';
+        addDefinition(dl, l('row'), row); addDefinition(dl, l('column'), column); addDefinition(dl, l('value'), value > 0 ? `${value}%` : '—');
+        Object.entries(detail.metadata).forEach(([key, metadataValue]) => addDefinition(dl, key, metadataValue));
+        body.appendChild(dl);
+        if (value <= 0) { const warning = document.createElement('div'); warning.className = 'alert alert-secondary mt-3'; warning.textContent = l('relationAbsent'); body.appendChild(warning); }
+        if (detail.requirementId) {
+            const link = document.createElement('a'); link.className = 'btn btn-primary mt-3'; link.href = `/projects/${projectId}/requirements/${detail.requirementId}?lang=${locale}`; link.textContent = l('openRequirement'); body.appendChild(link);
+        }
+        bootstrap.Offcanvas.getOrCreateInstance(document.getElementById('cellDetail')).show();
+    }
+
+    function describeRelationship(type, row, column, value) {
+        const metadata = {};
+        const requirements = state.portfolio.requirements || [];
+        const solutions = state.portfolio.solutions || [];
+        if (type === 'taxonomy') {
+            const requirement = requirements.find(item => item.requirementKey === row || item.requirementKey === column);
+            const nodeCode = requirement && requirement.requirementKey === row ? column : row;
+            const taxonomyNode = (state.portfolio.taxonomyNodes || []).find(node => node.nodeCode === nodeCode);
+            metadata[l('source')] = taxonomyNode ? `${taxonomyNode.title || nodeCode}` : nodeCode;
+            metadata[l('review')] = value > 0 ? (locale === 'de' ? 'Aus aktuellem Snapshot' : 'From current snapshot') : '—';
+            return { metadata, requirementId: requirement && requirement.id };
+        }
+        if (type === 'solution') {
+            const requirement = requirements.find(item => item.requirementKey === row || item.requirementKey === column);
+            const solutionKey = requirement && requirement.requirementKey === row ? column : row;
+            const solution = solutions.find(item => item.solution && item.solution.solutionKey === solutionKey);
+            const link = solution && (solution.requirements || []).find(item => requirement && item.requirementId === requirement.id);
+            metadata[l('review')] = link ? humanize(link.reviewStatus) : '—'; metadata[l('evidence')] = link && link.evidence || '—';
+            return { metadata, requirementId: requirement && requirement.id };
+        }
+        const solution = solutions.find(item => item.solution && (item.solution.solutionKey === row || item.solution.solutionKey === column));
+        const productKey = solution && solution.solution.solutionKey === row ? column : row;
+        const candidate = solution && (solution.productCandidates || []).find(item => item.product && item.product.productKey === productKey);
+        metadata[l('review')] = candidate ? humanize(candidate.reviewStatus) : '—';
+        metadata[l('selected')] = candidate ? humanize(candidate.selectionStatus) : '—';
+        metadata[l('source')] = candidate && candidate.product.sourceReference || '—';
+        return { metadata, requirementId: null };
+    }
+
+    function exportCurrent(format) {
+        const type = state.activeType; const matrix = filteredMatrix(type);
+        const definition = matrixDefinitions[type];
+        if (format === 'json') return download(`${state.project.projectKey}-${type}-matrix.json`, 'application/json', JSON.stringify({ projectId, projectKey: state.project.projectKey, matrixType: type, ...matrix }, null, 2));
+        const rows = [['row', ...matrix.columns]];
+        matrix.rows.forEach(row => rows.push([row, ...matrix.columns.map(column => matrix.values[row] && matrix.values[row][column] || 0)]));
+        download(`${state.project.projectKey}-${type}-matrix.csv`, 'text/csv;charset=utf-8', rows.map(values => values.map(csvCell).join(',')).join('\n'));
+        document.getElementById('matrixLive').textContent = `${definition.title} exported`;
+    }
+
+    function csvCell(value) { const text = String(value == null ? '' : value); return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text; }
+    function download(filename, contentType, content) { const blob = new Blob([content], { type: contentType }); const url = URL.createObjectURL(blob); const link = document.createElement('a'); link.href = url; link.download = filename; document.body.appendChild(link); link.click(); link.remove(); URL.revokeObjectURL(url); }
+    async function api(path) { const response = await fetch(path, { headers: { Accept: 'application/json' }, credentials: 'same-origin' }); if (!response.ok) { const payload = await response.json().catch(() => null); throw new Error(payload?.detail || payload?.message || `${l('failed')} HTTP ${response.status}`); } return response.json(); }
+    function addDefinition(target, term, value) { const dt = document.createElement('dt'); dt.textContent = term; const dd = document.createElement('dd'); dd.textContent = value == null ? '—' : value; target.append(dt, dd); }
+    function setBusy(active) { document.getElementById('matrixBusy').classList.toggle('d-none', !active); }
+    function showError(error) { const target = document.getElementById('matrixError'); target.textContent = error?.message || l('failed'); target.classList.remove('d-none'); target.focus(); }
+    function humanize(value) { return String(value || '—').toLowerCase().replaceAll('_', ' ').replace(/\b\w/g, character => character.toUpperCase()); }
+    function escapeHtml(value) { return String(value == null ? '' : value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;'); }
+})();

--- a/taxonomy-app/src/main/resources/static/js/portfolio/requirement-detail.js
+++ b/taxonomy-app/src/main/resources/static/js/portfolio/requirement-detail.js
@@ -1,0 +1,558 @@
+(function () {
+    'use strict';
+
+    const match = window.location.pathname.match(/^\/projects\/(\d+)\/requirements\/(\d+)$/);
+    if (!match) return;
+    const projectId = Number(match[1]);
+    const requirementId = Number(match[2]);
+    const locale = (new URLSearchParams(window.location.search).get('lang')
+        || document.documentElement.lang || 'en').toLowerCase().startsWith('de') ? 'de' : 'en';
+    const state = {
+        project: null,
+        requirement: null,
+        versions: [],
+        snapshots: [],
+        selectedVersion: null,
+        selectedSnapshot: null,
+        snapshotDetail: null,
+        portfolio: null,
+        account: null,
+        busy: 0
+    };
+
+    const text = {
+        en: {
+            loading: 'Loading…', portfolio: 'Portfolio', matrices: 'Matrices',
+            detail: 'Requirement detail', analyze: 'Analyze current version',
+            newVersion: 'New version', open: 'Open decisions', textSource: 'Text & source',
+            versions: 'Versions', analyses: 'Analyses', architecture: 'Taxonomy & architecture',
+            decisions: 'Decisions', solutions: 'Solutions & products', currentText: 'Current requirement text',
+            source: 'Original source fragment', noSource: 'No source fragment is recorded.',
+            noVersions: 'No versions are available.', noSnapshots: 'No analysis snapshots are available.',
+            noMappings: 'No taxonomy mappings are available.', noRelations: 'No relation mappings are available.',
+            noSolutions: 'No solution is currently linked to this requirement.',
+            versionCreated: 'A new immutable version was created.', analysisQueued: 'Analysis was queued.',
+            stale: 'The current requirement version has not been analysed.',
+            unreviewed: 'Taxonomy mappings still require human review.',
+            noConfirmedSolution: 'No confirmed solution covers this requirement.',
+            sourceMissing: 'The current version has no source provenance.',
+            allClear: 'No open decisions were derived from the current data.',
+            provider: 'Provider', model: 'Model', created: 'Created', duration: 'Duration',
+            baseline: 'Baseline', score: 'Score', relevance: 'Relevance', confidence: 'Confidence',
+            origin: 'Origin', review: 'Review', action: 'Action', evidence: 'Evidence',
+            node: 'Taxonomy node', relation: 'Relation', changeReason: 'Change reason',
+            author: 'Author', page: 'Page', section: 'Section', sourceArtifact: 'Source artifact',
+            snapshot: 'Snapshot', productCandidates: 'Product candidates', coverage: 'Coverage',
+            selected: 'Selected', retry: 'Retry failed analysis', comparePrevious: 'Compare with previous version',
+            added: 'Added', removed: 'Removed', unchanged: 'Unchanged', permission: 'Your role cannot change this requirement.',
+            failed: 'The operation failed.'
+        },
+        de: {
+            loading: 'Wird geladen…', portfolio: 'Portfolio', matrices: 'Matrizen',
+            detail: 'Anforderungsdetails', analyze: 'Aktuelle Version analysieren',
+            newVersion: 'Neue Version', open: 'Offene Entscheidungen', textSource: 'Text & Quelle',
+            versions: 'Versionen', analyses: 'Analysen', architecture: 'Taxonomie & Architektur',
+            decisions: 'Entscheidungen', solutions: 'Lösungen & Produkte', currentText: 'Aktueller Anforderungstext',
+            source: 'Ursprüngliches Quellfragment', noSource: 'Es ist kein Quellfragment hinterlegt.',
+            noVersions: 'Es sind keine Versionen verfügbar.', noSnapshots: 'Es sind keine Analyse-Snapshots verfügbar.',
+            noMappings: 'Es sind keine Taxonomiezuordnungen verfügbar.', noRelations: 'Es sind keine Beziehungszuordnungen verfügbar.',
+            noSolutions: 'Dieser Anforderung ist derzeit keine Lösung zugeordnet.',
+            versionCreated: 'Eine neue unveränderliche Version wurde angelegt.', analysisQueued: 'Die Analyse wurde eingereiht.',
+            stale: 'Die aktuelle Anforderungsversion wurde noch nicht analysiert.',
+            unreviewed: 'Taxonomiezuordnungen benötigen noch eine menschliche Prüfung.',
+            noConfirmedSolution: 'Keine bestätigte Lösung deckt diese Anforderung ab.',
+            sourceMissing: 'Für die aktuelle Version fehlt die Quellenprovenienz.',
+            allClear: 'Aus den aktuellen Daten wurden keine offenen Entscheidungen abgeleitet.',
+            provider: 'Provider', model: 'Modell', created: 'Erstellt', duration: 'Laufzeit',
+            baseline: 'Baseline', score: 'Score', relevance: 'Relevanz', confidence: 'Konfidenz',
+            origin: 'Herkunft', review: 'Prüfung', action: 'Maßnahme', evidence: 'Evidenz',
+            node: 'Taxonomieknoten', relation: 'Beziehung', changeReason: 'Änderungsgrund',
+            author: 'Autor', page: 'Seite', section: 'Abschnitt', sourceArtifact: 'Quellartefakt',
+            snapshot: 'Snapshot', productCandidates: 'Produktkandidaten', coverage: 'Abdeckung',
+            selected: 'Ausgewählt', retry: 'Fehlgeschlagene Analyse wiederholen', comparePrevious: 'Mit vorheriger Version vergleichen',
+            added: 'Hinzugefügt', removed: 'Entfernt', unchanged: 'Unverändert', permission: 'Ihre Rolle darf diese Anforderung nicht ändern.',
+            failed: 'Die Operation ist fehlgeschlagen.'
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', initialize);
+
+    function t(key) { return (text[locale] && text[locale][key]) || text.en[key] || key; }
+
+    async function initialize() {
+        translateSurface();
+        wireEvents();
+        await loadAll();
+        const requestedSnapshot = new URLSearchParams(window.location.search).get('snapshot');
+        if (requestedSnapshot) await selectSnapshot(requestedSnapshot);
+        else if (state.snapshots.length) await selectSnapshot(state.snapshots[0].id);
+    }
+
+    function translateSurface() {
+        document.documentElement.lang = locale;
+        document.title = t('detail') + ' — Taxonomy';
+        document.querySelector('.skip-link').textContent = locale === 'de'
+            ? 'Zu den Anforderungsdetails springen' : 'Skip to requirement detail';
+        document.getElementById('pageTitle').textContent = t('detail');
+        document.getElementById('portfolioBack').textContent = t('portfolio');
+        document.getElementById('matrixLink').textContent = t('matrices');
+        document.getElementById('reanalyzeRequirement').textContent = t('analyze');
+        document.getElementById('newVersionButton').textContent = t('newVersion');
+        document.getElementById('tasksHeading').textContent = t('open');
+        setTabText('text-tab', t('textSource'));
+        setTabText('versions-tab', t('versions'));
+        setTabText('analyses-tab', t('analyses'));
+        setTabText('architecture-tab', t('architecture'));
+        setTabText('decisions-tab', t('decisions'));
+        setTabText('solutions-tab', t('solutions'));
+        document.querySelector('#textPane h2').textContent = t('currentText');
+        document.querySelectorAll('#textPane h2')[1].textContent = t('source');
+    }
+
+    function setTabText(id, value) { document.getElementById(id).textContent = value; }
+
+    function wireEvents() {
+        document.getElementById('newVersionForm').addEventListener('submit', createVersion);
+        document.getElementById('reanalyzeRequirement').addEventListener('click', analyzeRequirement);
+        document.getElementById('versionList').addEventListener('click', event => {
+            const button = event.target.closest('[data-version-id]');
+            if (button) selectVersion(Number(button.dataset.versionId));
+        });
+        document.getElementById('snapshotList').addEventListener('click', event => {
+            const button = event.target.closest('[data-snapshot-id]');
+            if (button) selectSnapshot(button.dataset.snapshotId);
+        });
+    }
+
+    async function loadAll() {
+        setBusy(true);
+        try {
+            const [project, requirement, versions, snapshots, portfolio, account] = await Promise.all([
+                api(`/api/projects/${projectId}`),
+                api(`/api/projects/${projectId}/requirements/${requirementId}`),
+                api(`/api/projects/${projectId}/requirements/${requirementId}/versions`),
+                api(`/api/projects/${projectId}/requirements/${requirementId}/snapshots`),
+                api(`/api/projects/${projectId}/portfolio`),
+                api('/api/account/me')
+            ]);
+            Object.assign(state, { project, requirement, versions, snapshots, portfolio, account });
+            state.selectedVersion = requirement.currentVersion || versions[0] || null;
+            renderAll();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function renderAll() {
+        const requirement = state.requirement;
+        document.getElementById('portfolioBack').href = `/projects?lang=${locale}`;
+        document.getElementById('matrixLink').href = `/projects/${projectId}/matrices?lang=${locale}`;
+        document.getElementById('requirementKey').textContent = requirement.requirementKey;
+        document.getElementById('requirementStatus').textContent = humanize(requirement.status);
+        document.getElementById('requirementReview').textContent = humanize(requirement.reviewStatus);
+        document.getElementById('requirementHeading').textContent = requirement.title;
+        document.getElementById('requirementMeta').textContent = [
+            state.project.projectKey + ' — ' + state.project.title,
+            humanize(requirement.requirementType),
+            humanize(requirement.criticality),
+            requirement.ownerUsername || '—'
+        ].join(' · ');
+        renderCurrentText();
+        renderVersions();
+        renderSnapshots();
+        renderTasks();
+        renderSolutions();
+        applyCapabilities();
+    }
+
+    function renderCurrentText() {
+        const version = state.requirement.currentVersion;
+        document.getElementById('currentText').textContent = version ? version.text : '—';
+        document.getElementById('versionText').value = version ? version.text : '';
+        const source = version && version.source;
+        const metadata = document.getElementById('sourceMetadata');
+        metadata.textContent = '';
+        if (!source) {
+            document.getElementById('sourceText').textContent = t('noSource');
+            return;
+        }
+        addDefinition(metadata, t('sourceArtifact'), source.sourceArtifactId || '—');
+        addDefinition(metadata, t('section'), source.sectionReference || '—');
+        addDefinition(metadata, t('page'), source.pageNumber || '—');
+        document.getElementById('sourceText').textContent = source.originalText || t('noSource');
+        document.getElementById('sourceSection').value = source.sectionReference || '';
+        document.getElementById('sourcePage').value = source.pageNumber || '';
+        document.getElementById('sourceOriginal').value = source.originalText || '';
+    }
+
+    function renderVersions() {
+        const list = document.getElementById('versionList');
+        list.textContent = '';
+        if (!state.versions.length) return renderEmpty(list, t('noVersions'));
+        state.versions.forEach(version => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'list-group-item list-group-item-action';
+            button.dataset.versionId = version.id;
+            button.innerHTML = `<div class="d-flex justify-content-between gap-2"><strong>v${version.versionNumber}</strong>`
+                + `<span class="small">${escapeHtml(formatDate(version.createdAt))}</span></div>`
+                + `<div class="small text-body-secondary">${escapeHtml(version.changeReason || '—')}</div>`;
+            list.appendChild(button);
+        });
+        renderVersionDetail(state.selectedVersion);
+    }
+
+    function selectVersion(id) {
+        state.selectedVersion = state.versions.find(version => version.id === id) || null;
+        renderVersionDetail(state.selectedVersion);
+    }
+
+    function renderVersionDetail(version) {
+        const target = document.getElementById('versionDetail');
+        if (!version) return renderEmpty(target, t('noVersions'));
+        const index = state.versions.findIndex(candidate => candidate.id === version.id);
+        const previous = index >= 0 ? state.versions[index + 1] : null;
+        target.innerHTML = `<div class="d-flex justify-content-between gap-2"><h2 class="h5">v${version.versionNumber}</h2>`
+            + `<code>${escapeHtml(String(version.contentHash || '').slice(0, 16))}</code></div>`
+            + `<dl class="portfolio-card-meta"><dt>${escapeHtml(t('author'))}</dt><dd>${escapeHtml(version.createdBy || '—')}</dd>`
+            + `<dt>${escapeHtml(t('created'))}</dt><dd>${escapeHtml(formatDate(version.createdAt))}</dd>`
+            + `<dt>${escapeHtml(t('changeReason'))}</dt><dd>${escapeHtml(version.changeReason || '—')}</dd></dl>`
+            + `<pre class="border rounded p-3 bg-body-tertiary text-wrap mt-3">${escapeHtml(version.text)}</pre>`
+            + (previous ? `<details class="mt-3"><summary>${escapeHtml(t('comparePrevious'))}</summary>`
+                + `<div class="mt-2">${renderTextDiff(previous.text, version.text)}</div></details>` : '');
+    }
+
+    function renderTextDiff(older, newer) {
+        const oldLines = new Set(String(older || '').split(/\r?\n/));
+        const newLines = new Set(String(newer || '').split(/\r?\n/));
+        const rows = [];
+        oldLines.forEach(line => { if (!newLines.has(line)) rows.push(`<div class="text-danger">− ${escapeHtml(line)}</div>`); });
+        newLines.forEach(line => rows.push(oldLines.has(line)
+            ? `<div class="text-body-secondary">  ${escapeHtml(line)}</div>`
+            : `<div class="text-success">+ ${escapeHtml(line)}</div>`));
+        return `<div class="font-monospace small">${rows.join('')}</div>`;
+    }
+
+    function renderSnapshots() {
+        const list = document.getElementById('snapshotList');
+        list.textContent = '';
+        if (!state.snapshots.length) {
+            renderEmpty(list, t('noSnapshots'));
+            renderEmpty(document.getElementById('snapshotDetail'), t('noSnapshots'));
+            return;
+        }
+        state.snapshots.forEach(snapshot => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'list-group-item list-group-item-action';
+            button.dataset.snapshotId = snapshot.id;
+            button.innerHTML = `<div class="d-flex justify-content-between gap-2"><strong>v${snapshot.requirementVersionNumber}</strong>`
+                + `<span class="badge ${statusClass(snapshot.status)}">${escapeHtml(humanize(snapshot.status))}</span></div>`
+                + `<div class="small">${escapeHtml(formatDate(snapshot.createdAt))}</div>`;
+            list.appendChild(button);
+        });
+    }
+
+    async function selectSnapshot(id) {
+        setBusy(true);
+        try {
+            state.selectedSnapshot = state.snapshots.find(snapshot => snapshot.id === id) || null;
+            state.snapshotDetail = await api(`/api/projects/${projectId}/snapshots/${encodeURIComponent(id)}`);
+            const url = new URL(window.location.href);
+            url.searchParams.set('snapshot', id);
+            url.searchParams.set('lang', locale);
+            history.replaceState(null, '', url);
+            renderSnapshotDetail();
+            renderArchitecture();
+            renderDecisions();
+            renderTasks();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function renderSnapshotDetail() {
+        const target = document.getElementById('snapshotDetail');
+        const detail = state.snapshotDetail;
+        if (!detail) return renderEmpty(target, t('noSnapshots'));
+        const summary = detail.summary;
+        target.innerHTML = `<div class="d-flex justify-content-between gap-2"><h2 class="h5">${escapeHtml(t('snapshot'))} v${summary.requirementVersionNumber}</h2>`
+            + `<span class="badge ${statusClass(summary.status)}">${escapeHtml(humanize(summary.status))}</span></div>`
+            + `<dl class="portfolio-card-meta"><dt>${escapeHtml(t('provider'))}</dt><dd>${escapeHtml(summary.provider || '—')}</dd>`
+            + `<dt>${escapeHtml(t('model'))}</dt><dd>${escapeHtml(summary.modelName || '—')}</dd>`
+            + `<dt>${escapeHtml(t('created'))}</dt><dd>${escapeHtml(formatDate(summary.createdAt))}</dd>`
+            + `<dt>${escapeHtml(t('duration'))}</dt><dd>${escapeHtml(String(summary.durationMs))} ms</dd>`
+            + `<dt>${escapeHtml(t('baseline'))}</dt><dd><code>${escapeHtml(String(summary.taxonomyFingerprint || '').slice(0, 16))}</code> / <code>${escapeHtml(String(summary.promptFingerprint || '').slice(0, 16))}</code></dd></dl>`
+            + renderAnalysisSummary(detail);
+    }
+
+    function renderAnalysisSummary(detail) {
+        const warnings = detail.analysis && detail.analysis.warnings || [];
+        const gap = detail.gapAnalysis;
+        const recommendation = detail.recommendation;
+        return (warnings.length ? `<div class="alert alert-warning mt-3"><ul class="mb-0">${warnings.map(w => `<li>${escapeHtml(w)}</li>`).join('')}</ul></div>` : '')
+            + (gap ? `<section class="mt-3"><h3 class="h6">Gap analysis</h3><p>${escapeHtml(gap.summary || gap.description || JSON.stringify(gap))}</p></section>` : '')
+            + (recommendation ? `<section class="mt-3"><h3 class="h6">Recommendation</h3><p>${escapeHtml(recommendation.summary || recommendation.recommendation || JSON.stringify(recommendation))}</p></section>` : '');
+    }
+
+    function renderArchitecture() {
+        const detail = state.snapshotDetail;
+        const mappings = detail && detail.elementMappings || [];
+        const relations = detail && detail.relationMappings || [];
+        const summary = document.getElementById('architectureSummary');
+        summary.innerHTML = `<div class="row row-cols-2 row-cols-md-4 g-2">`
+            + metric(t('node'), mappings.length) + metric(t('relation'), relations.length)
+            + metric(t('review'), mappings.filter(m => m.reviewStatus === 'CONFIRMED').length)
+            + metric(t('open'), mappings.filter(m => m.reviewStatus === 'PROPOSED').length) + '</div>';
+        renderMappings(mappings);
+        renderRelations(relations);
+    }
+
+    function metric(label, value) {
+        return `<div><div class="card h-100"><div class="card-body"><div class="h3">${value}</div><div class="small text-body-secondary">${escapeHtml(label)}</div></div></div></div>`;
+    }
+
+    function renderMappings(mappings) {
+        const target = document.getElementById('mappingTable');
+        if (!mappings.length) return renderEmpty(target, t('noMappings'));
+        target.innerHTML = `<table class="table table-sm align-middle"><caption>${escapeHtml(t('architecture'))}</caption>`
+            + `<thead><tr><th>${escapeHtml(t('node'))}</th><th>${escapeHtml(t('score'))}</th><th>${escapeHtml(t('relevance'))}</th>`
+            + `<th>${escapeHtml(t('confidence'))}</th><th>${escapeHtml(t('origin'))}</th><th>${escapeHtml(t('review'))}</th><th>${escapeHtml(t('action'))}</th></tr></thead>`
+            + `<tbody>${mappings.map(mapping => `<tr><td><code>${escapeHtml(mapping.nodeCode)}</code><div class="small">${escapeHtml(mapping.nodeTitle || '')}</div><div class="small text-body-secondary">${escapeHtml(mapping.hierarchyPath || '')}</div></td>`
+                + `<td>${mapping.directScore}%</td><td>${Math.round(mapping.relevance * 100)}%</td><td>${Math.round(mapping.confidence * 100)}%</td>`
+                + `<td>${escapeHtml(humanize(mapping.mappingOrigin))}</td><td>${escapeHtml(humanize(mapping.reviewStatus))}</td><td>${escapeHtml(humanize(mapping.actionStatus))}</td></tr>`).join('')}</tbody></table>`;
+    }
+
+    function renderRelations(relations) {
+        const target = document.getElementById('relationTable');
+        if (!relations.length) return renderEmpty(target, t('noRelations'));
+        target.innerHTML = `<table class="table table-sm align-middle"><caption>${escapeHtml(t('relation'))}</caption>`
+            + `<thead><tr><th>${escapeHtml(t('relation'))}</th><th>${escapeHtml(t('relevance'))}</th><th>${escapeHtml(t('confidence'))}</th><th>${escapeHtml(t('review'))}</th></tr></thead>`
+            + `<tbody>${relations.map(relation => `<tr><td><code>${escapeHtml(relation.sourceCode)}</code> → <code>${escapeHtml(relation.targetCode)}</code><div class="small">${escapeHtml(relation.relationType)}</div></td>`
+                + `<td>${Math.round(relation.relevance * 100)}%</td><td>${Math.round(relation.confidence * 100)}%</td><td>${escapeHtml(humanize(relation.reviewStatus))}</td></tr>`).join('')}</tbody></table>`;
+    }
+
+    function renderDecisions() {
+        const target = document.getElementById('decisionList');
+        target.textContent = '';
+        const mappings = state.snapshotDetail && state.snapshotDetail.elementMappings || [];
+        if (!mappings.length) return renderEmpty(target, t('noMappings'));
+        mappings.forEach(mapping => {
+            const card = document.createElement('article');
+            card.className = 'card';
+            card.innerHTML = `<div class="card-body"><div class="d-flex justify-content-between gap-2"><div><code>${escapeHtml(mapping.nodeCode)}</code> · <strong>${escapeHtml(mapping.nodeTitle || '')}</strong></div>`
+                + `<span class="badge ${mapping.reviewStatus === 'CONFIRMED' ? 'text-bg-success' : 'text-bg-warning'}">${escapeHtml(humanize(mapping.reviewStatus))}</span></div>`
+                + `<dl class="portfolio-card-meta mt-2"><dt>${escapeHtml(t('action'))}</dt><dd>${escapeHtml(humanize(mapping.actionStatus))}</dd>`
+                + `<dt>${escapeHtml(t('evidence'))}</dt><dd>${escapeHtml(mapping.actionEvidence || '—')}</dd>`
+                + `<dt>${escapeHtml(t('author'))}</dt><dd>${escapeHtml(mapping.decisionBy || '—')}</dd>`
+                + `<dt>${escapeHtml(t('created'))}</dt><dd>${escapeHtml(formatDate(mapping.decisionAt))}</dd></dl></div>`;
+            target.appendChild(card);
+        });
+    }
+
+    function renderSolutions() {
+        const target = document.getElementById('solutionList');
+        target.textContent = '';
+        const solutions = (state.portfolio && state.portfolio.solutions || []).filter(projectSolution =>
+            (projectSolution.requirements || []).some(link => link.requirementId === requirementId));
+        if (!solutions.length) return renderEmpty(target, t('noSolutions'));
+        solutions.forEach(projectSolution => {
+            const link = projectSolution.requirements.find(item => item.requirementId === requirementId);
+            const column = document.createElement('div');
+            column.className = 'col-12 col-xl-6';
+            column.innerHTML = `<article class="card h-100"><div class="card-header d-flex justify-content-between gap-2"><strong>${escapeHtml(projectSolution.solution.title)}</strong>`
+                + `<span class="badge ${projectSolution.status === 'SELECTED' ? 'text-bg-success' : 'text-bg-secondary'}">${escapeHtml(humanize(projectSolution.status))}</span></div>`
+                + `<div class="card-body"><p>${escapeHtml(projectSolution.solution.description || '')}</p>`
+                + `<dl class="portfolio-card-meta"><dt>${escapeHtml(t('coverage'))}</dt><dd>${link.coveragePercent}%</dd>`
+                + `<dt>${escapeHtml(t('review'))}</dt><dd>${escapeHtml(humanize(link.reviewStatus))}</dd>`
+                + `<dt>${escapeHtml(t('evidence'))}</dt><dd>${escapeHtml(link.evidence || '—')}</dd></dl>`
+                + `<h3 class="h6 mt-3">${escapeHtml(t('productCandidates'))}</h3>`
+                + `<ul class="list-group list-group-flush border rounded">${(projectSolution.productCandidates || []).map(candidate => `<li class="list-group-item"><strong>${escapeHtml(candidate.product.manufacturer + ' ' + candidate.product.productName)}</strong>`
+                    + `<div class="small">${candidate.coveragePercent}% · ${escapeHtml(humanize(candidate.selectionStatus))}</div>`
+                    + `<div class="small text-body-secondary">${escapeHtml(candidate.product.sourceReference)}</div></li>`).join('') || '<li class="list-group-item">—</li>'}</ul></div></article>`;
+            target.appendChild(column);
+        });
+    }
+
+    function renderTasks() {
+        const target = document.getElementById('taskList');
+        target.textContent = '';
+        const tasks = [];
+        if (!state.requirement.currentAnalysisSnapshotId) tasks.push(t('stale'));
+        const mappings = state.snapshotDetail && state.snapshotDetail.elementMappings || [];
+        if (mappings.some(mapping => mapping.reviewStatus !== 'CONFIRMED')) tasks.push(t('unreviewed'));
+        const links = (state.portfolio && state.portfolio.solutions || []).flatMap(solution => solution.requirements || [])
+            .filter(link => link.requirementId === requirementId && link.reviewStatus === 'CONFIRMED');
+        if (!links.length) tasks.push(t('noConfirmedSolution'));
+        if (!(state.requirement.currentVersion && state.requirement.currentVersion.source)) tasks.push(t('sourceMissing'));
+        if (!tasks.length) tasks.push(t('allClear'));
+        tasks.forEach(task => {
+            const item = document.createElement('div');
+            item.className = 'list-group-item';
+            item.textContent = task;
+            target.appendChild(item);
+        });
+    }
+
+    async function createVersion(event) {
+        event.preventDefault();
+        setBusy(true);
+        try {
+            const sourcePage = document.getElementById('sourcePage').value;
+            await api(`/api/projects/${projectId}/requirements/${requirementId}/versions`, {
+                method: 'POST',
+                body: {
+                    text: document.getElementById('versionText').value,
+                    changeReason: document.getElementById('changeReason').value,
+                    source: {
+                        sourceArtifactId: state.requirement.currentVersion?.source?.sourceArtifactId || null,
+                        sourceVersionId: state.requirement.currentVersion?.source?.sourceVersionId || null,
+                        sourceFragmentIds: state.requirement.currentVersion?.source?.sourceFragmentIds || [],
+                        sectionReference: document.getElementById('sourceSection').value || null,
+                        pageNumber: sourcePage ? Number(sourcePage) : null,
+                        originalText: document.getElementById('sourceOriginal').value || null
+                    }
+                }
+            });
+            bootstrap.Modal.getOrCreateInstance(document.getElementById('newVersionModal')).hide();
+            showInfo(t('versionCreated'));
+            await loadAll();
+        } catch (error) {
+            showError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function analyzeRequirement() {
+        setBusy(true);
+        try {
+            const response = await api(`/api/projects/${projectId}/requirements/${requirementId}/analyses`, {
+                method: 'POST',
+                returnResponse: true,
+                body: { provider: null, maxArchitectureNodes: 25,
+                    idempotencyKey: `detail:${requirementId}:${Date.now()}` }
+            });
+            showInfo(t('analysisQueued'));
+            const location = response.headers.get('Location');
+            if (location) pollAnalysis(new URL(location, window.location.href).toString());
+        } catch (error) {
+            showError(error);
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    async function pollAnalysis(url) {
+        for (;;) {
+            await new Promise(resolve => setTimeout(resolve, 1500));
+            try {
+                const job = await api(url);
+                document.getElementById('requirementLive').textContent = humanize(job.status);
+                if (['SUCCESS', 'PARTIAL', 'FAILED', 'CANCELLED'].includes(job.status)) {
+                    await loadAll();
+                    if (job.items && job.items[0] && job.items[0].snapshotId) {
+                        await selectSnapshot(job.items[0].snapshotId);
+                    }
+                    return;
+                }
+            } catch (error) {
+                showError(error);
+                return;
+            }
+        }
+    }
+
+    function applyCapabilities() {
+        if (state.account && state.account.architectureMutationAllowed) return;
+        const versionButton = document.getElementById('newVersionButton');
+        versionButton.disabled = true;
+        versionButton.title = t('permission');
+    }
+
+    async function api(path, options) {
+        const config = Object.assign({ method: 'GET', headers: {} }, options || {});
+        const returnResponse = config.returnResponse;
+        delete config.returnResponse;
+        config.headers.Accept = 'application/json';
+        if (config.body !== undefined && typeof config.body !== 'string') {
+            config.headers['Content-Type'] = 'application/json';
+            config.body = JSON.stringify(config.body);
+        }
+        if (!['GET', 'HEAD', 'OPTIONS'].includes(String(config.method).toUpperCase())) {
+            const token = document.querySelector('meta[name="_csrf"]')?.content;
+            const header = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+            if (token) config.headers[header] = token;
+        }
+        const response = await fetch(path, config);
+        if (!response.ok) {
+            const payload = await response.json().catch(() => null);
+            throw new Error(payload?.detail || payload?.message || payload?.error || `${t('failed')} HTTP ${response.status}`);
+        }
+        if (returnResponse) return response;
+        if (response.status === 204) return null;
+        return response.json();
+    }
+
+    function addDefinition(target, term, value) {
+        const dt = document.createElement('dt'); dt.textContent = term;
+        const dd = document.createElement('dd'); dd.textContent = value;
+        target.append(dt, dd);
+    }
+
+    function renderEmpty(target, message) {
+        target.textContent = '';
+        const paragraph = document.createElement('p');
+        paragraph.className = 'text-body-secondary mb-0 p-3';
+        paragraph.textContent = message;
+        target.appendChild(paragraph);
+    }
+
+    function setBusy(active) {
+        state.busy += active ? 1 : -1;
+        state.busy = Math.max(0, state.busy);
+        document.getElementById('detailBusy').classList.toggle('d-none', state.busy === 0);
+    }
+
+    function showError(error) {
+        const target = document.getElementById('detailError');
+        target.textContent = error?.message || t('failed');
+        target.classList.remove('d-none');
+        target.focus();
+    }
+
+    function showInfo(message) {
+        const target = document.getElementById('detailInfo');
+        target.textContent = message;
+        target.classList.remove('d-none');
+        document.getElementById('requirementLive').textContent = message;
+    }
+
+    function humanize(value) {
+        return String(value || '—').toLowerCase().replaceAll('_', ' ')
+            .replace(/\b\w/g, character => character.toUpperCase());
+    }
+
+    function statusClass(status) {
+        if (['SUCCESS', 'CONFIRMED', 'ACTIVE', 'SELECTED'].includes(status)) return 'text-bg-success';
+        if (['FAILED', 'REJECTED', 'CANCELLED'].includes(status)) return 'text-bg-danger';
+        if (['PARTIAL', 'PROPOSED', 'DRAFT', 'PENDING'].includes(status)) return 'text-bg-warning';
+        return 'text-bg-secondary';
+    }
+
+    function formatDate(value) {
+        if (!value) return '—';
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString(locale);
+    }
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;').replaceAll("'", '&#39;');
+    }
+})();

--- a/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
+++ b/taxonomy-app/src/main/resources/static/js/portfolio/taxonomy-portfolio-async.js
@@ -1,44 +1,909 @@
 /*
- * Keeps the portfolio UI compatible with the asynchronous analysis API.
- * POST requests return 202 immediately; this page-local fetch adapter polls the
- * persisted job resource and resolves the existing UI call with its terminal view.
+ * Non-blocking portfolio analysis jobs and cross-cutting GUI ergonomics.
+ *
+ * This adapter deliberately runs before taxonomy-portfolio.js. It keeps the
+ * existing public REST contracts, but no longer blocks the entire page until a
+ * queued analysis completes. It also adds capability-aware controls, accessible
+ * job progress, guided evidence capture and translation of legacy hard-coded UI
+ * fragments while the portfolio is incrementally decomposed into components.
  */
 (function () {
     'use strict';
 
     const originalFetch = window.fetch.bind(window);
     const terminalStatuses = new Set(['SUCCESS', 'PARTIAL', 'FAILED', 'CANCELLED']);
-    const pollIntervalMs = 400;
-    const pollTimeoutMs = 10 * 60 * 1000;
+    const pollIntervalMs = 1500;
+    const storageKey = 'taxonomy.portfolio.analysisJobs.v2';
+    const maximumHistory = 20;
+    const maximumRenderedItems = 100;
+    const jobs = new Map();
+    let account = null;
+    let locale = 'en';
+    let dialogResolve = null;
 
-    window.fetch = async function portfolioAwareFetch(input, init) {
-        const response = await originalFetch(input, init);
-        const method = String((init && init.method)
-            || (input instanceof Request ? input.method : 'GET')).toUpperCase();
-        const requestUrl = resolveUrl(input);
-        if (method !== 'POST' || response.status !== 202 || !isAnalysisSubmission(requestUrl)) {
-            return response;
+    const messages = {
+        en: {
+            jobsTitle: 'Analysis jobs',
+            jobsHelp: 'Analyses continue in the background. You can keep working and return after a reload.',
+            jobsEmpty: 'No analysis jobs have been started in this browser.',
+            filterAll: 'All statuses',
+            retryFailed: 'Retry failed items',
+            openDetails: 'Show details',
+            hideDetails: 'Hide details',
+            analysisStarted: 'Analysis job started. Progress is available below.',
+            jobCompleted: 'Analysis job completed.',
+            jobPartial: 'Analysis job completed with partial results.',
+            jobFailed: 'Analysis job failed. Review the affected requirements below.',
+            queued: 'Queued',
+            running: 'Running',
+            successful: 'Successful',
+            partial: 'Partial',
+            failed: 'Failed',
+            cancelled: 'Cancelled',
+            requirement: 'Requirement',
+            status: 'Status',
+            attempts: 'Attempts',
+            result: 'Result',
+            moreItems: 'More items are available through the job resource.',
+            permissionDenied: 'Your role can view this information but cannot change it.',
+            evidenceTitle: 'Document review decision',
+            evidence: 'Evidence or rationale',
+            comment: 'Comment',
+            evidenceHelp: 'Record what you actually verified. The application does not invent human evidence.',
+            save: 'Save decision',
+            cancel: 'Cancel',
+            resolutionTitle: 'Resolve conflict',
+            resolutionNote: 'Resolution note',
+            evidenceRequired: 'Evidence is required for a confirmed decision.',
+            requestFailed: 'The operation failed.',
+            projectsNavigation: 'Projects',
+            language: 'Language',
+            close: 'Close',
+            skip: 'Skip to project portfolio',
+            title: 'Project, requirement, solution and product portfolio',
+            unknownError: 'No additional error information is available.'
+        },
+        de: {
+            jobsTitle: 'Analysejobs',
+            jobsHelp: 'Analysen laufen im Hintergrund weiter. Sie können weiterarbeiten und nach einem Neuladen zurückkehren.',
+            jobsEmpty: 'In diesem Browser wurde noch kein Analysejob gestartet.',
+            filterAll: 'Alle Status',
+            retryFailed: 'Fehlgeschlagene Einträge wiederholen',
+            openDetails: 'Details anzeigen',
+            hideDetails: 'Details ausblenden',
+            analysisStarted: 'Analysejob wurde gestartet. Der Fortschritt wird unten angezeigt.',
+            jobCompleted: 'Analysejob wurde abgeschlossen.',
+            jobPartial: 'Analysejob wurde mit Teilergebnissen abgeschlossen.',
+            jobFailed: 'Analysejob ist fehlgeschlagen. Prüfen Sie unten die betroffenen Anforderungen.',
+            queued: 'Wartend',
+            running: 'Laufend',
+            successful: 'Erfolgreich',
+            partial: 'Teilweise',
+            failed: 'Fehlgeschlagen',
+            cancelled: 'Abgebrochen',
+            requirement: 'Anforderung',
+            status: 'Status',
+            attempts: 'Versuche',
+            result: 'Ergebnis',
+            moreItems: 'Weitere Einträge sind über die Jobressource verfügbar.',
+            permissionDenied: 'Ihre Rolle darf diese Information sehen, aber nicht verändern.',
+            evidenceTitle: 'Prüfentscheidung dokumentieren',
+            evidence: 'Evidenz oder Begründung',
+            comment: 'Kommentar',
+            evidenceHelp: 'Dokumentieren Sie, was Sie tatsächlich geprüft haben. Die Anwendung erfindet keine menschliche Evidenz.',
+            save: 'Entscheidung speichern',
+            cancel: 'Abbrechen',
+            resolutionTitle: 'Konflikt lösen',
+            resolutionNote: 'Lösungsnotiz',
+            evidenceRequired: 'Für eine bestätigte Entscheidung ist eine Evidenz erforderlich.',
+            requestFailed: 'Die Operation ist fehlgeschlagen.',
+            projectsNavigation: 'Projekte',
+            language: 'Sprache',
+            close: 'Schließen',
+            skip: 'Zum Projektportfolio springen',
+            title: 'Projekt-, Anforderungs-, Lösungs- und Produktportfolio',
+            unknownError: 'Es sind keine weiteren Fehlerinformationen verfügbar.'
         }
-
-        const initialJob = await response.clone().json().catch(function () { return null; });
-        const location = response.headers.get('Location');
-        if (!initialJob || !initialJob.id || !location || terminalStatuses.has(initialJob.status)) {
-            return response;
-        }
-
-        const completedJob = await pollJob(location, init && init.signal);
-        const headers = new Headers(response.headers);
-        headers.set('Content-Type', 'application/json');
-        return new Response(JSON.stringify(completedJob), {
-            status: 200,
-            statusText: 'OK',
-            headers: headers
-        });
     };
 
-    function resolveUrl(input) {
-        const value = input instanceof Request ? input.url : String(input);
-        return new URL(value, window.location.href);
+    restoreJobs();
+    installFetchAdapter();
+    installGuidedReviewHandlers();
+    document.addEventListener('DOMContentLoaded', initializeEnhancements);
+
+    function m(key) {
+        return (messages[locale] && messages[locale][key]) || messages.en[key] || key;
+    }
+
+    function installFetchAdapter() {
+        window.fetch = async function portfolioAwareFetch(input, init) {
+            const requestUrl = resolveUrl(input);
+            const method = String((init && init.method)
+                || (input instanceof Request ? input.method : 'GET')).toUpperCase();
+            const sanitizedInit = sanitizeRequest(requestUrl, init);
+            const response = await originalFetch(input, sanitizedInit);
+
+            if (method !== 'POST' || response.status !== 202 || !isAnalysisSubmission(requestUrl)) {
+                return response;
+            }
+
+            const initialJob = await response.clone().json().catch(function () { return null; });
+            const location = response.headers.get('Location');
+            if (!initialJob || !initialJob.id || !location) {
+                return response;
+            }
+
+            const jobUrl = new URL(location, window.location.href).toString();
+            registerJob(jobUrl, initialJob);
+            queueMicrotask(function () {
+                announce(m('analysisStarted'));
+                replacePrematureCompletionMessage();
+            });
+
+            // Existing page code expects a parsed JSON response and refreshes the
+            // portfolio immediately. Return the accepted job without waiting; the
+            // browser network contract remains the original HTTP 202.
+            const headers = new Headers(response.headers);
+            headers.set('Content-Type', 'application/json');
+            return new Response(JSON.stringify(initialJob), {
+                status: 200,
+                statusText: 'Accepted for background processing',
+                headers: headers
+            });
+        };
+    }
+
+    function sanitizeRequest(url, init) {
+        if (!init || typeof init.body !== 'string'
+                || !String(init.headers && (init.headers['Content-Type']
+                    || init.headers.get && init.headers.get('Content-Type')) || '')
+                    .toLowerCase().includes('application/json')) {
+            return init;
+        }
+        let payload;
+        try {
+            payload = JSON.parse(init.body);
+        } catch (error) {
+            return init;
+        }
+        let changed = false;
+        const fakeEvidence = new Set([
+            'Reviewed in the project portfolio workspace',
+            'Confirmed in the project portfolio workspace',
+            'Recorded in the project portfolio workspace'
+        ]);
+        if (fakeEvidence.has(payload.actionEvidence)) {
+            payload.actionEvidence = null;
+            changed = true;
+        }
+        if (fakeEvidence.has(payload.evidence)) {
+            payload.evidence = null;
+            changed = true;
+        }
+        if (payload.comment === 'Human review completed') {
+            payload.comment = null;
+            changed = true;
+        }
+        if (payload.openEvidence === 'Human review required') {
+            payload.openEvidence = null;
+            changed = true;
+        }
+        if (!changed) return init;
+        return Object.assign({}, init, { body: JSON.stringify(payload) });
+    }
+
+    function initializeEnhancements() {
+        locale = resolveLocale();
+        translateStaticSurface();
+        normalizeProjectNavigation();
+        ensureDecisionDialog();
+        ensureJobCenter();
+        loadAccountCapabilities();
+        renderJobs();
+        pollActiveJobs();
+
+        const observer = new MutationObserver(function () {
+            translateLegacyFragments(document.body);
+            normalizeProjectNavigation();
+            applyCapabilities();
+            replacePrematureCompletionMessage();
+        });
+        observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    }
+
+    function resolveLocale() {
+        const requested = new URLSearchParams(window.location.search).get('lang');
+        const language = requested || document.documentElement.lang || navigator.language || 'en';
+        return String(language).toLowerCase().startsWith('de') ? 'de' : 'en';
+    }
+
+    function translateStaticSurface() {
+        document.title = m('title') + ' — Taxonomy';
+        const skip = document.querySelector('.skip-link');
+        if (skip) skip.textContent = m('skip');
+        const projectList = document.getElementById('projectList');
+        if (projectList) projectList.setAttribute('aria-label', m('projectsNavigation'));
+        document.querySelectorAll('[aria-label="Language"]').forEach(function (element) {
+            element.setAttribute('aria-label', m('language'));
+        });
+        document.querySelectorAll('.btn-close').forEach(function (button) {
+            button.setAttribute('aria-label', m('close'));
+        });
+        translateLegacyFragments(document.body);
+    }
+
+    function translateLegacyFragments(root) {
+        if (locale !== 'de' || !root) return;
+        const replacements = new Map([
+            ['Snapshot diff', 'Snapshot-Vergleich'],
+            ['Added elements', 'Hinzugekommene Elemente'],
+            ['Removed elements', 'Entfallene Elemente'],
+            ['Score changes', 'Score-Änderungen'],
+            ['Taxonomy changed:', 'Taxonomie geändert:'],
+            ['Prompts changed:', 'Prompts geändert:'],
+            ['Provider changed:', 'Provider geändert:'],
+            ['Node', 'Knoten'],
+            ['Proposed', 'Vorgeschlagen'],
+            ['Confirmed', 'Bestätigt'],
+            ['Functional', 'Funktional'],
+            ['Non-functional', 'Nichtfunktional'],
+            ['Organizational', 'Organisatorisch'],
+            ['Technical', 'Technisch'],
+            ['Legal', 'Rechtlich'],
+            ['Process', 'Prozess'],
+            ['Security', 'Sicherheit'],
+            ['Data', 'Daten'],
+            ['Other', 'Sonstige'],
+            ['Unspecified', 'Nicht festgelegt'],
+            ['On premises', 'On-Premises'],
+            ['Private cloud', 'Private Cloud'],
+            ['Public cloud', 'Public Cloud']
+        ]);
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        const nodes = [];
+        while (walker.nextNode()) nodes.push(walker.currentNode);
+        nodes.forEach(function (node) {
+            const trimmed = node.nodeValue.trim();
+            if (replacements.has(trimmed)) {
+                node.nodeValue = node.nodeValue.replace(trimmed, replacements.get(trimmed));
+            }
+        });
+    }
+
+    function normalizeProjectNavigation() {
+        const projectList = document.getElementById('projectList');
+        if (!projectList) return;
+        projectList.removeAttribute('role');
+        projectList.setAttribute('aria-label', m('projectsNavigation'));
+        projectList.querySelectorAll('.project-select').forEach(function (button) {
+            button.removeAttribute('role');
+            button.removeAttribute('aria-selected');
+            if (button.classList.contains('active')) button.setAttribute('aria-current', 'page');
+            else button.removeAttribute('aria-current');
+        });
+    }
+
+    async function loadAccountCapabilities() {
+        try {
+            const response = await originalFetch('/api/account/me', {
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+                cache: 'no-store'
+            });
+            account = response.ok ? await response.json() : null;
+        } catch (error) {
+            account = null;
+        }
+        applyCapabilities();
+    }
+
+    function applyCapabilities() {
+        if (!account || account.architectureMutationAllowed) return;
+        const selectors = [
+            '[data-bs-target="#projectModal"]',
+            '[data-bs-target="#requirementModal"]',
+            '[data-bs-target="#solutionModal"]',
+            '[data-bs-target="#productModal"]',
+            '#proposeSolutionsBtn', '#detectConflictsBtn',
+            '.requirement-confirm', '.mapping-review', '.save-solution-action',
+            '.confirm-requirement-link', '.add-solution-coverage',
+            '.add-product-candidate', '.product-candidate-review',
+            '.add-product-coverage', '.conflict-review'
+        ];
+        document.querySelectorAll(selectors.join(',')).forEach(function (control) {
+            control.disabled = true;
+            control.setAttribute('aria-disabled', 'true');
+            control.setAttribute('title', m('permissionDenied'));
+        });
+    }
+
+    function ensureJobCenter() {
+        if (document.getElementById('portfolioJobCenter')) return;
+        const metrics = document.querySelector('[aria-labelledby="portfolioMetricsHeading"]');
+        if (!metrics) return;
+        const section = document.createElement('section');
+        section.id = 'portfolioJobCenter';
+        section.className = 'card shadow-sm mb-3 portfolio-job-center';
+        section.setAttribute('aria-labelledby', 'portfolioJobCenterTitle');
+        section.innerHTML = '<div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">'
+            + '<div><h2 id="portfolioJobCenterTitle" class="h5 mb-1"></h2>'
+            + '<p id="portfolioJobCenterHelp" class="small text-body-secondary mb-0"></p></div>'
+            + '<select id="portfolioJobFilter" class="form-select form-select-sm w-auto" '
+            + 'aria-label="Job status filter"></select></div>'
+            + '<div id="portfolioJobSummary" class="card-body border-bottom"></div>'
+            + '<div id="portfolioJobList" class="list-group list-group-flush"></div>';
+        metrics.insertAdjacentElement('afterend', section);
+        document.getElementById('portfolioJobCenterTitle').textContent = m('jobsTitle');
+        document.getElementById('portfolioJobCenterHelp').textContent = m('jobsHelp');
+        const filter = document.getElementById('portfolioJobFilter');
+        const options = [
+            ['', m('filterAll')], ['PENDING', statusLabel('PENDING')],
+            ['RUNNING', statusLabel('RUNNING')], ['SUCCESS', statusLabel('SUCCESS')],
+            ['PARTIAL', statusLabel('PARTIAL')], ['FAILED', statusLabel('FAILED')],
+            ['CANCELLED', statusLabel('CANCELLED')]
+        ];
+        options.forEach(function (option) {
+            const element = document.createElement('option');
+            element.value = option[0];
+            element.textContent = option[1];
+            filter.appendChild(element);
+        });
+        filter.addEventListener('change', renderJobs);
+        document.getElementById('portfolioJobList').addEventListener('click', onJobAction);
+    }
+
+    function registerJob(url, job) {
+        const projectMatch = new URL(url).pathname.match(/^\/api\/projects\/(\d+)\/analysis-jobs\//);
+        const existing = jobs.get(url) || {};
+        jobs.set(url, {
+            url: url,
+            projectId: projectMatch ? Number(projectMatch[1]) : existing.projectId || null,
+            createdAt: existing.createdAt || Date.now(),
+            updatedAt: Date.now(),
+            expanded: existing.expanded || false,
+            job: job
+        });
+        trimHistory();
+        persistJobs();
+        renderJobs();
+        if (!terminalStatuses.has(job.status)) schedulePoll(url);
+    }
+
+    function restoreJobs() {
+        try {
+            const stored = JSON.parse(window.localStorage.getItem(storageKey) || '[]');
+            if (!Array.isArray(stored)) return;
+            stored.forEach(function (entry) {
+                if (entry && entry.url && entry.job) jobs.set(entry.url, entry);
+            });
+        } catch (error) {
+            window.localStorage.removeItem(storageKey);
+        }
+    }
+
+    function persistJobs() {
+        try {
+            window.localStorage.setItem(storageKey, JSON.stringify(Array.from(jobs.values())));
+        } catch (error) {
+            // Storage availability must not prevent analysis.
+        }
+    }
+
+    function trimHistory() {
+        const ordered = Array.from(jobs.values()).sort(function (left, right) {
+            return right.updatedAt - left.updatedAt;
+        });
+        ordered.slice(maximumHistory).forEach(function (entry) { jobs.delete(entry.url); });
+    }
+
+    function pollActiveJobs() {
+        jobs.forEach(function (entry, url) {
+            if (!terminalStatuses.has(entry.job.status)) schedulePoll(url, 50);
+        });
+    }
+
+    function schedulePoll(url, delay) {
+        const entry = jobs.get(url);
+        if (!entry || entry.pollScheduled || terminalStatuses.has(entry.job.status)) return;
+        entry.pollScheduled = true;
+        window.setTimeout(async function () {
+            const current = jobs.get(url);
+            if (!current) return;
+            current.pollScheduled = false;
+            try {
+                const response = await originalFetch(url, {
+                    method: 'GET',
+                    headers: { Accept: 'application/json' },
+                    credentials: 'same-origin',
+                    cache: 'no-store'
+                });
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const previousStatus = current.job.status;
+                current.job = await response.json();
+                current.updatedAt = Date.now();
+                persistJobs();
+                renderJobs();
+                if (terminalStatuses.has(current.job.status)) {
+                    announceTerminal(current.job);
+                    refreshCurrentProject(current.projectId);
+                } else {
+                    schedulePoll(url);
+                }
+                if (previousStatus !== current.job.status) announce(statusLabel(current.job.status));
+            } catch (error) {
+                current.lastPollError = String(error && error.message || error);
+                current.updatedAt = Date.now();
+                persistJobs();
+                renderJobs();
+                schedulePoll(url, Math.min(10000, pollIntervalMs * 3));
+            }
+        }, delay == null ? pollIntervalMs : delay);
+    }
+
+    function renderJobs() {
+        const list = document.getElementById('portfolioJobList');
+        const summary = document.getElementById('portfolioJobSummary');
+        if (!list || !summary) return;
+        const filter = document.getElementById('portfolioJobFilter');
+        const selectedStatus = filter ? filter.value : '';
+        const entries = Array.from(jobs.values())
+            .filter(function (entry) {
+                return !selectedStatus || entry.job.status === selectedStatus;
+            })
+            .sort(function (left, right) { return right.createdAt - left.createdAt; });
+
+        const totals = countStatuses(Array.from(jobs.values()).map(function (entry) { return entry.job; }));
+        summary.innerHTML = statusPills(totals);
+        list.textContent = '';
+        if (entries.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'p-4 text-center text-body-secondary';
+            empty.textContent = m('jobsEmpty');
+            list.appendChild(empty);
+            return;
+        }
+        entries.forEach(function (entry) { list.appendChild(renderJob(entry)); });
+    }
+
+    function renderJob(entry) {
+        const job = entry.job;
+        const wrapper = document.createElement('article');
+        wrapper.className = 'list-group-item portfolio-job';
+        wrapper.dataset.jobUrl = entry.url;
+        const headingId = 'job-' + String(job.id).replace(/[^A-Za-z0-9_-]/g, '-');
+        wrapper.setAttribute('aria-labelledby', headingId);
+        const counts = countItemStatuses(job.items || []);
+        wrapper.innerHTML = '<div class="d-flex flex-wrap justify-content-between align-items-start gap-2">'
+            + '<div><h3 id="' + headingId + '" class="h6 mb-1"><code>'
+            + escapeHtml(String(job.id).slice(0, 12)) + '</code> · '
+            + escapeHtml(statusLabel(job.status)) + '</h3>'
+            + '<div class="small text-body-secondary">'
+            + escapeHtml(formatDate(job.createdAt)) + ' · '
+            + escapeHtml(job.provider || '—') + '</div></div>'
+            + '<div class="d-flex flex-wrap gap-2">'
+            + '<button type="button" class="btn btn-sm btn-outline-secondary job-toggle" '
+            + 'aria-expanded="' + String(Boolean(entry.expanded)) + '">'
+            + escapeHtml(entry.expanded ? m('hideDetails') : m('openDetails')) + '</button>'
+            + (Number(job.failedItems || counts.FAILED || 0) > 0
+                ? '<button type="button" class="btn btn-sm btn-outline-primary job-retry">'
+                    + escapeHtml(m('retryFailed')) + '</button>' : '')
+            + '</div></div>'
+            + '<div class="mt-2">' + statusPills(counts) + '</div>'
+            + '<div class="progress mt-2" role="progressbar" aria-valuemin="0" aria-valuemax="100" '
+            + 'aria-valuenow="' + progressPercent(job) + '" aria-label="'
+            + escapeHtml(m('jobsTitle')) + '"><div class="progress-bar" style="width:'
+            + progressPercent(job) + '%">' + progressPercent(job) + '%</div></div>'
+            + (entry.lastPollError ? '<div class="small text-warning mt-2">'
+                + escapeHtml(entry.lastPollError) + '</div>' : '')
+            + '<div class="job-details mt-3 ' + (entry.expanded ? '' : 'd-none') + '"></div>';
+        if (entry.expanded) renderJobDetails(wrapper.querySelector('.job-details'), job);
+        return wrapper;
+    }
+
+    function renderJobDetails(target, job) {
+        const items = (job.items || []).slice(0, maximumRenderedItems);
+        if (items.length === 0) {
+            target.textContent = '—';
+            return;
+        }
+        const table = document.createElement('div');
+        table.className = 'table-responsive';
+        table.innerHTML = '<table class="table table-sm align-middle mb-0"><caption class="visually-hidden">'
+            + escapeHtml(m('jobsTitle')) + '</caption><thead><tr><th scope="col">'
+            + escapeHtml(m('requirement')) + '</th><th scope="col">'
+            + escapeHtml(m('status')) + '</th><th scope="col">'
+            + escapeHtml(m('attempts')) + '</th><th scope="col">'
+            + escapeHtml(m('result')) + '</th></tr></thead><tbody></tbody></table>';
+        const body = table.querySelector('tbody');
+        items.forEach(function (item) {
+            const row = document.createElement('tr');
+            row.innerHTML = '<td><code>' + escapeHtml(item.requirementKey || String(item.requirementId))
+                + '</code></td><td>' + escapeHtml(statusLabel(item.status)) + '</td><td>'
+                + escapeHtml(String(item.attempt == null ? '—' : item.attempt)) + '</td><td>'
+                + (item.snapshotId ? '<code>' + escapeHtml(String(item.snapshotId).slice(0, 12)) + '</code>'
+                    : escapeHtml(item.errorMessage || '—')) + '</td>';
+            body.appendChild(row);
+        });
+        target.appendChild(table);
+        if ((job.items || []).length > maximumRenderedItems) {
+            const note = document.createElement('p');
+            note.className = 'small text-body-secondary mt-2 mb-0';
+            note.textContent = m('moreItems');
+            target.appendChild(note);
+        }
+    }
+
+    async function onJobAction(event) {
+        const article = event.target.closest('.portfolio-job');
+        if (!article) return;
+        const entry = jobs.get(article.dataset.jobUrl);
+        if (!entry) return;
+        if (event.target.closest('.job-toggle')) {
+            entry.expanded = !entry.expanded;
+            persistJobs();
+            renderJobs();
+            return;
+        }
+        const retry = event.target.closest('.job-retry');
+        if (!retry) return;
+        retry.disabled = true;
+        try {
+            const response = await originalFetch(entry.url + '/retry-failed', {
+                method: 'POST',
+                headers: jsonHeaders(),
+                credentials: 'same-origin',
+                body: '{}'
+            });
+            if (!response.ok) throw await responseError(response);
+            const job = await response.json();
+            const location = response.headers.get('Location') || entry.url;
+            registerJob(new URL(location, window.location.href).toString(), job);
+        } catch (error) {
+            showError(error);
+        } finally {
+            retry.disabled = false;
+        }
+    }
+
+    function countStatuses(jobList) {
+        const counts = { PENDING: 0, RUNNING: 0, SUCCESS: 0, PARTIAL: 0, FAILED: 0, CANCELLED: 0 };
+        jobList.forEach(function (job) {
+            const status = String(job.status || '').toUpperCase();
+            if (Object.prototype.hasOwnProperty.call(counts, status)) counts[status] += 1;
+        });
+        return counts;
+    }
+
+    function countItemStatuses(items) {
+        const counts = { PENDING: 0, RUNNING: 0, SUCCESS: 0, PARTIAL: 0, FAILED: 0, CANCELLED: 0 };
+        items.forEach(function (item) {
+            const status = String(item.status || '').toUpperCase();
+            if (Object.prototype.hasOwnProperty.call(counts, status)) counts[status] += 1;
+        });
+        return counts;
+    }
+
+    function statusPills(counts) {
+        return ['PENDING', 'RUNNING', 'SUCCESS', 'PARTIAL', 'FAILED', 'CANCELLED']
+            .filter(function (status) { return Number(counts[status] || 0) > 0; })
+            .map(function (status) {
+                return '<span class="badge rounded-pill me-1 ' + statusClass(status) + '">'
+                    + escapeHtml(statusLabel(status)) + ': ' + Number(counts[status]) + '</span>';
+            }).join('') || '<span class="text-body-secondary">—</span>';
+    }
+
+    function progressPercent(job) {
+        const total = Number(job.totalItems || (job.items || []).length || 0);
+        if (total === 0) return terminalStatuses.has(job.status) ? 100 : 0;
+        const complete = Number(job.successfulItems || 0) + Number(job.partialItems || 0)
+            + Number(job.failedItems || 0)
+            + (job.items || []).filter(function (item) { return item.status === 'CANCELLED'; }).length;
+        return Math.max(0, Math.min(100, Math.round(complete * 100 / total)));
+    }
+
+    function statusClass(status) {
+        switch (status) {
+            case 'SUCCESS': return 'text-bg-success';
+            case 'PARTIAL': case 'PENDING': return 'text-bg-warning';
+            case 'FAILED': case 'CANCELLED': return 'text-bg-danger';
+            case 'RUNNING': return 'text-bg-info';
+            default: return 'text-bg-secondary';
+        }
+    }
+
+    function statusLabel(status) {
+        switch (String(status || '').toUpperCase()) {
+            case 'PENDING': return m('queued');
+            case 'RUNNING': return m('running');
+            case 'SUCCESS': return m('successful');
+            case 'PARTIAL': return m('partial');
+            case 'FAILED': return m('failed');
+            case 'CANCELLED': return m('cancelled');
+            default: return String(status || '—');
+        }
+    }
+
+    function announceTerminal(job) {
+        if (job.status === 'SUCCESS') announce(m('jobCompleted'));
+        else if (job.status === 'PARTIAL') announce(m('jobPartial'));
+        else if (job.status === 'FAILED') announce(m('jobFailed'));
+    }
+
+    function announce(message) {
+        const status = document.getElementById('portfolioStatus');
+        if (status) status.textContent = message;
+        const info = document.getElementById('portfolioInfo');
+        if (info) {
+            info.textContent = message;
+            info.classList.remove('d-none');
+        }
+    }
+
+    function replacePrematureCompletionMessage() {
+        const info = document.getElementById('portfolioInfo');
+        if (!info) return;
+        const active = Array.from(jobs.values()).some(function (entry) {
+            return !terminalStatuses.has(entry.job.status);
+        });
+        if (active && /(?:finished|abgeschlossen).*0/i.test(info.textContent || '')) {
+            info.textContent = m('analysisStarted');
+        }
+    }
+
+    function refreshCurrentProject(projectId) {
+        const storedProject = Number(window.localStorage.getItem('taxonomy.portfolio.projectId')) || null;
+        if (projectId && storedProject && projectId !== storedProject) return;
+        const refresh = document.getElementById('refreshPortfolioBtn');
+        if (refresh && !refresh.disabled) refresh.click();
+    }
+
+    function installGuidedReviewHandlers() {
+        document.addEventListener('click', function (event) {
+            const mapping = event.target.closest('.mapping-review');
+            const requirementLink = event.target.closest('.confirm-requirement-link');
+            const solutionCoverage = event.target.closest('.add-solution-coverage');
+            const productCoverage = event.target.closest('.add-product-coverage');
+            const conflict = event.target.closest('.conflict-review');
+            if (!mapping && !requirementLink && !solutionCoverage && !productCoverage && !conflict) return;
+            if (event.target.disabled) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            if (mapping) reviewMapping(mapping);
+            else if (requirementLink) confirmRequirementLink(requirementLink);
+            else if (solutionCoverage) addSolutionCoverage(solutionCoverage);
+            else if (productCoverage) addProductCoverage(productCoverage);
+            else reviewConflict(conflict);
+        }, true);
+    }
+
+    async function reviewMapping(button) {
+        const mappingId = Number(button.dataset.mappingId);
+        const action = document.querySelector(
+            '.mapping-action-select[data-mapping-id="' + mappingId + '"]').value;
+        const decision = await showDecisionDialog({
+            title: m('evidenceTitle'),
+            evidenceRequired: action !== 'UNDECIDED'
+        });
+        if (!decision) return;
+        await guardedRequest(button,
+            '/api/projects/' + currentProjectId()
+                + '/analysis-mappings/elements/' + mappingId,
+            'PATCH', {
+                reviewStatus: 'CONFIRMED',
+                actionStatus: action,
+                actionEvidence: decision.evidence || null,
+                comment: decision.comment || null
+            });
+    }
+
+    async function confirmRequirementLink(button) {
+        const decision = await showDecisionDialog({
+            title: m('evidenceTitle'), evidenceRequired: true
+        });
+        if (!decision) return;
+        await guardedRequest(button,
+            '/api/projects/' + currentProjectId() + '/solutions/'
+                + Number(button.dataset.projectSolutionId) + '/requirements',
+            'POST', {
+                requirementId: Number(button.dataset.requirementId),
+                snapshotId: button.dataset.snapshotId || null,
+                coveragePercent: Number(button.dataset.coverage),
+                role: 'USES',
+                reviewStatus: 'CONFIRMED',
+                evidence: decision.evidence
+            });
+    }
+
+    async function addSolutionCoverage(button) {
+        const projectSolutionId = Number(button.dataset.projectSolutionId);
+        const review = document.querySelector(
+            '.solution-node-review[data-project-solution-id="' + projectSolutionId + '"]').value;
+        const decision = await showDecisionDialog({
+            title: m('evidenceTitle'), evidenceRequired: review === 'CONFIRMED'
+        });
+        if (!decision) return;
+        await guardedRequest(button,
+            '/api/solutions/' + Number(button.dataset.solutionId) + '/taxonomy-coverage',
+            'POST', {
+                nodeCode: document.querySelector(
+                    '.solution-node-code[data-project-solution-id="' + projectSolutionId + '"]').value,
+                coveragePercent: Number(document.querySelector(
+                    '.solution-node-coverage[data-project-solution-id="' + projectSolutionId + '"]').value),
+                evidence: decision.evidence || null,
+                reviewStatus: review
+            });
+    }
+
+    async function addProductCoverage(button) {
+        const productId = Number(button.dataset.productId);
+        const review = document.querySelector(
+            '.product-node-review[data-product-id="' + productId + '"]').value;
+        const decision = await showDecisionDialog({
+            title: m('evidenceTitle'), evidenceRequired: review === 'CONFIRMED'
+        });
+        if (!decision) return;
+        await guardedRequest(button,
+            '/api/products/' + productId + '/taxonomy-coverage',
+            'POST', {
+                nodeCode: document.querySelector(
+                    '.product-node-code[data-product-id="' + productId + '"]').value,
+                coveragePercent: Number(document.querySelector(
+                    '.product-node-coverage[data-product-id="' + productId + '"]').value),
+                evidence: decision.evidence || null,
+                reviewStatus: review
+            });
+    }
+
+    async function reviewConflict(button) {
+        const status = button.dataset.status;
+        const decision = await showDecisionDialog({
+            title: status === 'RESOLVED' ? m('resolutionTitle') : m('evidenceTitle'),
+            evidenceLabel: status === 'RESOLVED' ? m('resolutionNote') : m('evidence'),
+            evidenceRequired: status === 'RESOLVED'
+        });
+        if (!decision) return;
+        await guardedRequest(button,
+            '/api/projects/' + currentProjectId() + '/conflicts/' + button.dataset.conflictId,
+            'PATCH', {
+                status: status,
+                resolutionNote: decision.evidence || decision.comment || null
+            });
+    }
+
+    async function guardedRequest(button, path, method, body) {
+        button.disabled = true;
+        try {
+            const response = await originalFetch(path, {
+                method: method,
+                headers: jsonHeaders(),
+                credentials: 'same-origin',
+                body: JSON.stringify(body)
+            });
+            if (!response.ok) throw await responseError(response);
+            announce(locale === 'de' ? 'Entscheidung wurde gespeichert.' : 'Decision saved.');
+            refreshCurrentProject(currentProjectId());
+            window.setTimeout(function () {
+                const selected = document.querySelector('.snapshot-select.active');
+                if (selected) selected.click();
+            }, 800);
+        } catch (error) {
+            showError(error);
+        } finally {
+            button.disabled = false;
+        }
+    }
+
+    function ensureDecisionDialog() {
+        if (document.getElementById('portfolioDecisionDialog')) return;
+        const dialog = document.createElement('div');
+        dialog.className = 'modal fade';
+        dialog.id = 'portfolioDecisionDialog';
+        dialog.tabIndex = -1;
+        dialog.setAttribute('aria-labelledby', 'portfolioDecisionDialogTitle');
+        dialog.setAttribute('aria-hidden', 'true');
+        dialog.innerHTML = '<div class="modal-dialog"><form class="modal-content" id="portfolioDecisionForm">'
+            + '<div class="modal-header"><h2 class="modal-title fs-5" id="portfolioDecisionDialogTitle"></h2>'
+            + '<button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>'
+            + '<div class="modal-body"><div class="mb-3"><label class="form-label" '
+            + 'for="portfolioDecisionEvidence" id="portfolioDecisionEvidenceLabel"></label>'
+            + '<textarea id="portfolioDecisionEvidence" class="form-control" rows="4" maxlength="2000"></textarea>'
+            + '<div class="form-text" id="portfolioDecisionHelp"></div>'
+            + '<div class="invalid-feedback" id="portfolioDecisionEvidenceError"></div></div>'
+            + '<div><label class="form-label" for="portfolioDecisionComment"></label>'
+            + '<textarea id="portfolioDecisionComment" class="form-control" rows="2" maxlength="2000"></textarea></div>'
+            + '</div><div class="modal-footer"><button type="button" class="btn btn-outline-secondary" '
+            + 'data-bs-dismiss="modal" id="portfolioDecisionCancel"></button>'
+            + '<button type="submit" class="btn btn-primary" id="portfolioDecisionSave"></button></div>'
+            + '</form></div>';
+        document.body.appendChild(dialog);
+        dialog.querySelector('.btn-close').setAttribute('aria-label', m('close'));
+        dialog.querySelector('label[for="portfolioDecisionComment"]').textContent = m('comment');
+        dialog.querySelector('#portfolioDecisionCancel').textContent = m('cancel');
+        dialog.querySelector('#portfolioDecisionSave').textContent = m('save');
+        dialog.querySelector('#portfolioDecisionHelp').textContent = m('evidenceHelp');
+        dialog.querySelector('#portfolioDecisionForm').addEventListener('submit', function (event) {
+            event.preventDefault();
+            const evidence = dialog.querySelector('#portfolioDecisionEvidence');
+            const required = dialog.dataset.evidenceRequired === 'true';
+            if (required && !evidence.value.trim()) {
+                evidence.classList.add('is-invalid');
+                dialog.querySelector('#portfolioDecisionEvidenceError').textContent = m('evidenceRequired');
+                evidence.focus();
+                return;
+            }
+            evidence.classList.remove('is-invalid');
+            const result = {
+                evidence: evidence.value.trim(),
+                comment: dialog.querySelector('#portfolioDecisionComment').value.trim()
+            };
+            const resolver = dialogResolve;
+            dialogResolve = null;
+            window.bootstrap.Modal.getOrCreateInstance(dialog).hide();
+            if (resolver) resolver(result);
+        });
+        dialog.addEventListener('hidden.bs.modal', function () {
+            if (dialogResolve) {
+                const resolver = dialogResolve;
+                dialogResolve = null;
+                resolver(null);
+            }
+        });
+    }
+
+    function showDecisionDialog(options) {
+        ensureDecisionDialog();
+        const dialog = document.getElementById('portfolioDecisionDialog');
+        dialog.dataset.evidenceRequired = String(Boolean(options.evidenceRequired));
+        dialog.querySelector('#portfolioDecisionDialogTitle').textContent = options.title || m('evidenceTitle');
+        dialog.querySelector('#portfolioDecisionEvidenceLabel').textContent = options.evidenceLabel || m('evidence');
+        dialog.querySelector('#portfolioDecisionEvidence').value = '';
+        dialog.querySelector('#portfolioDecisionComment').value = '';
+        dialog.querySelector('#portfolioDecisionEvidence').classList.remove('is-invalid');
+        return new Promise(function (resolve) {
+            dialogResolve = resolve;
+            const modal = window.bootstrap.Modal.getOrCreateInstance(dialog);
+            modal.show();
+            dialog.addEventListener('shown.bs.modal', function focusEvidence() {
+                dialog.removeEventListener('shown.bs.modal', focusEvidence);
+                dialog.querySelector('#portfolioDecisionEvidence').focus();
+            });
+        });
+    }
+
+    function jsonHeaders() {
+        const headers = { Accept: 'application/json', 'Content-Type': 'application/json' };
+        const token = document.querySelector('meta[name="_csrf"]')?.content;
+        const name = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+        if (token) headers[name] = token;
+        return headers;
+    }
+
+    async function responseError(response) {
+        const type = response.headers.get('content-type') || '';
+        const payload = type.includes('json')
+            ? await response.json().catch(function () { return null; })
+            : await response.text().catch(function () { return ''; });
+        const detail = payload && typeof payload === 'object'
+            ? (payload.detail || payload.message || payload.title || payload.error)
+            : payload;
+        return new Error(detail || m('requestFailed') + ' HTTP ' + response.status);
+    }
+
+    function showError(error) {
+        const target = document.getElementById('portfolioError');
+        const message = error && error.message ? error.message : m('unknownError');
+        if (target) {
+            target.textContent = message;
+            target.classList.remove('d-none');
+            target.tabIndex = -1;
+            target.focus();
+        }
+        const alert = document.getElementById('portfolioAlert');
+        if (alert) alert.textContent = message;
+    }
+
+    function currentProjectId() {
+        return Number(window.localStorage.getItem('taxonomy.portfolio.projectId')) || null;
     }
 
     function isAnalysisSubmission(url) {
@@ -47,49 +912,23 @@
             && (url.pathname.endsWith('/analyses') || url.pathname.endsWith('/retry-failed'));
     }
 
-    async function pollJob(location, signal) {
-        const startedAt = Date.now();
-        const jobUrl = new URL(location, window.location.href).toString();
-        while (Date.now() - startedAt < pollTimeoutMs) {
-            await delay(pollIntervalMs, signal);
-            const response = await originalFetch(jobUrl, {
-                method: 'GET',
-                headers: { Accept: 'application/json' },
-                credentials: 'same-origin',
-                cache: 'no-store',
-                signal: signal
-            });
-            if (!response.ok) {
-                throw new Error('Unable to read the queued portfolio analysis job (HTTP '
-                    + response.status + ').');
-            }
-            const job = await response.json();
-            if (job && terminalStatuses.has(job.status)) return job;
-        }
-        throw new Error('The queued portfolio analysis did not finish within ten minutes.');
+    function resolveUrl(input) {
+        const value = input instanceof Request ? input.url : String(input);
+        return new URL(value, window.location.href);
     }
 
-    function delay(milliseconds, signal) {
-        return new Promise(function (resolve, reject) {
-            if (signal && signal.aborted) {
-                reject(new DOMException('The operation was aborted.', 'AbortError'));
-                return;
-            }
+    function formatDate(value) {
+        if (!value) return '—';
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString(locale);
+    }
 
-            let settled = false;
-            const onAbort = function () {
-                if (settled) return;
-                settled = true;
-                window.clearTimeout(timeout);
-                reject(new DOMException('The operation was aborted.', 'AbortError'));
-            };
-            const timeout = window.setTimeout(function () {
-                if (settled) return;
-                settled = true;
-                if (signal) signal.removeEventListener('abort', onAbort);
-                resolve();
-            }, milliseconds);
-            if (signal) signal.addEventListener('abort', onAbort, { once: true });
-        });
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
     }
 })();

--- a/taxonomy-app/src/main/resources/templates/portfolio-matrices.html
+++ b/taxonomy-app/src/main/resources/templates/portfolio-matrices.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}" lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="_csrf" th:if="${_csrf}" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:if="${_csrf}" th:content="${_csrf.headerName}"/>
+    <title>Portfolio matrices — Taxonomy</title>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.8/dist/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy-ergonomics.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy-portfolio.css}"/>
+</head>
+<body class="bg-body-tertiary">
+<a class="skip-link" href="#matrixMain">Skip to matrices</a>
+<div id="matrixLive" class="visually-hidden" role="status" aria-live="polite"></div>
+<nav class="navbar navbar-dark bg-dark sticky-top" aria-label="Portfolio matrix navigation">
+    <div class="container-fluid gap-2">
+        <a class="navbar-brand fw-semibold" th:href="@{/}">🌐 Taxonomy</a>
+        <span class="navbar-text text-white fw-semibold me-auto" id="matrixPageTitle">Portfolio matrices</span>
+        <a class="btn btn-sm btn-outline-light" id="portfolioBack" href="/projects">Portfolio</a>
+        <div class="btn-group btn-group-sm" role="group" aria-label="Language">
+            <a class="btn btn-outline-light" href="?lang=en">EN</a>
+            <a class="btn btn-outline-light" href="?lang=de">DE</a>
+        </div>
+    </div>
+</nav>
+<main id="matrixMain" class="container-fluid py-3 px-lg-4">
+    <div id="matrixError" class="alert alert-danger d-none" role="alert" tabindex="-1"></div>
+    <section class="card shadow-sm mb-3" aria-labelledby="matrixHeading">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                <div><h1 id="matrixHeading" class="h2 mb-1">Portfolio matrices</h1><p id="matrixProject" class="text-body-secondary mb-0"></p></div>
+                <div class="d-flex flex-wrap gap-2">
+                    <button id="exportCsv" type="button" class="btn btn-outline-primary">Export filtered CSV</button>
+                    <button id="exportJson" type="button" class="btn btn-outline-primary">Export filtered JSON</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="card shadow-sm mb-3" aria-labelledby="filterHeading">
+        <div class="card-header"><h2 id="filterHeading" class="h5 mb-0">Filters</h2></div>
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-12 col-md-5"><label for="matrixSearch" class="form-label">Search rows and columns</label><input id="matrixSearch" type="search" class="form-control" autocomplete="off"/></div>
+                <div class="col-6 col-md-3"><label for="minimumValue" class="form-label">Minimum coverage</label><input id="minimumValue" type="number" min="0" max="100" value="0" class="form-control"/></div>
+                <div class="col-6 col-md-2"><label for="relationState" class="form-label">Relationship</label><select id="relationState" class="form-select"><option value="all">All</option><option value="related">Related</option><option value="empty">Empty</option></select></div>
+                <div class="col-12 col-md-2"><button id="resetFilters" type="button" class="btn btn-outline-secondary w-100">Reset</button></div>
+            </div>
+            <div id="activeFilters" class="small text-body-secondary mt-3"></div>
+        </div>
+    </section>
+
+    <section class="card shadow-sm">
+        <div class="card-header p-0 border-bottom-0">
+            <ul class="nav nav-tabs px-2 pt-2 flex-nowrap overflow-x-auto" role="tablist">
+                <li class="nav-item"><button class="nav-link active" id="taxonomyMatrixTab" data-bs-toggle="tab" data-bs-target="#taxonomyMatrixPane" type="button" role="tab">Requirements × taxonomy</button></li>
+                <li class="nav-item"><button class="nav-link" id="solutionMatrixTab" data-bs-toggle="tab" data-bs-target="#solutionMatrixPane" type="button" role="tab">Requirements × solutions</button></li>
+                <li class="nav-item"><button class="nav-link" id="productMatrixTab" data-bs-toggle="tab" data-bs-target="#productMatrixPane" type="button" role="tab">Solutions × products</button></li>
+            </ul>
+        </div>
+        <div class="card-body tab-content">
+            <div class="tab-pane fade show active" id="taxonomyMatrixPane" role="tabpanel" tabindex="0"><div id="taxonomyMatrix" class="portfolio-matrix table-responsive"></div></div>
+            <div class="tab-pane fade" id="solutionMatrixPane" role="tabpanel" tabindex="0"><div id="solutionMatrix" class="portfolio-matrix table-responsive"></div></div>
+            <div class="tab-pane fade" id="productMatrixPane" role="tabpanel" tabindex="0"><div id="productMatrix" class="portfolio-matrix table-responsive"></div></div>
+        </div>
+    </section>
+</main>
+
+<div class="offcanvas offcanvas-end" tabindex="-1" id="cellDetail" aria-labelledby="cellDetailTitle">
+    <div class="offcanvas-header"><h2 class="offcanvas-title h5" id="cellDetailTitle">Relationship detail</h2><button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button></div>
+    <div class="offcanvas-body"><div id="cellDetailBody"></div></div>
+</div>
+
+<div id="matrixBusy" class="portfolio-busy d-none" role="status" aria-live="polite"><div class="spinner-border" aria-hidden="true"></div><span>Loading…</span></div>
+<script th:src="@{/webjars/bootstrap/5.3.8/dist/js/bootstrap.bundle.min.js}"></script>
+<script th:src="@{/js/portfolio/portfolio-matrices.js}"></script>
+</body>
+</html>

--- a/taxonomy-app/src/main/resources/templates/requirement-detail.html
+++ b/taxonomy-app/src/main/resources/templates/requirement-detail.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}" lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="_csrf" th:if="${_csrf}" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:if="${_csrf}" th:content="${_csrf.headerName}"/>
+    <title>Requirement detail — Taxonomy</title>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.8/dist/css/bootstrap.min.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy-ergonomics.css}"/>
+    <link rel="stylesheet" th:href="@{/css/taxonomy-portfolio.css}"/>
+</head>
+<body class="bg-body-tertiary">
+<a class="skip-link" href="#requirementMain">Skip to requirement detail</a>
+<div id="requirementLive" class="visually-hidden" role="status" aria-live="polite"></div>
+<nav class="navbar navbar-dark bg-dark sticky-top" aria-label="Requirement navigation">
+    <div class="container-fluid gap-2">
+        <a class="navbar-brand fw-semibold" th:href="@{/}">🌐 Taxonomy</a>
+        <span class="navbar-text text-white fw-semibold me-auto" id="pageTitle">Requirement detail</span>
+        <a class="btn btn-sm btn-outline-light" id="portfolioBack" href="/projects">Portfolio</a>
+        <a class="btn btn-sm btn-outline-light" id="matrixLink" href="#">Matrices</a>
+        <div class="btn-group btn-group-sm" role="group" aria-label="Language">
+            <a class="btn btn-outline-light" href="?lang=en" hreflang="en">EN</a>
+            <a class="btn btn-outline-light" href="?lang=de" hreflang="de">DE</a>
+        </div>
+    </div>
+</nav>
+
+<main id="requirementMain" class="container-fluid py-3 px-lg-4">
+    <div id="detailError" class="alert alert-danger d-none" role="alert" tabindex="-1"></div>
+    <div id="detailInfo" class="alert alert-info d-none" role="status"></div>
+
+    <section class="card shadow-sm mb-3" aria-labelledby="requirementHeading">
+        <div class="card-body">
+            <div class="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                <div>
+                    <div class="d-flex flex-wrap gap-2 align-items-center">
+                        <span id="requirementKey" class="badge text-bg-primary"></span>
+                        <span id="requirementStatus" class="badge text-bg-secondary"></span>
+                        <span id="requirementReview" class="badge text-bg-secondary"></span>
+                    </div>
+                    <h1 id="requirementHeading" class="h2 mt-2 mb-1">Loading requirement…</h1>
+                    <p id="requirementMeta" class="text-body-secondary mb-0"></p>
+                </div>
+                <div class="d-flex flex-wrap gap-2 align-items-start">
+                    <button id="reanalyzeRequirement" type="button" class="btn btn-primary">Analyze current version</button>
+                    <button id="newVersionButton" type="button" class="btn btn-outline-primary"
+                            data-bs-toggle="modal" data-bs-target="#newVersionModal">New version</button>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="openTasks" class="card shadow-sm mb-3" aria-labelledby="tasksHeading">
+        <div class="card-header"><h2 id="tasksHeading" class="h5 mb-0">Open decisions</h2></div>
+        <div id="taskList" class="list-group list-group-flush"></div>
+    </section>
+
+    <section class="card shadow-sm">
+        <div class="card-header p-0 border-bottom-0">
+            <ul class="nav nav-tabs px-2 pt-2 flex-nowrap overflow-x-auto" id="detailTabs" role="tablist">
+                <li class="nav-item"><button class="nav-link active" id="text-tab" data-bs-toggle="tab"
+                    data-bs-target="#textPane" type="button" role="tab" aria-controls="textPane" aria-selected="true">Text & source</button></li>
+                <li class="nav-item"><button class="nav-link" id="versions-tab" data-bs-toggle="tab"
+                    data-bs-target="#versionsPane" type="button" role="tab" aria-controls="versionsPane" aria-selected="false">Versions</button></li>
+                <li class="nav-item"><button class="nav-link" id="analyses-tab" data-bs-toggle="tab"
+                    data-bs-target="#analysesPane" type="button" role="tab" aria-controls="analysesPane" aria-selected="false">Analyses</button></li>
+                <li class="nav-item"><button class="nav-link" id="architecture-tab" data-bs-toggle="tab"
+                    data-bs-target="#architecturePane" type="button" role="tab" aria-controls="architecturePane" aria-selected="false">Taxonomy & architecture</button></li>
+                <li class="nav-item"><button class="nav-link" id="decisions-tab" data-bs-toggle="tab"
+                    data-bs-target="#decisionsPane" type="button" role="tab" aria-controls="decisionsPane" aria-selected="false">Decisions</button></li>
+                <li class="nav-item"><button class="nav-link" id="solutions-tab" data-bs-toggle="tab"
+                    data-bs-target="#solutionsPane" type="button" role="tab" aria-controls="solutionsPane" aria-selected="false">Solutions & products</button></li>
+            </ul>
+        </div>
+        <div class="card-body tab-content">
+            <div class="tab-pane fade show active" id="textPane" role="tabpanel" aria-labelledby="text-tab" tabindex="0">
+                <div class="row g-3">
+                    <div class="col-12 col-xl-6">
+                        <h2 class="h5">Current requirement text</h2>
+                        <pre id="currentText" class="border rounded p-3 bg-body-tertiary text-wrap"></pre>
+                    </div>
+                    <div class="col-12 col-xl-6">
+                        <h2 class="h5">Original source fragment</h2>
+                        <dl id="sourceMetadata" class="portfolio-card-meta mb-3"></dl>
+                        <pre id="sourceText" class="border rounded p-3 bg-body-tertiary text-wrap"></pre>
+                    </div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="versionsPane" role="tabpanel" aria-labelledby="versions-tab" tabindex="0">
+                <div class="row g-3">
+                    <div class="col-12 col-lg-4"><div id="versionList" class="list-group"></div></div>
+                    <div class="col-12 col-lg-8"><div id="versionDetail" class="border rounded p-3 bg-body"></div></div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="analysesPane" role="tabpanel" aria-labelledby="analyses-tab" tabindex="0">
+                <div class="row g-3">
+                    <div class="col-12 col-lg-4"><div id="snapshotList" class="list-group"></div></div>
+                    <div class="col-12 col-lg-8"><div id="snapshotDetail" class="border rounded p-3 bg-body"></div></div>
+                </div>
+            </div>
+
+            <div class="tab-pane fade" id="architecturePane" role="tabpanel" aria-labelledby="architecture-tab" tabindex="0">
+                <div id="architectureSummary"></div>
+                <div id="mappingTable" class="table-responsive mt-3"></div>
+                <div id="relationTable" class="table-responsive mt-3"></div>
+            </div>
+
+            <div class="tab-pane fade" id="decisionsPane" role="tabpanel" aria-labelledby="decisions-tab" tabindex="0">
+                <div id="decisionList" class="vstack gap-2"></div>
+            </div>
+
+            <div class="tab-pane fade" id="solutionsPane" role="tabpanel" aria-labelledby="solutions-tab" tabindex="0">
+                <div id="solutionList" class="row g-3"></div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<div class="modal fade" id="newVersionModal" tabindex="-1" aria-labelledby="newVersionTitle" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+        <form id="newVersionForm" class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title fs-5" id="newVersionTitle">Create immutable requirement version</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label for="versionText" class="form-label">Requirement text</label>
+                    <textarea id="versionText" class="form-control" rows="12" required></textarea>
+                </div>
+                <div class="mb-3">
+                    <label for="changeReason" class="form-label">Change reason</label>
+                    <input id="changeReason" class="form-control" maxlength="1000" required/>
+                </div>
+                <details>
+                    <summary class="fw-semibold">Source reference</summary>
+                    <div class="row g-3 mt-1">
+                        <div class="col-md-6"><label for="sourceSection" class="form-label">Section</label><input id="sourceSection" class="form-control"/></div>
+                        <div class="col-md-3"><label for="sourcePage" class="form-label">Page</label><input id="sourcePage" type="number" min="1" class="form-control"/></div>
+                        <div class="col-12"><label for="sourceOriginal" class="form-label">Original text</label><textarea id="sourceOriginal" rows="5" class="form-control"></textarea></div>
+                    </div>
+                </details>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-primary">Create version</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="detailBusy" class="portfolio-busy d-none" role="status" aria-live="polite">
+    <div class="spinner-border" aria-hidden="true"></div><span>Loading…</span>
+</div>
+<script th:src="@{/webjars/bootstrap/5.3.8/dist/js/bootstrap.bundle.min.js}"></script>
+<script th:src="@{/js/portfolio/requirement-detail.js}"></script>
+</body>
+</html>

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioPageRoutesTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioPageRoutesTest.java
@@ -1,0 +1,49 @@
+package com.taxonomy.portfolio;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "gemini.api.key=", "openai.api.key=", "deepseek.api.key=",
+        "qwen.api.key=", "llama.api.key=", "mistral.api.key="
+})
+@WithMockUser(username = "architect", roles = "ARCHITECT")
+class PortfolioPageRoutesTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void requirementDetailHasStableShareableRoute() throws Exception {
+        mockMvc.perform(get("/projects/12/requirements/34"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("requirement-detail"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "id=\"requirementMain\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "/js/portfolio/requirement-detail.js")));
+    }
+
+    @Test
+    void projectMatricesHaveStableShareableRoute() throws Exception {
+        mockMvc.perform(get("/projects/12/matrices"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("portfolio-matrices"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "id=\"matrixMain\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "/js/portfolio/portfolio-matrices.js")));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the core of #570 and #571 as a stacked GUI increment on #587.

### Requirement detail workspace

- stable `/projects/{projectId}/requirements/{requirementId}` URL
- current text and source provenance side by side
- immutable version history with human-readable line comparison
- snapshot history and reproducibility metadata
- taxonomy and relation mappings with scores, confidence, origin and review state
- human decision/evidence view
- linked solutions and sourced product candidates
- derived open-decision list
- GUI creation of a new immutable version and reanalysis of the current version
- capability-aware write controls

### Matrix workspace

- stable `/projects/{projectId}/matrices` URL
- interactive requirement–taxonomy, requirement–solution and solution–product matrices
- text, minimum-coverage and relationship-state filters
- keyboard-operable cell buttons and accessible captions
- cell drill-down with evidence/review/source information and requirement deep links
- alternative list view for narrow/mobile/zoomed layouts
- filtered CSV and JSON exports with stable project context

### Verification

- controller/template route contracts
- browser acceptance for deep links, history, snapshot mappings, decision provenance, filters, cell drill-down and accessibility evidence

Relates to #570
Relates to #571