### PR TITLE
Enforce current reflog lookup indexes after migration

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/JgitStorageSchemaMigrationConfig.java
@@ -281,7 +281,7 @@ public class JgitStorageSchemaMigrationConfig {
         requireSafePackRows(dataSource, false);
         requireCurrentCoreColumnLengths(schema);
         requireRepositoryLockTable(schema);
-        requireCurrentCoreIndexes(schema);
+        requireMigratableCurrentCoreIndexes(schema);
         log.info(
                 "Establishing Flyway history for an exact unversioned 0.1.14.2-0.1.17 schema on {}",
                 family.displayName());
@@ -466,7 +466,7 @@ public class JgitStorageSchemaMigrationConfig {
         }
         if (schema.packColumns().equals(PRE_PACK_DESCRIPTION_PACK_COLUMNS)) {
             requireRepositoryLockTable(schema);
-            requireCurrentCoreIndexes(schema);
+            requireMigratableCurrentCoreIndexes(schema);
             return;
         }
         if (schema.packColumns().equals(CURRENT_PACK_COLUMNS)) {
@@ -567,16 +567,8 @@ public class JgitStorageSchemaMigrationConfig {
                 List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
-    /**
-     * Validate the actual managed lookup paths rather than redundant exact indexes.
-     *
-     * <p>Since Core 0.1.17 the unique pack identity index supplies the left prefixes
-     * {@code (repository_name)} and {@code (repository_name, pack_name)}, while the
-     * ordered reflog index extends {@code (repository_name, ref_name)} with the row id.
-     * Older released schemas remain valid because their exact indexes satisfy the same
-     * left-prefix contract.</p>
-     */
-    private static void requireManagedCoreIndexes(SchemaSnapshot schema) {
+    /** Validate the pack lookup paths shared by every managed post-0.1.5 schema. */
+    private static void requireManagedPackIndexes(SchemaSnapshot schema) {
         requireIndexPrefix(
                 "git_packs",
                 schema.packIndexes(),
@@ -591,10 +583,13 @@ public class JgitStorageSchemaMigrationConfig {
                 schema.packIndexes(),
                 false,
                 List.of("REPOSITORY_NAME", "COMMITTED"));
-        requireReleasedReflogLookupIndex(schema);
     }
 
-    private static void requireReleasedReflogLookupIndex(SchemaSnapshot schema) {
+    /**
+     * Accept released historical reflog indexes before Flyway advances the schema.
+     * A schema already carrying the 0.9.1 reference key must already carry its final index.
+     */
+    private static void requireMigratableReflogIndex(SchemaSnapshot schema) {
         if (hasReflogReferenceKey(schema)) {
             requireIndexPrefix(
                     "git_reflog",
@@ -608,12 +603,38 @@ public class JgitStorageSchemaMigrationConfig {
                 List.of("REPOSITORY_NAME", "REF_NAME"));
     }
 
+    /** Require the lookup path produced by the released migration stream. */
+    private static void requireCurrentReflogIndex(SchemaSnapshot schema) {
+        if (hasReflogReferenceKey(schema)) {
+            requireIndexPrefix(
+                    "git_reflog",
+                    schema.reflogIndexes(),
+                    List.of("REPOSITORY_NAME", "REF_NAME_KEY", "ID"));
+            return;
+        }
+        requireIndexPrefix(
+                "git_reflog",
+                schema.reflogIndexes(),
+                List.of("REPOSITORY_NAME", "REF_NAME", "ID"));
+    }
+
     private static void requirePreWriteLeaseCoreIndexes(SchemaSnapshot schema) {
-        requireManagedCoreIndexes(schema);
+        requireManagedPackIndexes(schema);
+        requireMigratableReflogIndex(schema);
+    }
+
+    private static void requireMigratableCurrentCoreIndexes(SchemaSnapshot schema) {
+        requirePreWriteLeaseCoreIndexes(schema);
+        requireIndex(
+                "git_packs",
+                schema.packIndexes(),
+                false,
+                List.of("REPOSITORY_NAME", "COMMITTED", "WRITE_LEASE_UNTIL"));
     }
 
     private static void requireCurrentCoreIndexes(SchemaSnapshot schema) {
-        requirePreWriteLeaseCoreIndexes(schema);
+        requireManagedPackIndexes(schema);
+        requireCurrentReflogIndex(schema);
         requireIndex(
                 "git_packs",
                 schema.packIndexes(),

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchema091CompatibilityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchema091CompatibilityTest.java
@@ -1,0 +1,97 @@
+package com.taxonomy.dsl.storage;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.flywaydb.core.Flyway;
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.jupiter.api.Test;
+
+class JgitStorageSchema091CompatibilityTest {
+
+    @Test
+    void acceptsKnown091ReflogShapeWhileRunningAgainstPinnedCore() throws Exception {
+        DataSource dataSource = dataSource("reflog-091-shape");
+        Flyway flyway = flyway(dataSource);
+        flyway.migrate();
+
+        execute(dataSource, "alter table git_reflog add column ref_name_key varchar(128)");
+        execute(dataSource, "alter table git_reflog alter column ref_name_key set not null");
+        execute(dataSource, "drop index if exists idx_reflog_repo_ref_id");
+        execute(dataSource, "drop index if exists idx_reflog_repo_ref_key_id");
+        execute(
+                dataSource,
+                "create index idx_reflog_repo_ref_key_id "
+                        + "on git_reflog (repository_name, ref_name_key, id desc)");
+
+        assertDoesNotThrow(
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false));
+    }
+
+    @Test
+    void rejectsCurrentPre091ShapeWithoutReleasedIdOrderingColumn() throws Exception {
+        DataSource dataSource = dataSource("reflog-pre-091-short-index");
+        Flyway flyway = flyway(dataSource);
+        flyway.migrate();
+        execute(dataSource, "drop index if exists idx_reflog_repo_ref_id");
+        execute(
+                dataSource,
+                "create index idx_reflog_repo_ref_id "
+                        + "on git_reflog (repository_name, ref_name)");
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false));
+
+        assertTrue(error.getMessage().contains("REPOSITORY_NAME, REF_NAME, ID"));
+    }
+
+    @Test
+    void stillRejectsUnknownReflogColumns() throws Exception {
+        DataSource dataSource = dataSource("reflog-unknown-shape");
+        Flyway flyway = flyway(dataSource);
+        flyway.migrate();
+        execute(dataSource, "alter table git_reflog add column unsupported_probe integer");
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false));
+
+        assertTrue(error.getMessage().contains("neither the exact pre-0.9.1 shape"));
+        assertTrue(error.getMessage().contains("UNSUPPORTED_PROBE"));
+    }
+
+    private static DataSource dataSource(String purpose) {
+        JDBCDataSource dataSource = new JDBCDataSource();
+        String databaseName = purpose + "_" + UUID.randomUUID().toString().replace("-", "");
+        dataSource.setUrl("jdbc:hsqldb:mem:" + databaseName + ";DB_CLOSE_DELAY=-1");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private static Flyway flyway(DataSource dataSource) {
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.HSQLDB_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+    }
+
+    private static void execute(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Tighten Taxonomy's fail-closed JGit Core schema guard on top of the 1.3.1 stabilization now merged to `main`.

The stabilization already accepts exactly the released pre-0.9.1 reflog shape or the 0.9.1 shape with `REF_NAME_KEY`, and validates the 0.9.1 lookup index. This PR now keeps only the additional contract proven by the upstream Core migrations:

- historical pre-0.1.17 reflog lookup indexes remain accepted **before** Flyway so released schemas can migrate;
- after migration, the pre-0.9.1 shape must expose `(repository_name, ref_name, id)` as created by `V0_1_17__optimize_reverse_reflog_reads.sql`;
- the 0.9.1 shape must expose `(repository_name, ref_name_key, id)` as created by `V0_9_1__add_reflog_reference_key.sql`;
- unknown reflog columns remain rejected;
- a focused regression test distinguishes migratable historical state from the required post-migration state.

This avoids duplicating the 0.9.1 column-shape support already merged through #660 while preserving the useful strictness discovered by the downstream candidate gate.