### PR TITLE
Integrate collision-safe disclosures into 1.3.1 stabilization

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/OnnxSeleniumIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.openqa.selenium.By;
+import org.openqa.selenium.ElementClickInterceptedException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -323,16 +324,30 @@ class OnnxSeleniumIT {
     private void openDetails(By locator) {
         new WebDriverWait(driver, Duration.ofSeconds(10))
                 .ignoring(StaleElementReferenceException.class)
+                .ignoring(ElementClickInterceptedException.class)
                 .until(currentDriver -> {
                     WebElement details = currentDriver.findElement(locator);
                     if (details.getAttribute("open") != null) {
                         return true;
                     }
                     WebElement summary = details.findElement(By.xpath("./summary"));
-                    ((JavascriptExecutor) currentDriver).executeScript(
+                    JavascriptExecutor javascript = (JavascriptExecutor) currentDriver;
+                    javascript.executeScript(
                             "arguments[0].scrollIntoView({block:'center', inline:'nearest'});",
                             summary);
                     if (!summary.isDisplayed() || !summary.isEnabled()) {
+                        return false;
+                    }
+                    Boolean unobscured = (Boolean) javascript.executeScript(
+                            "const target=arguments[0];"
+                                    + "const rect=target.getBoundingClientRect();"
+                                    + "const x=rect.left+rect.width/2;"
+                                    + "const y=rect.top+rect.height/2;"
+                                    + "if (x<0||y<0||x>=innerWidth||y>=innerHeight) return false;"
+                                    + "const top=document.elementFromPoint(x,y);"
+                                    + "return top===target || target.contains(top);",
+                            summary);
+                    if (!Boolean.TRUE.equals(unobscured)) {
                         return false;
                     }
                     summary.click();

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/OnnxDisclosureInteractionContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/OnnxDisclosureInteractionContractTest.java
@@ -1,0 +1,38 @@
+package com.taxonomy.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OnnxDisclosureInteractionContractTest {
+
+    @Test
+    void disclosureHelperWaitsForAnUnobscuredNativeClick() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/test/java/com/taxonomy/OnnxSeleniumIT.java"));
+        String helper = between(source,
+                "    private void openDetails(By locator) {",
+                "    private void clickWhenUnobscured(By locator) {");
+
+        assertThat(helper)
+                .contains("ignoring(ElementClickInterceptedException.class)")
+                .contains("document.elementFromPoint(x,y)")
+                .contains("target.contains(top)")
+                .contains("summary.click();")
+                .doesNotContain("details.open = true")
+                .doesNotContain("setAttribute(\"open\"");
+        assertThat(helper.indexOf("document.elementFromPoint(x,y)"))
+                .isLessThan(helper.indexOf("summary.click();"));
+    }
+
+    private static String between(String source, String start, String end) {
+        int startIndex = source.indexOf(start);
+        int endIndex = source.indexOf(end, startIndex + start.length());
+        assertThat(startIndex).as("start marker").isGreaterThanOrEqualTo(0);
+        assertThat(endIndex).as("end marker").isGreaterThan(startIndex);
+        return source.substring(startIndex, endIndex);
+    }
+}


### PR DESCRIPTION
Internal stabilization integration step. Applies #650 / #649 collision-aware native disclosure clicks last so the final OnnxSeleniumIT retains both deterministic LOCAL_ONNX setup and collision-safe browser interaction.