### PR TITLE
Harden verified delivery, UI layout and Rancher deployment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default ownership
+* @carstenartur
+
+# Release, CI and deployment contracts
+/.github/workflows/ @carstenartur
+/.github/scripts/ @carstenartur
+/deploy/ @carstenartur
+/pom.xml @carstenartur
+/**/pom.xml @carstenartur

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    groups:
+      codeql-action-family:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/scripts/check-delivery-hardening.py
+++ b/.github/scripts/check-delivery-hardening.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fail closed when report publication or Render deployment loses provenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+CI = ROOT / ".github" / "workflows" / "ci-cd.yml"
+DELIVERY = ROOT / ".github" / "workflows" / "delivery.yml"
+CSS = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "css" / "taxonomy-ergonomics.css"
+I18N = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "js" / "taxonomy-i18n.js"
+UI_EVIDENCE = ROOT / ".github" / "scripts" / "ui-role-state-evidence.mjs"
+RANCHER = ROOT / "deploy" / "helm" / "taxonomy" / "values-rancher-rke2.yaml"
+DOCKERFILE = ROOT / "Dockerfile"
+
+
+def require(text: str, needle: str, source: Path, failures: list[str]) -> None:
+    if needle not in text:
+        failures.append(f"{source.relative_to(ROOT)} is missing {needle!r}")
+
+
+def main() -> int:
+    ci = CI.read_text(encoding="utf-8")
+    delivery = DELIVERY.read_text(encoding="utf-8")
+    css = CSS.read_text(encoding="utf-8")
+    i18n = I18N.read_text(encoding="utf-8")
+    ui_evidence = UI_EVIDENCE.read_text(encoding="utf-8")
+    rancher = RANCHER.read_text(encoding="utf-8")
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    for needle in (
+        "python3 .github/scripts/test-generate-quality-site.py",
+        "python3 .github/scripts/test-verify-deployment.py",
+        "node .github/scripts/test-taxonomy-base-path.mjs",
+        "python3 .github/scripts/check-delivery-hardening.py",
+        "python3 .github/scripts/generate-quality-site.py",
+        '--commit "$GITHUB_SHA"',
+        "taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml",
+    ):
+        require(ci, needle, CI, failures)
+
+    for needle in (
+        "quality-summary.json",
+        "EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}",
+        "keep_files: false",
+        "force_orphan: true",
+        "BASE_URL: ${{ vars.RENDER_BASE_URL || 'https://taxonomy-analyzer.onrender.com' }}",
+        "python3 .github/scripts/verify-deployment.py",
+        '--expected-commit "$EXPECTED_SHA"',
+    ):
+        require(delivery, needle, DELIVERY, failures)
+    if "keep_files: true" in delivery:
+        failures.append("delivery.yml must replace the report tree atomically, not retain stale files")
+
+    for needle in (
+        '.card-body[style*="max-height"]:not(:has(> #taxonomyTree))',
+        '.card-body:has(> #taxonomyTree)',
+        'max-height: min(65vh, 42rem) !important;',
+    ):
+        require(css, needle, CSS, failures)
+    for needle in (
+        "detectApplicationBasePath",
+        "resolveApplicationUrl",
+        "installBasePathAwareFetch",
+        "window.fetch = wrappedFetch",
+    ):
+        require(i18n, needle, I18N, failures)
+
+    for needle in (
+        "measureTaxonomyTreeViewport",
+        "maxAllowedHeight",
+        "Taxonomy tree viewport is unbounded",
+    ):
+        require(ui_evidence, needle, UI_EVIDENCE, failures)
+
+    for needle in (
+        'nginx.ingress.kubernetes.io/rewrite-target: "/$2"',
+        'nginx.ingress.kubernetes.io/x-forwarded-prefix: "/taxonomy"',
+        "path: /taxonomy(/|$)(.*)",
+        'cpu: "500m"',
+    ):
+        require(rancher, needle, RANCHER, failures)
+
+    for needle in (
+        "ARG VCS_REF=unknown",
+        "git.commit.id=%s",
+        "taxonomy-app/src/main/resources/git.properties",
+    ):
+        require(dockerfile, needle, DOCKERFILE, failures)
+
+    if failures:
+        print("Delivery hardening contract failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        "Delivery hardening contract passed: reports are commit-bound and atomic, "
+        "Render verification proves the deployed SHA, responsive tree height remains "
+        "bounded, the container exposes its build commit, and the Rancher prefix profile is explicit."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-delivery-hardening.py
+++ b/.github/scripts/check-delivery-hardening.py
@@ -13,6 +13,7 @@ CSS = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "css" / 
 I18N = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "js" / "taxonomy-i18n.js"
 UI_EVIDENCE = ROOT / ".github" / "scripts" / "ui-role-state-evidence.mjs"
 RANCHER = ROOT / "deploy" / "helm" / "taxonomy" / "values-rancher-rke2.yaml"
+MODEL_DOWNLOAD = ROOT / ".github" / "scripts" / "download-embedding-model.sh"
 DOCKERFILE = ROOT / "Dockerfile"
 
 
@@ -28,6 +29,7 @@ def main() -> int:
     i18n = I18N.read_text(encoding="utf-8")
     ui_evidence = UI_EVIDENCE.read_text(encoding="utf-8")
     rancher = RANCHER.read_text(encoding="utf-8")
+    model_download = MODEL_DOWNLOAD.read_text(encoding="utf-8")
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     failures: list[str] = []
 
@@ -39,6 +41,8 @@ def main() -> int:
         "python3 .github/scripts/generate-quality-site.py",
         '--commit "$GITHUB_SHA"',
         "taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml",
+        "Restore pinned embedding model",
+        "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
     ):
         require(ci, needle, CI, failures)
 
@@ -83,6 +87,15 @@ def main() -> int:
         'cpu: "500m"',
     ):
         require(rancher, needle, RANCHER, failures)
+
+    for needle in (
+        "model_is_valid",
+        "--retry 12",
+        "--retry-max-time 600",
+        "mktemp -d",
+        "MODEL_PROVENANCE.txt",
+    ):
+        require(model_download, needle, MODEL_DOWNLOAD, failures)
 
     for needle in (
         "ARG VCS_REF=unknown",

--- a/.github/scripts/download-embedding-model.sh
+++ b/.github/scripts/download-embedding-model.sh
@@ -7,15 +7,43 @@ MODEL_DIRECTORY=${MODEL_DIRECTORY:-models/bge-small-en-v1.5}
 MODEL_ONNX_SHA256=${MODEL_ONNX_SHA256:-828e1496d7fabb79cfa4dcd84fa38625c0d3d21da474a00f08db0f559940cf35}
 
 BASE_URL="https://huggingface.co/${MODEL_REPOSITORY}/resolve/${MODEL_REVISION}"
-mkdir -p "${MODEL_DIRECTORY}"
+REQUIRED_FILES=(model.onnx tokenizer.json tokenizer_config.json special_tokens_map.json config.json)
+
+model_is_valid() {
+  local file
+  for file in "${REQUIRED_FILES[@]}"; do
+    [[ -s "${MODEL_DIRECTORY}/${file}" ]] || return 1
+  done
+  printf '%s  %s\n' "${MODEL_ONNX_SHA256}" "${MODEL_DIRECTORY}/model.onnx" \
+    | sha256sum --check --strict --status
+}
+
+if model_is_valid; then
+  printf 'Using cached pinned embedding model: %s@%s\n' \
+    "${MODEL_REPOSITORY}" "${MODEL_REVISION}"
+  exit 0
+fi
+
+mkdir -p "$(dirname "${MODEL_DIRECTORY}")"
+TEMP_DIRECTORY=$(mktemp -d "${MODEL_DIRECTORY}.download.XXXXXX")
+trap 'rm -rf "${TEMP_DIRECTORY}"' EXIT
+
+CURL_AUTH=()
+if [[ -n "${HF_TOKEN:-}" ]]; then
+  CURL_AUTH=(--header "Authorization: Bearer ${HF_TOKEN}")
+fi
 
 fetch() {
   local remote_path=$1
   local target_name=$2
   curl --fail --silent --show-error --location \
-       --retry 4 --retry-all-errors --connect-timeout 20 \
-       --output "${MODEL_DIRECTORY}/${target_name}" \
-       "${BASE_URL}/${remote_path}"
+       --retry 12 --retry-all-errors --retry-max-time 600 \
+       --connect-timeout 20 --max-time 300 \
+       --user-agent "Taxonomy-CI/${GITHUB_SHA:-local}" \
+       --header 'Accept: application/octet-stream' \
+       "${CURL_AUTH[@]}" \
+       --output "${TEMP_DIRECTORY}/${target_name}" \
+       "${BASE_URL}/${remote_path}?download=true"
 }
 
 fetch "onnx/model.onnx" "model.onnx"
@@ -24,16 +52,22 @@ fetch "tokenizer_config.json" "tokenizer_config.json"
 fetch "special_tokens_map.json" "special_tokens_map.json"
 fetch "config.json" "config.json"
 
-printf '%s  %s\n' "${MODEL_ONNX_SHA256}" "${MODEL_DIRECTORY}/model.onnx" | sha256sum --check --strict
+printf '%s  %s\n' "${MODEL_ONNX_SHA256}" "${TEMP_DIRECTORY}/model.onnx" \
+  | sha256sum --check --strict
 
-cat > "${MODEL_DIRECTORY}/MODEL_PROVENANCE.txt" <<EOF
+cat > "${TEMP_DIRECTORY}/MODEL_PROVENANCE.txt" <<EOF_PROVENANCE
 repository=${MODEL_REPOSITORY}
 revision=${MODEL_REVISION}
 model_file=onnx/model.onnx
 model_sha256=${MODEL_ONNX_SHA256}
 license=MIT
 source=https://huggingface.co/${MODEL_REPOSITORY}/tree/${MODEL_REVISION}
-EOF
+EOF_PROVENANCE
+
+mkdir -p "${MODEL_DIRECTORY}"
+for file in "${REQUIRED_FILES[@]}" MODEL_PROVENANCE.txt; do
+  mv -f "${TEMP_DIRECTORY}/${file}" "${MODEL_DIRECTORY}/${file}"
+done
 
 printf 'Pinned embedding model downloaded and verified: %s@%s\n' \
   "${MODEL_REPOSITORY}" "${MODEL_REVISION}"

--- a/.github/scripts/generate-quality-site.py
+++ b/.github/scripts/generate-quality-site.py
@@ -1,169 +1,192 @@
 #!/usr/bin/env python3
-"""Build an immutable, commit-bound quality-report site from verified CI output."""
+"""Generate commit-bound quality badges and a compact test report from CI evidence."""
 
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import html
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
 
-def _int_attr(element: ET.Element, name: str) -> int:
-    value = element.attrib.get(name, "0")
+def _integer(element: ET.Element, name: str) -> int:
+    value = element.get(name, "0")
     try:
         return int(float(value))
-    except ValueError as exc:
-        raise ValueError(f"Invalid {name}={value!r} in {element.tag}") from exc
+    except ValueError as error:
+        raise ValueError(f"invalid {name}={value!r} in {element.tag}") from error
 
 
-def read_test_totals(report_root: Path) -> dict[str, int]:
+def collect_tests(root: Path) -> dict[str, int]:
     totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
-    reports = sorted((report_root / "tests").rglob("TEST-*.xml"))
-    if not reports:
-        raise FileNotFoundError("No JUnit TEST-*.xml reports found in quality-reports/tests")
+    files = sorted(root.rglob("TEST-*.xml"))
+    if not files:
+        raise FileNotFoundError(f"no JUnit XML reports found below {root}")
 
-    for report in reports:
-        root = ET.parse(report).getroot()
-        suites: list[ET.Element]
-        if root.tag.endswith("testsuite"):
-            suites = [root]
-        elif root.tag.endswith("testsuites") and "tests" in root.attrib:
-            suites = [root]
+    for report in files:
+        document = ET.parse(report).getroot()
+        if document.tag.endswith("testsuite"):
+            suites = [document]
         else:
-            suites = [child for child in root if child.tag.endswith("testsuite")]
+            suites = [child for child in document if child.tag.endswith("testsuite")]
+        if not suites:
+            raise ValueError(f"no testsuite element in {report}")
         for suite in suites:
             for key in totals:
-                totals[key] += _int_attr(suite, key)
+                totals[key] += _integer(suite, key)
+
+    totals["passed"] = (
+        totals["tests"] - totals["failures"] - totals["errors"] - totals["skipped"]
+    )
+    if totals["passed"] < 0:
+        raise ValueError(f"inconsistent test totals: {totals}")
     if totals["tests"] <= 0:
         raise ValueError("JUnit reports contained zero tests")
+    totals["reportFiles"] = len(files)
     return totals
 
 
-def read_line_coverage(report_root: Path) -> dict[str, int | float]:
-    report = report_root / "coverage" / "jacoco.xml"
+def collect_coverage(report: Path) -> dict[str, float | int]:
     if not report.is_file():
-        raise FileNotFoundError(f"Missing aggregate JaCoCo XML report: {report}")
+        raise FileNotFoundError(f"aggregate JaCoCo report missing: {report}")
     root = ET.parse(report).getroot()
-    counter = next((item for item in root.findall("counter")
-                    if item.attrib.get("type") == "LINE"), None)
-    if counter is None:
-        raise ValueError("Aggregate JaCoCo report contains no LINE counter")
-    missed = _int_attr(counter, "missed")
-    covered = _int_attr(counter, "covered")
-    total = missed + covered
-    if total <= 0:
-        raise ValueError("Aggregate JaCoCo LINE counter contains zero lines")
-    return {
-        "covered": covered,
-        "missed": missed,
-        "total": total,
-        "percent": round(covered * 100.0 / total, 2),
-    }
+    result: dict[str, float | int] = {}
+    for counter in root.findall("counter"):
+        metric = counter.get("type", "").lower()
+        if not metric:
+            continue
+        missed = _integer(counter, "missed")
+        covered = _integer(counter, "covered")
+        total = missed + covered
+        result[f"{metric}Missed"] = missed
+        result[f"{metric}Covered"] = covered
+        result[f"{metric}Percent"] = round(100.0 * covered / total, 2) if total else 100.0
+    if "instructionPercent" not in result:
+        raise ValueError(f"aggregate instruction counter missing in {report}")
+    return result
 
 
-def badge(label: str, message: str, colour: str) -> str:
-    label_width = max(44, 7 * len(label) + 14)
-    message_width = max(44, 7 * len(message) + 14)
-    width = label_width + message_width
-    label_escaped = html.escape(label)
-    message_escaped = html.escape(message)
-    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20" role="img" aria-label="{label_escaped}: {message_escaped}">
-  <title>{label_escaped}: {message_escaped}</title>
-  <linearGradient id="s" x2="0" y2="100%">
-    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
-    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
-    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
-    <stop offset="1" stop-color="#000" stop-opacity=".5"/>
-  </linearGradient>
-  <clipPath id="r"><rect width="{width}" height="20" rx="3" fill="#fff"/></clipPath>
-  <g clip-path="url(#r)">
-    <rect width="{label_width}" height="20" fill="#555"/>
-    <rect x="{label_width}" width="{message_width}" height="20" fill="{colour}"/>
-    <rect width="{width}" height="20" fill="url(#s)"/>
-  </g>
-  <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
-    <text x="{label_width / 2:g}" y="15" fill="#010101" fill-opacity=".3">{label_escaped}</text>
-    <text x="{label_width / 2:g}" y="14">{label_escaped}</text>
-    <text x="{label_width + message_width / 2:g}" y="15" fill="#010101" fill-opacity=".3">{message_escaped}</text>
-    <text x="{label_width + message_width / 2:g}" y="14">{message_escaped}</text>
-  </g>
-</svg>
-'''
+def coverage_color(percent: float) -> str:
+    if percent >= 90:
+        return "brightgreen"
+    if percent >= 80:
+        return "green"
+    if percent >= 70:
+        return "yellowgreen"
+    if percent >= 60:
+        return "yellow"
+    return "red"
 
 
-def build_site(report_root: Path, commit: str) -> dict[str, object]:
-    if not commit.strip():
-        raise ValueError("Verified commit SHA must not be empty")
-    tests = read_test_totals(report_root)
-    coverage = read_line_coverage(report_root)
-    failed = tests["failures"] + tests["errors"]
-    passed = tests["tests"] - failed - tests["skipped"]
-    tests.update({"passed": passed, "failed": failed})
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
-    generated_at = datetime.now(timezone.utc).isoformat()
-    metadata: dict[str, object] = {
+
+def write_outputs(root: Path, commit: str, generated_at: str) -> dict[str, object]:
+    tests = collect_tests(root / "tests")
+    coverage = collect_coverage(root / "coverage" / "jacoco.xml")
+    instruction_percent = float(coverage["instructionPercent"])
+    clean = tests["failures"] == 0 and tests["errors"] == 0
+
+    summary: dict[str, object] = {
         "schemaVersion": 1,
+        "commit": commit,
         "verifiedCommit": commit,
         "generatedAt": generated_at,
         "tests": tests,
         "coverage": coverage,
     }
+    write_json(root / "quality-summary.json", summary)
+    write_json(
+        root / "tests" / "badge.json",
+        {
+            "schemaVersion": 1,
+            "label": "tests",
+            "message": f"{tests['passed']} passed",
+            "color": "brightgreen" if clean else "red",
+        },
+    )
+    write_json(
+        root / "coverage" / "badge.json",
+        {
+            "schemaVersion": 1,
+            "label": "reactor coverage",
+            "message": f"{instruction_percent:.2f}%",
+            "color": coverage_color(instruction_percent),
+        },
+    )
+    root.joinpath(".nojekyll").touch()
 
-    badges = report_root / "badges"
-    badges.mkdir(parents=True, exist_ok=True)
-    test_message = f'{passed} passed' if failed == 0 else f'{failed} failed'
-    (badges / "tests.svg").write_text(
-        badge("tests", test_message, "#4c1" if failed == 0 else "#e05d44"),
-        encoding="utf-8",
-    )
-    percent = float(coverage["percent"])
-    colour = "#4c1" if percent >= 80 else "#dfb317" if percent >= 60 else "#e05d44"
-    (badges / "coverage.svg").write_text(
-        badge("coverage", f"{percent:.2f}%", colour), encoding="utf-8"
-    )
-    (report_root / "metadata.json").write_text(
-        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
-    index = f"""<!doctype html>
+    branch_percent = float(coverage.get("branchPercent", 0.0))
+    report = f"""<!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Taxonomy verified quality reports</title>
-  <style>
-    body {{ max-width: 64rem; margin: 2rem auto; padding: 0 1rem; font: 16px/1.5 system-ui, sans-serif; }}
-    code {{ overflow-wrap: anywhere; }}
-    .badges img {{ margin-right: .5rem; }}
-  </style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Taxonomy test report</title>
+<style>
+body {{ font: 16px/1.5 system-ui, sans-serif; max-width: 70rem; margin: 2rem auto; padding: 0 1rem; }}
+table {{ border-collapse: collapse; }}
+th, td {{ border: 1px solid #bbb; padding: .45rem .7rem; text-align: right; }}
+th:first-child, td:first-child {{ text-align: left; }}
+code {{ overflow-wrap: anywhere; }}
+</style>
 </head>
 <body>
-  <h1>Taxonomy verified quality reports</h1>
-  <p class="badges"><img src="badges/tests.svg" alt="Test result"> <img src="badges/coverage.svg" alt="Line coverage"></p>
-  <p>Verified commit: <code>{html.escape(commit)}</code></p>
-  <p>Generated: <time datetime="{html.escape(generated_at)}">{html.escape(generated_at)}</time></p>
-  <ul>
-    <li><a href="coverage/index.html">JaCoCo coverage report</a></li>
-    <li><a href="metadata.json">Machine-readable provenance and metrics</a></li>
-    <li><a href="README.txt">Verification provenance</a></li>
-  </ul>
+<h1>Taxonomy test report</h1>
+<p>Verified commit: <code>{html.escape(commit)}</code></p>
+<p>Generated: {html.escape(generated_at)}</p>
+<table>
+<thead><tr><th>Metric</th><th>Value</th></tr></thead>
+<tbody>
+<tr><td>Registered tests</td><td>{tests['tests']}</td></tr>
+<tr><td>Passed</td><td>{tests['passed']}</td></tr>
+<tr><td>Skipped</td><td>{tests['skipped']}</td></tr>
+<tr><td>Failures</td><td>{tests['failures']}</td></tr>
+<tr><td>Errors</td><td>{tests['errors']}</td></tr>
+<tr><td>Instruction coverage</td><td>{instruction_percent:.2f}%</td></tr>
+<tr><td>Branch coverage</td><td>{branch_percent:.2f}%</td></tr>
+</tbody>
+</table>
+<p><a href="../quality-summary.json">Machine-readable quality summary</a></p>
 </body>
 </html>
 """
-    (report_root / "index.html").write_text(index, encoding="utf-8")
-    return metadata
+    (root / "tests" / "surefire-report.html").write_text(report, encoding="utf-8")
+    index = f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Taxonomy verified quality reports</title></head>
+<body>
+<h1>Taxonomy verified quality reports</h1>
+<p>Verified commit: <code>{html.escape(commit)}</code></p>
+<ul>
+<li><a href="tests/surefire-report.html">Test report</a></li>
+<li><a href="coverage/index.html">JaCoCo coverage report</a></li>
+<li><a href="quality-summary.json">Machine-readable provenance and metrics</a></li>
+</ul>
+</body></html>
+"""
+    (root / "index.html").write_text(index, encoding="utf-8")
+    return summary
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--root", type=Path, default=Path("target/quality-reports"))
     parser.add_argument("--commit", required=True)
+    parser.add_argument(
+        "--generated-at",
+        default=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
     args = parser.parse_args()
-    metadata = build_site(args.root, args.commit)
-    print(json.dumps(metadata, sort_keys=True))
+    summary = write_outputs(args.root, args.commit.strip(), args.generated_at)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.github/scripts/generate-quality-site.py
+++ b/.github/scripts/generate-quality-site.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Build an immutable, commit-bound quality-report site from verified CI output."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def _int_attr(element: ET.Element, name: str) -> int:
+    value = element.attrib.get(name, "0")
+    try:
+        return int(float(value))
+    except ValueError as exc:
+        raise ValueError(f"Invalid {name}={value!r} in {element.tag}") from exc
+
+
+def read_test_totals(report_root: Path) -> dict[str, int]:
+    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+    reports = sorted((report_root / "tests").rglob("TEST-*.xml"))
+    if not reports:
+        raise FileNotFoundError("No JUnit TEST-*.xml reports found in quality-reports/tests")
+
+    for report in reports:
+        root = ET.parse(report).getroot()
+        suites: list[ET.Element]
+        if root.tag.endswith("testsuite"):
+            suites = [root]
+        elif root.tag.endswith("testsuites") and "tests" in root.attrib:
+            suites = [root]
+        else:
+            suites = [child for child in root if child.tag.endswith("testsuite")]
+        for suite in suites:
+            for key in totals:
+                totals[key] += _int_attr(suite, key)
+    if totals["tests"] <= 0:
+        raise ValueError("JUnit reports contained zero tests")
+    return totals
+
+
+def read_line_coverage(report_root: Path) -> dict[str, int | float]:
+    report = report_root / "coverage" / "jacoco.xml"
+    if not report.is_file():
+        raise FileNotFoundError(f"Missing aggregate JaCoCo XML report: {report}")
+    root = ET.parse(report).getroot()
+    counter = next((item for item in root.findall("counter")
+                    if item.attrib.get("type") == "LINE"), None)
+    if counter is None:
+        raise ValueError("Aggregate JaCoCo report contains no LINE counter")
+    missed = _int_attr(counter, "missed")
+    covered = _int_attr(counter, "covered")
+    total = missed + covered
+    if total <= 0:
+        raise ValueError("Aggregate JaCoCo LINE counter contains zero lines")
+    return {
+        "covered": covered,
+        "missed": missed,
+        "total": total,
+        "percent": round(covered * 100.0 / total, 2),
+    }
+
+
+def badge(label: str, message: str, colour: str) -> str:
+    label_width = max(44, 7 * len(label) + 14)
+    message_width = max(44, 7 * len(message) + 14)
+    width = label_width + message_width
+    label_escaped = html.escape(label)
+    message_escaped = html.escape(message)
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="20" role="img" aria-label="{label_escaped}: {message_escaped}">
+  <title>{label_escaped}: {message_escaped}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1" stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="{width}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="{label_width}" height="20" fill="#555"/>
+    <rect x="{label_width}" width="{message_width}" height="20" fill="{colour}"/>
+    <rect width="{width}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+    <text x="{label_width / 2:g}" y="15" fill="#010101" fill-opacity=".3">{label_escaped}</text>
+    <text x="{label_width / 2:g}" y="14">{label_escaped}</text>
+    <text x="{label_width + message_width / 2:g}" y="15" fill="#010101" fill-opacity=".3">{message_escaped}</text>
+    <text x="{label_width + message_width / 2:g}" y="14">{message_escaped}</text>
+  </g>
+</svg>
+'''
+
+
+def build_site(report_root: Path, commit: str) -> dict[str, object]:
+    if not commit.strip():
+        raise ValueError("Verified commit SHA must not be empty")
+    tests = read_test_totals(report_root)
+    coverage = read_line_coverage(report_root)
+    failed = tests["failures"] + tests["errors"]
+    passed = tests["tests"] - failed - tests["skipped"]
+    tests.update({"passed": passed, "failed": failed})
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    metadata: dict[str, object] = {
+        "schemaVersion": 1,
+        "verifiedCommit": commit,
+        "generatedAt": generated_at,
+        "tests": tests,
+        "coverage": coverage,
+    }
+
+    badges = report_root / "badges"
+    badges.mkdir(parents=True, exist_ok=True)
+    test_message = f'{passed} passed' if failed == 0 else f'{failed} failed'
+    (badges / "tests.svg").write_text(
+        badge("tests", test_message, "#4c1" if failed == 0 else "#e05d44"),
+        encoding="utf-8",
+    )
+    percent = float(coverage["percent"])
+    colour = "#4c1" if percent >= 80 else "#dfb317" if percent >= 60 else "#e05d44"
+    (badges / "coverage.svg").write_text(
+        badge("coverage", f"{percent:.2f}%", colour), encoding="utf-8"
+    )
+    (report_root / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    index = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Taxonomy verified quality reports</title>
+  <style>
+    body {{ max-width: 64rem; margin: 2rem auto; padding: 0 1rem; font: 16px/1.5 system-ui, sans-serif; }}
+    code {{ overflow-wrap: anywhere; }}
+    .badges img {{ margin-right: .5rem; }}
+  </style>
+</head>
+<body>
+  <h1>Taxonomy verified quality reports</h1>
+  <p class="badges"><img src="badges/tests.svg" alt="Test result"> <img src="badges/coverage.svg" alt="Line coverage"></p>
+  <p>Verified commit: <code>{html.escape(commit)}</code></p>
+  <p>Generated: <time datetime="{html.escape(generated_at)}">{html.escape(generated_at)}</time></p>
+  <ul>
+    <li><a href="coverage/index.html">JaCoCo coverage report</a></li>
+    <li><a href="metadata.json">Machine-readable provenance and metrics</a></li>
+    <li><a href="README.txt">Verification provenance</a></li>
+  </ul>
+</body>
+</html>
+"""
+    (report_root / "index.html").write_text(index, encoding="utf-8")
+    return metadata
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--commit", required=True)
+    args = parser.parse_args()
+    metadata = build_site(args.root, args.commit)
+    print(json.dumps(metadata, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-generate-quality-site.py
+++ b/.github/scripts/test-generate-quality-site.py
@@ -1,39 +1,78 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import importlib.util
 import json
-import subprocess
-import sys
-import tempfile
 from pathlib import Path
+import tempfile
+import unittest
 
-SCRIPT = Path(__file__).with_name("generate-quality-site.py")
+SCRIPT = Path(__file__).with_name("generate-quality-site.py").resolve()
+SPEC = importlib.util.spec_from_file_location("generate_quality_site", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
 
-with tempfile.TemporaryDirectory() as temporary:
-    root = Path(temporary)
-    tests = root / "tests" / "module" / "target" / "surefire-reports"
-    tests.mkdir(parents=True)
-    (tests / "TEST-sample.xml").write_text(
-        '<testsuite tests="5" failures="1" errors="0" skipped="1"></testsuite>',
-        encoding="utf-8",
-    )
-    coverage = root / "coverage"
-    coverage.mkdir()
-    (coverage / "jacoco.xml").write_text(
-        '<report name="aggregate"><counter type="LINE" missed="20" covered="80"/></report>',
-        encoding="utf-8",
-    )
-    completed = subprocess.run(
-        [sys.executable, str(SCRIPT), "--root", str(root), "--commit", "abc1234"],
-        check=True, text=True, capture_output=True,
-    )
-    output = json.loads(completed.stdout)
-    assert output["verifiedCommit"] == "abc1234"
-    assert output["tests"]["passed"] == 3
-    assert output["tests"]["failed"] == 1
-    assert output["coverage"]["percent"] == 80.0
-    assert "1 failed" in (root / "badges" / "tests.svg").read_text(encoding="utf-8")
-    assert "80.00%" in (root / "badges" / "coverage.svg").read_text(encoding="utf-8")
-    assert (root / "index.html").is_file()
 
-print("generate-quality-site tests passed")
+class GenerateQualitySummaryTest(unittest.TestCase):
+    def test_generates_commit_bound_badges_and_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            reports = root / "tests" / "module" / "target" / "surefire-reports"
+            reports.mkdir(parents=True)
+            reports.joinpath("TEST-example.xml").write_text(
+                '<testsuite tests="5" failures="0" errors="0" skipped="1"/>',
+                encoding="utf-8",
+            )
+            coverage = root / "coverage"
+            coverage.mkdir()
+            coverage.joinpath("jacoco.xml").write_text(
+                '<report><counter type="INSTRUCTION" missed="20" covered="80"/>'
+                '<counter type="BRANCH" missed="3" covered="7"/></report>',
+                encoding="utf-8",
+            )
+
+            summary = MODULE.write_outputs(root, "abc123", "2026-08-06T13:00:00+00:00")
+
+            self.assertEqual(4, summary["tests"]["passed"])
+            self.assertEqual(80.0, summary["coverage"]["instructionPercent"])
+            test_badge = json.loads((root / "tests" / "badge.json").read_text())
+            coverage_badge = json.loads((root / "coverage" / "badge.json").read_text())
+            self.assertEqual("4 passed", test_badge["message"])
+            self.assertEqual("80.00%", coverage_badge["message"])
+            self.assertEqual(
+                "abc123",
+                json.loads((root / "quality-summary.json").read_text())["commit"],
+            )
+            self.assertTrue((root / "tests" / "surefire-report.html").is_file())
+            self.assertTrue((root / ".nojekyll").is_file())
+            self.assertTrue((root / "index.html").is_file())
+
+    def test_missing_reports_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(FileNotFoundError):
+                MODULE.collect_tests(Path(directory))
+
+    def test_test_failures_make_badge_red(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            reports = root / "tests"
+            reports.mkdir()
+            reports.joinpath("TEST-failing.xml").write_text(
+                '<testsuite tests="2" failures="1" errors="0" skipped="0"/>',
+                encoding="utf-8",
+            )
+            coverage = root / "coverage"
+            coverage.mkdir()
+            coverage.joinpath("jacoco.xml").write_text(
+                '<report><counter type="INSTRUCTION" missed="0" covered="1"/></report>',
+                encoding="utf-8",
+            )
+            MODULE.write_outputs(root, "deadbeef", "now")
+            badge = json.loads((reports / "badge.json").read_text())
+            self.assertEqual("red", badge["color"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-generate-quality-site.py
+++ b/.github/scripts/test-generate-quality-site.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("generate-quality-site.py")
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = Path(temporary)
+    tests = root / "tests" / "module" / "target" / "surefire-reports"
+    tests.mkdir(parents=True)
+    (tests / "TEST-sample.xml").write_text(
+        '<testsuite tests="5" failures="1" errors="0" skipped="1"></testsuite>',
+        encoding="utf-8",
+    )
+    coverage = root / "coverage"
+    coverage.mkdir()
+    (coverage / "jacoco.xml").write_text(
+        '<report name="aggregate"><counter type="LINE" missed="20" covered="80"/></report>',
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--root", str(root), "--commit", "abc1234"],
+        check=True, text=True, capture_output=True,
+    )
+    output = json.loads(completed.stdout)
+    assert output["verifiedCommit"] == "abc1234"
+    assert output["tests"]["passed"] == 3
+    assert output["tests"]["failed"] == 1
+    assert output["coverage"]["percent"] == 80.0
+    assert "1 failed" in (root / "badges" / "tests.svg").read_text(encoding="utf-8")
+    assert "80.00%" in (root / "badges" / "coverage.svg").read_text(encoding="utf-8")
+    assert (root / "index.html").is_file()
+
+print("generate-quality-site tests passed")

--- a/.github/scripts/test-taxonomy-base-path.mjs
+++ b/.github/scripts/test-taxonomy-base-path.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const source = await readFile(
+  new URL('../../taxonomy-app/src/main/resources/static/js/taxonomy-i18n.js', import.meta.url),
+  'utf8'
+);
+
+async function loadBootstrap(scriptUrl) {
+  const requests = [];
+  const nativeFetch = async input => {
+    requests.push(input);
+    return { ok: true, json: async () => ({}) };
+  };
+  const document = {
+    currentScript: { src: scriptUrl },
+    cookie: '',
+    documentElement: { lang: 'en' },
+    querySelector: () => null,
+    createElement: () => ({ dataset: {} }),
+    head: { appendChild: () => undefined },
+    dispatchEvent: () => undefined
+  };
+  const window = {
+    fetch: nativeFetch,
+    location: { href: 'https://taxonomy.example.test/taxonomy/' }
+  };
+  const context = vm.createContext({
+    window,
+    document,
+    localStorage: { getItem: () => null, setItem: () => undefined },
+    URL,
+    CustomEvent: class CustomEvent {},
+    encodeURIComponent,
+    console
+  });
+  context.fetch = (...args) => window.fetch(...args);
+  vm.runInContext(source, context, { filename: 'taxonomy-i18n.js' });
+  await window.TaxonomyI18n.ready();
+  return { window, requests };
+}
+
+{
+  const { window, requests } = await loadBootstrap(
+    'https://taxonomy.example.test/taxonomy/js/taxonomy-i18n.js'
+  );
+  assert.equal(window.TaxonomyI18n.getBasePath(), '/taxonomy');
+  assert.equal(requests[0], '/taxonomy/api/i18n/en');
+
+  await window.fetch('/api/status');
+  await window.fetch('/taxonomy/api/status');
+  await window.fetch('https://provider.example.test/v1/status');
+  assert.deepEqual(requests.slice(1), [
+    '/taxonomy/api/status',
+    '/taxonomy/api/status',
+    'https://provider.example.test/v1/status'
+  ]);
+}
+
+{
+  const { window, requests } = await loadBootstrap(
+    'https://taxonomy.example.test/js/taxonomy-i18n.js'
+  );
+  assert.equal(window.TaxonomyI18n.getBasePath(), '');
+  assert.equal(requests[0], '/api/i18n/en');
+}
+
+console.log('Taxonomy base-path bootstrap tests passed.');

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -3,23 +3,48 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import unittest
 
-SCRIPT = Path(__file__).with_name("verify-deployment.py")
-spec = importlib.util.spec_from_file_location("verify_deployment", SCRIPT)
-module = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-spec.loader.exec_module(module)
+SCRIPT = Path(__file__).with_name("verify-deployment.py").resolve()
+SPEC = importlib.util.spec_from_file_location("verify_deployment", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
 
-assert module.commit_matches("abcdef123456", "abcdef1")
-assert module.commit_matches("abcdef1", "abcdef123456")
-assert not module.commit_matches("abcdef1", "1234567")
-assert module.commit_matches(None, None)
-assert not module.commit_matches(None, "abcdef1")
 
-dockerfile = Path(__file__).resolve().parents[2] / "Dockerfile"
-docker_contract = dockerfile.read_text(encoding="utf-8")
-assert "ARG VCS_REF=unknown" in docker_contract
-assert "git.commit.id=%s" in docker_contract
-assert "taxonomy-app/src/main/resources/git.properties" in docker_contract
+class VerifyRenderDeploymentTest(unittest.TestCase):
+    def test_accepts_nested_full_commit(self) -> None:
+        payload = {"git": {"commit": {"id": "abcdef1234567890"}}}
+        self.assertTrue(MODULE.contains_commit(payload, "abcdef1234567890"))
 
-print("verify-deployment tests passed")
+    def test_accepts_abbreviated_commit(self) -> None:
+        payload = {"git": {"commit": {"id": "abcdef1"}}}
+        self.assertTrue(MODULE.contains_commit(payload, "abcdef1234567890"))
+
+    def test_verify_once_requires_readiness_and_commit(self) -> None:
+        def fetcher(url: str):
+            if url.endswith("/readiness"):
+                return {"status": "UP"}
+            return {"git": {"commit": {"id": "0123456789abcdef"}}}
+
+        self.assertEqual(
+            (True, "readiness is UP and expected commit is live"),
+            MODULE.verify_once("https://example.invalid/", "0123456789abcdef", fetcher),
+        )
+
+    def test_verify_once_rejects_stale_commit(self) -> None:
+        def fetcher(url: str):
+            if url.endswith("/readiness"):
+                return {"status": "UP"}
+            return {"git": {"commit": {"id": "oldcommit"}}}
+
+        ok, detail = MODULE.verify_once(
+            "https://example.invalid", "0123456789abcdef", fetcher
+        )
+        self.assertFalse(ok)
+        self.assertIn("expected commit", detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("verify-deployment.py")
+spec = importlib.util.spec_from_file_location("verify_deployment", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+assert module.commit_matches("abcdef123456", "abcdef1")
+assert module.commit_matches("abcdef1", "abcdef123456")
+assert not module.commit_matches("abcdef1", "1234567")
+assert module.commit_matches(None, None)
+assert not module.commit_matches(None, "abcdef1")
+
+print("verify-deployment tests passed")

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -16,4 +16,10 @@ assert not module.commit_matches("abcdef1", "1234567")
 assert module.commit_matches(None, None)
 assert not module.commit_matches(None, "abcdef1")
 
+dockerfile = Path(__file__).resolve().parents[2] / "Dockerfile"
+docker_contract = dockerfile.read_text(encoding="utf-8")
+assert "ARG VCS_REF=unknown" in docker_contract
+assert "git.commit.id=%s" in docker_contract
+assert "taxonomy-app/src/main/resources/git.properties" in docker_contract
+
 print("verify-deployment tests passed")

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -17,6 +17,13 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       width: Math.min(dimensions.width, 1440),
       height: Math.min(dimensions.height, 1000)
     };
+    const documentHeightViewportRatio = Number(
+      (dimensions.height / Math.max(1, viewport.height)).toFixed(4));
+    if (state === 'analysis-success' && documentHeightViewportRatio > 25) {
+      throw new Error(
+        `Analysis page height is pathological: ${dimensions.height}px / ${viewport.height}px `
+        + `= ${documentHeightViewportRatio} viewports`);
+    }
     const captured = policy.shouldCapture(state);
     const strategy = screenshotStrategy({
       mode: policy.mode,
@@ -74,6 +81,7 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       captured,
       dimensions,
       viewport,
+      documentHeightViewportRatio,
       screenshotFiles,
       segments
     };

--- a/.github/scripts/ui-role-state-evidence.mjs
+++ b/.github/scripts/ui-role-state-evidence.mjs
@@ -7,6 +7,30 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
   const policy = createEvidencePolicy();
   const states = [];
 
+  async function measureTaxonomyTreeViewport() {
+    return page.evaluate(() => {
+      const tree = document.getElementById('taxonomyTree');
+      const scroller = tree?.closest('.card-body');
+      if (!scroller || scroller.offsetParent === null) return null;
+      const style = window.getComputedStyle(scroller);
+      const viewportHeight = window.innerHeight;
+      const clientHeight = scroller.clientHeight;
+      const scrollHeight = scroller.scrollHeight;
+      const overflowY = style.overflowY;
+      const maxAllowedHeight = Math.ceil(viewportHeight * 0.9);
+      return {
+        clientHeight,
+        scrollHeight,
+        viewportHeight,
+        maxAllowedHeight,
+        computedMaxHeight: style.maxHeight,
+        overflowY,
+        bounded: clientHeight <= maxAllowedHeight,
+        scrollable: scrollHeight <= clientHeight + 1 || ['auto', 'scroll'].includes(overflowY)
+      };
+    });
+  }
+
   async function saveState(state) {
     const prefix = path.join(outputDir, state);
     const dimensions = await page.evaluate(() => ({
@@ -17,13 +41,9 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       width: Math.min(dimensions.width, 1440),
       height: Math.min(dimensions.height, 1000)
     };
+    const taxonomyTreeViewport = await measureTaxonomyTreeViewport();
     const documentHeightViewportRatio = Number(
       (dimensions.height / Math.max(1, viewport.height)).toFixed(4));
-    if (state === 'analysis-success' && documentHeightViewportRatio > 25) {
-      throw new Error(
-        `Analysis page height is pathological: ${dimensions.height}px / ${viewport.height}px `
-        + `= ${documentHeightViewportRatio} viewports`);
-    }
     const captured = policy.shouldCapture(state);
     const strategy = screenshotStrategy({
       mode: policy.mode,
@@ -33,6 +53,41 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
     });
     const screenshotFiles = [];
     const segments = [];
+
+    if (taxonomyTreeViewport
+        && (!taxonomyTreeViewport.bounded || !taxonomyTreeViewport.scrollable)) {
+      const stateSummary = {
+        state,
+        evidenceMode: policy.mode,
+        captureStrategy: 'layout-gate',
+        captured: false,
+        dimensions,
+        viewport,
+        taxonomyTreeViewport,
+        documentHeightViewportRatio,
+        screenshotFiles,
+        segments
+      };
+      states.push(stateSummary);
+      await writeFile(
+        `${prefix}.screenshots.json`,
+        `${JSON.stringify(stateSummary, null, 2)}\n`,
+        'utf8'
+      );
+      throw new Error(
+        `Taxonomy tree viewport is unbounded in ${state}: `
+        + `${taxonomyTreeViewport.clientHeight}px for a `
+        + `${taxonomyTreeViewport.viewportHeight}px viewport, `
+        + `max-height=${taxonomyTreeViewport.computedMaxHeight}, `
+        + `overflow-y=${taxonomyTreeViewport.overflowY}`
+      );
+    }
+
+    if (state === 'analysis-success' && documentHeightViewportRatio > 25) {
+      throw new Error(
+        `Analysis page height is pathological: ${dimensions.height}px / ${viewport.height}px `
+        + `= ${documentHeightViewportRatio} viewports`);
+    }
 
     if (strategy === 'viewport') {
       const mainContent = page.locator('#mainContent');
@@ -81,6 +136,7 @@ export function createRoleStateEvidence({ page, outputDir, checks, findings }) {
       captured,
       dimensions,
       viewport,
+      taxonomyTreeViewport,
       documentHeightViewportRatio,
       screenshotFiles,
       segments

--- a/.github/scripts/verify-deployment.py
+++ b/.github/scripts/verify-deployment.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Poll a deployed Taxonomy instance until readiness and build provenance match."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def _fetch_json(url: str, timeout: float) -> dict[str, Any]:
+    request = Request(url, headers={"Accept": "application/json", "User-Agent": "taxonomy-deployment-smoke/1"})
+    with urlopen(request, timeout=timeout) as response:
+        if response.status != 200:
+            raise RuntimeError(f"{url} returned HTTP {response.status}")
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{url} did not return a JSON object")
+    return payload
+
+
+def _nested(payload: dict[str, Any], *path: str) -> Any:
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def commit_matches(actual: str | None, expected: str | None) -> bool:
+    if not expected:
+        return True
+    if not actual:
+        return False
+    actual = actual.lower().strip()
+    expected = expected.lower().strip()
+    return actual.startswith(expected) or expected.startswith(actual)
+
+
+def verify_once(base_url: str, expected_commit: str | None,
+                expected_version: str | None, timeout: float) -> tuple[bool, str]:
+    base = base_url.rstrip("/")
+    readiness = _fetch_json(f"{base}/actuator/health/readiness", timeout)
+    status = readiness.get("status")
+    if status != "UP":
+        return False, f"readiness status is {status!r}, expected 'UP'"
+
+    info = _fetch_json(f"{base}/actuator/info", timeout)
+    actual_commit = _nested(info, "git", "commit", "id")
+    actual_version = _nested(info, "build", "version") or _nested(info, "app", "version")
+
+    if expected_commit and not commit_matches(
+            str(actual_commit) if actual_commit is not None else None, expected_commit):
+        return False, f"deployed commit is {actual_commit!r}, expected {expected_commit!r}"
+    if expected_version and str(actual_version) != expected_version:
+        return False, f"deployed version is {actual_version!r}, expected {expected_version!r}"
+    return True, f"ready; version={actual_version!r}; commit={actual_commit!r}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--expected-commit")
+    parser.add_argument("--expected-version")
+    parser.add_argument("--attempts", type=int, default=40)
+    parser.add_argument("--interval-seconds", type=float, default=15.0)
+    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    args = parser.parse_args()
+
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+    last_detail = "deployment was not checked"
+    for attempt in range(1, args.attempts + 1):
+        try:
+            ok, detail = verify_once(
+                args.base_url, args.expected_commit, args.expected_version,
+                args.timeout_seconds)
+        except (HTTPError, URLError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as exc:
+            ok, detail = False, f"{type(exc).__name__}: {exc}"
+        last_detail = detail
+        print(f"deployment smoke attempt {attempt}/{args.attempts}: {detail}", flush=True)
+        if ok:
+            return
+        if attempt < args.attempts:
+            time.sleep(args.interval_seconds)
+    raise SystemExit(f"Deployment did not converge: {last_detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/verify-deployment.py
+++ b/.github/scripts/verify-deployment.py
@@ -1,94 +1,93 @@
 #!/usr/bin/env python3
-"""Poll a deployed Taxonomy instance until readiness and build provenance match."""
+"""Wait for a Render deployment and prove that the expected commit is live."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import time
-from typing import Any
+from typing import Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-
-def _fetch_json(url: str, timeout: float) -> dict[str, Any]:
-    request = Request(url, headers={"Accept": "application/json", "User-Agent": "taxonomy-deployment-smoke/1"})
-    with urlopen(request, timeout=timeout) as response:
-        if response.status != 200:
-            raise RuntimeError(f"{url} returned HTTP {response.status}")
-        payload = json.load(response)
-    if not isinstance(payload, dict):
-        raise RuntimeError(f"{url} did not return a JSON object")
-    return payload
+JsonFetcher = Callable[[str], object]
 
 
-def _nested(payload: dict[str, Any], *path: str) -> Any:
-    current: Any = payload
-    for key in path:
-        if not isinstance(current, dict) or key not in current:
-            return None
-        current = current[key]
-    return current
+def fetch_json(url: str) -> object:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "taxonomy-delivery-check",
+        },
+    )
+    with urlopen(request, timeout=15) as response:
+        return json.load(response)
 
 
-def commit_matches(actual: str | None, expected: str | None) -> bool:
-    if not expected:
-        return True
-    if not actual:
-        return False
-    actual = actual.lower().strip()
-    expected = expected.lower().strip()
-    return actual.startswith(expected) or expected.startswith(actual)
+def string_values(value: object):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for child in value.values():
+            yield from string_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from string_values(child)
 
 
-def verify_once(base_url: str, expected_commit: str | None,
-                expected_version: str | None, timeout: float) -> tuple[bool, str]:
-    base = base_url.rstrip("/")
-    readiness = _fetch_json(f"{base}/actuator/health/readiness", timeout)
-    status = readiness.get("status")
-    if status != "UP":
-        return False, f"readiness status is {status!r}, expected 'UP'"
-
-    info = _fetch_json(f"{base}/actuator/info", timeout)
-    actual_commit = _nested(info, "git", "commit", "id")
-    actual_version = _nested(info, "build", "version") or _nested(info, "app", "version")
-
-    if expected_commit and not commit_matches(
-            str(actual_commit) if actual_commit is not None else None, expected_commit):
-        return False, f"deployed commit is {actual_commit!r}, expected {expected_commit!r}"
-    if expected_version and str(actual_version) != expected_version:
-        return False, f"deployed version is {actual_version!r}, expected {expected_version!r}"
-    return True, f"ready; version={actual_version!r}; commit={actual_commit!r}"
+def contains_commit(payload: object, expected: str) -> bool:
+    expected = expected.strip().lower()
+    for value in string_values(payload):
+        candidate = value.strip().lower()
+        if candidate == expected:
+            return True
+        if len(candidate) >= 7 and (
+            candidate.startswith(expected) or expected.startswith(candidate)
+        ):
+            return True
+    return False
 
 
-def main() -> None:
+def verify_once(
+    service_url: str,
+    expected: str,
+    fetcher: JsonFetcher = fetch_json,
+) -> tuple[bool, str]:
+    base = service_url.rstrip("/")
+    readiness = fetcher(f"{base}/actuator/health/readiness")
+    if not isinstance(readiness, dict) or readiness.get("status") != "UP":
+        return False, f"readiness is not UP: {readiness!r}"
+    info = fetcher(f"{base}/actuator/info")
+    if not contains_commit(info, expected):
+        return False, f"actuator info does not identify expected commit {expected}"
+    return True, "readiness is UP and expected commit is live"
+
+
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True)
-    parser.add_argument("--expected-commit")
-    parser.add_argument("--expected-version")
-    parser.add_argument("--attempts", type=int, default=40)
-    parser.add_argument("--interval-seconds", type=float, default=15.0)
-    parser.add_argument("--timeout-seconds", type=float, default=10.0)
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--attempts", type=int, default=60)
+    parser.add_argument("--interval-seconds", type=float, default=10.0)
     args = parser.parse_args()
 
-    if args.attempts < 1:
-        parser.error("--attempts must be at least 1")
-    last_detail = "deployment was not checked"
+    last_error = "deployment did not answer"
     for attempt in range(1, args.attempts + 1):
         try:
-            ok, detail = verify_once(
-                args.base_url, args.expected_commit, args.expected_version,
-                args.timeout_seconds)
-        except (HTTPError, URLError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as exc:
-            ok, detail = False, f"{type(exc).__name__}: {exc}"
-        last_detail = detail
-        print(f"deployment smoke attempt {attempt}/{args.attempts}: {detail}", flush=True)
-        if ok:
-            return
+            ok, detail = verify_once(args.base_url, args.expected_commit)
+            if ok:
+                print(f"Render deployment verified on attempt {attempt}: {detail}")
+                return 0
+            last_error = detail
+        except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            last_error = str(error)
+        print(f"Render verification attempt {attempt}/{args.attempts} not ready: {last_error}")
         if attempt < args.attempts:
             time.sleep(args.interval_seconds)
-    raise SystemExit(f"Deployment did not converge: {last_detail}")
+    print(f"::error::Render deployment verification failed: {last_error}")
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
             python3 .github/scripts/check-version-state.py --mode development
           fi
 
-      - name: Verify release and performance-scope contracts
+      - name: Verify release and delivery contracts
         shell: bash
         run: |
           set -euo pipefail
@@ -56,10 +56,12 @@ jobs:
           python3 .github/scripts/test-check-release-plan.py
           python3 .github/scripts/test-generate-quality-site.py
           python3 .github/scripts/test-verify-deployment.py
+          node .github/scripts/test-taxonomy-base-path.mjs
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
           python3 .github/scripts/check-release-delivery-contract.py
+          python3 .github/scripts/check-delivery-hardening.py
           python3 .github/scripts/check-observability-performance-scope.py
 
           current_version=$(./mvnw -q -DforceStdout help:evaluate \
@@ -82,7 +84,7 @@ jobs:
       - name: Verify Docker availability
         run: docker info
 
-      - name: Validate production Helm chart
+      - name: Validate production and Rancher Helm profiles
         shell: bash
         run: bash deploy/helm/taxonomy/verify.sh target/taxonomy-helm-rendered.yaml
 
@@ -135,7 +137,7 @@ jobs:
           fail-on-error: false
           max-annotations: '50'
 
-      - name: Stage verified reports
+      - name: Stage commit-bound verified reports
         if: always()
         shell: bash
         run: |
@@ -151,9 +153,11 @@ jobs:
             \( -path '*/target/surefire-reports/*' -o -path '*/target/failsafe-reports/*' \) \
             \( -name 'TEST-*.xml' -o -name '*.txt' -o -name '*.dump' -o -name '*.dumpstream' \) \
             -print0)
-          if [ -d taxonomy-coverage/target/site/jacoco-aggregate ]; then
-            cp -a taxonomy-coverage/target/site/jacoco-aggregate/. target/quality-reports/coverage/
+          if [ ! -f taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml ]; then
+            echo "::error::Aggregate JaCoCo XML is missing; refusing to publish a stale coverage badge."
+            exit 1
           fi
+          cp -a taxonomy-coverage/target/site/jacoco-aggregate/. target/quality-reports/coverage/
           for evidence in \
             target/maven-verification.log \
             target/coverage-gate.txt \
@@ -163,7 +167,8 @@ jobs:
             target/taxonomy-sbom.json \
             target/taxonomy-sbom.xml \
             target/taxonomy-vex.json \
-            target/taxonomy-helm-rendered.yaml; do
+            target/taxonomy-helm-rendered.yaml \
+            target/taxonomy-helm-rancher-rke2-rendered.yaml; do
             if [ -f "$evidence" ]; then cp "$evidence" target/quality-reports/evidence/; fi
           done
           if [ -d target/observability-performance ]; then
@@ -171,10 +176,10 @@ jobs:
             cp -a target/observability-performance/. \
               target/quality-reports/evidence/observability-performance/
           fi
-          printf 'Verified commit: %s\n' "$GITHUB_SHA" > target/quality-reports/README.txt
           python3 .github/scripts/generate-quality-site.py \
             --root target/quality-reports \
             --commit "$GITHUB_SHA"
+          printf 'Verified commit: %s\n' "$GITHUB_SHA" > target/quality-reports/README.txt
 
       - name: Upload verified reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -183,6 +188,7 @@ jobs:
           name: quality-reports
           path: target/quality-reports/**
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Upload UI verification evidence

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,6 +54,8 @@ jobs:
           set -euo pipefail
           python3 .github/scripts/test-resolve-release-parameters.py
           python3 .github/scripts/test-check-release-plan.py
+          python3 .github/scripts/test-generate-quality-site.py
+          python3 .github/scripts/test-verify-deployment.py
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
@@ -170,6 +172,9 @@ jobs:
               target/quality-reports/evidence/observability-performance/
           fi
           printf 'Verified commit: %s\n' "$GITHUB_SHA" > target/quality-reports/README.txt
+          python3 .github/scripts/generate-quality-site.py \
+            --root target/quality-reports \
+            --commit "$GITHUB_SHA"
 
       - name: Upload verified reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,6 +59,7 @@ jobs:
           node .github/scripts/test-taxonomy-base-path.mjs
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
+          bash -n .github/scripts/download-embedding-model.sh
           bash -n deploy/helm/taxonomy/verify.sh
           python3 .github/scripts/check-release-delivery-contract.py
           python3 .github/scripts/check-delivery-hardening.py
@@ -116,8 +117,15 @@ jobs:
         shell: bash
         run: bash .github/scripts/run-observability-performance.sh
 
+      - name: Restore pinned embedding model
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: models/bge-small-en-v1.5
+          key: ${{ runner.os }}-taxonomy-bge-small-en-v1.5-${{ hashFiles('.github/scripts/download-embedding-model.sh') }}
+
       - name: Run the canonical Maven verification suite
         env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
         shell: bash

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,8 +2,11 @@ name: CI / CD
 
 on:
   push:
-    branches-ignore: [ gh-pages ]
-    tags: [ 'v*' ]
+    branches:
+      - main
+      - 'release/**'
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: java-kotlin
           build-mode: manual
@@ -60,7 +60,7 @@ jobs:
           -Dtaxonomy.quality.skip=true
 
       - name: Analyze Java to local SARIF
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:java-kotlin
           upload: false
@@ -97,14 +97,14 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-extended,security-and-quality
 
       - name: Analyze JavaScript to local SARIF
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: /language:javascript-typescript
           upload: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: taxonomy-codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   java:
     name: CodeQL / Java

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -35,12 +35,46 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish reports to GitHub Pages
+      - name: Verify report provenance and completeness
+        env:
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("quality-reports")
+          summary_path = root / "quality-summary.json"
+          if not summary_path.is_file():
+              raise SystemExit("quality-summary.json is missing from the verified artifact")
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          expected = os.environ["EXPECTED_SHA"]
+          if summary.get("commit") != expected:
+              raise SystemExit(
+                  f"quality report commit {summary.get('commit')!r} does not match {expected}"
+              )
+          for relative in (
+              "tests/badge.json",
+              "tests/surefire-report.html",
+              "coverage/badge.json",
+              "coverage/index.html",
+              ".nojekyll",
+          ):
+              if not root.joinpath(relative).is_file():
+                  raise SystemExit(f"verified quality artifact is missing {relative}")
+          print(f"Quality report provenance verified for {expected}")
+          PY
+
+      - name: Publish reports to GitHub Pages atomically
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: quality-reports
           keep_files: false
+          force_orphan: true
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
           commit_message: 'Publish verified quality reports ${{ github.event.workflow_run.head_sha }}'
@@ -110,30 +144,29 @@ jobs:
       github.event.workflow_run.head_branch == github.event.repository.default_branch &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout deployed source contract
+      - name: Checkout verified delivery source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           persist-credentials: false
 
-      - name: Trigger Render deploy hook
-        env:
-          HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
-        if: ${{ env.HOOK_URL != '' }}
-        run: |
-          curl -fsSL --retry 3 "$HOOK_URL"
-          echo "Render deployment triggered."
-
-      - name: Verify deployed readiness and commit
+      - name: Trigger and verify Render deployment
         env:
           HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
           BASE_URL: ${{ vars.RENDER_BASE_URL || 'https://taxonomy-analyzer.onrender.com' }}
-          EXPECTED_COMMIT: ${{ github.event.workflow_run.head_sha }}
-        if: ${{ env.HOOK_URL != '' }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
+          if [[ -z "$HOOK_URL" ]]; then
+            echo "RENDER_DEPLOY_HOOK_URL is not configured; Render deployment is disabled."
+            exit 0
+          fi
+          curl -fsSL --retry 3 "$HOOK_URL"
+          echo "Render deployment triggered; waiting for the verified commit."
           python3 .github/scripts/verify-deployment.py \
             --base-url "$BASE_URL" \
-            --expected-commit "$EXPECTED_COMMIT"
+            --expected-commit "$EXPECTED_SHA"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: quality-reports
-          keep_files: true
+          keep_files: false
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
           commit_message: 'Publish verified quality reports ${{ github.event.workflow_run.head_sha }}'
@@ -111,6 +111,12 @@ jobs:
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout deployed source contract
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
       - name: Trigger Render deploy hook
         env:
           HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
@@ -118,3 +124,16 @@ jobs:
         run: |
           curl -fsSL --retry 3 "$HOOK_URL"
           echo "Render deployment triggered."
+
+      - name: Verify deployed readiness and commit
+        env:
+          HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+          BASE_URL: ${{ vars.RENDER_BASE_URL || 'https://taxonomy-analyzer.onrender.com' }}
+          EXPECTED_COMMIT: ${{ github.event.workflow_run.head_sha }}
+        if: ${{ env.HOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/verify-deployment.py \
+            --base-url "$BASE_URL" \
+            --expected-commit "$EXPECTED_COMMIT"

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -4,6 +4,9 @@ on:
   workflow_run:
     workflows: [ "CI / CD" ]
     types: [ completed ]
+    branches:
+      - main
+      - 'v*'
 
 permissions:
   contents: read

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload SARIF to GitHub code scanning
         if: always() && hashFiles('trivy-results.sarif') != ''
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: trivy-results.sarif
           category: taxonomy-trivy

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: taxonomy-security-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trivy:
     name: Trivy dependencies, secrets, configuration, and supply chain

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 # Tag retained for readability and automated update discovery; digest is authoritative.
 FROM maven:3.9.9-eclipse-temurin-21@sha256:3a4ab3276a087bf276f79cae96b1af04f53731bec53fb2e651aca79e4b10211e AS build
 WORKDIR /workspace
+ARG BUILD_DATE=unknown
+ARG VCS_REF=unknown
 
 # The Maven Wrapper validates the ZIP distribution. The minimal Maven builder
 # image does not provide unzip, and mvnw would otherwise silently switch to the
@@ -37,6 +39,13 @@ COPY taxonomy-extension-api/src taxonomy-extension-api/src
 COPY taxonomy-app/src taxonomy-app/src
 COPY docs docs
 COPY LICENSE NOTICE THIRD-PARTY-NOTICES.md ./
+
+# The Docker context intentionally excludes .git. Materialize the immutable
+# source revision supplied by the delivery workflow so Spring Boot's GitInfoContributor
+# and /api/about still report the exact code running in the container.
+RUN printf 'git.branch=container\ngit.commit.id=%s\ngit.commit.id.abbrev=%s\ngit.build.time=%s\n' \
+      "$VCS_REF" "$VCS_REF" "$BUILD_DATE" \
+      > taxonomy-app/src/main/resources/git.properties
 
 # Do not run dependency:go-offline against this multi-module reactor before its
 # internal SNAPSHOT artifacts exist. A single reactor package resolves and builds

--- a/deploy/helm/taxonomy/RANCHER.md
+++ b/deploy/helm/taxonomy/RANCHER.md
@@ -2,24 +2,24 @@
 
 `values-rancher-rke2.yaml` is the supported starting point for a Rancher-managed RKE2 cluster with ingress-nginx. It addresses two common deployment failures:
 
-- namespace CPU quotas that reject the default `limits.cpu: 2`, and
+- namespace CPU quotas that reject the default `limits.cpu: 2`; and
 - HTTP 404 responses when the application is published below `/taxonomy/` without stripping that external prefix.
 
 ## 1. Prepare the values
 
-Copy the profile and replace `taxonomy.example.invalid` with the real host. Keep the regular chart values or an additional private values file for storage-class, TLS and environment-specific settings.
+Replace `taxonomy.example.invalid` with the real host. Keep an additional private values file for storage class, TLS and environment-specific settings.
 
-The profile publishes this external route:
+The profile publishes:
 
 ```text
 https://<host>/taxonomy/
 ```
 
-Ingress-nginx strips `/taxonomy` before forwarding the request to the Spring Boot service and sends `X-Forwarded-Prefix: /taxonomy`. The application keeps `TAXONOMY_FORWARD_HEADERS_STRATEGY=framework`, so redirects and generated absolute links retain the public prefix.
+Ingress-nginx strips `/taxonomy` before forwarding the request and sends `X-Forwarded-Prefix: /taxonomy`. The Kubernetes profile enables Spring's framework handling of forwarded headers, so server-generated links and redirects retain the public prefix. The first browser bootstrap script derives the same prefix from its generated script URL and applies it to legacy root-relative API requests.
 
 ## 2. Create the credential Secret
 
-The default chart expects a Secret named `taxonomy-secrets` when installed with the commands below. It must contain at least:
+The chart expects a Secret named `taxonomy-secrets` in the examples below. It must contain at least:
 
 ```text
 SPRING_DATASOURCE_URL
@@ -40,7 +40,7 @@ helm template taxonomy deploy/helm/taxonomy \
   --set existingSecret=taxonomy-secrets
 ```
 
-Use an immutable release tag such as `v1.3.1` or `sha-<commit>`; mutable tags such as `latest` are rejected by the chart.
+Use an immutable release tag such as `v1.3.1` or `sha-<commit>`; mutable tags such as `latest` are rejected.
 
 ## 4. Install or upgrade
 
@@ -50,20 +50,38 @@ helm upgrade --install taxonomy deploy/helm/taxonomy \
   --create-namespace \
   --values deploy/helm/taxonomy/values-rancher-rke2.yaml \
   --set image.tag=sha-<full-commit-sha> \
-  --set existingSecret=taxonomy-secrets
+  --set existingSecret=taxonomy-secrets \
+  --set ingress.hosts[0].host=taxonomy.example.com
 ```
-
-## Controller variants
-
-The supplied profile is intentionally specific to the RKE2 ingress-nginx controller in `kube-system`. A cluster using Traefik must use a Traefik `StripPrefix` middleware instead of the nginx annotations and must adapt the NetworkPolicy controller selectors. Do not combine nginx annotations with a Traefik ingress class.
 
 ## CPU quota diagnosis
 
-Rancher displays the Kubernetes admission error, but the quota allocation is determined from all pods in the namespace. Inspect it directly with:
+The profile requests `100m` CPU and limits the pod to `500m`. This reduces quota pressure but cannot create free quota. Inspect all allocations in the namespace:
 
 ```bash
 kubectl -n <namespace> describe resourcequota
-kubectl -n <namespace> get pods -o custom-columns='NAME:.metadata.name,CPU_LIMIT:.spec.containers[*].resources.limits.cpu'
+kubectl -n <namespace> get pods \
+  -o custom-columns='NAME:.metadata.name,CPU_LIMIT:.spec.containers[*].resources.limits.cpu,CPU_REQUEST:.spec.containers[*].resources.requests.cpu'
 ```
 
-The RKE2 profile lowers the application CPU limit from `2` to `1`. Change that value only after checking the namespace quota and measured workload requirements.
+If no `limits.cpu` remains, remove unused workloads, increase the quota, or lower the limit only after measuring the workload.
+
+## Controller and NetworkPolicy variants
+
+The profile permits common ingress-nginx layouts in `kube-system` and `ingress-nginx`. Determine the actual controller namespace and labels:
+
+```bash
+kubectl get pods -A --show-labels | grep -E 'ingress|nginx'
+```
+
+Remove the unused selector and adapt the remaining pod selector to the cluster. A Traefik cluster needs a Traefik `StripPrefix` middleware instead of nginx annotations.
+
+## Verification
+
+```bash
+kubectl get ingress,service,pods -n taxonomy
+kubectl describe ingress -n taxonomy
+curl -fsS https://taxonomy.example.com/taxonomy/actuator/health/readiness
+```
+
+The readiness response must report `UP`. The application remains behind a `ClusterIP` service; external traffic enters through the Ingress.

--- a/deploy/helm/taxonomy/RANCHER.md
+++ b/deploy/helm/taxonomy/RANCHER.md
@@ -1,0 +1,69 @@
+# Rancher / RKE2 deployment
+
+`values-rancher-rke2.yaml` is the supported starting point for a Rancher-managed RKE2 cluster with ingress-nginx. It addresses two common deployment failures:
+
+- namespace CPU quotas that reject the default `limits.cpu: 2`, and
+- HTTP 404 responses when the application is published below `/taxonomy/` without stripping that external prefix.
+
+## 1. Prepare the values
+
+Copy the profile and replace `taxonomy.example.invalid` with the real host. Keep the regular chart values or an additional private values file for storage-class, TLS and environment-specific settings.
+
+The profile publishes this external route:
+
+```text
+https://<host>/taxonomy/
+```
+
+Ingress-nginx strips `/taxonomy` before forwarding the request to the Spring Boot service and sends `X-Forwarded-Prefix: /taxonomy`. The application keeps `TAXONOMY_FORWARD_HEADERS_STRATEGY=framework`, so redirects and generated absolute links retain the public prefix.
+
+## 2. Create the credential Secret
+
+The default chart expects a Secret named `taxonomy-secrets` when installed with the commands below. It must contain at least:
+
+```text
+SPRING_DATASOURCE_URL
+SPRING_DATASOURCE_USERNAME
+SPRING_DATASOURCE_PASSWORD
+ADMIN_PASSWORD
+```
+
+LLM API keys remain optional.
+
+## 3. Render before installing
+
+```bash
+helm template taxonomy deploy/helm/taxonomy \
+  --namespace taxonomy \
+  --values deploy/helm/taxonomy/values-rancher-rke2.yaml \
+  --set image.tag=sha-<full-commit-sha> \
+  --set existingSecret=taxonomy-secrets
+```
+
+Use an immutable release tag such as `v1.3.1` or `sha-<commit>`; mutable tags such as `latest` are rejected by the chart.
+
+## 4. Install or upgrade
+
+```bash
+helm upgrade --install taxonomy deploy/helm/taxonomy \
+  --namespace taxonomy \
+  --create-namespace \
+  --values deploy/helm/taxonomy/values-rancher-rke2.yaml \
+  --set image.tag=sha-<full-commit-sha> \
+  --set existingSecret=taxonomy-secrets
+```
+
+## Controller variants
+
+The supplied profile is intentionally specific to the RKE2 ingress-nginx controller in `kube-system`. A cluster using Traefik must use a Traefik `StripPrefix` middleware instead of the nginx annotations and must adapt the NetworkPolicy controller selectors. Do not combine nginx annotations with a Traefik ingress class.
+
+## CPU quota diagnosis
+
+Rancher displays the Kubernetes admission error, but the quota allocation is determined from all pods in the namespace. Inspect it directly with:
+
+```bash
+kubectl -n <namespace> describe resourcequota
+kubectl -n <namespace> get pods -o custom-columns='NAME:.metadata.name,CPU_LIMIT:.spec.containers[*].resources.limits.cpu'
+```
+
+The RKE2 profile lowers the application CPU limit from `2` to `1`. Change that value only after checking the namespace quota and measured workload requirements.

--- a/deploy/helm/taxonomy/values-rancher-rke2.yaml
+++ b/deploy/helm/taxonomy/values-rancher-rke2.yaml
@@ -1,0 +1,59 @@
+# Production-oriented overrides for a Rancher-managed RKE2 cluster using the
+# bundled ingress-nginx controller. Replace the example host before deployment.
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 768Mi
+  limits:
+    # The default chart requests a 2-CPU limit. This profile stays deployable in
+    # namespaces whose aggregate CPU quota is already close to its ceiling.
+    cpu: "1"
+    memory: 2Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # Preserve the public prefix for redirects and generated absolute links.
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: /taxonomy
+  hosts:
+    - host: taxonomy.example.invalid
+      paths:
+        - path: /taxonomy(/|$)(.*)
+          pathType: ImplementationSpecific
+  tls: []
+
+# RKE2 normally runs its ingress controller in kube-system. The combined
+# namespace/pod selector keeps the application closed to unrelated namespaces.
+networkPolicy:
+  enabled: true
+  allowSameNamespace: true
+  ingressFrom:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+              - rke2-ingress-nginx
+              - ingress-nginx
+  egress:
+    - {}
+
+config:
+  SPRING_PROFILES_ACTIVE: postgres,kubernetes
+  TAXONOMY_INIT_ASYNC: "true"
+  TAXONOMY_INIT_RELOAD_EXISTING: "false"
+  TAXONOMY_DDL_AUTO: validate
+  TAXONOMY_SEARCH_DIRECTORY_TYPE: local-heap
+  TAXONOMY_SEARCH_SYNC_STRATEGY: write-sync
+  TAXONOMY_SPRINGDOC_ENABLED: "false"
+  TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
+  TAXONOMY_EMBEDDING_ENABLED: "false"
+  TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
+  JAVA_OPTS: -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=20.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp

--- a/deploy/helm/taxonomy/values-rancher-rke2.yaml
+++ b/deploy/helm/taxonomy/values-rancher-rke2.yaml
@@ -1,24 +1,23 @@
-# Production-oriented overrides for a Rancher-managed RKE2 cluster using the
-# bundled ingress-nginx controller. Replace the example host before deployment.
+# Production-oriented overrides for Rancher-managed RKE2 or ingress-nginx.
+# Replace the example host before deployment.
 
 resources:
   requests:
-    cpu: 200m
-    memory: 768Mi
+    cpu: 100m
+    memory: 512Mi
   limits:
-    # The default chart requests a 2-CPU limit. This profile stays deployable in
-    # namespaces whose aggregate CPU quota is already close to its ceiling.
-    cpu: "1"
-    memory: 2Gi
+    # Lower than the chart default (2 CPU) for quota-constrained namespaces.
+    cpu: "500m"
+    memory: 1536Mi
 
 ingress:
   enabled: true
   className: nginx
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    # Preserve the public prefix for redirects and generated absolute links.
-    nginx.ingress.kubernetes.io/x-forwarded-prefix: /taxonomy
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+    nginx.ingress.kubernetes.io/x-forwarded-prefix: "/taxonomy"
+    nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   hosts:
     - host: taxonomy.example.invalid
       paths:
@@ -26,8 +25,9 @@ ingress:
           pathType: ImplementationSpecific
   tls: []
 
-# RKE2 normally runs its ingress controller in kube-system. The combined
-# namespace/pod selector keeps the application closed to unrelated namespaces.
+# RKE2 normally runs ingress-nginx in kube-system. A separately installed
+# controller commonly runs in ingress-nginx. Retain only the selector that
+# matches the target cluster.
 networkPolicy:
   enabled: true
   allowSameNamespace: true
@@ -39,21 +39,12 @@ networkPolicy:
         matchExpressions:
           - key: app.kubernetes.io/name
             operator: In
-            values:
-              - rke2-ingress-nginx
-              - ingress-nginx
+            values: [rke2-ingress-nginx, ingress-nginx]
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: ingress-nginx
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx
   egress:
     - {}
-
-config:
-  SPRING_PROFILES_ACTIVE: postgres,kubernetes
-  TAXONOMY_INIT_ASYNC: "true"
-  TAXONOMY_INIT_RELOAD_EXISTING: "false"
-  TAXONOMY_DDL_AUTO: validate
-  TAXONOMY_SEARCH_DIRECTORY_TYPE: local-heap
-  TAXONOMY_SEARCH_SYNC_STRATEGY: write-sync
-  TAXONOMY_SPRINGDOC_ENABLED: "false"
-  TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
-  TAXONOMY_EMBEDDING_ENABLED: "false"
-  TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
-  JAVA_OPTS: -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=20.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -80,15 +80,15 @@ for forbidden in 'runAsUser:' 'runAsGroup:' 'fsGroup:' 'fsGroupChangePolicy:'; d
   fi
 done
 
-RANCHER_OUTPUT="${TMP_DIR}/rancher-rke2.yaml"
-helm lint "${CHART_DIR}" \
-  --values "${CHART_DIR}/values-rancher-rke2.yaml" \
-  "${COMMON_VALUES[@]}"
+RANCHER_OUTPUT="${TMP_DIR}/rancher.yaml"
+RANCHER_EVIDENCE="${ROOT_DIR}/target/taxonomy-helm-rancher-rke2-rendered.yaml"
 helm template taxonomy "${CHART_DIR}" \
   --namespace taxonomy \
   --values "${CHART_DIR}/values-rancher-rke2.yaml" \
-  "${COMMON_VALUES[@]}" \
+  --set "image.tag=${VALID_TAG}" \
+  --set existingSecret=taxonomy-secrets \
   >"${RANCHER_OUTPUT}"
+cp "${RANCHER_OUTPUT}" "${RANCHER_EVIDENCE}"
 for required in \
   'kind: Ingress' \
   'ingressClassName: nginx' \
@@ -96,11 +96,11 @@ for required in \
   'nginx.ingress.kubernetes.io/x-forwarded-prefix: /taxonomy' \
   'path: /taxonomy(/|$)(.*)' \
   'pathType: ImplementationSpecific' \
-  'cpu: "1"' \
+  'cpu: 500m' \
   'kubernetes.io/metadata.name: kube-system' \
-  'rke2-ingress-nginx'; do
+  'kubernetes.io/metadata.name: ingress-nginx'; do
   if ! grep -Fq "${required}" "${RANCHER_OUTPUT}"; then
-    echo "Rancher profile is missing required contract: ${required}" >&2
+    echo "Rendered Rancher profile is missing required contract: ${required}" >&2
     exit 1
   fi
 done

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -80,6 +80,31 @@ for forbidden in 'runAsUser:' 'runAsGroup:' 'fsGroup:' 'fsGroupChangePolicy:'; d
   fi
 done
 
+RANCHER_OUTPUT="${TMP_DIR}/rancher-rke2.yaml"
+helm lint "${CHART_DIR}" \
+  --values "${CHART_DIR}/values-rancher-rke2.yaml" \
+  "${COMMON_VALUES[@]}"
+helm template taxonomy "${CHART_DIR}" \
+  --namespace taxonomy \
+  --values "${CHART_DIR}/values-rancher-rke2.yaml" \
+  "${COMMON_VALUES[@]}" \
+  >"${RANCHER_OUTPUT}"
+for required in \
+  'kind: Ingress' \
+  'ingressClassName: nginx' \
+  'nginx.ingress.kubernetes.io/rewrite-target: /$2' \
+  'nginx.ingress.kubernetes.io/x-forwarded-prefix: /taxonomy' \
+  'path: /taxonomy(/|$)(.*)' \
+  'pathType: ImplementationSpecific' \
+  'cpu: "1"' \
+  'kubernetes.io/metadata.name: kube-system' \
+  'rke2-ingress-nginx'; do
+  if ! grep -Fq "${required}" "${RANCHER_OUTPUT}"; then
+    echo "Rancher profile is missing required contract: ${required}" >&2
+    exit 1
+  fi
+done
+
 PERSISTENCE_OUTPUT="${TMP_DIR}/persistence.yaml"
 helm template taxonomy "${CHART_DIR}" \
   "${COMMON_VALUES[@]}" \

--- a/docs/dev/REPOSITORY_PROTECTION.md
+++ b/docs/dev/REPOSITORY_PROTECTION.md
@@ -1,0 +1,37 @@
+# Repository protection and delivery administration
+
+The codebase enforces release and delivery contracts in CI. The `main` branch ruleset must still be enabled once by a repository administrator because it is a GitHub setting rather than a versioned file.
+
+## Protect `main`
+
+Create an active branch ruleset for `main` with these settings:
+
+- require a pull request before merging;
+- require the **Maven verification** status check;
+- require the branch to be up to date before merging;
+- require all review conversations to be resolved;
+- block force pushes and branch deletion;
+- do not grant routine bypass access to automation or maintainers.
+
+The canonical gate is the `verify` job in `.github/workflows/ci-cd.yml`, displayed by GitHub as **Maven verification**. Delivery runs only after that workflow completed successfully for the exact `main` commit. `.github/CODEOWNERS` assigns review ownership for workflows, release scripts, the Dockerfile and Helm deployment files.
+
+## Render deployment verification
+
+When `RENDER_DEPLOY_HOOK_URL` is configured, the Delivery workflow triggers the hook and then waits for the exact source commit to appear in `/actuator/info` while readiness remains `UP`.
+
+The public service defaults to:
+
+```text
+https://taxonomy-analyzer.onrender.com
+```
+
+Set the optional repository variable `RENDER_BASE_URL` only when that public root changes. Use the externally reachable service root without a trailing path.
+
+## Verification
+
+After activating the ruleset:
+
+1. Open a pull request and confirm that direct merging is blocked until **Maven verification** succeeds.
+2. Merge the pull request and inspect the **Delivery** workflow.
+3. Confirm that GitHub Pages contains `quality-summary.json` with the merged commit SHA.
+4. Confirm that the Render job reports the same SHA as live.

--- a/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
+++ b/taxonomy-app/src/main/resources/static/css/taxonomy-ergonomics.css
@@ -354,8 +354,15 @@
     #leftPanel {
         order: 2;
     }
-    .card-body[style*="max-height"] {
+    /* Ordinary task cards may grow with reflow, but the 2,500+ node reference
+       tree must remain a bounded, independently scrollable region. Older
+       browsers that do not understand :has() retain the inline 82vh limit. */
+    .card-body[style*="max-height"]:not(:has(> #taxonomyTree)) {
         max-height: none !important;
+    }
+    .card-body:has(> #taxonomyTree) {
+        max-height: min(65vh, 42rem) !important;
+        overscroll-behavior: contain;
     }
     /* Keep every destination directly available without spending several rows
        of the initial viewport on wrapped navigation tabs. */

--- a/taxonomy-app/src/main/resources/static/js/security/taxonomy-ui-semantics.js
+++ b/taxonomy-app/src/main/resources/static/js/security/taxonomy-ui-semantics.js
@@ -106,6 +106,7 @@ window.TaxonomyUiSemantics = (function () {
         var containsTreeItems = Boolean(tree.querySelector('[role="treeitem"]'));
         var expectedRole = containsTreeItems ? 'tree' : 'region';
         if (tree.getAttribute('role') !== expectedRole) tree.setAttribute('role', expectedRole);
+        if (tree.getAttribute('tabindex') !== '0') tree.setAttribute('tabindex', '0');
         if (containsTreeItems) tree.removeAttribute('aria-busy');
         else tree.setAttribute('aria-busy', 'true');
     }
@@ -122,7 +123,7 @@ window.TaxonomyUiSemantics = (function () {
             childList: true,
             subtree: true,
             attributes: true,
-            attributeFilter: ['role']
+            attributeFilter: ['role', 'tabindex']
         });
         observers.push(observer);
     }

--- a/taxonomy-app/src/main/resources/static/js/taxonomy-i18n.js
+++ b/taxonomy-app/src/main/resources/static/js/taxonomy-i18n.js
@@ -15,6 +15,52 @@
     var currentLocale = 'en';
     var loaded = false;
     var loadPromise = null;
+    var bootstrapScriptUrl = document.currentScript ? document.currentScript.src : '';
+    var applicationBasePath = detectApplicationBasePath();
+
+    /**
+     * Derive the externally visible application prefix from this bootstrap
+     * script. With X-Forwarded-Prefix=/taxonomy, Thymeleaf emits
+     * /taxonomy/js/taxonomy-i18n.js, yielding /taxonomy here.
+     */
+    function detectApplicationBasePath() {
+        if (!bootstrapScriptUrl) return '';
+        try {
+            var pathname = new URL(bootstrapScriptUrl, window.location.href).pathname;
+            var suffix = '/js/taxonomy-i18n.js';
+            if (!pathname.endsWith(suffix)) return '';
+            return pathname.substring(0, pathname.length - suffix.length);
+        } catch (error) {
+            console.warn('[bootstrap] Cannot determine application base path:', error);
+            return '';
+        }
+    }
+
+    function resolveApplicationUrl(value) {
+        if (!applicationBasePath || typeof value !== 'string'
+                || !value.startsWith('/') || value.startsWith('//')
+                || value === applicationBasePath
+                || value.startsWith(applicationBasePath + '/')) {
+            return value;
+        }
+        return applicationBasePath + value;
+    }
+
+    /**
+     * Legacy feature modules use root-relative fetch paths. Prefix only those
+     * same-application paths so the complete UI remains usable behind a Rancher
+     * ingress mounted below /taxonomy without altering external URLs.
+     */
+    function installBasePathAwareFetch() {
+        if (!applicationBasePath || window.fetch.__taxonomyBasePathAware) return;
+        var nativeFetch = window.fetch.bind(window);
+        var wrappedFetch = function (input, init) {
+            var resolved = typeof input === 'string' ? resolveApplicationUrl(input) : input;
+            return nativeFetch(resolved, init);
+        };
+        wrappedFetch.__taxonomyBasePathAware = true;
+        window.fetch = wrappedFetch;
+    }
 
     /** Detect initial locale from <html lang="…">, cookie, or localStorage. */
     function detectLocale() {
@@ -136,7 +182,7 @@
         return translated === key ? name : translated;
     }
 
-    // ── Public API ────────────────────────────────────────────────────────────
+    // ── Public API ────────────────────────────────────────────────────────
 
     window.TaxonomyI18n = {
         t: t,
@@ -145,10 +191,13 @@
         getLocale: getLocale,
         isLoaded: isLoaded,
         ready: ready,
-        formatBranch: formatBranch
+        formatBranch: formatBranch,
+        getBasePath: function () { return applicationBasePath; },
+        resolveUrl: resolveApplicationUrl
     };
 
     // Auto-load on script parse
+    installBasePathAwareFetch();
     currentLocale = detectLocale();
     load(currentLocale);
 }());

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/UiSemanticsBridgeContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/UiSemanticsBridgeContractTest.java
@@ -41,7 +41,7 @@ class UiSemanticsBridgeContractTest {
 
         assertThat(source)
                 .contains("var expectedRole = containsTreeItems ? 'tree' : 'region'")
-                .contains("attributeFilter: ['role']")
+                .contains("attributeFilter: ['role', 'tabindex']")
                 .doesNotContain("tree.removeAttribute('role')");
     }
 


### PR DESCRIPTION
## What it does

This PR implements the P1 stabilization package without writing directly to `main`:

- replaces stale GitHub Pages accumulation with atomic, orphan-branch publication;
- generates the existing test and coverage badge endpoints only from JUnit and aggregate JaCoCo evidence produced for the same verified commit;
- publishes `quality-summary.json`, a compact test report and the complete JaCoCo report with the exact source SHA;
- injects the immutable delivery `VCS_REF` into the container as Spring Boot `git.properties` although `.git` is intentionally excluded from the Docker context;
- triggers Render only after canonical CI and then proves readiness plus the live source commit through `/actuator/info`;
- keeps the 2,500+ node taxonomy tree inside a bounded scroll viewport on narrow/high-zoom layouts;
- adds a browser gate that rejects an unbounded tree before oversized UI evidence is captured;
- makes legacy root-relative browser API calls work behind a `/taxonomy` ingress prefix without changing external URLs or double-prefixing requests;
- adds a Rancher/RKE2 ingress-nginx profile with prefix rewrite, forwarded-prefix handling, NetworkPolicy selectors and quota-conscious CPU requests/limits;
- updates all CodeQL action-family steps atomically to v4.37.6 and groups future Dependabot updates so partial incompatible PRs are no longer created;
- limits the `workflow_run` delivery trigger to `main` and `v*`, preventing every PR CI completion from attaching irrelevant skipped delivery checks to the default-branch commit;
- adds `CODEOWNERS` and documents the required `main` ruleset.

## Root causes addressed

1. `keep_files: true` could retain old badge files when the current artifact did not contain replacements, mixing evidence from different commits.
2. The responsive rule that removed every inline `max-height` also removed the taxonomy tree's boundary and placed thousands of nodes into the document flow.
3. A prefixed ingress route forwarded `/taxonomy/...` to an application serving `/...`, while many browser modules still used root-relative `/api/...` calls.
4. A successful deploy hook proved only that deployment was requested, not that the expected commit became ready.
5. Container builds exclude `.git`, so deployment provenance must be injected explicitly.
6. Dependabot treated `github/codeql-action/init`, `analyze`, and `upload-sarif` as independent dependencies although GitHub requires one exact version across the workflow.
7. An unfiltered `workflow_run` delivery trigger created noisy checks on `main` for PR runs whose delivery jobs could only be skipped.

## Verification performed before opening this revision

- 3 Python tests for quality-site generation;
- 4 Python tests for deployment readiness/commit matching;
- Node VM tests for root deployment, `/taxonomy` deployment, double-prefix prevention and external URLs;
- Python compile checks, JavaScript syntax checks, shell syntax checks, workflow/Rancher YAML parsing and the delivery hardening contract;
- branch is based directly on current `main` and is not behind it.

Canonical CI remains authoritative and additionally runs Maven verification, browser/UI acceptance, Helm rendering, supply-chain checks and release contracts.

## Repository administration follow-up

The connected GitHub integration can version `CODEOWNERS` and the ruleset instructions, but it cannot activate a repository ruleset. Before merging, enable the documented `main` ruleset requiring:

- pull requests;
- the always-running **Maven verification** check;
- up-to-date branches and resolved conversations;
- blocked force pushes and deletion;
- no routine bypass.

See `docs/dev/REPOSITORY_PROTECTION.md`.