### PR TITLE
Complete repository membership authorization for multi-repository foundation

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -75,6 +75,12 @@ public class AuthorizationRulesConfigurer {
                 .hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST, "/api/repositories/*/forks")
                 .hasAnyRole("ARCHITECT", "ADMIN");
+        // Global authentication is only the outer gate. Repository OWNER authority is
+        // enforced by ArchitectureRepositoryController/RepositoryMembershipService.
+        auth.requestMatchers(HttpMethod.PUT, "/api/repositories/*/members/*")
+                .authenticated();
+        auth.requestMatchers(HttpMethod.DELETE, "/api/repositories/*/members/*")
+                .authenticated();
 
         auth.requestMatchers(HttpMethod.POST, "/api/import/preview/**")
                 .hasAnyRole("USER", "ARCHITECT", "ADMIN");

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/ArchitectureRepositoryController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/ArchitectureRepositoryController.java
@@ -1,5 +1,7 @@
 package com.taxonomy.workspace.controller;
 
+import com.taxonomy.workspace.model.RepositoryMembership;
+import com.taxonomy.workspace.model.RepositoryRole;
 import com.taxonomy.workspace.model.RepositoryVisibility;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.model.UserWorkspace;
@@ -10,14 +12,19 @@ import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -105,21 +112,25 @@ public class ArchitectureRepositoryController {
             if (!canView(repository, user)) {
                 return ResponseEntity.notFound().build();
             }
+            if (!membershipService.canContribute(repository, user)) {
+                return forbidden("Repository CONTRIBUTOR role required");
+            }
             UserWorkspace workspace = workspaceService.createWorkingCopy(
                     user,
                     repositoryId,
                     request.sourceBranch(),
                     request.displayName(),
                     request.description());
-            return ResponseEntity.ok(Map.of(
-                    "workspaceId", workspace.getWorkspaceId(),
-                    "displayName", workspace.getDisplayName(),
-                    "sourceRepositoryId", workspace.getSourceRepositoryId(),
-                    "sourceBranch", workspace.getSourceBranch(),
-                    "currentBranch", workspace.getCurrentBranch(),
-                    "baseCommit", workspace.getBaseCommit(),
-                    "currentCommit", workspace.getCurrentCommit(),
-                    "provisioningStatus", workspace.getProvisioningStatus().name()));
+            LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+            result.put("workspaceId", workspace.getWorkspaceId());
+            result.put("displayName", workspace.getDisplayName());
+            result.put("sourceRepositoryId", workspace.getSourceRepositoryId());
+            result.put("sourceBranch", workspace.getSourceBranch());
+            result.put("currentBranch", workspace.getCurrentBranch());
+            result.put("baseCommit", workspace.getBaseCommit());
+            result.put("currentCommit", workspace.getCurrentCommit());
+            result.put("provisioningStatus", workspace.getProvisioningStatus().name());
+            return ResponseEntity.ok(result);
         } catch (IllegalArgumentException | IllegalStateException exception) {
             return ResponseEntity.badRequest().body(Map.of("error", safeMessage(exception)));
         }
@@ -135,6 +146,9 @@ public class ArchitectureRepositoryController {
             SystemRepository source = repositoryService.getRepository(repositoryId);
             if (!canView(source, user)) {
                 return ResponseEntity.notFound().build();
+            }
+            if (!membershipService.canContribute(source, user)) {
+                return forbidden("Repository CONTRIBUTOR role required");
             }
             SystemRepository fork = provisioningService.createFork(
                     repositoryId,
@@ -154,12 +168,85 @@ public class ArchitectureRepositoryController {
         }
     }
 
+    @GetMapping("/{repositoryId}/members")
+    @Operation(summary = "List repository memberships")
+    public ResponseEntity<?> listMemberships(@PathVariable String repositoryId) {
+        String user = workspaceResolver.resolveCurrentUsername();
+        SystemRepository repository = visibleRepository(repositoryId, user);
+        if (repository == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!membershipService.isOwner(repository, user)) {
+            return forbidden("Repository OWNER role required");
+        }
+        return ResponseEntity.ok(membershipService.listMemberships(repository, user).stream()
+                .map(this::toMembershipMap)
+                .toList());
+    }
+
+    @PutMapping("/{repositoryId}/members/{username}")
+    @Operation(summary = "Assign or change a repository membership")
+    public ResponseEntity<?> updateMembership(
+            @PathVariable String repositoryId,
+            @PathVariable String username,
+            @RequestBody UpdateMembershipRequest request) {
+        String user = workspaceResolver.resolveCurrentUsername();
+        SystemRepository repository = visibleRepository(repositoryId, user);
+        if (repository == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!membershipService.isOwner(repository, user)) {
+            return forbidden("Repository OWNER role required");
+        }
+        try {
+            RepositoryMembership membership = membershipService.assignRole(
+                    repository, username, request.role(), user);
+            return ResponseEntity.ok(toMembershipMap(membership));
+        } catch (IllegalArgumentException | IllegalStateException exception) {
+            return ResponseEntity.badRequest().body(Map.of("error", safeMessage(exception)));
+        } catch (AccessDeniedException exception) {
+            return forbidden(safeMessage(exception));
+        }
+    }
+
+    @DeleteMapping("/{repositoryId}/members/{username}")
+    @Operation(summary = "Remove a repository membership")
+    public ResponseEntity<?> removeMembership(
+            @PathVariable String repositoryId,
+            @PathVariable String username) {
+        String user = workspaceResolver.resolveCurrentUsername();
+        SystemRepository repository = visibleRepository(repositoryId, user);
+        if (repository == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!membershipService.isOwner(repository, user)) {
+            return forbidden("Repository OWNER role required");
+        }
+        try {
+            membershipService.removeMembership(repository, username, user);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalArgumentException | IllegalStateException exception) {
+            return ResponseEntity.badRequest().body(Map.of("error", safeMessage(exception)));
+        } catch (AccessDeniedException exception) {
+            return forbidden(safeMessage(exception));
+        }
+    }
+
+    private SystemRepository visibleRepository(String repositoryId, String username) {
+        try {
+            SystemRepository repository = repositoryService.getRepository(repositoryId);
+            return canView(repository, username) ? repository : null;
+        } catch (IllegalArgumentException exception) {
+            return null;
+        }
+    }
+
     private boolean canView(SystemRepository repository, String username) {
         return membershipService.canRead(repository, username);
     }
 
     private Map<String, Object> toMap(SystemRepository repository) {
-        java.util.LinkedHashMap<String, Object> result = new java.util.LinkedHashMap<>();
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
         result.put("repositoryId", repository.getRepositoryId());
         result.put("slug", repository.getSlug());
         result.put("displayName", repository.getDisplayName());
@@ -177,6 +264,21 @@ public class ArchitectureRepositoryController {
         result.put("createdAt", repository.getCreatedAt());
         result.put("updatedAt", repository.getUpdatedAt());
         return result;
+    }
+
+    private Map<String, Object> toMembershipMap(RepositoryMembership membership) {
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+        result.put("username", membership.getUsername());
+        result.put("role", membership.getRole());
+        result.put("createdAt", membership.getCreatedAt());
+        result.put("createdBy", membership.getCreatedBy());
+        result.put("updatedAt", membership.getUpdatedAt());
+        return result;
+    }
+
+    private static ResponseEntity<Map<String, String>> forbidden(String message) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("error", message));
     }
 
     private static String safeMessage(Throwable throwable) {
@@ -203,5 +305,8 @@ public class ArchitectureRepositoryController {
             String description,
             RepositoryVisibility visibility,
             String sourceBranch) {
+    }
+
+    public record UpdateMembershipRequest(RepositoryRole role) {
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/RepositoryMembershipService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/RepositoryMembershipService.java
@@ -2,10 +2,12 @@ package com.taxonomy.workspace.service;
 
 import com.taxonomy.workspace.model.RepositoryLifecycleState;
 import com.taxonomy.workspace.model.RepositoryMembership;
+import com.taxonomy.workspace.model.RepositoryOwnerType;
 import com.taxonomy.workspace.model.RepositoryRole;
 import com.taxonomy.workspace.model.RepositoryVisibility;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.repository.RepositoryMembershipRepository;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,13 +64,63 @@ public class RepositoryMembershipService {
         return membershipRepository.save(membership);
     }
 
+    /** Assign or change a membership after enforcing repository-owner authority. */
+    @Transactional
+    public RepositoryMembership assignRole(
+            SystemRepository repository,
+            String username,
+            RepositoryRole role,
+            String actor) {
+        requireOwner(repository, actor);
+        String member = requireText(username, "username");
+        if (isUserCatalogOwner(repository, member) && role != RepositoryRole.OWNER) {
+            throw new IllegalArgumentException(
+                    "The repository catalog owner must retain the OWNER role");
+        }
+        Optional<RepositoryMembership> existing = membershipRepository
+                .findByRepositoryIdAndUsername(repository.getRepositoryId(), member);
+        if (existing.map(RepositoryMembership::getRole)
+                        .filter(existingRole -> existingRole == RepositoryRole.OWNER)
+                        .isPresent()
+                && role != RepositoryRole.OWNER
+                && !hasImplicitUserOwner(repository)
+                && countOwners(repository.getRepositoryId()) <= 1) {
+            throw new IllegalStateException("A repository must retain at least one OWNER");
+        }
+        return assignRole(repository.getRepositoryId(), member, role, actor);
+    }
+
+    /** Remove a membership after enforcing repository-owner authority and owner retention. */
+    @Transactional
+    public void removeMembership(
+            SystemRepository repository,
+            String username,
+            String actor) {
+        requireOwner(repository, actor);
+        String member = requireText(username, "username");
+        if (isUserCatalogOwner(repository, member)) {
+            throw new IllegalArgumentException(
+                    "The repository catalog owner membership cannot be removed");
+        }
+        RepositoryMembership membership = membershipRepository
+                .findByRepositoryIdAndUsername(repository.getRepositoryId(), member)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Repository membership does not exist: " + member));
+        if (membership.getRole() == RepositoryRole.OWNER
+                && !hasImplicitUserOwner(repository)
+                && countOwners(repository.getRepositoryId()) <= 1) {
+            throw new IllegalStateException("A repository must retain at least one OWNER");
+        }
+        membershipRepository.delete(membership);
+    }
+
     public Optional<RepositoryRole> effectiveRole(
             SystemRepository repository, String username) {
         if (repository == null || username == null || username.isBlank()) {
             return Optional.empty();
         }
         String member = username.strip();
-        if (member.equals(repository.getOwnerId())) {
+        if (isUserCatalogOwner(repository, member)) {
             return Optional.of(RepositoryRole.OWNER);
         }
         return membershipRepository.findByRepositoryIdAndUsername(
@@ -81,8 +133,7 @@ public class RepositoryMembershipService {
      * readable without an explicit membership; all other visibility modes require membership.
      */
     public boolean canRead(SystemRepository repository, String username) {
-        if (repository == null
-                || repository.getLifecycleState() != RepositoryLifecycleState.ACTIVE) {
+        if (!isActive(repository)) {
             return false;
         }
         if (repository.isPrimaryRepo()
@@ -94,9 +145,19 @@ public class RepositoryMembershipService {
                 .orElse(false);
     }
 
+    /**
+     * Working-copy creation requires CONTRIBUTOR. The historic primary repository remains a
+     * compatibility exception for authenticated users until installations can bootstrap explicit
+     * memberships for that pre-existing shared repository.
+     */
     public boolean canContribute(SystemRepository repository, String username) {
-        return isActive(repository)
-                && effectiveRole(repository, username)
+        if (!isActive(repository) || username == null || username.isBlank()) {
+            return false;
+        }
+        if (repository.isPrimaryRepo()) {
+            return true;
+        }
+        return effectiveRole(repository, username)
                 .map(role -> role.grants(RepositoryRole.CONTRIBUTOR))
                 .orElse(false);
     }
@@ -120,9 +181,40 @@ public class RepositoryMembershipService {
                 requireText(repositoryId, "repositoryId"));
     }
 
+    /** List memberships only for an explicit repository owner. */
+    public List<RepositoryMembership> listMemberships(
+            SystemRepository repository, String actor) {
+        requireOwner(repository, actor);
+        return listMemberships(repository.getRepositoryId());
+    }
+
     public long countOwners(String repositoryId) {
         return membershipRepository.countByRepositoryIdAndRole(
                 requireText(repositoryId, "repositoryId"), RepositoryRole.OWNER);
+    }
+
+    private void requireOwner(SystemRepository repository, String actor) {
+        if (!isOwner(repository, actor)) {
+            throw new AccessDeniedException("Repository OWNER role required");
+        }
+    }
+
+    private static boolean isUserCatalogOwner(
+            SystemRepository repository, String username) {
+        if (repository == null || username == null) {
+            return false;
+        }
+        RepositoryOwnerType ownerType = repository.getOwnerType();
+        return (ownerType == null || ownerType == RepositoryOwnerType.USER)
+                && username.equals(repository.getOwnerId());
+    }
+
+    private static boolean hasImplicitUserOwner(SystemRepository repository) {
+        return repository != null
+                && (repository.getOwnerType() == null
+                        || repository.getOwnerType() == RepositoryOwnerType.USER)
+                && repository.getOwnerId() != null
+                && !repository.getOwnerId().isBlank();
     }
 
     private static boolean isActive(SystemRepository repository) {

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ArchitectureRepositoryControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ArchitectureRepositoryControllerTest.java
@@ -1,0 +1,186 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.workspace.model.RepositoryLifecycleState;
+import com.taxonomy.workspace.model.RepositoryMembership;
+import com.taxonomy.workspace.model.RepositoryOwnerType;
+import com.taxonomy.workspace.model.RepositoryRole;
+import com.taxonomy.workspace.model.RepositoryVisibility;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.ArchitectureRepositoryProvisioningService;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryWorkspaceService;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ArchitectureRepositoryControllerTest {
+
+    private SystemRepositoryService repositoryService;
+    private ArchitectureRepositoryProvisioningService provisioningService;
+    private RepositoryWorkspaceService workspaceService;
+    private RepositoryMembershipService membershipService;
+    private WorkspaceResolver workspaceResolver;
+    private ArchitectureRepositoryController controller;
+
+    @BeforeEach
+    void setUp() {
+        repositoryService = mock(SystemRepositoryService.class);
+        provisioningService = mock(ArchitectureRepositoryProvisioningService.class);
+        workspaceService = mock(RepositoryWorkspaceService.class);
+        membershipService = mock(RepositoryMembershipService.class);
+        workspaceResolver = mock(WorkspaceResolver.class);
+        controller = new ArchitectureRepositoryController(
+                repositoryService,
+                provisioningService,
+                workspaceService,
+                membershipService,
+                workspaceResolver);
+    }
+
+    @Test
+    void readerCannotCreateWorkingCopyWithoutContributorRole() {
+        SystemRepository repository = repository();
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("reader");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "reader")).thenReturn(true);
+        when(membershipService.canContribute(repository, "reader")).thenReturn(false);
+
+        ResponseEntity<?> response = controller.createWorkspace(
+                "repo-a",
+                new ArchitectureRepositoryController.CreateWorkspaceRequest(
+                        "Reader copy", null, "main"));
+
+        assertEquals(403, response.getStatusCode().value());
+        verify(workspaceService, never()).createWorkingCopy(
+                any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void readerCannotCreateForkWithoutContributorRole() {
+        SystemRepository repository = repository();
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("reader");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "reader")).thenReturn(true);
+        when(membershipService.canContribute(repository, "reader")).thenReturn(false);
+
+        ResponseEntity<?> response = controller.createFork(
+                "repo-a",
+                new ArchitectureRepositoryController.CreateForkRequest(
+                        "Derived", "derived", null, RepositoryVisibility.PRIVATE, "main"));
+
+        assertEquals(403, response.getStatusCode().value());
+        verify(provisioningService, never()).createFork(
+                any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void ownerCanAssignMembership() {
+        SystemRepository repository = repository();
+        RepositoryMembership membership = membership("bob", RepositoryRole.CONTRIBUTOR);
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("owner");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "owner")).thenReturn(true);
+        when(membershipService.isOwner(repository, "owner")).thenReturn(true);
+        when(membershipService.assignRole(
+                        repository, "bob", RepositoryRole.CONTRIBUTOR, "owner"))
+                .thenReturn(membership);
+
+        ResponseEntity<?> response = controller.updateMembership(
+                "repo-a",
+                "bob",
+                new ArchitectureRepositoryController.UpdateMembershipRequest(
+                        RepositoryRole.CONTRIBUTOR));
+
+        assertEquals(200, response.getStatusCode().value());
+        Map<?, ?> body = assertInstanceOf(Map.class, response.getBody());
+        assertEquals("bob", body.get("username"));
+        assertEquals(RepositoryRole.CONTRIBUTOR, body.get("role"));
+    }
+
+    @Test
+    void visibleRepositoryReaderCannotListMemberships() {
+        SystemRepository repository = repository();
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("reader");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "reader")).thenReturn(true);
+        when(membershipService.isOwner(repository, "reader")).thenReturn(false);
+
+        ResponseEntity<?> response = controller.listMemberships("repo-a");
+
+        assertEquals(403, response.getStatusCode().value());
+        verify(membershipService, never()).listMemberships(repository, "reader");
+    }
+
+    @Test
+    void hiddenRepositoryReturnsNotFoundBeforeMembershipDisclosure() {
+        SystemRepository repository = repository();
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("outsider");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "outsider")).thenReturn(false);
+
+        ResponseEntity<?> response = controller.updateMembership(
+                "repo-a",
+                "bob",
+                new ArchitectureRepositoryController.UpdateMembershipRequest(
+                        RepositoryRole.READER));
+
+        assertEquals(404, response.getStatusCode().value());
+        verify(membershipService, never()).isOwner(repository, "outsider");
+    }
+
+    @Test
+    void ownerCanListAndRemoveMemberships() {
+        SystemRepository repository = repository();
+        RepositoryMembership reader = membership("reader", RepositoryRole.READER);
+        when(workspaceResolver.resolveCurrentUsername()).thenReturn("owner");
+        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
+        when(membershipService.canRead(repository, "owner")).thenReturn(true);
+        when(membershipService.isOwner(repository, "owner")).thenReturn(true);
+        when(membershipService.listMemberships(repository, "owner"))
+                .thenReturn(List.of(reader));
+
+        ResponseEntity<?> listResponse = controller.listMemberships("repo-a");
+        ResponseEntity<?> deleteResponse = controller.removeMembership("repo-a", "reader");
+
+        assertEquals(200, listResponse.getStatusCode().value());
+        assertEquals(204, deleteResponse.getStatusCode().value());
+        verify(membershipService).removeMembership(repository, "reader", "owner");
+    }
+
+    private static SystemRepository repository() {
+        SystemRepository repository = new SystemRepository();
+        repository.setRepositoryId("repo-a");
+        repository.setOwnerType(RepositoryOwnerType.USER);
+        repository.setOwnerId("owner");
+        repository.setVisibility(RepositoryVisibility.PRIVATE);
+        repository.setLifecycleState(RepositoryLifecycleState.ACTIVE);
+        repository.setPrimaryRepo(false);
+        return repository;
+    }
+
+    private static RepositoryMembership membership(
+            String username, RepositoryRole role) {
+        RepositoryMembership membership = new RepositoryMembership();
+        membership.setRepositoryId("repo-a");
+        membership.setUsername(username);
+        membership.setRole(role);
+        membership.setCreatedAt(Instant.parse("2026-08-09T12:00:00Z"));
+        membership.setCreatedBy("owner");
+        membership.setUpdatedAt(Instant.parse("2026-08-09T12:00:00Z"));
+        return membership;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/RepositoryMembershipServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/RepositoryMembershipServiceTest.java
@@ -2,18 +2,21 @@ package com.taxonomy.workspace.service;
 
 import com.taxonomy.workspace.model.RepositoryLifecycleState;
 import com.taxonomy.workspace.model.RepositoryMembership;
+import com.taxonomy.workspace.model.RepositoryOwnerType;
 import com.taxonomy.workspace.model.RepositoryRole;
 import com.taxonomy.workspace.model.RepositoryVisibility;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.repository.RepositoryMembershipRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -97,6 +100,20 @@ class RepositoryMembershipServiceTest {
     }
 
     @Test
+    void organizationIdentifierIsNotImplicitlyTreatedAsAUserOwner() {
+        SystemRepository organization = repository(
+                RepositoryVisibility.ORGANIZATION, RepositoryLifecycleState.ACTIVE, false);
+        organization.setOwnerType(RepositoryOwnerType.ORGANIZATION);
+        organization.setOwnerId("architecture-team");
+        when(membershipRepository.findByRepositoryIdAndUsername(
+                        "repo-a", "architecture-team"))
+                .thenReturn(Optional.empty());
+
+        assertTrue(service.effectiveRole(organization, "architecture-team").isEmpty());
+        assertFalse(service.isOwner(organization, "architecture-team"));
+    }
+
+    @Test
     void repositoryRolesGrantOnlyTheirDeclaredCapabilityLevel() {
         SystemRepository repository = repository(
                 RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
@@ -120,6 +137,87 @@ class RepositoryMembershipServiceTest {
     }
 
     @Test
+    void primaryRepositoryRetainsWorkingCopyCompatibilityForAuthenticatedUsers() {
+        SystemRepository primary = repository(
+                RepositoryVisibility.ORGANIZATION, RepositoryLifecycleState.ACTIVE, true);
+
+        assertTrue(service.canContribute(primary, "authenticated-user"));
+        assertFalse(service.canContribute(primary, " "));
+    }
+
+    @Test
+    void ownerCanAssignContributorRole() {
+        SystemRepository repository = repository(
+                RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
+        when(membershipRepository.findByRepositoryIdAndUsername("repo-a", "bob"))
+                .thenReturn(Optional.empty());
+
+        RepositoryMembership assigned = service.assignRole(
+                repository, "bob", RepositoryRole.CONTRIBUTOR, "owner");
+
+        assertEquals("bob", assigned.getUsername());
+        assertEquals(RepositoryRole.CONTRIBUTOR, assigned.getRole());
+        assertEquals("owner", assigned.getCreatedBy());
+        verify(membershipRepository).save(assigned);
+    }
+
+    @Test
+    void nonOwnerCannotAssignRepositoryRoles() {
+        SystemRepository repository = repository(
+                RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
+        when(membershipRepository.findByRepositoryIdAndUsername("repo-a", "reader"))
+                .thenReturn(Optional.of(membership(
+                        "repo-a", "reader", RepositoryRole.READER)));
+
+        assertThrows(AccessDeniedException.class, () -> service.assignRole(
+                repository, "bob", RepositoryRole.CONTRIBUTOR, "reader"));
+        verify(membershipRepository, never()).save(any());
+    }
+
+    @Test
+    void userCatalogOwnerCannotBeDemotedOrRemoved() {
+        SystemRepository repository = repository(
+                RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
+
+        assertThrows(IllegalArgumentException.class, () -> service.assignRole(
+                repository, "owner", RepositoryRole.MAINTAINER, "owner"));
+        assertThrows(IllegalArgumentException.class, () -> service.removeMembership(
+                repository, "owner", "owner"));
+        verify(membershipRepository, never()).delete(any());
+    }
+
+    @Test
+    void organizationRepositoryCannotLoseItsLastExplicitOwner() {
+        SystemRepository repository = repository(
+                RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
+        repository.setOwnerType(RepositoryOwnerType.ORGANIZATION);
+        repository.setOwnerId("architecture-team");
+        RepositoryMembership owner = membership("repo-a", "alice", RepositoryRole.OWNER);
+        when(membershipRepository.findByRepositoryIdAndUsername("repo-a", "alice"))
+                .thenReturn(Optional.of(owner));
+        when(membershipRepository.countByRepositoryIdAndRole(
+                        "repo-a", RepositoryRole.OWNER))
+                .thenReturn(1L);
+
+        assertThrows(IllegalStateException.class, () -> service.removeMembership(
+                repository, "alice", "alice"));
+        verify(membershipRepository, never()).delete(any());
+    }
+
+    @Test
+    void ownerCanRemoveOrdinaryMembership() {
+        SystemRepository repository = repository(
+                RepositoryVisibility.PRIVATE, RepositoryLifecycleState.ACTIVE, false);
+        RepositoryMembership reader = membership("repo-a", "reader", RepositoryRole.READER);
+        when(membershipRepository.findByRepositoryIdAndUsername("repo-a", "reader"))
+                .thenReturn(Optional.of(reader));
+
+        service.removeMembership(repository, "reader", "owner");
+
+        verify(membershipRepository).delete(reader);
+    }
+
+    @Test
     void inactiveRepositoriesAreNeverReadableOrMutable() {
         SystemRepository failed = repository(
                 RepositoryVisibility.PUBLIC, RepositoryLifecycleState.FAILED, true);
@@ -138,6 +236,7 @@ class RepositoryMembershipServiceTest {
         repository.setRepositoryId("repo-a");
         repository.setVisibility(visibility);
         repository.setLifecycleState(lifecycleState);
+        repository.setOwnerType(RepositoryOwnerType.USER);
         repository.setOwnerId("owner");
         repository.setPrimaryRepo(primary);
         return repository;


### PR DESCRIPTION
## Scope

Completes the first remaining authorization blocker of draft PR #610 without widening the change into relational/search tenancy.

- adds owner-governed `GET`/`PUT`/`DELETE` membership APIs;
- enforces `CONTRIBUTOR` for new working copies and durable forks;
- keeps the historic primary repository as an explicit working-copy compatibility exception until existing installations can bootstrap memberships;
- distinguishes user ownership from organization/system owner identifiers;
- prevents demoting/removing the catalog user owner and prevents organization/system repositories from losing their last explicit owner;
- returns 404 before exposing membership state for repositories the caller cannot read;
- adds focused service and controller negative-path tests.

The global Spring Security rules remain only an authentication/app-role outer gate. Repository authorization is enforced from the selected repository metadata and explicit membership.

Targets the draft integration branch and is intended to be merged into #610 after its exact head passes the normal gates.

Part of #609
Advances #610 blocker 1.