### PR TITLE
Make workflow test authority catalogue-driven

### DIFF
--- a/.github/jgit-storage-hibernate-contract.sh
+++ b/.github/jgit-storage-hibernate-contract.sh
@@ -49,26 +49,38 @@ export ANTHROPIC_API_KEY=
 export TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD=false
 export TAXONOMY_MODEL_DOWNLOAD_SKIP=true
 
-unit_tests=(
-  JgitStorageHibernateIntegrationTest
-  JgitStorageOptimizedIndexContractTest
-  JgitStorageSchemaIndexValidationTest
-  JgitStorageSchemaMigrationConfigTest
-  CommitIndexHibernateSearchTest
+# Keep the exact test authority in the same verification catalogue used by the
+# workflow policy. The shell owns only environment checks, Maven orchestration
+# and retained evidence; adding/removing contract tests happens in one place.
+mapfile -t contract_selectors < <(
+  python3 - <<'PY'
+import json
+from pathlib import Path
+
+catalog = json.loads(Path(".mvn/verification-suites.json").read_text(encoding="utf-8"))
+profile = catalog.get("profiles", {}).get("jgit-storage-hibernate-contract")
+if not isinstance(profile, dict):
+    raise SystemExit("verification catalogue is missing jgit-storage-hibernate-contract")
+for key in ("test", "itTest", "excludedGroups"):
+    value = profile.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SystemExit(f"jgit-storage-hibernate-contract is missing {key}")
+    print(value)
+PY
 )
-postgres_it_tests=(
-  JgitStoragePostgresMigrationIT
-  TaxonomyPostgresValidateStartupIT
-  TaxonomySchemaPostgresMigrationIT
-)
-unit_csv=$(IFS=,; echo "${unit_tests[*]}")
-postgres_it_csv=$(IFS=,; echo "${postgres_it_tests[*]}")
+if [[ ${#contract_selectors[@]} -ne 3 ]]; then
+  echo "Could not resolve the storage contract from .mvn/verification-suites.json." >&2
+  exit 1
+fi
+unit_csv=${contract_selectors[0]}
+postgres_it_csv=${contract_selectors[1]}
+excluded_groups=${contract_selectors[2]}
 
 set -o pipefail
 "${maven[@]}" -B -ntp -nsu \
   -pl taxonomy-app -am \
   -DskipITs=false \
-  -DexcludedGroups=real-llm,onnx,db-mssql,db-oracle \
+  -DexcludedGroups="$excluded_groups" \
   -Dtaxonomy.model.download.skip=true \
   -Dtaxonomy.ui.skip=true \
   -Dtaxonomy.quality.skip=true \

--- a/.github/jgit-storage-hibernate-contract.sh
+++ b/.github/jgit-storage-hibernate-contract.sh
@@ -7,6 +7,17 @@ candidate_version=${JGIT_STORAGE_HIBERNATE_CANDIDATE_VERSION:-}
 evidence_dir=target/jgit-storage-hibernate-contract
 mkdir -p "$evidence_dir"
 
+printf 'bash %s\n' "$BASH_VERSION" | tee "$evidence_dir/bash-version.log"
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "Taxonomy's storage contract requires Bash 4 or newer." >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Taxonomy's storage contract requires Python 3." >&2
+  exit 1
+fi
+python3 --version 2>&1 | tee "$evidence_dir/python-version.log"
+
 case "$mode" in
   candidate)
     if [[ -z "$candidate_version" ]]; then

--- a/.github/scripts/check-workflow-test-authority.py
+++ b/.github/scripts/check-workflow-test-authority.py
@@ -11,17 +11,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 CATALOG = ROOT / ".mvn" / "verification-suites.json"
-ALLOWED = {
-    "ci-cd.yml",
-    "database-compatibility.yml",
-    "codeql.yml",
-    "security-scan.yml",
-    "dependency-submission.yml",
-    "documentation-screenshots.yml",
-    "delivery.yml",
-    "deploy-release.yml",
-    "cleanup-workflow-runs.yml",
-}
 REMOVED = {
     "accessibility.yml",
     "archimate-import-evidence.yml",
@@ -86,9 +75,31 @@ def main() -> int:
     if catalog.get("canonicalCommand") != "./mvnw -B verify -Pci":
         errors.append("verification catalogue must declare './mvnw -B verify -Pci'")
 
+    responsibilities = catalog.get("workflowResponsibilities")
+    if not isinstance(responsibilities, dict) or not responsibilities:
+        errors.append("verification catalogue must classify workflow responsibilities")
+        classified_workflows: set[str] = set()
+    else:
+        invalid_responsibilities = [
+            name
+            for name, purpose in responsibilities.items()
+            if not isinstance(name, str)
+            or not name.endswith(".yml")
+            or not isinstance(purpose, str)
+            or not purpose.strip()
+        ]
+        if invalid_responsibilities:
+            errors.append(
+                "verification catalogue contains invalid workflow responsibilities: "
+                + ", ".join(sorted(str(name) for name in invalid_responsibilities))
+            )
+        classified_workflows = {
+            name for name in responsibilities if isinstance(name, str) and name.endswith(".yml")
+        }
+
     workflow_files = {path.name for path in WORKFLOWS.glob("*.yml")}
-    unexpected = workflow_files - ALLOWED
-    missing = ALLOWED - workflow_files
+    unexpected = workflow_files - classified_workflows
+    missing = classified_workflows - workflow_files
     if unexpected:
         errors.append(f"unclassified workflows remain: {', '.join(sorted(unexpected))}")
     if missing:

--- a/.github/scripts/check-workflow-test-authority.py
+++ b/.github/scripts/check-workflow-test-authority.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 CATALOG = ROOT / ".mvn" / "verification-suites.json"
+WORKFLOW_SUFFIXES = {".yml", ".yaml"}
 REMOVED = {
     "accessibility.yml",
     "archimate-import-evidence.yml",
@@ -39,6 +40,19 @@ DIRECT_TEST_PATTERNS = {
         r"check-dependency-hygiene)\.py"
     ),
 }
+
+
+def workflow_paths() -> set[Path]:
+    """Return every workflow file extension accepted by GitHub Actions."""
+    return {
+        path
+        for path in WORKFLOWS.iterdir()
+        if path.is_file() and path.suffix.lower() in WORKFLOW_SUFFIXES
+    }
+
+
+def is_workflow_name(value: object) -> bool:
+    return isinstance(value, str) and Path(value).suffix.lower() in WORKFLOW_SUFFIXES
 
 
 def run_blocks(text: str) -> str:
@@ -83,8 +97,7 @@ def main() -> int:
         invalid_responsibilities = [
             name
             for name, purpose in responsibilities.items()
-            if not isinstance(name, str)
-            or not name.endswith(".yml")
+            if not is_workflow_name(name)
             or not isinstance(purpose, str)
             or not purpose.strip()
         ]
@@ -94,10 +107,11 @@ def main() -> int:
                 + ", ".join(sorted(str(name) for name in invalid_responsibilities))
             )
         classified_workflows = {
-            name for name in responsibilities if isinstance(name, str) and name.endswith(".yml")
+            name for name in responsibilities if is_workflow_name(name)
         }
 
-    workflow_files = {path.name for path in WORKFLOWS.glob("*.yml")}
+    paths = workflow_paths()
+    workflow_files = {path.name for path in paths}
     unexpected = workflow_files - classified_workflows
     missing = classified_workflows - workflow_files
     if unexpected:
@@ -108,7 +122,7 @@ def main() -> int:
     if lingering:
         errors.append(f"redundant workflows were not removed: {', '.join(sorted(lingering))}")
 
-    for path in sorted(WORKFLOWS.glob("*.yml")):
+    for path in sorted(paths):
         commands = run_blocks(path.read_text(encoding="utf-8"))
         for description, pattern in DIRECT_TEST_PATTERNS.items():
             if pattern.search(commands):

--- a/.mvn/verification-suites.json
+++ b/.mvn/verification-suites.json
@@ -22,7 +22,7 @@
       "test": "JgitStorageHibernateIntegrationTest,JgitStorageOptimizedIndexContractTest,JgitStorageSchemaIndexValidationTest,JgitStorageSchemaMigrationConfigTest,CommitIndexHibernateSearchTest",
       "itTest": "JgitStoragePostgresMigrationIT,TaxonomyPostgresValidateStartupIT,TaxonomySchemaPostgresMigrationIT",
       "excludedGroups": "real-llm,onnx,db-mssql,db-oracle",
-      "requires": ["Java 21", "Docker", "Python 3", "POSIX shell"]
+      "requires": ["Java 21", "Docker", "Python 3", "Bash 4+"]
     }
   },
   "focusedCommands": {

--- a/.mvn/verification-suites.json
+++ b/.mvn/verification-suites.json
@@ -21,7 +21,8 @@
       "purpose": "Bounded consumer-owned Core schema, Hibernate Search and PostgreSQL compatibility contract for jgit-storage-hibernate upgrades",
       "test": "JgitStorageHibernateIntegrationTest,JgitStorageOptimizedIndexContractTest,JgitStorageSchemaIndexValidationTest,JgitStorageSchemaMigrationConfigTest,CommitIndexHibernateSearchTest",
       "itTest": "JgitStoragePostgresMigrationIT,TaxonomyPostgresValidateStartupIT,TaxonomySchemaPostgresMigrationIT",
-      "requires": ["Java 21", "Docker", "POSIX shell"]
+      "excludedGroups": "real-llm,onnx,db-mssql,db-oracle",
+      "requires": ["Java 21", "Docker", "Python 3", "POSIX shell"]
     }
   },
   "focusedCommands": {

--- a/.mvn/verification-suites.json
+++ b/.mvn/verification-suites.json
@@ -16,7 +16,13 @@
     "architecture-tests": {"test": "ArchitectureTest,ArchitectureCycleBoundaryTest,ArchitectureExceptionLedgerTest,ArchitectureCycleRuleRegressionTest"},
     "document-import-tests": {"test": "DocumentImportControllerTest,DocumentParserServiceTest,DocumentImportLimitsTest"},
     "archimate-import-tests": {"test": "ArchiMateWorkspaceImportTests,CatalogFacadeTest"},
-    "ui-tests": {"runner": ".github/scripts/run-ui-suite.mjs"}
+    "ui-tests": {"runner": ".github/scripts/run-ui-suite.mjs"},
+    "jgit-storage-hibernate-contract": {
+      "purpose": "Bounded consumer-owned Core schema, Hibernate Search and PostgreSQL compatibility contract for jgit-storage-hibernate upgrades",
+      "test": "JgitStorageHibernateIntegrationTest,JgitStorageOptimizedIndexContractTest,JgitStorageSchemaIndexValidationTest,JgitStorageSchemaMigrationConfigTest,CommitIndexHibernateSearchTest",
+      "itTest": "JgitStoragePostgresMigrationIT,TaxonomyPostgresValidateStartupIT,TaxonomySchemaPostgresMigrationIT",
+      "requires": ["Java 21", "Docker", "POSIX shell"]
+    }
   },
   "focusedCommands": {
     "keycloak-security": {
@@ -28,6 +34,7 @@
   "workflowResponsibilities": {
     "ci-cd.yml": "authoritative Maven verification and report publication",
     "database-compatibility.yml": "scheduled/manual environment matrix invoking Maven-owned profiles",
+    "jgit-storage-hibernate-contract.yml": "consumer-owned storage compatibility contract with Maven verification catalogue selectors",
     "codeql.yml": "external source analysis",
     "security-scan.yml": "external Trivy analysis",
     "dependency-submission.yml": "Maven dependency graph publication",


### PR DESCRIPTION
## What it does

Fixes the red `main` build caused by the newly added JGit storage consumer workflow being absent from a second, hard-coded workflow allowlist.

- makes `.mvn/verification-suites.json` the single source of truth for workflow responsibilities;
- classifies `jgit-storage-hibernate-contract.yml` there;
- keeps the exact bounded storage contract test selectors in the same verification catalogue;
- makes the reusable storage contract script read those selectors instead of duplicating them;
- retains the existing fail-closed checks for removed/redundant workflows and workflow-owned test logic.

This addresses the root cause rather than merely adding another entry to a duplicated allowlist.

Closes #645

## Verification

The canonical `./mvnw -B verify -Pci` gate must pass on the exact PR head. The dedicated storage-consumer workflow additionally exercises the catalogue-backed contract.