### PR TITLE
Make reference-key schema tests compatible with current storage migrations

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStorageSchemaIndexValidationTest.java
@@ -104,9 +104,13 @@ class JgitStorageSchemaIndexValidationTest {
 
     private static void installReferenceKeyShape(
             DataSource dataSource, boolean createMatchingIndex) throws SQLException {
-        execute(dataSource,
-                "alter table git_reflog add column ref_name_key varchar(128) default '' not null");
-        execute(dataSource, "drop index idx_reflog_repo_ref_id");
+        if (!columnExists(dataSource, "git_reflog", "ref_name_key")) {
+            execute(dataSource,
+                    "alter table git_reflog add column ref_name_key varchar(128) "
+                            + "default '' not null");
+        }
+        execute(dataSource, "drop index if exists idx_reflog_repo_ref_id");
+        execute(dataSource, "drop index if exists idx_reflog_repo_ref_key_id");
         if (createMatchingIndex) {
             execute(dataSource,
                     "create index idx_reflog_repo_ref_key_id "


### PR DESCRIPTION
## Summary

Make the unversioned-schema index validation fixture work with both the released `jgit-storage-hibernate` baseline and the current 0.9.1 candidate.

- reuse `REF_NAME_KEY` when the selected library migration already created it;
- remove both the legacy and current reflog lookup indexes before constructing the requested positive/negative fixture;
- preserve the actual contract: matching portable index is accepted, missing matching index is rejected before Flyway history is established.

This fixes the remaining Taxonomy failure in `jgit-storage-hibernate` PR #224 without weakening the consumer-owned contract.