### PR TITLE
Harden release QA gates and immutable image evidence

### DIFF
--- a/.github/scripts/check-frontend-api-boundary.py
+++ b/.github/scripts/check-frontend-api-boundary.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Prevent new direct frontend fetch debt outside the central API layer.
+
+The current UI still contains legacy feature modules that call ``fetch()``
+directly. Rewriting all of them in one release-blocker change would create a
+large regression surface, so this check acts as a ratchet instead:
+
+* API-client modules under ``static/js/api`` may own HTTP transport calls;
+* the base-path bootstrap wrapper is an explicit infrastructure exception;
+* every other JavaScript module may only keep or reduce the number of direct
+  ``fetch()`` calls that existed in the comparison revision;
+* a new non-API module may not introduce a direct ``fetch()`` call at all.
+
+This makes the legacy count monotonically non-increasing while allowing the
+migration to the central client to be performed incrementally.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+JS_ROOT = ROOT / "taxonomy-app" / "src" / "main" / "resources" / "static" / "js"
+REPO_JS_PREFIX = "taxonomy-app/src/main/resources/static/js/"
+DIRECT_FETCH = re.compile(r"\bfetch\s*\(")
+INFRASTRUCTURE_EXCEPTIONS = {
+    "taxonomy-i18n.js",  # installs the application-base-path-aware fetch wrapper
+}
+
+
+def count_direct_fetch(text: str) -> int:
+    """Return the number of direct fetch() call sites in JavaScript source."""
+    return len(DIRECT_FETCH.findall(text))
+
+
+def is_transport_owner(relative_path: str) -> bool:
+    normalized = relative_path.replace("\\", "/")
+    return normalized.startswith("api/") or normalized in INFRASTRUCTURE_EXCEPTIONS
+
+
+def current_counts(root: Path = JS_ROOT) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in {".js", ".mjs"}:
+            continue
+        relative = path.relative_to(root).as_posix()
+        count = count_direct_fetch(path.read_text(encoding="utf-8"))
+        if count:
+            counts[relative] = count
+    return counts
+
+
+def git_text(base_ref: str, repository_path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{base_ref}:{repository_path}"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return result.stdout
+    if "does not exist" in result.stderr or "exists on disk, but not in" in result.stderr:
+        return None
+    raise RuntimeError(
+        f"git show failed for {base_ref}:{repository_path}: {result.stderr.strip()}"
+    )
+
+
+def baseline_counts(base_ref: str, paths: set[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for relative in sorted(paths):
+        text = git_text(base_ref, REPO_JS_PREFIX + relative)
+        if text is None:
+            continue
+        count = count_direct_fetch(text)
+        if count:
+            counts[relative] = count
+    return counts
+
+
+def evaluate(current: dict[str, int], baseline: dict[str, int]) -> list[str]:
+    failures: list[str] = []
+    current_debt = {
+        path: count for path, count in current.items() if not is_transport_owner(path)
+    }
+    baseline_debt = {
+        path: count for path, count in baseline.items() if not is_transport_owner(path)
+    }
+
+    for path, count in sorted(current_debt.items()):
+        previous = baseline_debt.get(path, 0)
+        if previous == 0:
+            failures.append(
+                f"{path}: introduces {count} direct fetch() call(s); use static/js/api instead"
+            )
+        elif count > previous:
+            failures.append(
+                f"{path}: direct fetch() count increased from {previous} to {count}"
+            )
+
+    current_total = sum(current_debt.values())
+    baseline_total = sum(baseline_debt.values())
+    if current_total > baseline_total:
+        failures.append(
+            f"legacy direct fetch() debt increased from {baseline_total} to {current_total}"
+        )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        required=True,
+        help="Git revision used as the maximum allowed legacy direct-fetch baseline",
+    )
+    args = parser.parse_args()
+
+    current = current_counts()
+    baseline = baseline_counts(args.base_ref, set(current))
+    failures = evaluate(current, baseline)
+
+    current_debt = {
+        path: count for path, count in current.items() if not is_transport_owner(path)
+    }
+    baseline_debt = {
+        path: count for path, count in baseline.items() if not is_transport_owner(path)
+    }
+    print(
+        "Frontend API boundary: "
+        f"legacy direct fetch debt {sum(current_debt.values())} call(s) in "
+        f"{len(current_debt)} file(s); baseline "
+        f"{sum(baseline_debt.values())} call(s) in {len(baseline_debt)} file(s)."
+    )
+
+    if failures:
+        print("Frontend API boundary check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("No new direct frontend fetch debt was introduced outside the API layer.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check-observability-performance-scope.py
+++ b/.github/scripts/check-observability-performance-scope.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Keep the expensive observability performance gate scoped to actual PR changes."""
+"""Keep the performance gate broad enough for releases and relevant PR changes."""
 
 from pathlib import Path
 import sys
@@ -13,10 +13,16 @@ def main() -> int:
     failures: list[str] = []
 
     required = (
+        "- name: Detect performance-sensitive changes",
         "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
         "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
         'git diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" --',
+        "pom.xml",
+        "Dockerfile",
+        "taxonomy-app/pom.xml",
+        "taxonomy-app/src/main",
         ".github/scripts/run-observability-performance.sh",
+        "github.event_name != 'pull_request' || steps.observability-performance-scope.outputs.run == 'true'",
         "TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE: 'true'",
         "run: bash .github/scripts/run-observability-performance.sh",
     )
@@ -25,12 +31,15 @@ def main() -> int:
             failures.append(f"ci-cd.yml is missing {needle!r}")
 
     try:
-        start = workflow.index("- name: Detect observability performance changes")
+        start = workflow.index("- name: Detect performance-sensitive changes")
         end = workflow.index("- name: Measure OpenTelemetry performance budget")
         scope_block = workflow[start:end]
+        performance_end = workflow.index("- name: Restore pinned embedding model")
+        performance_block = workflow[end:performance_end]
     except ValueError as error:
-        failures.append(f"Could not locate observability scope steps: {error}")
+        failures.append(f"Could not locate performance scope steps: {error}")
         scope_block = ""
+        performance_block = ""
 
     if "...HEAD" in scope_block:
         failures.append(
@@ -38,16 +47,26 @@ def main() -> int:
         )
     if ".github/workflows/ci-cd.yml" in scope_block:
         failures.append(
-            "Editing unrelated CI steps must not force the expensive observability benchmark"
+            "Editing unrelated CI steps must not by itself force the expensive benchmark"
+        )
+    if "taxonomy-app/src/main" not in scope_block:
+        failures.append(
+            "Application runtime changes must trigger the performance budget on pull requests"
+        )
+    if "github.event_name != 'pull_request'" not in performance_block:
+        failures.append(
+            "Main, tag, release and manual CI runs must not be allowed to skip the performance budget"
         )
 
     if failures:
-        print("Observability performance scope contract failed:", file=sys.stderr)
+        print("Performance scope contract failed:", file=sys.stderr)
         for failure in failures:
             print(f"- {failure}", file=sys.stderr)
         return 1
 
-    print("Observability performance scope is limited to actual PR observability changes.")
+    print(
+        "Performance scope covers runtime-sensitive PR changes and always runs on non-PR CI."
+    )
     return 0
 
 

--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 ROOT_POM = ROOT / "pom.xml"
 RELEASE_PLAN_CHECK = ROOT / ".github" / "scripts" / "check-release-plan.py"
 RELEASE_SCRIPT = ROOT / ".github" / "scripts" / "release.sh"
+RELEASE_IMAGE_GATE = ROOT / ".github" / "scripts" / "check-release-image-gate.py"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-release.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci-cd.yml"
 
@@ -26,6 +28,22 @@ def main() -> int:
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     failures: list[str] = []
+
+    image_gate = subprocess.run(
+        [sys.executable, str(RELEASE_IMAGE_GATE)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if image_gate.stdout:
+        print(image_gate.stdout, end="")
+    if image_gate.returncode != 0:
+        if image_gate.stderr:
+            print(image_gate.stderr, end="", file=sys.stderr)
+        failures.append(
+            "Immutable OCI image verification contract failed; see check-release-image-gate.py output"
+        )
 
     for needle in (
         "<id>release-check</id>",
@@ -112,6 +130,9 @@ def main() -> int:
         "- name: Checkout immutable release source",
         "- name: Package and stage immutable Helm artifacts",
         "- name: Build and publish immutable release image",
+        "- name: Scan immutable release image digest",
+        "- name: Bind release evidence and Helm deployment to immutable image digest",
+        "- name: Archive immutable release image evidence",
         "- name: Verify exact final main snapshot with canonical CI",
         "- name: Publish complete release and trigger deployment",
         "EXPECTED_MAIN_SHA: ${{ steps.final_main.outputs.sha }}",
@@ -165,18 +186,23 @@ def main() -> int:
         checkout_tag = workflow.index("- name: Checkout immutable release source")
         package = workflow.index("- name: Package and stage immutable Helm artifacts")
         image = workflow.index("- name: Build and publish immutable release image")
+        scan = workflow.index("- name: Scan immutable release image digest")
+        bind = workflow.index(
+            "- name: Bind release evidence and Helm deployment to immutable image digest"
+        )
+        archive = workflow.index("- name: Archive immutable release image evidence")
         final_ci = workflow.index(
             "- name: Verify exact final main snapshot with canonical CI"
         )
         publish = workflow.index(
             "- name: Publish complete release and trigger deployment"
         )
-        if not checkout < resolve < stage < resume < record_main < checkout_tag < package < image < final_ci < publish:
+        if not checkout < resolve < stage < resume < record_main < checkout_tag < package < image < scan < bind < archive < final_ci < publish:
             failures.append(
                 "deploy-release.yml must bind checkout to the triggering source, "
                 "then either stage or validate a resumable draft, record the exact "
-                "main commit, fetch and build the immutable tag, verify that exact "
-                "main commit, and publish last"
+                "main commit, fetch and build the immutable tag, scan and bind the "
+                "pushed image digest, verify that exact main commit, and publish last"
             )
 
         checkout_block = workflow[checkout:resolve]
@@ -247,11 +273,10 @@ def main() -> int:
         return 1
 
     print(
-        "Release delivery contract is Maven-verifiable, atomic, freely versionable "
-        "and resumable: the local profile validates the release plan without SCM "
-        "mutation, the triggering source is preserved, immutable sources are fetched "
-        "explicitly, the exact main snapshot is verified, and publication remains "
-        "the final gate."
+        "Release delivery contract is Maven-verifiable, atomic, freely versionable, "
+        "resumable and digest-bound: the local profile validates the release plan "
+        "without SCM mutation, immutable sources and images are verified explicitly, "
+        "the exact main snapshot is checked, and publication remains the final gate."
     )
     return 0
 

--- a/.github/scripts/check-release-image-gate.py
+++ b/.github/scripts/check-release-image-gate.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Fail closed if release publication stops verifying the exact OCI digest."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "deploy-release.yml"
+
+
+def require(text: str, needle: str, failures: list[str]) -> None:
+    if needle not in text:
+        failures.append(f"deploy-release.yml is missing {needle!r}")
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    for needle in (
+        "id: release_image",
+        "provenance: mode=max",
+        "sbom: true",
+        "- name: Scan immutable release image digest",
+        "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25",
+        "image-ref: ghcr.io/${{ github.repository_owner }}/taxonomy@${{ steps.release_image.outputs.digest }}",
+        "severity: HIGH,CRITICAL",
+        "exit-code: '1'",
+        "- name: Bind release evidence and Helm deployment to immutable image digest",
+        "IMAGE_DIGEST: ${{ steps.release_image.outputs.digest }}",
+        "^sha256:[0-9a-f]{64}$",
+        'immutable_image="${repository}@${IMAGE_DIGEST}"',
+        '"attestations"',
+        '"provenance": True',
+        '"sbom": True',
+        '"result": "passed"',
+        "--set-string \"image.digest=${IMAGE_DIGEST}\"",
+        "taxonomy-${RELEASE_VERSION}-kubernetes-digest.yaml",
+        "taxonomy-${RELEASE_VERSION}-image-evidence.json",
+        "taxonomy-${RELEASE_VERSION}-image-trivy.sarif",
+        "taxonomy-${RELEASE_VERSION}-release.sha256",
+        "retention-days: 90",
+        "docker buildx imagetools inspect \"$image\"",
+        'if [[ "$evidence_digest" != "$IMAGE_DIGEST" ]]; then',
+    ):
+        require(workflow, needle, failures)
+
+    try:
+        build = workflow.index("- name: Build and publish immutable release image")
+        scan = workflow.index("- name: Scan immutable release image digest")
+        bind = workflow.index(
+            "- name: Bind release evidence and Helm deployment to immutable image digest"
+        )
+        archive = workflow.index("- name: Archive immutable release image evidence")
+        final_ci = workflow.index(
+            "- name: Verify exact final main snapshot with canonical CI"
+        )
+        publish = workflow.index(
+            "- name: Publish complete release and trigger deployment"
+        )
+        if not build < scan < bind < archive < final_ci < publish:
+            failures.append(
+                "release image must be built, digest-scanned, evidence-bound and archived "
+                "before final CI and publication"
+            )
+
+        scan_block = workflow[scan:bind]
+        if "exit-code: '1'" not in scan_block:
+            failures.append("immutable digest scan must fail the release on blocking findings")
+        if "steps.release_image.outputs.digest" not in scan_block:
+            failures.append("image scan must consume the build-push digest output")
+
+        bind_block = workflow[bind:archive]
+        if "gh release upload" not in bind_block:
+            failures.append("digest evidence must be attached to the draft release")
+        if "image.digest=${IMAGE_DIGEST}" not in bind_block:
+            failures.append("Helm release evidence must include a digest-bound manifest")
+
+        publish_block = workflow[publish:]
+        evidence_check = publish_block.find("evidence_digest")
+        publish_release = publish_block.find("gh release edit")
+        if evidence_check < 0 or publish_release < 0 or evidence_check > publish_release:
+            failures.append(
+                "release image evidence must be verified before the draft becomes public"
+            )
+        if 'image="${repository}@${IMAGE_DIGEST}"' not in publish_block:
+            failures.append("final publication must inspect the immutable digest, not only a tag")
+    except ValueError as error:
+        failures.append(f"Could not determine immutable image gate order: {error}")
+
+    if failures:
+        print("Immutable release image gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(
+        "Immutable release image gate passed: provenance/SBOM attestations are enabled, "
+        "the pushed digest is vulnerability-scanned, release evidence is digest-bound, "
+        "and publication occurs only after those checks."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test-check-frontend-api-boundary.py
+++ b/.github/scripts/test-check-frontend-api-boundary.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Unit tests for check-frontend-api-boundary.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT = Path(__file__).with_name("check-frontend-api-boundary.py")
+SPEC = importlib.util.spec_from_file_location("frontend_api_boundary", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class FrontendApiBoundaryTest(unittest.TestCase):
+
+    def test_counts_fetch_calls(self) -> None:
+        self.assertEqual(2, MODULE.count_direct_fetch("fetch('/a'); window.fetch('/b');"))
+
+    def test_api_clients_and_base_path_wrapper_are_transport_owners(self) -> None:
+        self.assertTrue(MODULE.is_transport_owner("api/taxonomy-api-client.js"))
+        self.assertTrue(MODULE.is_transport_owner("taxonomy-i18n.js"))
+        self.assertFalse(MODULE.is_transport_owner("shared/taxonomy-search.js"))
+
+    def test_existing_legacy_call_count_may_decrease(self) -> None:
+        failures = MODULE.evaluate(
+            {"shared/search.js": 2, "api/client.js": 5},
+            {"shared/search.js": 3, "api/client.js": 1},
+        )
+        self.assertEqual([], failures)
+
+    def test_existing_legacy_call_count_may_not_increase(self) -> None:
+        failures = MODULE.evaluate(
+            {"shared/search.js": 4},
+            {"shared/search.js": 3},
+        )
+        self.assertTrue(any("increased from 3 to 4" in failure for failure in failures))
+
+    def test_new_feature_module_may_not_introduce_fetch(self) -> None:
+        failures = MODULE.evaluate(
+            {"workspace/new-feature.js": 1},
+            {},
+        )
+        self.assertTrue(any("introduces 1 direct fetch()" in failure for failure in failures))
+
+    def test_new_api_client_may_own_transport(self) -> None:
+        failures = MODULE.evaluate(
+            {"api/new-client.js": 7},
+            {},
+        )
+        self.assertEqual([], failures)
+
+    def test_total_legacy_debt_cannot_grow_by_shifting_calls(self) -> None:
+        failures = MODULE.evaluate(
+            {"shared/a.js": 1, "shared/b.js": 2},
+            {"shared/a.js": 2, "shared/b.js": 0},
+        )
+        self.assertTrue(any("debt increased from 2 to 3" in failure for failure in failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,6 +52,8 @@ jobs:
           fi
 
       - name: Verify release and delivery contracts
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -60,6 +62,7 @@ jobs:
           python3 .github/scripts/test-generate-quality-site.py
           python3 .github/scripts/test-verify-quality-publication.py
           python3 .github/scripts/test-verify-deployment.py
+          python3 .github/scripts/test-check-frontend-api-boundary.py
           node .github/scripts/test-taxonomy-base-path.mjs
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/install-helm.sh
@@ -68,6 +71,9 @@ jobs:
           python3 .github/scripts/check-release-delivery-contract.py
           python3 .github/scripts/check-delivery-hardening.py
           python3 .github/scripts/check-observability-performance-scope.py
+
+          frontend_base="${PR_BASE_SHA:-HEAD^}"
+          python3 .github/scripts/check-frontend-api-boundary.py --base-ref "$frontend_base"
 
           current_version=$(./mvnw -q -DforceStdout help:evaluate \
             -Dexpression=project.version)
@@ -93,7 +99,7 @@ jobs:
         shell: bash
         run: bash deploy/helm/taxonomy/verify.sh target/taxonomy-helm-rendered.yaml
 
-      - name: Detect observability performance changes
+      - name: Detect performance-sensitive changes
         id: observability-performance-scope
         if: github.event_name == 'pull_request'
         env:
@@ -103,10 +109,14 @@ jobs:
         run: |
           set -euo pipefail
           if git diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" -- \
-            observability \
+            pom.xml \
+            Dockerfile \
+            taxonomy-app/pom.xml \
+            taxonomy-app/src/main \
             taxonomy-app/src/test/java/com/taxonomy/ObservabilityContainerIT.java \
             taxonomy-app/src/test/java/com/taxonomy/ObservabilityPerformanceIT.java \
             taxonomy-app/src/test/resources/observability \
+            observability \
             .github/scripts/run-observability-performance.sh \
             docs/dev/OBSERVABILITY_PERFORMANCE.md; then
             echo 'run=false' >> "$GITHUB_OUTPUT"
@@ -115,7 +125,7 @@ jobs:
           fi
 
       - name: Measure OpenTelemetry performance budget
-        if: steps.observability-performance-scope.outputs.run == 'true'
+        if: github.event_name != 'pull_request' || steps.observability-performance-scope.outputs.run == 'true'
         env:
           TAXONOMY_OBSERVABILITY_PERFORMANCE_ENFORCE: 'true'
         shell: bash
@@ -216,7 +226,7 @@ jobs:
           path: target/quality-reports/**
           if-no-files-found: warn
           include-hidden-files: true
-          retention-days: 14
+          retention-days: 90
 
       - name: Upload UI verification evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -225,4 +235,4 @@ jobs:
           name: ui-verification
           path: target/ui-verification/**
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 90

--- a/.github/workflows/database-compatibility.yml
+++ b/.github/workflows/database-compatibility.yml
@@ -3,16 +3,9 @@ name: Database Compatibility
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'pom.xml'
-      - 'taxonomy-app/pom.xml'
-      - 'taxonomy-app/src/main/resources/application-*.properties'
-      - 'taxonomy-app/src/main/java/com/taxonomy/dsl/storage/**'
-      - 'taxonomy-app/src/test/java/com/taxonomy/**/*Postgres*IT.java'
-      - 'taxonomy-app/src/test/java/com/taxonomy/**/*Mssql*IT.java'
-      - 'taxonomy-app/src/test/java/com/taxonomy/**/*Oracle*IT.java'
-      - 'taxonomy-app/src/test/java/com/taxonomy/AbstractSeleniumContainerIT.java'
-      - '.github/workflows/database-compatibility.yml'
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
   schedule:
     - cron: '17 2 * * 0'
@@ -79,4 +72,4 @@ jobs:
             target/database-${{ matrix.profile }}.log
             **/target/failsafe-reports/**
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 90

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -261,12 +261,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish immutable release image
+        id: release_image
         if: steps.release_parameters.outputs.dry_run != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/taxonomy:v${{ steps.release_parameters.outputs.release_version }}
+          provenance: mode=max
+          sbom: true
           labels: |
             org.opencontainers.image.title=Taxonomy Architecture Analyzer
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
@@ -276,6 +279,114 @@ jobs:
             BUILD_DATE=${{ steps.release_source.outputs.created }}
             VCS_REF=${{ steps.release_source.outputs.sha }}
             VERSION=${{ steps.release_parameters.outputs.release_version }}
+
+      - name: Scan immutable release image digest
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/${{ github.repository_owner }}/taxonomy@${{ steps.release_image.outputs.digest }}
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: false
+          format: sarif
+          output: release-image-trivy.sarif
+          exit-code: '1'
+
+      - name: Bind release evidence and Helm deployment to immutable image digest
+        if: steps.release_parameters.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
+          IMAGE_DIGEST: ${{ steps.release_image.outputs.digest }}
+          RELEASE_SOURCE_SHA: ${{ steps.release_source.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Build did not return a valid immutable image digest: $IMAGE_DIGEST"
+            exit 1
+          fi
+
+          tag="v${RELEASE_VERSION}"
+          repository="ghcr.io/${GITHUB_REPOSITORY_OWNER}/taxonomy"
+          immutable_image="${repository}@${IMAGE_DIGEST}"
+          docker buildx imagetools inspect "$immutable_image" >/dev/null
+
+          artifact_dir="$RUNNER_TEMP/helm-release"
+          mkdir -p "$artifact_dir" target
+          evidence_file="target/release-image-evidence.json"
+          export RELEASE_VERSION IMAGE_DIGEST RELEASE_SOURCE_SHA immutable_image evidence_file
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = {
+              "schemaVersion": 1,
+              "releaseVersion": os.environ["RELEASE_VERSION"],
+              "sourceCommit": os.environ["RELEASE_SOURCE_SHA"],
+              "image": os.environ["immutable_image"],
+              "digest": os.environ["IMAGE_DIGEST"],
+              "scan": {
+                  "tool": "trivy",
+                  "severityGate": ["HIGH", "CRITICAL"],
+                  "result": "passed",
+              },
+              "attestations": {
+                  "provenance": True,
+                  "sbom": True,
+              },
+          }
+          Path(os.environ["evidence_file"]).write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          cp "$evidence_file" \
+            "$artifact_dir/taxonomy-${RELEASE_VERSION}-image-evidence.json"
+          cp release-image-trivy.sarif \
+            "$artifact_dir/taxonomy-${RELEASE_VERSION}-image-trivy.sarif"
+
+          release_checksum_inputs=(
+            "taxonomy-${RELEASE_VERSION}-image-evidence.json"
+            "taxonomy-${RELEASE_VERSION}-image-trivy.sarif"
+          )
+          if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+            digest_manifest="$artifact_dir/taxonomy-${RELEASE_VERSION}-kubernetes-digest.yaml"
+            helm lint deploy/helm/taxonomy \
+              --set-string image.tag='' \
+              --set-string "image.digest=${IMAGE_DIGEST}" \
+              --set existingSecret=taxonomy-secrets
+            helm template taxonomy deploy/helm/taxonomy \
+              --namespace taxonomy \
+              --set-string image.tag='' \
+              --set-string "image.digest=${IMAGE_DIGEST}" \
+              --set existingSecret=taxonomy-secrets \
+              > "$digest_manifest"
+            grep -Fq "image: \"${immutable_image}\"" "$digest_manifest"
+            grep -Fq 'readOnlyRootFilesystem: true' "$digest_manifest"
+            grep -Fq 'runAsUser: 10001' "$digest_manifest"
+            release_checksum_inputs+=("taxonomy-${RELEASE_VERSION}-kubernetes-digest.yaml")
+          fi
+
+          (
+            cd "$artifact_dir"
+            sha256sum "${release_checksum_inputs[@]}" \
+              > "taxonomy-${RELEASE_VERSION}-release.sha256"
+          )
+          gh release upload "$tag" "$artifact_dir"/* --clobber
+
+      - name: Archive immutable release image evidence
+        if: always() && steps.release_parameters.outputs.dry_run != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-image-security-${{ steps.release_parameters.outputs.release_version }}
+          path: |
+            release-image-trivy.sarif
+            target/release-image-evidence.json
+          if-no-files-found: warn
+          retention-days: 90
 
       - name: Verify exact final main snapshot with canonical CI
         if: steps.release_parameters.outputs.dry_run != 'true'
@@ -337,18 +448,30 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
+          IMAGE_DIGEST: ${{ steps.release_image.outputs.digest }}
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         shell: bash
         run: |
           set -euo pipefail
           tag="v${RELEASE_VERSION}"
-          image="ghcr.io/${GITHUB_REPOSITORY_OWNER}/taxonomy:${tag}"
+          repository="ghcr.io/${GITHUB_REPOSITORY_OWNER}/taxonomy"
+          image="${repository}@${IMAGE_DIGEST}"
 
+          assets=$(gh release view "$tag" --json assets --jq '.assets[].name')
+          for expected in \
+            "taxonomy-${RELEASE_VERSION}-image-evidence.json" \
+            "taxonomy-${RELEASE_VERSION}-image-trivy.sarif" \
+            "taxonomy-${RELEASE_VERSION}-release.sha256"; do
+            if ! grep -Fxq "$expected" <<< "$assets"; then
+              echo "::error::Draft release is missing required image evidence $expected"
+              exit 1
+            fi
+          done
           if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
-            assets=$(gh release view "$tag" --json assets --jq '.assets[].name')
             for expected in \
               "taxonomy-${RELEASE_VERSION}.tgz" \
               "taxonomy-${RELEASE_VERSION}-kubernetes.yaml" \
+              "taxonomy-${RELEASE_VERSION}-kubernetes-digest.yaml" \
               "taxonomy-${RELEASE_VERSION}-helm.sha256"; do
               if ! grep -Fxq "$expected" <<< "$assets"; then
                 echo "::error::Draft release is missing required Helm asset $expected"
@@ -358,6 +481,16 @@ jobs:
           fi
 
           docker buildx imagetools inspect "$image" >/dev/null
+          evidence_digest=$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+          print(json.loads(Path('target/release-image-evidence.json').read_text())['digest'])
+          PY
+          )
+          if [[ "$evidence_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "::error::Release image evidence records $evidence_digest, expected $IMAGE_DIGEST"
+            exit 1
+          fi
 
           is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft')
           if [[ "$is_draft" == "true" ]]; then


### PR DESCRIPTION
Implements the remaining objective release-hardening work from #611 without weakening existing gates.

Key changes:
- run the PostgreSQL / SQL Server / Oracle compatibility matrix for every PR and release tag;
- broaden OpenTelemetry performance-gate scope and always enforce it for non-PR CI;
- add a ratchet that prevents new direct frontend `fetch()` debt outside the central API transport layer;
- retain QA/UI evidence for 90 days;
- build the release image with provenance + SBOM attestations;
- scan the exact pushed OCI digest with Trivy (HIGH/CRITICAL fail closed);
- bind release evidence and a Helm manifest to that immutable digest before publication;
- make the shared release-delivery contract execute the immutable-image gate in both CI and release guard paths.

This PR addresses #611. I am intentionally not using `Closes #611` yet: the issue should only be closed once CI is green and the remaining acceptance criteria have been re-verified.