### PR TITLE
Resolve an explicit repository context for every request

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/RepositoryContext.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/RepositoryContext.java
@@ -3,9 +3,9 @@ package com.taxonomy.workspace.service;
 /**
  * Explicit routing identity for every repository-sensitive operation.
  *
- * <p>The repository ID is mandatory. A {@code null} workspace ID addresses the
- * selected central repository; a non-null workspace ID addresses an isolated
- * working copy derived from that repository.</p>
+ * <p>The repository ID, branch, username and scope are mandatory. A central
+ * context has no workspace ID; a workspace context must identify the isolated
+ * working copy derived from the selected repository.</p>
  */
 public record RepositoryContext(
         String repositoryId,
@@ -15,18 +15,21 @@ public record RepositoryContext(
         RepositoryScope scope) {
 
     public RepositoryContext {
-        if (repositoryId == null || repositoryId.isBlank()) {
-            throw new IllegalArgumentException("repositoryId must not be blank");
-        }
-        if (branch == null || branch.isBlank()) {
-            throw new IllegalArgumentException("branch must not be blank");
-        }
+        repositoryId = requireText(repositoryId, "repositoryId");
+        branch = requireText(branch, "branch");
+        username = requireText(username, "username");
         if (scope == null) {
             throw new IllegalArgumentException("scope must not be null");
         }
-        if (scope == RepositoryScope.WORKSPACE
-                && (workspaceId == null || workspaceId.isBlank())) {
+        if (workspaceId != null) {
+            workspaceId = requireText(workspaceId, "workspaceId");
+        }
+        if (scope == RepositoryScope.WORKSPACE && workspaceId == null) {
             throw new IllegalArgumentException("workspaceId is required for WORKSPACE scope");
+        }
+        if (scope == RepositoryScope.CENTRAL_READ && workspaceId != null) {
+            throw new IllegalArgumentException(
+                    "workspaceId must be absent for CENTRAL_READ scope");
         }
     }
 
@@ -40,5 +43,12 @@ public record RepositoryContext(
             String repositoryId, String workspaceId, String branch, String username) {
         return new RepositoryContext(
                 repositoryId, workspaceId, branch, username, RepositoryScope.WORKSPACE);
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.strip();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
@@ -119,7 +119,7 @@ public class WorkspaceContextResolver {
                     workspace.getSourceRepositoryId().strip());
         }
         SystemRepository primary = systemRepositoryService.getPrimaryRepository();
-        log.info(
+        log.debug(
                 "Resolved legacy workspace {} to primary repository {}",
                 workspace.getWorkspaceId(), primary.getRepositoryId());
         return primary;

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContextResolver.java
@@ -1,5 +1,6 @@
 package com.taxonomy.workspace.service;
 
+import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.model.UserWorkspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,16 +9,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 /**
- * Resolves the current {@link WorkspaceContext} from the security context
- * and the persistent workspace metadata.
+ * Resolves the current workspace and repository contexts from the authenticated
+ * principal and persistent workspace metadata.
  *
- * <p>Combines the username (from Spring Security) with the
- * workspace metadata (from {@link WorkspaceManager}) to produce a
- * consistent context value that downstream services can use for
- * data isolation (workspace-scoped relations, hypotheses, proposals, etc.).
- *
- * <p>Falls back to {@link WorkspaceContext#SHARED} when no provisioned
- * workspace exists for the current user.
+ * <p>The legacy {@link WorkspaceContext} is retained while existing callers are
+ * migrated. New repository-sensitive code must use {@link RepositoryContext} so
+ * a {@code null} workspace can never mean an unspecified global repository.</p>
  */
 @Service
 public class WorkspaceContextResolver {
@@ -33,26 +30,17 @@ public class WorkspaceContextResolver {
         this.systemRepositoryService = systemRepositoryService;
     }
 
-    /**
-     * Resolve the workspace context for the currently authenticated user.
-     *
-     * @return the active workspace context (never {@code null})
-     */
+    /** Resolve the legacy workspace context for the currently authenticated user. */
     public WorkspaceContext resolveCurrentContext() {
-        String username = resolveUsername();
-        return resolveForUser(username);
+        return resolveForUser(resolveUsername());
     }
 
     /**
-     * Resolve the workspace context for a specific user.
+     * Resolve the legacy workspace context for a specific user.
      *
-     * <p>Only users with an explicitly provisioned persistent workspace
-     * receive a workspace-scoped context. Users with only a default
-     * in-memory workspace state receive the {@link WorkspaceContext#SHARED}
-     * fallback (backward-compatible, no data isolation).
-     *
-     * @param username the username to resolve context for
-     * @return the workspace context (never {@code null})
+     * <p>Only users with an explicitly provisioned persistent workspace receive
+     * a workspace-scoped context. Callers that need repository identity must use
+     * {@link #resolveRepositoryContextForUser(String)} instead.</p>
      */
     public WorkspaceContext resolveForUser(String username) {
         if (username == null || username.isBlank()
@@ -60,31 +48,112 @@ public class WorkspaceContextResolver {
             return WorkspaceContext.SHARED;
         }
 
-        // Try active workspace first (multi-workspace aware)
-        UserWorkspace ws = workspaceManager.findActiveWorkspace(username);
-        if (ws == null) {
-            // Fall back to legacy single-workspace lookup for backward compatibility
-            ws = workspaceManager.findUserWorkspace(username);
-        }
-
-        if (ws != null && ws.getWorkspaceId() != null) {
-            String branch = ws.getCurrentBranch() != null
-                    ? ws.getCurrentBranch()
+        UserWorkspace workspace = findWorkspace(username);
+        if (workspace != null && hasText(workspace.getWorkspaceId())) {
+            String branch = hasText(workspace.getCurrentBranch())
+                    ? workspace.getCurrentBranch().strip()
                     : systemRepositoryService.getSharedBranch();
             log.debug("Resolved workspace context for user '{}': workspace={}, branch={}",
-                    username, ws.getWorkspaceId(), branch);
-            return new WorkspaceContext(username, ws.getWorkspaceId(), branch);
+                    username, workspace.getWorkspaceId(), branch);
+            return new WorkspaceContext(
+                    username.strip(), workspace.getWorkspaceId().strip(), branch);
         }
 
         log.debug("No provisioned workspace for user '{}'; falling back to SHARED", username);
         return WorkspaceContext.SHARED;
     }
 
+    /** Resolve an explicit repository context for the authenticated user. */
+    public RepositoryContext resolveCurrentRepositoryContext() {
+        return resolveRepositoryContextForUser(resolveUsername());
+    }
+
+    /**
+     * Resolve the selected logical repository and optional workspace for one user.
+     *
+     * <p>A user without a personal workspace receives an explicit read-only
+     * context for the primary central repository. A legacy workspace without
+     * {@code sourceRepositoryId} is assigned to that same primary repository,
+     * which is the only repository such rows could originate from before the
+     * multi-repository migration.</p>
+     */
+    public RepositoryContext resolveRepositoryContextForUser(String username) {
+        String user = normalizeUsername(username);
+        UserWorkspace workspace = WorkspaceManager.DEFAULT_USER.equals(user)
+                ? null
+                : findWorkspace(user);
+
+        if (workspace != null && hasText(workspace.getWorkspaceId())) {
+            SystemRepository repository = resolveWorkspaceSource(workspace);
+            String branch = hasText(workspace.getCurrentBranch())
+                    ? workspace.getCurrentBranch().strip()
+                    : requireBranch(repository);
+            RepositoryContext context = RepositoryContext.workspace(
+                    requireRepositoryId(repository),
+                    workspace.getWorkspaceId().strip(),
+                    branch,
+                    user);
+            log.debug(
+                    "Resolved repository context for user '{}': repository={}, workspace={}, branch={}",
+                    user, context.repositoryId(), context.workspaceId(), context.branch());
+            return context;
+        }
+
+        SystemRepository primary = systemRepositoryService.getPrimaryRepository();
+        RepositoryContext context = RepositoryContext.centralRead(
+                requireRepositoryId(primary), requireBranch(primary), user);
+        log.debug(
+                "Resolved central repository context for user '{}': repository={}, branch={}",
+                user, context.repositoryId(), context.branch());
+        return context;
+    }
+
+    private UserWorkspace findWorkspace(String username) {
+        UserWorkspace workspace = workspaceManager.findActiveWorkspace(username);
+        return workspace != null ? workspace : workspaceManager.findUserWorkspace(username);
+    }
+
+    private SystemRepository resolveWorkspaceSource(UserWorkspace workspace) {
+        if (hasText(workspace.getSourceRepositoryId())) {
+            return systemRepositoryService.getRepository(
+                    workspace.getSourceRepositoryId().strip());
+        }
+        SystemRepository primary = systemRepositoryService.getPrimaryRepository();
+        log.info(
+                "Resolved legacy workspace {} to primary repository {}",
+                workspace.getWorkspaceId(), primary.getRepositoryId());
+        return primary;
+    }
+
+    private static String requireRepositoryId(SystemRepository repository) {
+        if (repository == null || !hasText(repository.getRepositoryId())) {
+            throw new IllegalStateException("Resolved repository has no repositoryId");
+        }
+        return repository.getRepositoryId().strip();
+    }
+
+    private static String requireBranch(SystemRepository repository) {
+        if (repository == null || !hasText(repository.getDefaultBranch())) {
+            throw new IllegalStateException("Resolved repository has no default branch");
+        }
+        return repository.getDefaultBranch().strip();
+    }
+
+    private static String normalizeUsername(String username) {
+        return username == null || username.isBlank()
+                ? WorkspaceManager.DEFAULT_USER
+                : username.strip();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
     private String resolveUsername() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.isAuthenticated()
-                && !"anonymousUser".equals(auth.getPrincipal())) {
-            return auth.getName();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && !"anonymousUser".equals(authentication.getPrincipal())) {
+            return authentication.getName();
         }
         return WorkspaceManager.DEFAULT_USER;
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
@@ -7,18 +7,19 @@ import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
 /**
- * Resolves the current workspace username and request-bound workspace context.
+ * Resolves the current username plus request-bound workspace and repository contexts.
  *
- * <p>A successfully resolved context is cached for the lifetime of the HTTP
- * request. All collaborators in one request therefore observe the same
- * workspace even when the underlying persistence state changes or becomes
- * temporarily unavailable later in the request.</p>
+ * <p>Successfully resolved contexts are cached for the lifetime of the HTTP request.
+ * All collaborators in one request therefore observe the same logical repository
+ * even when active-workspace metadata changes concurrently.</p>
  */
 @Component
 public class WorkspaceResolver {
 
     private static final String REQUEST_CONTEXT_ATTRIBUTE =
             WorkspaceResolver.class.getName() + ".resolvedContext";
+    private static final String REQUEST_REPOSITORY_CONTEXT_ATTRIBUTE =
+            WorkspaceResolver.class.getName() + ".resolvedRepositoryContext";
 
     private final WorkspaceContextResolver contextResolver;
 
@@ -26,12 +27,7 @@ public class WorkspaceResolver {
         this.contextResolver = contextResolver;
     }
 
-    /**
-     * Resolve the current user's username from the security context.
-     *
-     * @return the authenticated username, or the configured default user when
-     *         no authenticated principal exists
-     */
+    /** Resolve the authenticated username or the configured default user. */
     public String resolveCurrentUsername() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth != null && auth.isAuthenticated()
@@ -42,10 +38,8 @@ public class WorkspaceResolver {
     }
 
     /**
-     * Resolve the full workspace context for the current request. Resolver
-     * failures propagate; this method never manufactures a shared fallback.
-     *
-     * @return the stable active workspace context for this request
+     * Resolve the legacy workspace context for the current request.
+     * Resolver failures propagate; this method never manufactures a fallback.
      */
     public WorkspaceContext resolveCurrentContext() {
         RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
@@ -61,12 +55,39 @@ public class WorkspaceResolver {
         if (resolved == null) {
             throw new IllegalStateException("Workspace context resolver returned null");
         }
+        cache(attributes, REQUEST_CONTEXT_ATTRIBUTE, resolved);
+        return resolved;
+    }
+
+    /**
+     * Resolve the mandatory logical repository identity for the current request.
+     * A central context always carries a repository ID; it never reuses the
+     * ambiguous legacy {@link WorkspaceContext#SHARED} sentinel.
+     */
+    public RepositoryContext resolveCurrentRepositoryContext() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes != null) {
+            Object cached = attributes.getAttribute(
+                    REQUEST_REPOSITORY_CONTEXT_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
+            if (cached instanceof RepositoryContext context) {
+                return context;
+            }
+        }
+
+        RepositoryContext resolved = contextResolver.resolveRepositoryContextForUser(
+                resolveCurrentUsername());
+        if (resolved == null) {
+            throw new IllegalStateException("Repository context resolver returned null");
+        }
+        cache(attributes, REQUEST_REPOSITORY_CONTEXT_ATTRIBUTE, resolved);
+        return resolved;
+    }
+
+    private static void cache(
+            RequestAttributes attributes, String attributeName, Object value) {
         if (attributes != null) {
             attributes.setAttribute(
-                    REQUEST_CONTEXT_ATTRIBUTE,
-                    resolved,
-                    RequestAttributes.SCOPE_REQUEST);
+                    attributeName, value, RequestAttributes.SCOPE_REQUEST);
         }
-        return resolved;
     }
 }

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V4__bind_existing_workspaces_to_primary_repository.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V4__bind_existing_workspaces_to_primary_repository.sql
@@ -1,0 +1,42 @@
+-- Make pre-multi-repository workspace provenance explicit without changing the
+-- lifecycle of future, not-yet-provisioned workspace rows. Existing rows could
+-- only have been created from the historic primary repository.
+
+do $$
+declare
+    unbound_workspace_count bigint;
+    primary_repository_count bigint;
+begin
+    select count(*)
+    into unbound_workspace_count
+    from user_workspace
+    where source_repository_id is null;
+
+    if unbound_workspace_count > 0 then
+        select count(*)
+        into primary_repository_count
+        from system_repository
+        where primary_repo = true;
+
+        if primary_repository_count <> 1 then
+            raise exception
+                'Cannot bind % existing workspace(s): expected exactly one primary repository, found %',
+                unbound_workspace_count,
+                primary_repository_count;
+        end if;
+
+        update user_workspace
+        set source_repository_id = (
+            select repository_id
+            from system_repository
+            where primary_repo = true
+        )
+        where source_repository_id is null;
+    end if;
+end
+$$;
+
+alter table user_workspace
+    add constraint fk_workspace_source_repository
+        foreign key (source_repository_id)
+        references system_repository (repository_id);

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -56,7 +56,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(columnExists(dataSource, "user_workspace", "relationship_type")).isTrue();
         assertThat(tableExists(dataSource, TaxonomySchemaMigrationConfig.HISTORY_TABLE)).isTrue();
         assertThat(successfulVersions(dataSource))
-                .containsExactly("0", "1", "2", "3");
+                .containsExactly("0", "1", "2", "3", "4");
     }
 
     @Test
@@ -90,7 +90,127 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(columnExists(dataSource, "user_workspace", "source_branch"))
                 .isTrue();
         assertThat(successfulVersions(dataSource))
-                .containsExactly("1", "2", "3");
+                .containsExactly("1", "2", "3", "4");
+    }
+
+    @Test
+    void bindsExistingWorkspacesToTheOnlyPrimaryRepository() throws Exception {
+        DataSource dataSource = isolatedDataSource("workspace_repository_binding");
+        migrateJgit(dataSource);
+        installApplicationAtVersion(dataSource, "3");
+        execute(dataSource, """
+                insert into system_repository (
+                    repository_id,
+                    display_name,
+                    topology_mode,
+                    default_branch,
+                    primary_repo,
+                    created_at,
+                    storage_repository_name,
+                    slug,
+                    visibility,
+                    lifecycle_state,
+                    owner_type,
+                    owner_id,
+                    created_by,
+                    updated_at)
+                values (
+                    'primary-repository',
+                    'Primary',
+                    'INTERNAL_SHARED',
+                    'draft',
+                    true,
+                    current_timestamp,
+                    'taxonomy-dsl',
+                    'shared-architecture',
+                    'ORGANIZATION',
+                    'ACTIVE',
+                    'SYSTEM',
+                    'system',
+                    'system',
+                    current_timestamp)
+                """);
+        execute(dataSource, """
+                insert into user_workspace (
+                    workspace_id,
+                    username,
+                    display_name,
+                    current_branch,
+                    base_branch,
+                    shared,
+                    created_at,
+                    provisioning_status,
+                    topology_mode,
+                    archived,
+                    is_default,
+                    source_branch,
+                    relationship_type)
+                values (
+                    'legacy-workspace',
+                    'alice',
+                    'Legacy workspace',
+                    'alice/workspace',
+                    'draft',
+                    false,
+                    current_timestamp,
+                    'READY',
+                    'INTERNAL_SHARED',
+                    false,
+                    true,
+                    'draft',
+                    'WORKING_COPY')
+                """);
+
+        TaxonomySchemaMigrationConfig.migrateApplicationSchema(
+                Flyway.configure().dataSource(dataSource).load().getConfiguration());
+
+        assertThat(singleString(dataSource, """
+                select source_repository_id
+                from user_workspace
+                where workspace_id = 'legacy-workspace'
+                """))
+                .isEqualTo("primary-repository");
+        assertThatThrownBy(() -> execute(dataSource, """
+                update user_workspace
+                set source_repository_id = 'missing-repository'
+                where workspace_id = 'legacy-workspace'
+                """))
+                .isInstanceOf(SQLException.class);
+    }
+
+    @Test
+    void refusesToBindExistingWorkspacesWithoutExactlyOnePrimaryRepository() throws Exception {
+        DataSource dataSource = isolatedDataSource("workspace_repository_binding_failure");
+        migrateJgit(dataSource);
+        installApplicationAtVersion(dataSource, "3");
+        execute(dataSource, """
+                insert into user_workspace (
+                    workspace_id,
+                    username,
+                    display_name,
+                    current_branch,
+                    shared,
+                    created_at,
+                    provisioning_status,
+                    topology_mode,
+                    archived,
+                    is_default)
+                values (
+                    'unbound-workspace',
+                    'alice',
+                    'Unbound workspace',
+                    'draft',
+                    false,
+                    current_timestamp,
+                    'READY',
+                    'INTERNAL_SHARED',
+                    false,
+                    true)
+                """);
+
+        assertThatThrownBy(() -> TaxonomySchemaMigrationConfig.migrateApplicationSchema(
+                Flyway.configure().dataSource(dataSource).load().getConfiguration()))
+                .hasStackTraceContaining("expected exactly one primary repository");
     }
 
     @Test
@@ -128,6 +248,10 @@ class TaxonomySchemaPostgresMigrationIT {
     }
 
     private static void installApplicationBaseline(DataSource dataSource) {
+        installApplicationAtVersion(dataSource, "1");
+    }
+
+    private static void installApplicationAtVersion(DataSource dataSource, String version) {
         Flyway.configure()
                 .dataSource(dataSource)
                 .locations(TaxonomySchemaMigrationConfig.POSTGRES_LOCATION)
@@ -135,7 +259,7 @@ class TaxonomySchemaPostgresMigrationIT {
                 .baselineOnMigrate(true)
                 .baselineVersion("0")
                 .baselineDescription("before Taxonomy application schema")
-                .target("1")
+                .target(version)
                 .load()
                 .migrate();
     }
@@ -205,6 +329,15 @@ class TaxonomySchemaPostgresMigrationIT {
              ResultSet resultSet = statement.executeQuery(sql)) {
             resultSet.next();
             return resultSet.getLong(1);
+        }
+    }
+
+    private static String singleString(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getString(1);
         }
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/RepositoryContextTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/RepositoryContextTest.java
@@ -1,0 +1,52 @@
+package com.taxonomy.workspace.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class RepositoryContextTest {
+
+    @Test
+    void contextCanonicalizesRoutingIdentifiers() {
+        RepositoryContext context = RepositoryContext.workspace(
+                " repo-a ", " workspace-a ", " feature/a ", " alice ");
+
+        assertThat(context.repositoryId()).isEqualTo("repo-a");
+        assertThat(context.workspaceId()).isEqualTo("workspace-a");
+        assertThat(context.branch()).isEqualTo("feature/a");
+        assertThat(context.username()).isEqualTo("alice");
+    }
+
+    @Test
+    void centralContextRejectsWorkspaceIdentity() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new RepositoryContext(
+                "repo-a",
+                "workspace-a",
+                "main",
+                "alice",
+                RepositoryScope.CENTRAL_READ));
+    }
+
+    @Test
+    void workspaceContextRequiresWorkspaceIdentity() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new RepositoryContext(
+                "repo-a",
+                null,
+                "main",
+                "alice",
+                RepositoryScope.WORKSPACE));
+    }
+
+    @Test
+    void contextRejectsMissingRepositoryBranchUsernameAndScope() {
+        assertThatIllegalArgumentException().isThrownBy(() ->
+                RepositoryContext.centralRead(" ", "main", "alice"));
+        assertThatIllegalArgumentException().isThrownBy(() ->
+                RepositoryContext.centralRead("repo-a", " ", "alice"));
+        assertThatIllegalArgumentException().isThrownBy(() ->
+                RepositoryContext.centralRead("repo-a", "main", " "));
+        assertThatIllegalArgumentException().isThrownBy(() -> new RepositoryContext(
+                "repo-a", null, "main", "alice", null));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceContextResolverTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceContextResolverTest.java
@@ -1,5 +1,6 @@
 package com.taxonomy.workspace.service;
 
+import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.model.UserWorkspace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,11 +9,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-/**
- * Unit tests for {@link WorkspaceContextResolver}.
- */
+/** Unit tests for {@link WorkspaceContextResolver}. */
 @ExtendWith(MockitoExtension.class)
 class WorkspaceContextResolverTest {
 
@@ -53,31 +53,25 @@ class WorkspaceContextResolverTest {
 
     @Test
     void userWithProvisionedWorkspaceReturnsContext() {
-        UserWorkspace ws = new UserWorkspace();
-        ws.setUsername("alice");
-        ws.setWorkspaceId("alice-ws-123");
-        ws.setCurrentBranch("alice/workspace");
+        UserWorkspace workspace = workspace("alice", "alice-ws-123", "alice/workspace");
+        when(workspaceManager.findUserWorkspace("alice")).thenReturn(workspace);
 
-        when(workspaceManager.findUserWorkspace("alice")).thenReturn(ws);
+        WorkspaceContext context = resolver.resolveForUser("alice");
 
-        WorkspaceContext ctx = resolver.resolveForUser("alice");
-        assertThat(ctx.username()).isEqualTo("alice");
-        assertThat(ctx.workspaceId()).isEqualTo("alice-ws-123");
-        assertThat(ctx.currentBranch()).isEqualTo("alice/workspace");
+        assertThat(context.username()).isEqualTo("alice");
+        assertThat(context.workspaceId()).isEqualTo("alice-ws-123");
+        assertThat(context.currentBranch()).isEqualTo("alice/workspace");
     }
 
     @Test
     void provisionedWorkspaceWithNullBranchFallsBackToSharedBranch() {
-        UserWorkspace ws = new UserWorkspace();
-        ws.setUsername("bob");
-        ws.setWorkspaceId("bob-ws");
-        ws.setCurrentBranch(null);
-
-        when(workspaceManager.findUserWorkspace("bob")).thenReturn(ws);
+        UserWorkspace workspace = workspace("bob", "bob-ws", null);
+        when(workspaceManager.findUserWorkspace("bob")).thenReturn(workspace);
         when(systemRepositoryService.getSharedBranch()).thenReturn("draft");
 
-        WorkspaceContext ctx = resolver.resolveForUser("bob");
-        assertThat(ctx.currentBranch()).isEqualTo("draft");
+        WorkspaceContext context = resolver.resolveForUser("bob");
+
+        assertThat(context.currentBranch()).isEqualTo("draft");
     }
 
     @Test
@@ -89,23 +83,100 @@ class WorkspaceContextResolverTest {
 
     @Test
     void differentWorkspacesAreIsolated() {
-        UserWorkspace aliceWs = new UserWorkspace();
-        aliceWs.setUsername("alice");
-        aliceWs.setWorkspaceId("alice-ws");
-        aliceWs.setCurrentBranch("alice/workspace");
+        UserWorkspace aliceWorkspace = workspace("alice", "alice-ws", "alice/workspace");
+        UserWorkspace bobWorkspace = workspace("bob", "bob-ws", "bob/workspace");
+        when(workspaceManager.findUserWorkspace("alice")).thenReturn(aliceWorkspace);
+        when(workspaceManager.findUserWorkspace("bob")).thenReturn(bobWorkspace);
 
-        UserWorkspace bobWs = new UserWorkspace();
-        bobWs.setUsername("bob");
-        bobWs.setWorkspaceId("bob-ws");
-        bobWs.setCurrentBranch("bob/workspace");
+        WorkspaceContext aliceContext = resolver.resolveForUser("alice");
+        WorkspaceContext bobContext = resolver.resolveForUser("bob");
 
-        when(workspaceManager.findUserWorkspace("alice")).thenReturn(aliceWs);
-        when(workspaceManager.findUserWorkspace("bob")).thenReturn(bobWs);
+        assertThat(aliceContext.workspaceId()).isNotEqualTo(bobContext.workspaceId());
+        assertThat(aliceContext.currentBranch()).isNotEqualTo(bobContext.currentBranch());
+    }
 
-        WorkspaceContext aliceCtx = resolver.resolveForUser("alice");
-        WorkspaceContext bobCtx = resolver.resolveForUser("bob");
+    @Test
+    void activeWorkspaceProducesExplicitRepositoryContext() {
+        UserWorkspace workspace = workspace("alice", "alice-ws", "feature/a");
+        workspace.setSourceRepositoryId("repo-a");
+        SystemRepository repository = repository("repo-a", "main");
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(workspace);
+        when(systemRepositoryService.getRepository("repo-a")).thenReturn(repository);
 
-        assertThat(aliceCtx.workspaceId()).isNotEqualTo(bobCtx.workspaceId());
-        assertThat(aliceCtx.currentBranch()).isNotEqualTo(bobCtx.currentBranch());
+        RepositoryContext context = resolver.resolveRepositoryContextForUser("alice");
+
+        assertThat(context.repositoryId()).isEqualTo("repo-a");
+        assertThat(context.workspaceId()).isEqualTo("alice-ws");
+        assertThat(context.branch()).isEqualTo("feature/a");
+        assertThat(context.username()).isEqualTo("alice");
+        assertThat(context.scope()).isEqualTo(RepositoryScope.WORKSPACE);
+    }
+
+    @Test
+    void workspaceWithoutCurrentBranchUsesItsSourceRepositoryDefault() {
+        UserWorkspace workspace = workspace("alice", "alice-ws", null);
+        workspace.setSourceRepositoryId("repo-a");
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(workspace);
+        when(systemRepositoryService.getRepository("repo-a"))
+                .thenReturn(repository("repo-a", "main"));
+
+        RepositoryContext context = resolver.resolveRepositoryContextForUser("alice");
+
+        assertThat(context.branch()).isEqualTo("main");
+        assertThat(context.repositoryId()).isEqualTo("repo-a");
+    }
+
+    @Test
+    void legacyWorkspaceWithoutSourceRepositoryIsBoundToPrimaryRepository() {
+        UserWorkspace workspace = workspace("alice", "legacy-ws", "draft");
+        SystemRepository primary = repository("primary-repo", "draft");
+        when(workspaceManager.findActiveWorkspace("alice")).thenReturn(workspace);
+        when(systemRepositoryService.getPrimaryRepository()).thenReturn(primary);
+
+        RepositoryContext context = resolver.resolveRepositoryContextForUser("alice");
+
+        assertThat(context.repositoryId()).isEqualTo("primary-repo");
+        assertThat(context.workspaceId()).isEqualTo("legacy-ws");
+        assertThat(context.scope()).isEqualTo(RepositoryScope.WORKSPACE);
+    }
+
+    @Test
+    void userWithoutWorkspaceGetsExplicitPrimaryCentralReadContext() {
+        when(systemRepositoryService.getPrimaryRepository())
+                .thenReturn(repository("primary-repo", "draft"));
+
+        RepositoryContext context = resolver.resolveRepositoryContextForUser("alice");
+
+        assertThat(context.repositoryId()).isEqualTo("primary-repo");
+        assertThat(context.workspaceId()).isNull();
+        assertThat(context.branch()).isEqualTo("draft");
+        assertThat(context.username()).isEqualTo("alice");
+        assertThat(context.scope()).isEqualTo(RepositoryScope.CENTRAL_READ);
+    }
+
+    @Test
+    void repositoryResolutionFailsClosedWhenCatalogIdentityIsIncomplete() {
+        SystemRepository primary = repository(null, "draft");
+        when(systemRepositoryService.getPrimaryRepository()).thenReturn(primary);
+
+        assertThatThrownBy(() -> resolver.resolveRepositoryContextForUser("alice"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("repositoryId");
+    }
+
+    private static UserWorkspace workspace(
+            String username, String workspaceId, String branch) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setUsername(username);
+        workspace.setWorkspaceId(workspaceId);
+        workspace.setCurrentBranch(branch);
+        return workspace;
+    }
+
+    private static SystemRepository repository(String repositoryId, String branch) {
+        SystemRepository repository = new SystemRepository();
+        repository.setRepositoryId(repositoryId);
+        repository.setDefaultBranch(branch);
+        return repository;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceResolverTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceResolverTest.java
@@ -1,0 +1,86 @@
+package com.taxonomy.workspace.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WorkspaceResolverTest {
+
+    @AfterEach
+    void clearRequestAndSecurityContext() {
+        RequestContextHolder.resetRequestAttributes();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void repositoryContextIsResolvedOnceAndRemainsStableForTheRequest() {
+        WorkspaceContextResolver contextResolver = mock(WorkspaceContextResolver.class);
+        WorkspaceResolver resolver = new WorkspaceResolver(contextResolver);
+        RepositoryContext expected = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+        authenticate("alice");
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(new MockHttpServletRequest()));
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(expected);
+
+        RepositoryContext first = resolver.resolveCurrentRepositoryContext();
+        RepositoryContext second = resolver.resolveCurrentRepositoryContext();
+
+        assertThat(first).isSameAs(expected);
+        assertThat(second).isSameAs(expected);
+        verify(contextResolver, times(1)).resolveRepositoryContextForUser("alice");
+    }
+
+    @Test
+    void separateRequestsCannotReuseARepositoryContext() {
+        WorkspaceContextResolver contextResolver = mock(WorkspaceContextResolver.class);
+        WorkspaceResolver resolver = new WorkspaceResolver(contextResolver);
+        RepositoryContext firstContext = RepositoryContext.centralRead(
+                "repo-a", "main", "alice");
+        RepositoryContext secondContext = RepositoryContext.centralRead(
+                "repo-b", "main", "alice");
+        authenticate("alice");
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(firstContext, secondContext);
+
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(new MockHttpServletRequest()));
+        assertThat(resolver.resolveCurrentRepositoryContext()).isSameAs(firstContext);
+
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(new MockHttpServletRequest()));
+        assertThat(resolver.resolveCurrentRepositoryContext()).isSameAs(secondContext);
+
+        verify(contextResolver, times(2)).resolveRepositoryContextForUser("alice");
+    }
+
+    @Test
+    void unauthenticatedResolutionUsesTheConfiguredDefaultUser() {
+        WorkspaceContextResolver contextResolver = mock(WorkspaceContextResolver.class);
+        WorkspaceResolver resolver = new WorkspaceResolver(contextResolver);
+        RepositoryContext expected = RepositoryContext.centralRead(
+                "primary", "draft", WorkspaceManager.DEFAULT_USER);
+        when(contextResolver.resolveRepositoryContextForUser(WorkspaceManager.DEFAULT_USER))
+                .thenReturn(expected);
+
+        assertThat(resolver.resolveCurrentRepositoryContext()).isSameAs(expected);
+    }
+
+    private static void authenticate(String username) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(username, "n/a", List.of()));
+    }
+}


### PR DESCRIPTION
## Scope

Introduces the mandatory routing identity needed before relational projections and Hibernate Search can be made tenant-safe.

- resolves `RepositoryContext` from active workspace provenance (`sourceRepositoryId`) instead of inferring one global repository;
- returns an explicit `CENTRAL_READ` context for users without a workspace rather than reusing ambiguous `WorkspaceContext.SHARED`;
- validates repository ID, branch, workspace and scope fail-closed;
- caches the resolved repository context for one HTTP request and proves that a later request resolves independently;
- adds PostgreSQL migration V4, which binds pre-multi-repository workspaces to the only primary repository and adds the source-repository foreign key;
- proves V4 refuses ambiguous/no-primary legacy state rather than silently selecting a repository;
- retains the legacy workspace resolver only as a compatibility boundary while callers migrate.

This intentionally does not yet add `repository_id` to relational entities. It establishes the non-optional context those persistence and search changes will consume.

The exact base head `9434cb8b544117d1e6325bcab9b1f82599f6a5db` passed CI/CD, Database Compatibility, CodeQL, Security Scan and the JGit Storage Consumer Contract before this slice was merged.

Targets draft PR #610.

Part of #609
Prerequisite for #610 blockers 2, 3 and 4.