### PR TITLE
Prepare fail-closed Core schema validation for jgit-storage-hibernate 0.9.1

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -52,9 +52,12 @@ public class JgitStorageSchemaMigrationConfig {
     private static final String PRE_PACK_DESCRIPTION_SCHEMA_VERSION = "0.1.14.2";
     private static final String PRE_PACK_DESCRIPTION_BASELINE_DESCRIPTION =
             "jgit-storage-hibernate-core 0.1.14";
-    private static final String LATEST_CORE_SCHEMA_VERSION = "0.1.18";
-    private static final String LATEST_CORE_BASELINE_DESCRIPTION =
+    private static final String PRE_REFLOG_KEY_SCHEMA_VERSION = "0.1.18";
+    private static final String PRE_REFLOG_KEY_BASELINE_DESCRIPTION =
             "jgit-storage-hibernate-core 0.1.18";
+    private static final String LATEST_CORE_SCHEMA_VERSION = "0.9.1";
+    private static final String LATEST_CORE_BASELINE_DESCRIPTION =
+            "jgit-storage-hibernate-core 0.9.1";
 
     private static final Set<String> LEGACY_PACK_COLUMNS = Set.of(
             "ID",
@@ -112,8 +115,8 @@ public class JgitStorageSchemaMigrationConfig {
             "MIN_UPDATE_INDEX",
             "MAX_UPDATE_INDEX");
 
-    /** Exact reflog shape released through jgit-storage-hibernate 0.1.18. */
-    private static final Set<String> REFLOG_COLUMNS = Set.of(
+    /** Exact physical reflog shape released through Core 0.1.18. */
+    private static final Set<String> PRE_REFLOG_KEY_COLUMNS = Set.of(
             "ID",
             "VERSION",
             "REPOSITORY_NAME",
@@ -125,8 +128,8 @@ public class JgitStorageSchemaMigrationConfig {
             "WHO_WHEN",
             "MESSAGE");
 
-    /** Exact reflog shape using the portable indexed reference-name prefix. */
-    private static final Set<String> REFLOG_COLUMNS_WITH_REFERENCE_KEY = Set.of(
+    /** Exact physical reflog shape released by Core 0.9.1. */
+    private static final Set<String> CURRENT_REFLOG_COLUMNS = Set.of(
             "ID",
             "VERSION",
             "REPOSITORY_NAME",
@@ -222,9 +225,8 @@ public class JgitStorageSchemaMigrationConfig {
                             + "JGit storage schema automatically.");
         }
 
-        requireSupportedReflogColumns(schema);
-
         if (schema.packColumns().equals(LEGACY_PACK_COLUMNS)) {
+            requirePreReflogKeyColumns(schema);
             migrateLegacyTaxonomySchema(
                     configuration, family, dataSource, schema, legacyAdoptionEnabled);
             requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
@@ -232,11 +234,13 @@ public class JgitStorageSchemaMigrationConfig {
         }
 
         if (schema.packColumns().equals(PRE_WRITE_LEASE_PACK_COLUMNS)) {
+            requirePreReflogKeyColumns(schema);
             establishUnversionedPreWriteLeaseSchema(configuration, family, dataSource, schema);
             return;
         }
 
         if (schema.packColumns().equals(PRE_PACK_DESCRIPTION_PACK_COLUMNS)) {
+            requirePreReflogKeyColumns(schema);
             establishUnversionedPrePackDescriptionSchema(
                     configuration, family, dataSource, schema);
             return;
@@ -297,15 +301,24 @@ public class JgitStorageSchemaMigrationConfig {
         requireSafePackRows(dataSource, false);
         requireCurrentCoreColumnLengths(schema);
         requireCurrentCoreTables(schema);
+        requireSupportedReflogColumns(schema);
         requireCurrentCoreIndexes(schema);
+        boolean currentReflogShape = hasReflogReferenceKey(schema);
+        String baselineVersion = currentReflogShape
+                ? LATEST_CORE_SCHEMA_VERSION
+                : PRE_REFLOG_KEY_SCHEMA_VERSION;
+        String baselineDescription = currentReflogShape
+                ? LATEST_CORE_BASELINE_DESCRIPTION
+                : PRE_REFLOG_KEY_BASELINE_DESCRIPTION;
         log.info(
-                "Establishing Flyway history for an exact unversioned 0.1.18 schema on {}",
+                "Establishing Flyway history for an exact unversioned {} schema on {}",
+                baselineVersion,
                 family.displayName());
         migrateNormalWithBaseline(
                 configuration,
                 family,
-                LATEST_CORE_SCHEMA_VERSION,
-                LATEST_CORE_BASELINE_DESCRIPTION);
+                baselineVersion,
+                baselineDescription);
         requireCurrentCoreShape(SchemaSnapshot.inspect(dataSource));
     }
 
@@ -491,7 +504,7 @@ public class JgitStorageSchemaMigrationConfig {
         requireRepositoryLockTable(schema);
         if (!schema.hasTable("git_repository_lifecycle")) {
             throw unsafeSchema(
-                    "The 0.1.18 Core schema requires the git_repository_lifecycle table.");
+                    "The released Core schema requires the git_repository_lifecycle table.");
         }
     }
 
@@ -558,10 +571,10 @@ public class JgitStorageSchemaMigrationConfig {
      * Validate the actual managed lookup paths rather than redundant exact indexes.
      *
      * <p>Since Core 0.1.17 the unique pack identity index supplies the left prefixes
-     * {@code (repository_name)} and {@code (repository_name, pack_name)}. Reflog lookup uses
-     * either the released {@code (repository_name, ref_name, id)} path or the portable
-     * {@code (repository_name, ref_name_key, id)} path. Older released schemas remain valid
-     * because their exact indexes satisfy the same left-prefix contract.</p>
+     * {@code (repository_name)} and {@code (repository_name, pack_name)}, while the
+     * ordered reflog index extends {@code (repository_name, ref_name)} with the row id.
+     * Older released schemas remain valid because their exact indexes satisfy the same
+     * left-prefix contract.</p>
      */
     private static void requireManagedCoreIndexes(SchemaSnapshot schema) {
         requireIndexPrefix(
@@ -578,13 +591,21 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 false,
                 List.of("REPOSITORY_NAME", "COMMITTED"));
-        List<String> reflogLookupColumns = schema.reflogColumns().contains("REF_NAME_KEY")
-                ? List.of("REPOSITORY_NAME", "REF_NAME_KEY")
-                : List.of("REPOSITORY_NAME", "REF_NAME");
+        requireReleasedReflogLookupIndex(schema);
+    }
+
+    private static void requireReleasedReflogLookupIndex(SchemaSnapshot schema) {
+        if (hasReflogReferenceKey(schema)) {
+            requireIndexPrefix(
+                    "git_reflog",
+                    schema.reflogIndexes(),
+                    List.of("REPOSITORY_NAME", "REF_NAME_KEY", "ID"));
+            return;
+        }
         requireIndexPrefix(
                 "git_reflog",
                 schema.reflogIndexes(),
-                reflogLookupColumns);
+                List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
     private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
@@ -631,22 +652,23 @@ public class JgitStorageSchemaMigrationConfig {
                         + "index on " + columns + "; actual indexes=" + indexes);
     }
 
+    private static boolean hasReflogReferenceKey(SchemaSnapshot schema) {
+        return schema.reflogColumns().equals(CURRENT_REFLOG_COLUMNS);
+    }
+
+    private static void requirePreReflogKeyColumns(SchemaSnapshot schema) {
+        requireExactColumns(
+                "git_reflog", schema.reflogColumns(), PRE_REFLOG_KEY_COLUMNS);
+    }
+
     private static void requireSupportedReflogColumns(SchemaSnapshot schema) {
-        Set<String> actual = schema.reflogColumns();
-        if (actual.equals(REFLOG_COLUMNS)) {
+        if (schema.reflogColumns().equals(PRE_REFLOG_KEY_COLUMNS)
+                || schema.reflogColumns().equals(CURRENT_REFLOG_COLUMNS)) {
             return;
         }
-        if (actual.equals(REFLOG_COLUMNS_WITH_REFERENCE_KEY)) {
-            if (!schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
-                throw unsafeSchema(
-                        "git_reflog.ref_name_key is supported only with the current Core pack schema");
-            }
-            return;
-        }
-        Set<String> expected = actual.contains("REF_NAME_KEY")
-                ? REFLOG_COLUMNS_WITH_REFERENCE_KEY
-                : REFLOG_COLUMNS;
-        requireExactColumns("git_reflog", actual, expected);
+        throw unsafeSchema(
+                "git_reflog is neither the exact pre-0.9.1 shape nor the exact 0.9.1 "
+                        + "shape; actual=" + schema.reflogColumns());
     }
 
     private static void requireExactColumns(

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -112,11 +112,26 @@ public class JgitStorageSchemaMigrationConfig {
             "MIN_UPDATE_INDEX",
             "MAX_UPDATE_INDEX");
 
+    /** Exact reflog shape released through jgit-storage-hibernate 0.1.18. */
     private static final Set<String> REFLOG_COLUMNS = Set.of(
             "ID",
             "VERSION",
             "REPOSITORY_NAME",
             "REF_NAME",
+            "OLD_ID",
+            "NEW_ID",
+            "WHO_NAME",
+            "WHO_EMAIL",
+            "WHO_WHEN",
+            "MESSAGE");
+
+    /** Exact reflog shape using the portable indexed reference-name prefix. */
+    private static final Set<String> REFLOG_COLUMNS_WITH_REFERENCE_KEY = Set.of(
+            "ID",
+            "VERSION",
+            "REPOSITORY_NAME",
+            "REF_NAME",
+            "REF_NAME_KEY",
             "OLD_ID",
             "NEW_ID",
             "WHO_NAME",
@@ -207,7 +222,7 @@ public class JgitStorageSchemaMigrationConfig {
                             + "JGit storage schema automatically.");
         }
 
-        requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
+        requireSupportedReflogColumns(schema);
 
         if (schema.packColumns().equals(LEGACY_PACK_COLUMNS)) {
             migrateLegacyTaxonomySchema(
@@ -431,7 +446,7 @@ public class JgitStorageSchemaMigrationConfig {
 
     private static void requireMigratableCoreContract(SchemaSnapshot schema) {
         requireCoreTables(schema);
-        requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
+        requireSupportedReflogColumns(schema);
         if (schema.packColumns().equals(PRE_WRITE_LEASE_PACK_COLUMNS)) {
             requirePreWriteLeaseCoreIndexes(schema);
             return;
@@ -453,7 +468,7 @@ public class JgitStorageSchemaMigrationConfig {
         requireCoreTables(schema);
         requireCurrentCoreTables(schema);
         requireExactColumns("git_packs", schema.packColumns(), CURRENT_PACK_COLUMNS);
-        requireExactColumns("git_reflog", schema.reflogColumns(), REFLOG_COLUMNS);
+        requireSupportedReflogColumns(schema);
         requireCurrentCoreColumnLengths(schema);
         requireCurrentCoreIndexes(schema);
     }
@@ -543,10 +558,10 @@ public class JgitStorageSchemaMigrationConfig {
      * Validate the actual managed lookup paths rather than redundant exact indexes.
      *
      * <p>Since Core 0.1.17 the unique pack identity index supplies the left prefixes
-     * {@code (repository_name)} and {@code (repository_name, pack_name)}, while the
-     * ordered reflog index extends {@code (repository_name, ref_name)} with the row id.
-     * Older released schemas remain valid because their exact indexes satisfy the same
-     * left-prefix contract.</p>
+     * {@code (repository_name)} and {@code (repository_name, pack_name)}. Reflog lookup uses
+     * either the released {@code (repository_name, ref_name, id)} path or the portable
+     * {@code (repository_name, ref_name_key, id)} path. Older released schemas remain valid
+     * because their exact indexes satisfy the same left-prefix contract.</p>
      */
     private static void requireManagedCoreIndexes(SchemaSnapshot schema) {
         requireIndexPrefix(
@@ -563,10 +578,13 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 false,
                 List.of("REPOSITORY_NAME", "COMMITTED"));
+        List<String> reflogLookupColumns = schema.reflogColumns().contains("REF_NAME_KEY")
+                ? List.of("REPOSITORY_NAME", "REF_NAME_KEY")
+                : List.of("REPOSITORY_NAME", "REF_NAME");
         requireIndexPrefix(
                 "git_reflog",
                 schema.reflogIndexes(),
-                List.of("REPOSITORY_NAME", "REF_NAME"));
+                reflogLookupColumns);
     }
 
     private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
@@ -611,6 +629,24 @@ public class JgitStorageSchemaMigrationConfig {
                 table + " is missing the required "
                         + (unique ? "unique " : "")
                         + "index on " + columns + "; actual indexes=" + indexes);
+    }
+
+    private static void requireSupportedReflogColumns(SchemaSnapshot schema) {
+        Set<String> actual = schema.reflogColumns();
+        if (actual.equals(REFLOG_COLUMNS)) {
+            return;
+        }
+        if (actual.equals(REFLOG_COLUMNS_WITH_REFERENCE_KEY)) {
+            if (!schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
+                throw unsafeSchema(
+                        "git_reflog.ref_name_key is supported only with the current Core pack schema");
+            }
+            return;
+        }
+        Set<String> expected = actual.contains("REF_NAME_KEY")
+                ? REFLOG_COLUMNS_WITH_REFERENCE_KEY
+                : REFLOG_COLUMNS;
+        requireExactColumns("git_reflog", actual, expected);
     }
 
     private static void requireExactColumns(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
@@ -62,9 +62,14 @@ class JgitStoragePostgresMigrationIT {
                 successfulVersions(
                         dataSource,
                         CoreSchemaMigrations.LEGACY_ADOPTION_SCHEMA_HISTORY_TABLE));
-        assertEquals(
-                List.of("0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2", "0.1.17", "0.1.18"),
-                successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+        List<String> coreVersions = successfulVersions(
+                dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
+        List<String> expectedCoreVersions = new ArrayList<>(List.of(
+                "0.1.5", "0.1.14", "0.1.14.1", "0.1.14.2", "0.1.17", "0.1.18"));
+        if (columnExists(dataSource, "git_reflog", "ref_name_key")) {
+            expectedCoreVersions.add("0.9.1");
+        }
+        assertEquals(expectedCoreVersions, coreVersions);
 
         SQLException duplicate = assertThrows(
                 SQLException.class,
@@ -212,6 +217,22 @@ class JgitStoragePostgresMigrationIT {
             }
         }
         return versions;
+    }
+
+    private static boolean columnExists(
+            DataSource dataSource, String tableName, String columnName) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            try (ResultSet resultSet = metadata.getColumns(
+                    null, connection.getSchema(), tableName, "%")) {
+                while (resultSet.next()) {
+                    if (columnName.equalsIgnoreCase(resultSet.getString("COLUMN_NAME"))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private static int columnSize(

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
@@ -41,6 +41,34 @@ class JgitStorageSchemaIndexValidationTest {
     }
 
     @Test
+    void acceptsPortableReferenceKeyShapeWithMatchingIndex() throws Exception {
+        DataSource dataSource = dataSource("portable-reference-key");
+        flyway(dataSource).migrate();
+        dropTable(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
+        installReferenceKeyShape(dataSource, true);
+
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
+
+        assertTrue(tableExists(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+    }
+
+    @Test
+    void rejectsReferenceKeyShapeWithoutMatchingIndex() throws Exception {
+        DataSource dataSource = dataSource("missing-reference-key-index");
+        flyway(dataSource).migrate();
+        dropTable(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
+        installReferenceKeyShape(dataSource, false);
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(
+                        flyway(dataSource), false));
+
+        assertTrue(error.getMessage().contains("REF_NAME_KEY"));
+        assertFalse(tableExists(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
+    }
+
+    @Test
     void rejectsLegacySchemaWithoutRequiredIndexesBeforeDdl() throws Exception {
         DataSource dataSource = dataSource("missing-legacy-indexes");
         installLegacyTablesWithoutIndexes(dataSource);
@@ -72,6 +100,18 @@ class JgitStorageSchemaIndexValidationTest {
                 .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
                 .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
                 .load();
+    }
+
+    private static void installReferenceKeyShape(
+            DataSource dataSource, boolean createMatchingIndex) throws SQLException {
+        execute(dataSource,
+                "alter table git_reflog add column ref_name_key varchar(128) default '' not null");
+        execute(dataSource, "drop index idx_reflog_repo_ref_id");
+        if (createMatchingIndex) {
+            execute(dataSource,
+                    "create index idx_reflog_repo_ref_key_id "
+                            + "on git_reflog (repository_name, ref_name_key, id desc)");
+        }
     }
 
     private static void installLegacyTablesWithoutIndexes(DataSource dataSource)

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfigTest.java
@@ -69,6 +69,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(columns(dataSource, "git_packs").contains("LAST_MODIFIED"));
         assertEquals(32, columnSize(dataSource, "git_packs", "pack_extension"));
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
+        assertReflogKeyMatchesMigrationHistory(dataSource);
         assertVersionPrefix(
                 FULL_CORE_HISTORY,
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
@@ -142,6 +143,7 @@ class JgitStorageSchemaMigrationConfigTest {
         assertTrue(columnSize(dataSource, "git_reflog", "ref_name") >= 1024);
         assertArrayEquals(original, packData(dataSource, "legacy", "pack-a", "reftable"));
         assertEquals(refName, reflogRefName(dataSource));
+        assertReflogKeyMatchesMigrationHistory(dataSource);
         try (Connection connection = dataSource.getConnection();
              var statement = connection.prepareStatement(
                      "select committed, committed_at from git_packs "
@@ -346,12 +348,13 @@ class JgitStorageSchemaMigrationConfigTest {
     void establishesHistoryForExactUnversionedCurrentCoreSchema() throws Exception {
         DataSource dataSource = dataSource("unversioned-current");
         flyway(dataSource).migrate();
+        boolean hasReflogKey = columns(dataSource, "git_reflog").contains("REF_NAME_KEY");
         dropTable(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE);
 
         JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway(dataSource), false);
 
         assertVersionPrefix(
-                List.of("0.1.18"),
+                List.of(hasReflogKey ? "0.9.1" : "0.1.18"),
                 successfulVersions(dataSource, CoreSchemaMigrations.SCHEMA_HISTORY_TABLE));
         assertTrue(columns(dataSource, "git_packs").contains("WRITE_LEASE_UNTIL"));
         assertTrue(columns(dataSource, "git_packs").contains("PACK_SOURCE"));
@@ -540,6 +543,18 @@ class JgitStorageSchemaMigrationConfigTest {
             assertTrue(resultSet.next());
             return resultSet.getString(1);
         }
+    }
+
+    private static void assertReflogKeyMatchesMigrationHistory(DataSource dataSource)
+            throws SQLException {
+        boolean migrated = successfulVersions(
+                dataSource,
+                CoreSchemaMigrations.SCHEMA_HISTORY_TABLE).contains("0.9.1");
+        boolean columnPresent = columns(dataSource, "git_reflog").contains("REF_NAME_KEY");
+        assertEquals(
+                migrated,
+                columnPresent,
+                "Core migration 0.9.1 and git_reflog.ref_name_key must appear together");
     }
 
     private static void assertVersionPrefix(


### PR DESCRIPTION
## Scope

Consolidates the complete Taxonomy-side schema contract for the portable reflog key introduced by merged `jgit-storage-hibernate` PR #203.

Taxonomy remains fail-closed while recognizing exactly two released/target physical reflog shapes:

- pre-0.9.1: `ref_name` with the existing `(repository_name, ref_name[, id])` lookup path;
- 0.9.1: `ref_name_key` with `(repository_name, ref_name_key, id)` while retaining the full `ref_name` for exact semantics.

The migration validator now:

- distinguishes the exact pre-0.9.1 and 0.9.1 reflog column sets;
- requires the matching lookup index for each shape;
- rejects `REF_NAME_KEY` without its matching index before establishing Flyway history;
- baselines exact unversioned 0.1.18 and 0.9.1 schemas at their matching versions;
- keeps legacy/pre-write-lease/pre-pack-description adoption tied to the pre-key physical shape;
- verifies that Core migration 0.9.1 and `git_reflog.ref_name_key` appear together;
- extends both HSQLDB and PostgreSQL migration evidence.

This PR supersedes #642 and retains the additional index-level regression tests originally introduced in this branch.

`jgit-storage-hibernate` main is currently `0.9.1-SNAPSHOT`; the latest published release is still 0.9.0, so this PR prepares the consumer validator without prematurely changing Taxonomy's dependency version.

Closes #640