### PR TITLE
Address post-merge review findings from architecture workbench

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/workbench/ArchitecturePdfRenderer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/workbench/ArchitecturePdfRenderer.java
@@ -3,6 +3,7 @@ package com.taxonomy.portfolio.workbench;
 import com.taxonomy.diagram.DiagramScene;
 import com.taxonomy.diagram.DiagramSceneEdge;
 import com.taxonomy.diagram.DiagramSceneNode;
+import com.taxonomy.export.DiagramTextWrapper;
 import com.taxonomy.portfolio.workbench.ArchitectureWorkbenchDtos.Projection;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
@@ -17,7 +18,6 @@ import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.Normalizer;
-import java.util.ArrayList;
 import java.util.List;
 
 /** Draws a vector PDF directly from the same deterministic scene returned to the browser. */
@@ -147,7 +147,7 @@ public class ArchitecturePdfRenderer {
                     x + width - 62 * scale,
                     top - 14 * scale,
                     node.type() + " " + Math.round(node.relevance() * 100.0) + "%");
-            List<String> labelLines = wrap(node.label(), 34, 2);
+            List<String> labelLines = DiagramTextWrapper.wrap(node.label(), 34, 2, "n/a");
             for (int index = 0; index < labelLines.size(); index++) {
                 text(stream, REGULAR, 8.3f * fontScale,
                         x + 8 * scale,
@@ -199,23 +199,6 @@ public class ArchitecturePdfRenderer {
         stream.newLineAtOffset(x, y);
         stream.showText(safe);
         stream.endText();
-    }
-
-    private static List<String> wrap(String value, int maximum, int maximumLines) {
-        String normalized = safe(value);
-        List<String> lines = new ArrayList<>();
-        StringBuilder line = new StringBuilder();
-        for (String word : normalized.split("\\s+")) {
-            if (!line.isEmpty() && line.length() + word.length() + 1 > maximum) {
-                lines.add(line.toString());
-                line.setLength(0);
-                if (lines.size() == maximumLines - 1) break;
-            }
-            if (!line.isEmpty()) line.append(' ');
-            line.append(word);
-        }
-        if (!line.isEmpty() && lines.size() < maximumLines) lines.add(line.toString());
-        return lines;
     }
 
     private static Color fill(String type) {

--- a/taxonomy-app/src/main/resources/static/js/architecture-workbench.js
+++ b/taxonomy-app/src/main/resources/static/js/architecture-workbench.js
@@ -295,7 +295,10 @@
         return;
     }
 
-    ArchitectureWorkbenchApi.load(projectId, snapshotId)
+    Promise.resolve()
+        .then(function () {
+            return ArchitectureWorkbenchApi.load(projectId, snapshotId);
+        })
         .then(render)
         .catch(showError);
 }());

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/workbench/ArchitectureWorkbenchAssetContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/workbench/ArchitectureWorkbenchAssetContractTest.java
@@ -29,7 +29,9 @@ class ArchitectureWorkbenchAssetContractTest {
         assertThat(adapter)
                 .doesNotContain("window.print")
                 .doesNotContain("fetch(")
-                .contains("ArchitectureWorkbenchApi.load")
+                .contains("Promise.resolve()")
+                .contains("return ArchitectureWorkbenchApi.load(projectId, snapshotId)")
+                .contains(".catch(showError)")
                 .contains("ArchitectureWorkbenchApi.pdfUrl");
     }
 

--- a/taxonomy-export/src/main/java/com/taxonomy/export/DiagramTextWrapper.java
+++ b/taxonomy-export/src/main/java/com/taxonomy/export/DiagramTextWrapper.java
@@ -1,0 +1,72 @@
+package com.taxonomy.export;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Deterministically wraps diagram labels without silently dropping the final visible line. */
+public final class DiagramTextWrapper {
+
+    private static final String ELLIPSIS = "...";
+    private static final String DEFAULT_FALLBACK = "Unnamed architecture element";
+
+    private DiagramTextWrapper() {
+    }
+
+    public static List<String> wrap(String value,
+                                    int maximumCharacters,
+                                    int maximumLines,
+                                    String fallback) {
+        if (maximumCharacters < 1) {
+            throw new IllegalArgumentException("maximumCharacters must be positive");
+        }
+        if (maximumLines < 1) {
+            throw new IllegalArgumentException("maximumLines must be positive");
+        }
+
+        String normalized = normalize(value, fallback);
+        List<String> lines = new ArrayList<>(maximumLines);
+        String remaining = normalized;
+
+        while (!remaining.isEmpty() && lines.size() < maximumLines) {
+            if (lines.size() == maximumLines - 1) {
+                lines.add(ellipsize(remaining, maximumCharacters));
+                break;
+            }
+            if (remaining.length() <= maximumCharacters) {
+                lines.add(remaining);
+                break;
+            }
+
+            int split = remaining.lastIndexOf(' ', maximumCharacters);
+            if (split <= 0) {
+                split = maximumCharacters;
+            }
+            String line = remaining.substring(0, split).strip();
+            if (!line.isEmpty()) {
+                lines.add(line);
+            }
+            remaining = remaining.substring(split).strip();
+        }
+
+        return List.copyOf(lines);
+    }
+
+    private static String normalize(String value, String fallback) {
+        String candidate = value == null || value.isBlank() ? fallback : value;
+        if (candidate == null || candidate.isBlank()) {
+            candidate = DEFAULT_FALLBACK;
+        }
+        return candidate.strip().replaceAll("\\s+", " ");
+    }
+
+    private static String ellipsize(String value, int maximumCharacters) {
+        if (value.length() <= maximumCharacters) {
+            return value;
+        }
+        if (maximumCharacters <= ELLIPSIS.length()) {
+            return ELLIPSIS.substring(0, maximumCharacters);
+        }
+        String prefix = value.substring(0, maximumCharacters - ELLIPSIS.length()).stripTrailing();
+        return prefix + ELLIPSIS;
+    }
+}

--- a/taxonomy-export/src/main/java/com/taxonomy/export/SvgDiagramRenderer.java
+++ b/taxonomy-export/src/main/java/com/taxonomy/export/SvgDiagramRenderer.java
@@ -4,7 +4,6 @@ import com.taxonomy.diagram.DiagramScene;
 import com.taxonomy.diagram.DiagramSceneEdge;
 import com.taxonomy.diagram.DiagramSceneNode;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -67,7 +66,8 @@ public class SvgDiagramRenderer {
                     .append("font-size=\"11\" font-weight=\"bold\" fill=\"#334155\">")
                     .append(xml(node.id())).append("</text>\n");
 
-            List<String> lines = wrap(node.label(), 32, 2);
+            List<String> lines = DiagramTextWrapper.wrap(
+                    node.label(), 32, 2, "Unnamed architecture element");
             for (int index = 0; index < lines.size(); index++) {
                 svg.append("    <text x=\"14\" y=\"")
                         .append(44 + index * 17)
@@ -85,31 +85,6 @@ public class SvgDiagramRenderer {
 
         svg.append("</svg>\n");
         return svg.toString();
-    }
-
-    private static List<String> wrap(String value, int maximum, int maximumLines) {
-        String normalized = value == null || value.isBlank() ? "Unnamed architecture element" : value.strip();
-        List<String> lines = new ArrayList<>();
-        StringBuilder line = new StringBuilder();
-        for (String word : normalized.split("\\s+")) {
-            if (!line.isEmpty() && line.length() + word.length() + 1 > maximum) {
-                lines.add(line.toString());
-                line.setLength(0);
-                if (lines.size() == maximumLines - 1) {
-                    break;
-                }
-            }
-            if (!line.isEmpty()) line.append(' ');
-            line.append(word);
-        }
-        if (!line.isEmpty() && lines.size() < maximumLines) {
-            String tail = line.toString();
-            if (lines.size() == maximumLines - 1 && tail.length() > maximum) {
-                tail = tail.substring(0, Math.max(1, maximum - 1)) + "…";
-            }
-            lines.add(tail);
-        }
-        return lines;
     }
 
     private static String fill(String type) {

--- a/taxonomy-export/src/test/java/com/taxonomy/export/DiagramTextWrapperTest.java
+++ b/taxonomy-export/src/test/java/com/taxonomy/export/DiagramTextWrapperTest.java
@@ -1,0 +1,44 @@
+package com.taxonomy.export;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class DiagramTextWrapperTest {
+
+    @Test
+    void preservesTheSecondVisibleLine() {
+        assertThat(DiagramTextWrapper.wrap(
+                "Alpha bravo charlie", 11, 2, "Fallback label"))
+                .containsExactly("Alpha bravo", "charlie");
+    }
+
+    @Test
+    void marksTruncationOnTheLastAllowedLine() {
+        assertThat(DiagramTextWrapper.wrap(
+                "Alpha bravo charlie delta", 11, 2, "Fallback label"))
+                .containsExactly("Alpha bravo", "charlie...");
+    }
+
+    @Test
+    void hardWrapsLongTokensWithoutDroppingTheTailIndicator() {
+        assertThat(DiagramTextWrapper.wrap(
+                "ABCDEFGHIJK secondary", 5, 2, "Fallback label"))
+                .containsExactly("ABCDE", "FG...");
+    }
+
+    @Test
+    void wrapsTheFallbackForBlankLabels() {
+        assertThat(DiagramTextWrapper.wrap(" ", 10, 2, "Fallback label"))
+                .containsExactly("Fallback", "label");
+    }
+
+    @Test
+    void rejectsNonPositiveLimits() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DiagramTextWrapper.wrap("label", 0, 2, "fallback"));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DiagramTextWrapper.wrap("label", 10, 0, "fallback"));
+    }
+}


### PR DESCRIPTION
## Purpose

Follows up the three valid Copilot review findings posted immediately after PR #600 became green and was merged.

## Changes

- replaces the duplicated SVG/PDF label wrapping with one deterministic `DiagramTextWrapper`
- preserves the second visible line instead of dropping it at the line limit
- marks remaining truncated text with an ASCII ellipsis that is readable in both SVG and Standard 14 PDF fonts
- wraps the workbench API invocation in a Promise chain so synchronous validation failures and asynchronous request failures reach the same UI error surface

## Regression coverage

- second-line preservation
- final-line truncation indicator
- hard wrapping for long tokens
- blank-label fallback
- invalid wrapper limits
- asset contract for synchronous API error capture

Follow-up to #600 and review comments `3723862487`, `3723862521`, and `3723862562`.