### PR TITLE
chore: expand weekly Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,20 @@
 
 version: 2
 updates:
-  - package-ecosystem: "maven" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: maven
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: /.github
+    schedule:
+      interval: weekly
+
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
-      interval: daily
+      interval: weekly
     groups:
       codeql-action-family:
         patterns:


### PR DESCRIPTION
## Summary
- change GitHub Actions updates from daily to weekly
- add npm dependency updates for `/.github`
- keep Maven updates weekly

## Rationale
The repository contains npm development dependencies for browser verification under `.github/package.json`; these were not covered by Dependabot.