### PR TITLE
Request Taxonomy 1.3.1 release

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -1,8 +1,8 @@
 {
-  "release_version": "1.3.0",
-  "next_development_version": "1.3.1-SNAPSHOT",
+  "release_version": "1.3.1",
+  "next_development_version": "1.3.2-SNAPSHOT",
   "skip_tests": false,
   "dry_run": false,
-  "request_revision": 6,
-  "requested_after_commit": "6073fa6195080149fa8b7eae7ce867e44a320e48"
+  "request_revision": 7,
+  "requested_after_commit": "64a6a7227a8cf13c1b349004bdd911cdffcf3f45"
 }


### PR DESCRIPTION
## Release request

Trigger the repository-owned release workflow for the verified 1.3.1 stabilization state.

- release: `1.3.1`
- next development version: `1.3.2-SNAPSHOT`
- tests: enabled
- dry run: false
- requested after verified main commit: `64a6a7227a8cf13c1b349004bdd911cdffcf3f45`

Merging this PR changes only `.github/release-request.json`; the resulting push to `main` is the supported trigger for `.github/workflows/deploy-release.yml`.