### PR TITLE
Complete commit-bound QA publishing and deployment verification

### DIFF
--- a/.github/scripts/check-delivery-hardening.py
+++ b/.github/scripts/check-delivery-hardening.py
@@ -9,6 +9,8 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 CI = ROOT / ".github" / "workflows" / "ci-cd.yml"
 DELIVERY = ROOT / ".github" / "workflows" / "delivery.yml"
+QUALITY_VERIFY = ROOT / ".github" / "scripts" / "verify-quality-publication.py"
+DEPLOY_VERIFY = ROOT / ".github" / "scripts" / "verify-deployment.py"
 CSS = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "css" / "taxonomy-ergonomics.css"
 I18N = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "js" / "taxonomy-i18n.js"
 UI_EVIDENCE = ROOT / ".github" / "scripts" / "ui-role-state-evidence.mjs"
@@ -25,6 +27,8 @@ def require(text: str, needle: str, source: Path, failures: list[str]) -> None:
 def main() -> int:
     ci = CI.read_text(encoding="utf-8")
     delivery = DELIVERY.read_text(encoding="utf-8")
+    quality_verify = QUALITY_VERIFY.read_text(encoding="utf-8")
+    deploy_verify = DEPLOY_VERIFY.read_text(encoding="utf-8")
     css = CSS.read_text(encoding="utf-8")
     i18n = I18N.read_text(encoding="utf-8")
     ui_evidence = UI_EVIDENCE.read_text(encoding="utf-8")
@@ -35,11 +39,17 @@ def main() -> int:
 
     for needle in (
         "python3 .github/scripts/test-generate-quality-site.py",
+        "python3 .github/scripts/test-verify-quality-publication.py",
         "python3 .github/scripts/test-verify-deployment.py",
         "node .github/scripts/test-taxonomy-base-path.mjs",
         "python3 .github/scripts/check-delivery-hardening.py",
         "python3 .github/scripts/generate-quality-site.py",
+        "python3 .github/scripts/verify-quality-publication.py",
         '--commit "$GITHUB_SHA"',
+        '--source-tree "$source_tree"',
+        '--build-id "$build_id"',
+        '--tool "java=$java_version"',
+        '--tool "maven=$maven_version"',
         "taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml",
         "Restore pinned embedding model",
         "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
@@ -47,17 +57,48 @@ def main() -> int:
         require(ci, needle, CI, failures)
 
     for needle in (
-        "quality-summary.json",
+        "Checkout verified quality tooling",
+        "Verify report provenance and badge consistency",
+        "Verify published GitHub Pages evidence",
+        "QUALITY_REPORT_BASE_URL",
+        "verify-quality-publication.py",
+        '--base-url "$base_url"',
         "EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}",
         "keep_files: false",
         "force_orphan: true",
+        'query["ref"] = expected',
+        "render-deploy-hook.json",
+        "render-verification.json",
+        "RENDER_API_KEY",
+        "RENDER_SERVICE_ID",
         "BASE_URL: ${{ vars.RENDER_BASE_URL || 'https://taxonomy-analyzer.onrender.com' }}",
         "python3 .github/scripts/verify-deployment.py",
-        '--expected-commit "$EXPECTED_SHA"',
+        "render-deployment-evidence-${{ github.event.workflow_run.head_sha }}",
     ):
         require(delivery, needle, DELIVERY, failures)
     if "keep_files: true" in delivery:
         failures.append("delivery.yml must replace the report tree atomically, not retain stale files")
+
+    for needle in (
+        '"sourceTree"',
+        '"buildId"',
+        '"tools"',
+        "expected_test_message",
+        "expected_coverage_message",
+        "verify_remote_once",
+        '"Cache-Control": "no-cache"',
+    ):
+        require(quality_verify, needle, QUALITY_VERIFY, failures)
+
+    for needle in (
+        "RENDER_FAILURE_STATES",
+        "fetch_render_deploy",
+        "renderDeployId",
+        "renderDeployStatus",
+        "root smoke test",
+        "write_evidence",
+    ):
+        require(deploy_verify, needle, DEPLOY_VERIFY, failures)
 
     for needle in (
         '.card-body[style*="max-height"]:not(:has(> #taxonomyTree))',
@@ -111,8 +152,9 @@ def main() -> int:
         return 1
 
     print(
-        "Delivery hardening contract passed: reports are commit-bound and atomic, "
-        "Render verification proves the deployed SHA, responsive tree height remains "
+        "Delivery hardening contract passed: reports are commit-bound, internally consistent, "
+        "atomically published and remotely re-verified; Render is pinned to the verified commit, "
+        "records deployment evidence and can poll platform status; responsive tree height remains "
         "bounded, the container exposes its build commit, and the Rancher prefix profile is explicit."
     )
     return 0

--- a/.github/scripts/generate-quality-site.py
+++ b/.github/scripts/generate-quality-site.py
@@ -34,13 +34,12 @@ def collect_tests(root: Path) -> dict[str, int]:
         if not suites:
             raise ValueError(f"no testsuite element in {report}")
         for suite in suites:
-            for key in totals:
+            for key in ("tests", "failures", "errors", "skipped"):
                 totals[key] += _integer(suite, key)
 
-    totals["passed"] = (
-        totals["tests"] - totals["failures"] - totals["errors"] - totals["skipped"]
-    )
-    if totals["passed"] < 0:
+    totals["executed"] = totals["tests"] - totals["skipped"]
+    totals["passed"] = totals["executed"] - totals["failures"] - totals["errors"]
+    if totals["executed"] < 0 or totals["passed"] < 0:
         raise ValueError(f"inconsistent test totals: {totals}")
     if totals["tests"] <= 0:
         raise ValueError("JUnit reports contained zero tests")
@@ -177,6 +176,7 @@ code {{ overflow-wrap: anywhere; }}
 <thead><tr><th>Metric</th><th>Value</th></tr></thead>
 <tbody>
 <tr><td>Registered tests</td><td>{tests['tests']}</td></tr>
+<tr><td>Executed</td><td>{tests['executed']}</td></tr>
 <tr><td>Passed</td><td>{tests['passed']}</td></tr>
 <tr><td>Skipped</td><td>{tests['skipped']}</td></tr>
 <tr><td>Failures</td><td>{tests['failures']}</td></tr>

--- a/.github/scripts/generate-quality-site.py
+++ b/.github/scripts/generate-quality-site.py
@@ -85,17 +85,42 @@ def write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def write_outputs(root: Path, commit: str, generated_at: str) -> dict[str, object]:
+def parse_tools(entries: list[str]) -> dict[str, str]:
+    tools: dict[str, str] = {}
+    for entry in entries:
+        name, separator, value = entry.partition("=")
+        name = name.strip()
+        value = value.strip()
+        if not separator or not name or not value:
+            raise ValueError(f"tool metadata must use NAME=VALUE, got {entry!r}")
+        tools[name] = value
+    return tools
+
+
+def write_outputs(
+    root: Path,
+    commit: str,
+    generated_at: str,
+    *,
+    source_tree: str = "unknown",
+    build_id: str = "local",
+    tools: dict[str, str] | None = None,
+) -> dict[str, object]:
     tests = collect_tests(root / "tests")
     coverage = collect_coverage(root / "coverage" / "jacoco.xml")
     instruction_percent = float(coverage["instructionPercent"])
     clean = tests["failures"] == 0 and tests["errors"] == 0
+    tool_metadata = dict(tools or {})
 
     summary: dict[str, object] = {
-        "schemaVersion": 1,
+        "schemaVersion": 2,
         "commit": commit,
         "verifiedCommit": commit,
+        "sourceCommit": commit,
+        "sourceTree": source_tree,
+        "buildId": build_id,
         "generatedAt": generated_at,
+        "tools": tool_metadata,
         "tests": tests,
         "coverage": coverage,
     }
@@ -121,6 +146,13 @@ def write_outputs(root: Path, commit: str, generated_at: str) -> dict[str, objec
     root.joinpath(".nojekyll").touch()
 
     branch_percent = float(coverage.get("branchPercent", 0.0))
+    method_percent = float(coverage.get("methodPercent", 0.0))
+    class_percent = float(coverage.get("classPercent", 0.0))
+    line_percent = float(coverage.get("linePercent", 0.0))
+    tool_rows = "".join(
+        "<tr><td>" + html.escape(name) + "</td><td><code>" + html.escape(value) + "</code></td></tr>"
+        for name, value in sorted(tool_metadata.items())
+    ) or '<tr><td colspan="2">No tool metadata recorded</td></tr>'
     report = f"""<!doctype html>
 <html lang="en">
 <head>
@@ -129,7 +161,7 @@ def write_outputs(root: Path, commit: str, generated_at: str) -> dict[str, objec
 <title>Taxonomy test report</title>
 <style>
 body {{ font: 16px/1.5 system-ui, sans-serif; max-width: 70rem; margin: 2rem auto; padding: 0 1rem; }}
-table {{ border-collapse: collapse; }}
+table {{ border-collapse: collapse; margin-bottom: 1.25rem; }}
 th, td {{ border: 1px solid #bbb; padding: .45rem .7rem; text-align: right; }}
 th:first-child, td:first-child {{ text-align: left; }}
 code {{ overflow-wrap: anywhere; }}
@@ -138,6 +170,8 @@ code {{ overflow-wrap: anywhere; }}
 <body>
 <h1>Taxonomy test report</h1>
 <p>Verified commit: <code>{html.escape(commit)}</code></p>
+<p>Source tree: <code>{html.escape(source_tree)}</code></p>
+<p>Build ID: <code>{html.escape(build_id)}</code></p>
 <p>Generated: {html.escape(generated_at)}</p>
 <table>
 <thead><tr><th>Metric</th><th>Value</th></tr></thead>
@@ -148,9 +182,14 @@ code {{ overflow-wrap: anywhere; }}
 <tr><td>Failures</td><td>{tests['failures']}</td></tr>
 <tr><td>Errors</td><td>{tests['errors']}</td></tr>
 <tr><td>Instruction coverage</td><td>{instruction_percent:.2f}%</td></tr>
+<tr><td>Line coverage</td><td>{line_percent:.2f}%</td></tr>
 <tr><td>Branch coverage</td><td>{branch_percent:.2f}%</td></tr>
+<tr><td>Method coverage</td><td>{method_percent:.2f}%</td></tr>
+<tr><td>Class coverage</td><td>{class_percent:.2f}%</td></tr>
 </tbody>
 </table>
+<h2>Toolchain</h2>
+<table><thead><tr><th>Tool</th><th>Version/configuration</th></tr></thead><tbody>{tool_rows}</tbody></table>
 <p><a href="../quality-summary.json">Machine-readable quality summary</a></p>
 </body>
 </html>
@@ -163,6 +202,8 @@ code {{ overflow-wrap: anywhere; }}
 <body>
 <h1>Taxonomy verified quality reports</h1>
 <p>Verified commit: <code>{html.escape(commit)}</code></p>
+<p>Source tree: <code>{html.escape(source_tree)}</code></p>
+<p>Build ID: <code>{html.escape(build_id)}</code></p>
 <ul>
 <li><a href="tests/surefire-report.html">Test report</a></li>
 <li><a href="coverage/index.html">JaCoCo coverage report</a></li>
@@ -178,12 +219,22 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path, default=Path("target/quality-reports"))
     parser.add_argument("--commit", required=True)
+    parser.add_argument("--source-tree", default="unknown")
+    parser.add_argument("--build-id", default="local")
+    parser.add_argument("--tool", action="append", default=[], metavar="NAME=VALUE")
     parser.add_argument(
         "--generated-at",
         default=datetime.now(timezone.utc).isoformat(timespec="seconds"),
     )
     args = parser.parse_args()
-    summary = write_outputs(args.root, args.commit.strip(), args.generated_at)
+    summary = write_outputs(
+        args.root,
+        args.commit.strip(),
+        args.generated_at,
+        source_tree=args.source_tree.strip(),
+        build_id=args.build_id.strip(),
+        tools=parse_tools(args.tool),
+    )
     print(json.dumps(summary, sort_keys=True))
     return 0
 

--- a/.github/scripts/test-generate-quality-site.py
+++ b/.github/scripts/test-generate-quality-site.py
@@ -45,6 +45,8 @@ class GenerateQualitySummaryTest(unittest.TestCase):
                 tools={"java": "21", "maven": "3.9.11"},
             )
 
+            self.assertEqual(5, summary["tests"]["tests"])
+            self.assertEqual(4, summary["tests"]["executed"])
             self.assertEqual(4, summary["tests"]["passed"])
             self.assertEqual(80.0, summary["coverage"]["instructionPercent"])
             self.assertEqual("tree456", summary["sourceTree"])
@@ -58,6 +60,7 @@ class GenerateQualitySummaryTest(unittest.TestCase):
             self.assertEqual("abc123", persisted["commit"])
             self.assertEqual("tree456", persisted["sourceTree"])
             report_html = (root / "tests" / "surefire-report.html").read_text()
+            self.assertIn("Executed", report_html)
             self.assertIn("Method coverage", report_html)
             self.assertIn("Class coverage", report_html)
             self.assertIn("run-7.1", report_html)
@@ -84,7 +87,9 @@ class GenerateQualitySummaryTest(unittest.TestCase):
                 '<report><counter type="INSTRUCTION" missed="0" covered="1"/></report>',
                 encoding="utf-8",
             )
-            MODULE.write_outputs(root, "deadbeef", "now")
+            summary = MODULE.write_outputs(root, "deadbeef", "now")
+            self.assertEqual(2, summary["tests"]["executed"])
+            self.assertEqual(1, summary["tests"]["passed"])
             badge = json.loads((reports / "badge.json").read_text())
             self.assertEqual("red", badge["color"])
 

--- a/.github/scripts/test-generate-quality-site.py
+++ b/.github/scripts/test-generate-quality-site.py
@@ -29,23 +29,38 @@ class GenerateQualitySummaryTest(unittest.TestCase):
             coverage.mkdir()
             coverage.joinpath("jacoco.xml").write_text(
                 '<report><counter type="INSTRUCTION" missed="20" covered="80"/>'
-                '<counter type="BRANCH" missed="3" covered="7"/></report>',
+                '<counter type="LINE" missed="10" covered="90"/>'
+                '<counter type="BRANCH" missed="3" covered="7"/>'
+                '<counter type="METHOD" missed="2" covered="8"/>'
+                '<counter type="CLASS" missed="1" covered="9"/></report>',
                 encoding="utf-8",
             )
 
-            summary = MODULE.write_outputs(root, "abc123", "2026-08-06T13:00:00+00:00")
+            summary = MODULE.write_outputs(
+                root,
+                "abc123",
+                "2026-08-06T13:00:00+00:00",
+                source_tree="tree456",
+                build_id="run-7.1",
+                tools={"java": "21", "maven": "3.9.11"},
+            )
 
             self.assertEqual(4, summary["tests"]["passed"])
             self.assertEqual(80.0, summary["coverage"]["instructionPercent"])
+            self.assertEqual("tree456", summary["sourceTree"])
+            self.assertEqual("run-7.1", summary["buildId"])
+            self.assertEqual("21", summary["tools"]["java"])
             test_badge = json.loads((root / "tests" / "badge.json").read_text())
             coverage_badge = json.loads((root / "coverage" / "badge.json").read_text())
             self.assertEqual("4 passed", test_badge["message"])
             self.assertEqual("80.00%", coverage_badge["message"])
-            self.assertEqual(
-                "abc123",
-                json.loads((root / "quality-summary.json").read_text())["commit"],
-            )
-            self.assertTrue((root / "tests" / "surefire-report.html").is_file())
+            persisted = json.loads((root / "quality-summary.json").read_text())
+            self.assertEqual("abc123", persisted["commit"])
+            self.assertEqual("tree456", persisted["sourceTree"])
+            report_html = (root / "tests" / "surefire-report.html").read_text()
+            self.assertIn("Method coverage", report_html)
+            self.assertIn("Class coverage", report_html)
+            self.assertIn("run-7.1", report_html)
             self.assertTrue((root / ".nojekyll").is_file())
             self.assertTrue((root / "index.html").is_file())
 
@@ -72,6 +87,14 @@ class GenerateQualitySummaryTest(unittest.TestCase):
             MODULE.write_outputs(root, "deadbeef", "now")
             badge = json.loads((reports / "badge.json").read_text())
             self.assertEqual("red", badge["color"])
+
+    def test_tool_metadata_requires_name_and_value(self) -> None:
+        self.assertEqual(
+            {"java": "21", "maven": "3.9.11"},
+            MODULE.parse_tools(["java=21", "maven=3.9.11"]),
+        )
+        with self.assertRaises(ValueError):
+            MODULE.parse_tools(["broken"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 SCRIPT = Path(__file__).with_name("verify-deployment.py").resolve()
 SPEC = importlib.util.spec_from_file_location("verify_deployment", SCRIPT)
@@ -55,20 +56,33 @@ class VerifyRenderDeploymentTest(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("expected commit", detail)
 
-    def test_verify_once_rejects_failed_smoke(self) -> None:
+    def test_verify_once_rejects_4xx_and_5xx_smoke_responses(self) -> None:
         def fetcher(url: str):
             if url.endswith("/readiness"):
                 return {"status": "UP"}
             return {"git": {"commit": {"id": "0123456789abcdef"}}}
 
-        ok, detail = MODULE.verify_once(
-            "https://example.invalid",
-            "0123456789abcdef",
-            fetcher,
-            lambda _url: 503,
+        for status in (401, 404, 503):
+            with self.subTest(status=status):
+                ok, detail = MODULE.verify_once(
+                    "https://example.invalid",
+                    "0123456789abcdef",
+                    fetcher,
+                    lambda _url, value=status: value,
+                )
+                self.assertFalse(ok)
+                self.assertIn(f"HTTP {status}", detail)
+
+    def test_fetch_status_preserves_http_error_status_code(self) -> None:
+        error = MODULE.HTTPError(
+            "https://example.invalid/",
+            404,
+            "Not Found",
+            hdrs=None,
+            fp=None,
         )
-        self.assertFalse(ok)
-        self.assertIn("HTTP 503", detail)
+        with patch.object(MODULE, "urlopen", side_effect=error):
+            self.assertEqual(404, MODULE.fetch_status("https://example.invalid/"))
 
     def test_extracts_render_deploy_id_and_status(self) -> None:
         payload = {"deploy": {"id": "dep-xyz789", "status": "build_in_progress"}}

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -76,6 +76,25 @@ class VerifyRenderDeploymentTest(unittest.TestCase):
         self.assertEqual("build_in_progress", MODULE.deploy_status(payload))
         self.assertIn("update_failed", MODULE.RENDER_FAILURE_STATES)
 
+    def test_render_status_requires_live_before_application_verification(self) -> None:
+        decision, detail = MODULE.render_status_decision(
+            "dep-xyz789", "build_in_progress"
+        )
+        self.assertEqual("pending", decision)
+        self.assertIn("waiting for live", detail)
+
+        decision, detail = MODULE.render_status_decision("dep-xyz789", None)
+        self.assertEqual("pending", decision)
+        self.assertIn("unknown", detail)
+
+        decision, detail = MODULE.render_status_decision("dep-xyz789", "live")
+        self.assertEqual("live", decision)
+        self.assertIn("is live", detail)
+
+        decision, detail = MODULE.render_status_decision("dep-xyz789", "update_failed")
+        self.assertEqual("failure", decision)
+        self.assertIn("ended with update_failed", detail)
+
     def test_load_deploy_id_is_tolerant_of_queued_or_invalid_response(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "hook.json"

--- a/.github/scripts/test-verify-deployment.py
+++ b/.github/scripts/test-verify-deployment.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
+import tempfile
 import unittest
 
 SCRIPT = Path(__file__).with_name("verify-deployment.py").resolve()
@@ -22,15 +24,23 @@ class VerifyRenderDeploymentTest(unittest.TestCase):
         payload = {"git": {"commit": {"id": "abcdef1"}}}
         self.assertTrue(MODULE.contains_commit(payload, "abcdef1234567890"))
 
-    def test_verify_once_requires_readiness_and_commit(self) -> None:
+    def test_verify_once_requires_readiness_commit_and_smoke(self) -> None:
         def fetcher(url: str):
             if url.endswith("/readiness"):
                 return {"status": "UP"}
             return {"git": {"commit": {"id": "0123456789abcdef"}}}
 
         self.assertEqual(
-            (True, "readiness is UP and expected commit is live"),
-            MODULE.verify_once("https://example.invalid/", "0123456789abcdef", fetcher),
+            (
+                True,
+                "readiness is UP, expected commit is live, and root smoke test passed",
+            ),
+            MODULE.verify_once(
+                "https://example.invalid/",
+                "0123456789abcdef",
+                fetcher,
+                lambda _url: 200,
+            ),
         )
 
     def test_verify_once_rejects_stale_commit(self) -> None:
@@ -44,6 +54,43 @@ class VerifyRenderDeploymentTest(unittest.TestCase):
         )
         self.assertFalse(ok)
         self.assertIn("expected commit", detail)
+
+    def test_verify_once_rejects_failed_smoke(self) -> None:
+        def fetcher(url: str):
+            if url.endswith("/readiness"):
+                return {"status": "UP"}
+            return {"git": {"commit": {"id": "0123456789abcdef"}}}
+
+        ok, detail = MODULE.verify_once(
+            "https://example.invalid",
+            "0123456789abcdef",
+            fetcher,
+            lambda _url: 503,
+        )
+        self.assertFalse(ok)
+        self.assertIn("HTTP 503", detail)
+
+    def test_extracts_render_deploy_id_and_status(self) -> None:
+        payload = {"deploy": {"id": "dep-xyz789", "status": "build_in_progress"}}
+        self.assertEqual("dep-xyz789", MODULE.deploy_id_from_payload(payload))
+        self.assertEqual("build_in_progress", MODULE.deploy_status(payload))
+        self.assertIn("update_failed", MODULE.RENDER_FAILURE_STATES)
+
+    def test_load_deploy_id_is_tolerant_of_queued_or_invalid_response(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "hook.json"
+            path.write_text(json.dumps({"message": "queued"}), encoding="utf-8")
+            self.assertIsNone(MODULE.load_deploy_id(path))
+            path.write_text("not json", encoding="utf-8")
+            self.assertIsNone(MODULE.load_deploy_id(path))
+
+    def test_writes_machine_readable_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "nested" / "evidence.json"
+            MODULE.write_evidence(path, {"result": "success", "attempts": 2})
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual("success", payload["result"])
+            self.assertEqual(2, payload["attempts"])
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-verify-quality-publication.py
+++ b/.github/scripts/test-verify-quality-publication.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("verify-quality-publication.py").resolve()
+SPEC = importlib.util.spec_from_file_location("verify_quality_publication", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Cannot load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VerifyQualityPublicationTest(unittest.TestCase):
+    COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+    def _payloads(self):
+        summary = {
+            "commit": self.COMMIT,
+            "verifiedCommit": self.COMMIT,
+            "generatedAt": "2026-08-07T03:00:00+00:00",
+            "sourceTree": "tree123",
+            "buildId": "run-1",
+            "tools": {"java": "21", "maven": "3.9.11"},
+            "tests": {"passed": 4, "tests": 5, "skipped": 1, "failures": 0, "errors": 0},
+            "coverage": {"instructionPercent": 82.74},
+        }
+        return (
+            summary,
+            {"message": "4 passed"},
+            {"message": "82.74%"},
+        )
+
+    def _write_local(self, root: Path) -> None:
+        summary, tests, coverage = self._payloads()
+        for relative in MODULE.REQUIRED_FILES:
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if relative.endswith(".json"):
+                payload = summary if relative == "quality-summary.json" else (
+                    tests if relative == "tests/badge.json" else coverage
+                )
+                path.write_text(json.dumps(payload), encoding="utf-8")
+            elif relative == ".nojekyll":
+                path.touch()
+            else:
+                path.write_text(f"verified {self.COMMIT}", encoding="utf-8")
+
+    def test_local_publication_matches_summary_and_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_local(root)
+            MODULE.verify_local(root, self.COMMIT)
+
+    def test_badge_mismatch_fails_closed(self) -> None:
+        summary, tests, coverage = self._payloads()
+        tests["message"] = "2153 passed"
+        with self.assertRaisesRegex(ValueError, "does not match summary"):
+            MODULE.verify_payloads(summary, tests, coverage, self.COMMIT)
+
+    def test_wrong_commit_fails_closed(self) -> None:
+        summary, tests, coverage = self._payloads()
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            MODULE.verify_payloads(summary, tests, coverage, "deadbeef")
+
+    def test_remote_verification_checks_html_and_json(self) -> None:
+        summary, tests, coverage = self._payloads()
+
+        def json_fetcher(url: str):
+            if "quality-summary.json" in url:
+                return summary
+            if "tests/badge.json" in url:
+                return tests
+            if "coverage/badge.json" in url:
+                return coverage
+            raise AssertionError(url)
+
+        def text_fetcher(url: str) -> str:
+            self.assertIn("verified=", url)
+            return f"quality report for {self.COMMIT}"
+
+        MODULE.verify_remote_once(
+            "https://example.invalid/Taxonomy",
+            self.COMMIT,
+            json_fetcher=json_fetcher,
+            text_fetcher=text_fetcher,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test-verify-quality-publication.py
+++ b/.github/scripts/test-verify-quality-publication.py
@@ -26,7 +26,14 @@ class VerifyQualityPublicationTest(unittest.TestCase):
             "sourceTree": "tree123",
             "buildId": "run-1",
             "tools": {"java": "21", "maven": "3.9.11"},
-            "tests": {"passed": 4, "tests": 5, "skipped": 1, "failures": 0, "errors": 0},
+            "tests": {
+                "tests": 5,
+                "executed": 4,
+                "passed": 4,
+                "skipped": 1,
+                "failures": 0,
+                "errors": 0,
+            },
             "coverage": {"instructionPercent": 82.74},
         }
         return (
@@ -56,10 +63,24 @@ class VerifyQualityPublicationTest(unittest.TestCase):
             self._write_local(root)
             MODULE.verify_local(root, self.COMMIT)
 
+    def test_missing_badge_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_local(root)
+            (root / "tests" / "badge.json").unlink()
+            with self.assertRaisesRegex(FileNotFoundError, "tests/badge.json"):
+                MODULE.verify_local(root, self.COMMIT)
+
     def test_badge_mismatch_fails_closed(self) -> None:
         summary, tests, coverage = self._payloads()
         tests["message"] = "2153 passed"
         with self.assertRaisesRegex(ValueError, "does not match summary"):
+            MODULE.verify_payloads(summary, tests, coverage, self.COMMIT)
+
+    def test_inconsistent_executed_total_fails_closed(self) -> None:
+        summary, tests, coverage = self._payloads()
+        summary["tests"]["executed"] = 5
+        with self.assertRaisesRegex(ValueError, "executed-test total is inconsistent"):
             MODULE.verify_payloads(summary, tests, coverage, self.COMMIT)
 
     def test_wrong_commit_fails_closed(self) -> None:

--- a/.github/scripts/verify-deployment.py
+++ b/.github/scripts/verify-deployment.py
@@ -15,6 +15,7 @@ from urllib.request import Request, urlopen
 JsonFetcher = Callable[[str], object]
 StatusFetcher = Callable[[str], int]
 
+RENDER_SUCCESS_STATE = "live"
 RENDER_FAILURE_STATES = {
     "build_failed",
     "update_failed",
@@ -123,6 +124,17 @@ def deploy_status(payload: object) -> str | None:
     return None
 
 
+def render_status_decision(deploy_id: str, status: str | None) -> tuple[str, str]:
+    normalized = (status or "").strip().lower()
+    if normalized in RENDER_FAILURE_STATES:
+        return "failure", f"Render deploy {deploy_id} ended with {normalized}"
+    if normalized != RENDER_SUCCESS_STATE:
+        return "pending", (
+            f"Render deploy {deploy_id} is {normalized or 'unknown'}; waiting for live"
+        )
+    return "live", f"Render deploy {deploy_id} is live"
+
+
 def verify_once(
     service_url: str,
     expected: str,
@@ -199,8 +211,11 @@ def main() -> int:
                 )
                 last_render_status = deploy_status(render_payload)
                 evidence["renderDeployStatus"] = last_render_status
-                if last_render_status in RENDER_FAILURE_STATES:
-                    last_error = f"Render deploy {deploy_id} ended with {last_render_status}"
+                decision, render_detail = render_status_decision(
+                    deploy_id, last_render_status
+                )
+                if decision == "failure":
+                    last_error = render_detail
                     evidence.update(
                         {
                             "attempts": attempt,
@@ -212,6 +227,15 @@ def main() -> int:
                     write_evidence(args.evidence_file, evidence)
                     print(f"::error::{last_error}")
                     return 1
+                if decision != "live":
+                    last_error = render_detail
+                    print(
+                        f"Render verification attempt {attempt}/{attempts} not ready: "
+                        f"{last_error}"
+                    )
+                    if attempt < attempts:
+                        time.sleep(interval)
+                    continue
 
             ok, detail = verify_once(
                 args.base_url,

--- a/.github/scripts/verify-deployment.py
+++ b/.github/scripts/verify-deployment.py
@@ -53,8 +53,11 @@ def fetch_status(url: str) -> int:
             "User-Agent": "taxonomy-delivery-check",
         },
     )
-    with urlopen(request, timeout=15) as response:
-        return int(response.status)
+    try:
+        with urlopen(request, timeout=15) as response:
+            return int(response.status)
+    except HTTPError as error:
+        return int(error.code)
 
 
 def fetch_render_deploy(service_id: str, deploy_id: str, api_key: str) -> object:
@@ -150,7 +153,7 @@ def verify_once(
         return False, f"actuator info does not identify expected commit {expected}"
     if smoke_fetcher is not None:
         status = smoke_fetcher(f"{base}/")
-        if status < 200 or status >= 500:
+        if status < 200 or status >= 400:
             return False, f"root smoke test returned HTTP {status}"
     return True, "readiness is UP, expected commit is live, and root smoke test passed"
 

--- a/.github/scripts/verify-deployment.py
+++ b/.github/scripts/verify-deployment.py
@@ -4,13 +4,30 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
+from pathlib import Path
 import time
 from typing import Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 JsonFetcher = Callable[[str], object]
+StatusFetcher = Callable[[str], int]
+
+RENDER_FAILURE_STATES = {
+    "build_failed",
+    "update_failed",
+    "pre_deploy_failed",
+    "canceled",
+    "cancelled",
+    "deactivated",
+    "failed",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 def fetch_json(url: str) -> object:
@@ -18,6 +35,33 @@ def fetch_json(url: str) -> object:
         url,
         headers={
             "Accept": "application/json",
+            "Cache-Control": "no-cache",
+            "User-Agent": "taxonomy-delivery-check",
+        },
+    )
+    with urlopen(request, timeout=15) as response:
+        return json.load(response)
+
+
+def fetch_status(url: str) -> int:
+    request = Request(
+        url,
+        headers={
+            "Accept": "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
+            "Cache-Control": "no-cache",
+            "User-Agent": "taxonomy-delivery-check",
+        },
+    )
+    with urlopen(request, timeout=15) as response:
+        return int(response.status)
+
+
+def fetch_render_deploy(service_id: str, deploy_id: str, api_key: str) -> object:
+    request = Request(
+        f"https://api.render.com/v1/services/{service_id}/deploys/{deploy_id}",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {api_key}",
             "User-Agent": "taxonomy-delivery-check",
         },
     )
@@ -49,10 +93,41 @@ def contains_commit(payload: object, expected: str) -> bool:
     return False
 
 
+def deploy_id_from_payload(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        direct = payload.get("id")
+        if isinstance(direct, str) and direct.startswith("dep-"):
+            return direct
+        for value in payload.values():
+            found = deploy_id_from_payload(value)
+            if found:
+                return found
+    elif isinstance(payload, list):
+        for value in payload:
+            found = deploy_id_from_payload(value)
+            if found:
+                return found
+    return None
+
+
+def deploy_status(payload: object) -> str | None:
+    if isinstance(payload, dict):
+        status = payload.get("status")
+        if isinstance(status, str):
+            return status.strip().lower()
+        for key in ("deploy", "data"):
+            if key in payload:
+                nested = deploy_status(payload[key])
+                if nested:
+                    return nested
+    return None
+
+
 def verify_once(
     service_url: str,
     expected: str,
     fetcher: JsonFetcher = fetch_json,
+    smoke_fetcher: StatusFetcher | None = None,
 ) -> tuple[bool, str]:
     base = service_url.rstrip("/")
     readiness = fetcher(f"{base}/actuator/health/readiness")
@@ -61,7 +136,27 @@ def verify_once(
     info = fetcher(f"{base}/actuator/info")
     if not contains_commit(info, expected):
         return False, f"actuator info does not identify expected commit {expected}"
-    return True, "readiness is UP and expected commit is live"
+    if smoke_fetcher is not None:
+        status = smoke_fetcher(f"{base}/")
+        if status < 200 or status >= 500:
+            return False, f"root smoke test returned HTTP {status}"
+    return True, "readiness is UP, expected commit is live, and root smoke test passed"
+
+
+def write_evidence(path: Path | None, payload: dict[str, object]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_deploy_id(path: Path | None) -> str | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        return deploy_id_from_payload(json.loads(path.read_text(encoding="utf-8")))
+    except json.JSONDecodeError:
+        return None
 
 
 def main() -> int:
@@ -70,21 +165,92 @@ def main() -> int:
     parser.add_argument("--expected-commit", required=True)
     parser.add_argument("--attempts", type=int, default=60)
     parser.add_argument("--interval-seconds", type=float, default=10.0)
+    parser.add_argument("--evidence-file", type=Path)
+    parser.add_argument("--deploy-response-file", type=Path)
+    parser.add_argument("--render-service-id")
+    parser.add_argument("--render-api-key")
     args = parser.parse_args()
 
+    attempts = max(1, args.attempts)
+    interval = max(0.0, args.interval_seconds)
+    started_at = utc_now()
+    deploy_id = load_deploy_id(args.deploy_response_file)
     last_error = "deployment did not answer"
-    for attempt in range(1, args.attempts + 1):
+    last_render_status: str | None = None
+    api_status_enabled = bool(args.render_api_key and args.render_service_id and deploy_id)
+
+    evidence: dict[str, object] = {
+        "schemaVersion": 1,
+        "targetUrl": args.base_url.rstrip("/"),
+        "expectedCommit": args.expected_commit,
+        "startedAt": started_at,
+        "renderDeployId": deploy_id,
+        "renderApiStatusVerification": api_status_enabled,
+        "result": "in_progress",
+    }
+
+    for attempt in range(1, attempts + 1):
         try:
-            ok, detail = verify_once(args.base_url, args.expected_commit)
+            if api_status_enabled:
+                render_payload = fetch_render_deploy(
+                    args.render_service_id,
+                    deploy_id,
+                    args.render_api_key,
+                )
+                last_render_status = deploy_status(render_payload)
+                evidence["renderDeployStatus"] = last_render_status
+                if last_render_status in RENDER_FAILURE_STATES:
+                    last_error = f"Render deploy {deploy_id} ended with {last_render_status}"
+                    evidence.update(
+                        {
+                            "attempts": attempt,
+                            "endedAt": utc_now(),
+                            "result": "failure",
+                            "detail": last_error,
+                        }
+                    )
+                    write_evidence(args.evidence_file, evidence)
+                    print(f"::error::{last_error}")
+                    return 1
+
+            ok, detail = verify_once(
+                args.base_url,
+                args.expected_commit,
+                fetch_json,
+                fetch_status,
+            )
             if ok:
+                evidence.update(
+                    {
+                        "attempts": attempt,
+                        "endedAt": utc_now(),
+                        "result": "success",
+                        "detail": detail,
+                        "renderDeployStatus": last_render_status,
+                    }
+                )
+                write_evidence(args.evidence_file, evidence)
                 print(f"Render deployment verified on attempt {attempt}: {detail}")
                 return 0
             last_error = detail
         except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as error:
             last_error = str(error)
-        print(f"Render verification attempt {attempt}/{args.attempts} not ready: {last_error}")
-        if attempt < args.attempts:
-            time.sleep(args.interval_seconds)
+            if api_status_enabled and isinstance(error, HTTPError):
+                last_error = f"Render/application verification HTTP error: {error}"
+        print(f"Render verification attempt {attempt}/{attempts} not ready: {last_error}")
+        if attempt < attempts:
+            time.sleep(interval)
+
+    evidence.update(
+        {
+            "attempts": attempts,
+            "endedAt": utc_now(),
+            "result": "failure",
+            "detail": last_error,
+            "renderDeployStatus": last_render_status,
+        }
+    )
+    write_evidence(args.evidence_file, evidence)
     print(f"::error::Render deployment verification failed: {last_error}")
     return 1
 

--- a/.github/scripts/verify-quality-publication.py
+++ b/.github/scripts/verify-quality-publication.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import time
 from typing import Callable
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
+from urllib.parse import parse_qsl, urlencode, urljoin, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 
 JsonFetcher = Callable[[str], object]
@@ -122,9 +122,13 @@ def fetch_text(url: str) -> str:
 
 
 def _remote_url(base_url: str, relative: str, expected_commit: str) -> str:
-    base = base_url.rstrip("/")
-    separator = "&" if "?" in relative else "?"
-    return f"{base}/{relative}{separator}verified={quote(expected_commit)}"
+    target = urljoin(base_url.rstrip("/") + "/", relative)
+    parts = urlsplit(target)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(("verified", expected_commit))
+    return urlunsplit(
+        (parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)
+    )
 
 
 def verify_remote_once(

--- a/.github/scripts/verify-quality-publication.py
+++ b/.github/scripts/verify-quality-publication.py
@@ -55,9 +55,22 @@ def verify_payloads(
     if not isinstance(tests, dict) or not isinstance(coverage, dict):
         raise ValueError("quality summary tests/coverage fields must be objects")
 
-    passed = int(tests.get("passed", -1))
-    if passed < 0:
-        raise ValueError("quality summary contains an invalid passed-test count")
+    try:
+        registered = int(tests["tests"])
+        executed = int(tests["executed"])
+        passed = int(tests["passed"])
+        skipped = int(tests["skipped"])
+        failures = int(tests["failures"])
+        errors = int(tests["errors"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("quality summary has incomplete or invalid test totals") from error
+    if min(registered, executed, passed, skipped, failures, errors) < 0:
+        raise ValueError("quality summary contains negative test totals")
+    if executed != registered - skipped:
+        raise ValueError("quality summary executed-test total is inconsistent")
+    if passed != executed - failures - errors:
+        raise ValueError("quality summary passed-test total is inconsistent")
+
     expected_test_message = f"{passed} passed"
     if test_badge.get("message") != expected_test_message:
         raise ValueError(

--- a/.github/scripts/verify-quality-publication.py
+++ b/.github/scripts/verify-quality-publication.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Verify that published quality evidence is complete, commit-bound, and internally consistent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import time
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+JsonFetcher = Callable[[str], object]
+TextFetcher = Callable[[str], str]
+
+REQUIRED_FILES = (
+    "index.html",
+    "quality-summary.json",
+    "tests/badge.json",
+    "tests/surefire-report.html",
+    "coverage/badge.json",
+    "coverage/index.html",
+    ".nojekyll",
+)
+
+
+def _normalise_commit(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def verify_payloads(
+    summary: object,
+    test_badge: object,
+    coverage_badge: object,
+    expected_commit: str,
+) -> None:
+    if not isinstance(summary, dict):
+        raise ValueError("quality-summary.json must contain a JSON object")
+    if not isinstance(test_badge, dict) or not isinstance(coverage_badge, dict):
+        raise ValueError("badge JSON must contain JSON objects")
+
+    expected = _normalise_commit(expected_commit)
+    actual = _normalise_commit(summary.get("commit") or summary.get("verifiedCommit"))
+    if not expected or actual != expected:
+        raise ValueError(f"quality report commit {actual!r} does not match {expected!r}")
+
+    for key in ("generatedAt", "sourceTree", "buildId", "tests", "coverage", "tools"):
+        if key not in summary:
+            raise ValueError(f"quality summary is missing required metadata field {key!r}")
+
+    tests = summary.get("tests")
+    coverage = summary.get("coverage")
+    if not isinstance(tests, dict) or not isinstance(coverage, dict):
+        raise ValueError("quality summary tests/coverage fields must be objects")
+
+    passed = int(tests.get("passed", -1))
+    if passed < 0:
+        raise ValueError("quality summary contains an invalid passed-test count")
+    expected_test_message = f"{passed} passed"
+    if test_badge.get("message") != expected_test_message:
+        raise ValueError(
+            f"test badge {test_badge.get('message')!r} does not match summary {expected_test_message!r}"
+        )
+
+    try:
+        instruction_percent = float(coverage["instructionPercent"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("quality summary has no valid instructionPercent") from error
+    expected_coverage_message = f"{instruction_percent:.2f}%"
+    if coverage_badge.get("message") != expected_coverage_message:
+        raise ValueError(
+            "coverage badge "
+            f"{coverage_badge.get('message')!r} does not match summary {expected_coverage_message!r}"
+        )
+
+
+def verify_local(root: Path, expected_commit: str) -> None:
+    missing = [relative for relative in REQUIRED_FILES if not root.joinpath(relative).is_file()]
+    if missing:
+        raise FileNotFoundError(f"quality publication is missing: {', '.join(missing)}")
+    summary = json.loads(root.joinpath("quality-summary.json").read_text(encoding="utf-8"))
+    test_badge = json.loads(root.joinpath("tests/badge.json").read_text(encoding="utf-8"))
+    coverage_badge = json.loads(root.joinpath("coverage/badge.json").read_text(encoding="utf-8"))
+    verify_payloads(summary, test_badge, coverage_badge, expected_commit)
+
+
+def _request(url: str) -> Request:
+    return Request(
+        url,
+        headers={
+            "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "User-Agent": "taxonomy-quality-publication-check",
+        },
+    )
+
+
+def fetch_json(url: str) -> object:
+    with urlopen(_request(url), timeout=20) as response:
+        return json.load(response)
+
+
+def fetch_text(url: str) -> str:
+    with urlopen(_request(url), timeout=20) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def _remote_url(base_url: str, relative: str, expected_commit: str) -> str:
+    base = base_url.rstrip("/")
+    separator = "&" if "?" in relative else "?"
+    return f"{base}/{relative}{separator}verified={quote(expected_commit)}"
+
+
+def verify_remote_once(
+    base_url: str,
+    expected_commit: str,
+    json_fetcher: JsonFetcher = fetch_json,
+    text_fetcher: TextFetcher = fetch_text,
+) -> None:
+    summary = json_fetcher(_remote_url(base_url, "quality-summary.json", expected_commit))
+    test_badge = json_fetcher(_remote_url(base_url, "tests/badge.json", expected_commit))
+    coverage_badge = json_fetcher(_remote_url(base_url, "coverage/badge.json", expected_commit))
+    verify_payloads(summary, test_badge, coverage_badge, expected_commit)
+
+    index = text_fetcher(_remote_url(base_url, "index.html", expected_commit))
+    report = text_fetcher(_remote_url(base_url, "tests/surefire-report.html", expected_commit))
+    if expected_commit.lower() not in index.lower():
+        raise ValueError("published index does not identify the expected commit")
+    if expected_commit.lower() not in report.lower():
+        raise ValueError("published test report does not identify the expected commit")
+
+
+def verify_remote(
+    base_url: str,
+    expected_commit: str,
+    attempts: int,
+    interval_seconds: float,
+) -> None:
+    last_error = "publication did not answer"
+    for attempt in range(1, attempts + 1):
+        try:
+            verify_remote_once(base_url, expected_commit)
+            print(
+                f"Published quality evidence verified for {expected_commit} "
+                f"on attempt {attempt}."
+            )
+            return
+        except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError) as error:
+            last_error = str(error)
+        print(
+            f"Quality publication attempt {attempt}/{attempts} not ready: {last_error}"
+        )
+        if attempt < attempts:
+            time.sleep(interval_seconds)
+    raise RuntimeError(f"published quality evidence verification failed: {last_error}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--root", type=Path)
+    source.add_argument("--base-url")
+    parser.add_argument("--expected-commit", required=True)
+    parser.add_argument("--attempts", type=int, default=30)
+    parser.add_argument("--interval-seconds", type=float, default=10.0)
+    args = parser.parse_args()
+
+    try:
+        if args.root is not None:
+            verify_local(args.root, args.expected_commit)
+            print(f"Local quality evidence verified for {args.expected_commit}.")
+        else:
+            verify_remote(
+                args.base_url,
+                args.expected_commit,
+                max(1, args.attempts),
+                max(0.0, args.interval_seconds),
+            )
+    except (FileNotFoundError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        print(f"::error::{error}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,6 +58,7 @@ jobs:
           python3 .github/scripts/test-resolve-release-parameters.py
           python3 .github/scripts/test-check-release-plan.py
           python3 .github/scripts/test-generate-quality-site.py
+          python3 .github/scripts/test-verify-quality-publication.py
           python3 .github/scripts/test-verify-deployment.py
           node .github/scripts/test-taxonomy-base-path.mjs
           bash -n .github/scripts/release.sh
@@ -187,10 +188,25 @@ jobs:
             cp -a target/observability-performance/. \
               target/quality-reports/evidence/observability-performance/
           fi
+
+          source_tree=$(git rev-parse "${GITHUB_SHA}^{tree}")
+          build_id="${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+          java_version=$(java -version 2>&1 | head -n 1)
+          maven_version=$(./mvnw -version 2>&1 | head -n 1)
           python3 .github/scripts/generate-quality-site.py \
             --root target/quality-reports \
-            --commit "$GITHUB_SHA"
-          printf 'Verified commit: %s\n' "$GITHUB_SHA" > target/quality-reports/README.txt
+            --commit "$GITHUB_SHA" \
+            --source-tree "$source_tree" \
+            --build-id "$build_id" \
+            --tool "java=$java_version" \
+            --tool "maven=$maven_version" \
+            --tool "codeql-action=v4.37.6" \
+            --tool "trivy-action=v0.36.0"
+          python3 .github/scripts/verify-quality-publication.py \
+            --root target/quality-reports \
+            --expected-commit "$GITHUB_SHA"
+          printf 'Verified commit: %s\nSource tree: %s\nBuild ID: %s\n' \
+            "$GITHUB_SHA" "$source_tree" "$build_id" > target/quality-reports/README.txt
 
       - name: Upload verified reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -191,8 +191,8 @@ jobs:
 
           source_tree=$(git rev-parse "${GITHUB_SHA}^{tree}")
           build_id="${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
-          java_version=$(java -version 2>&1 | head -n 1)
-          maven_version=$(./mvnw -version 2>&1 | head -n 1)
+          java_version=$(java -version 2>&1 | sed -n '1p')
+          maven_version=$(./mvnw -version 2>&1 | sed -n '1p')
           python3 .github/scripts/generate-quality-site.py \
             --root target/quality-reports \
             --commit "$GITHUB_SHA" \

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -30,6 +30,12 @@ jobs:
       group: taxonomy-quality-report-publication
       cancel-in-progress: false
     steps:
+      - name: Checkout verified quality tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
       - name: Download verified report artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -38,38 +44,15 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify report provenance and completeness
+      - name: Verify report provenance and badge consistency
         env:
           EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          root = Path("quality-reports")
-          summary_path = root / "quality-summary.json"
-          if not summary_path.is_file():
-              raise SystemExit("quality-summary.json is missing from the verified artifact")
-          summary = json.loads(summary_path.read_text(encoding="utf-8"))
-          expected = os.environ["EXPECTED_SHA"]
-          if summary.get("commit") != expected:
-              raise SystemExit(
-                  f"quality report commit {summary.get('commit')!r} does not match {expected}"
-              )
-          for relative in (
-              "tests/badge.json",
-              "tests/surefire-report.html",
-              "coverage/badge.json",
-              "coverage/index.html",
-              ".nojekyll",
-          ):
-              if not root.joinpath(relative).is_file():
-                  raise SystemExit(f"verified quality artifact is missing {relative}")
-          print(f"Quality report provenance verified for {expected}")
-          PY
+          python3 .github/scripts/verify-quality-publication.py \
+            --root quality-reports \
+            --expected-commit "$EXPECTED_SHA"
 
       - name: Publish reports to GitHub Pages atomically
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
@@ -81,6 +64,25 @@ jobs:
           user_name: github-actions[bot]
           user_email: github-actions[bot]@users.noreply.github.com
           commit_message: 'Publish verified quality reports ${{ github.event.workflow_run.head_sha }}'
+
+      - name: Verify published GitHub Pages evidence
+        env:
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          CONFIGURED_BASE_URL: ${{ vars.QUALITY_REPORT_BASE_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "$CONFIGURED_BASE_URL" ]]; then
+            base_url="$CONFIGURED_BASE_URL"
+          else
+            repo_name="${GITHUB_REPOSITORY#*/}"
+            base_url="https://${GITHUB_REPOSITORY_OWNER}.github.io/${repo_name}"
+          fi
+          python3 .github/scripts/verify-quality-publication.py \
+            --base-url "$base_url" \
+            --expected-commit "$EXPECTED_SHA" \
+            --attempts 60 \
+            --interval-seconds 10
 
   publish-image:
     name: Publish Docker Image
@@ -168,8 +170,33 @@ jobs:
             echo "RENDER_DEPLOY_HOOK_URL is not configured; Render deployment is disabled."
             exit 0
           fi
-          curl -fsSL --retry 3 "$HOOK_URL"
-          echo "Render deployment triggered; waiting for the verified commit."
+          mkdir -p target/delivery-evidence
+          deploy_url=$(python3 - <<'PY'
+          import os
+          from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+          url = os.environ["HOOK_URL"]
+          expected = os.environ["EXPECTED_SHA"]
+          parts = urlsplit(url)
+          query = dict(parse_qsl(parts.query, keep_blank_values=True))
+          query["ref"] = expected
+          print(urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)))
+          PY
+          )
+          curl --fail --silent --show-error --retry 3 \
+            --output target/delivery-evidence/render-deploy-hook.json \
+            "$deploy_url"
+          echo "Render deployment triggered for the verified commit; waiting for readiness."
           python3 .github/scripts/verify-deployment.py \
             --base-url "$BASE_URL" \
-            --expected-commit "$EXPECTED_SHA"
+            --expected-commit "$EXPECTED_SHA" \
+            --evidence-file target/delivery-evidence/render-verification.json
+
+      - name: Archive Render deployment evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: render-deployment-evidence-${{ github.event.workflow_run.head_sha }}
+          path: target/delivery-evidence/**
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -161,6 +161,8 @@ jobs:
       - name: Trigger and verify Render deployment
         env:
           HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+          RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
+          CONFIGURED_RENDER_SERVICE_ID: ${{ vars.RENDER_SERVICE_ID }}
           BASE_URL: ${{ vars.RENDER_BASE_URL || 'https://taxonomy-analyzer.onrender.com' }}
           EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
@@ -186,11 +188,38 @@ jobs:
           curl --fail --silent --show-error --retry 3 \
             --output target/delivery-evidence/render-deploy-hook.json \
             "$deploy_url"
-          echo "Render deployment triggered for the verified commit; waiting for readiness."
-          python3 .github/scripts/verify-deployment.py \
-            --base-url "$BASE_URL" \
-            --expected-commit "$EXPECTED_SHA" \
+
+          render_service_id="$CONFIGURED_RENDER_SERVICE_ID"
+          if [[ -z "$render_service_id" ]]; then
+            render_service_id=$(python3 - <<'PY'
+          import os
+          import re
+          from urllib.parse import urlsplit
+
+          match = re.search(r"(?:^|/)(srv-[A-Za-z0-9]+)(?:/|$)", urlsplit(os.environ["HOOK_URL"]).path)
+          print(match.group(1) if match else "")
+          PY
+          )
+          fi
+
+          verify_args=(
+            --base-url "$BASE_URL"
+            --expected-commit "$EXPECTED_SHA"
+            --deploy-response-file target/delivery-evidence/render-deploy-hook.json
             --evidence-file target/delivery-evidence/render-verification.json
+          )
+          if [[ -n "$RENDER_API_KEY" && -n "$render_service_id" ]]; then
+            verify_args+=(
+              --render-api-key "$RENDER_API_KEY"
+              --render-service-id "$render_service_id"
+            )
+            echo "Render API deploy-status verification enabled."
+          else
+            echo "Render API credentials/service ID not configured; live readiness and commit verification remain authoritative."
+          fi
+
+          echo "Render deployment triggered for the verified commit; waiting for readiness."
+          python3 .github/scripts/verify-deployment.py "${verify_args[@]}"
 
       - name: Archive Render deployment evidence
         if: always()


### PR DESCRIPTION
## What it does

Follow-up to #607 for the remaining delivery-evidence parts of #611.

- records the verified source commit, source tree, workflow build ID, test totals, aggregate JaCoCo metrics and toolchain/scanner versions in `quality-summary.json`;
- verifies test/coverage badge values against that same summary before publication;
- publishes GitHub Pages atomically as before, then re-fetches the actually served Pages JSON/HTML with bounded retries and proves that it contains the expected commit and internally consistent badge values;
- pins the Render deploy hook to the exact verified Git commit via `ref` instead of implicitly deploying whatever happens to be current;
- performs readiness, live commit and root smoke verification after deployment;
- archives machine-readable Render deployment evidence for 90 days;
- records the Render deploy ID from the hook response when available and optionally polls the Render API deploy status when `RENDER_API_KEY` plus a service ID are configured;
- extends the delivery hardening contract so these guarantees cannot silently regress.

## Failure semantics

The report publisher fails closed for missing/mismatched evidence, stale badges, wrong SHA, or an unobservable Pages publication. The Render gate fails when readiness/commit/smoke verification cannot prove the expected release; when Render API polling is configured, terminal platform failures fail immediately.

## Tests added/extended

- stale badge mismatch rejection;
- wrong commit rejection;
- local and remote publication consistency;
- quality provenance/toolchain fields;
- Render root smoke failure;
- Render deploy ID/status extraction;
- machine-readable deployment evidence.

This intentionally does **not** claim the large-taxonomy DOM-performance part of #611 is complete; true incremental/lazy tree rendering is being treated separately because it touches the core browser rendering path and deserves an isolated regression surface.