### PR TITLE
Move version-state adapter contract from Python unittest to JUnit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,18 +38,6 @@ jobs:
           distribution: temurin
           cache: maven
 
-      - name: Verify repository version state
-        shell: bash
-        run: |
-          set -euo pipefail
-          python3 .github/scripts/test-check-version-state.py
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            python3 .github/scripts/check-version-state.py \
-              --mode release --tag "${GITHUB_REF_NAME}"
-          else
-            python3 .github/scripts/check-version-state.py --mode development
-          fi
-
       - name: Verify release and delivery contracts
         shell: bash
         run: |
@@ -138,6 +126,8 @@ jobs:
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
           FRONTEND_API_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          VERSION_STATE_MODE: ${{ startsWith(github.ref, 'refs/tags/') && 'release' || 'development' }}
+          VERSION_STATE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
         shell: bash
         run: |
           mkdir -p target
@@ -178,6 +168,7 @@ jobs:
           cp -a taxonomy-coverage/target/site/jacoco-aggregate/. target/quality-reports/coverage/
           for evidence in \
             target/maven-verification.log \
+            target/version-state-report.txt \
             target/coverage-gate.txt \
             target/dependency-hygiene-report.txt \
             target/frontend-api-boundary-report.txt \

--- a/docs/dev/PYTHON_TOOLING_POLICY.md
+++ b/docs/dev/PYTHON_TOOLING_POLICY.md
@@ -28,10 +28,12 @@ one-file checker is convenient.
 | Action and production-image pinning | #683 |
 | Packaged CycloneDX dependency hygiene | #685 |
 | Frontend API transport boundaries | #687 |
+| Release version-state adapter contract | #689 |
 
 The entries after #680 remain subject to exact-head verification and ordered
-integration. Their Python implementations are removed in the corresponding
-slice rather than retained as fallback code.
+integration. Python policy implementations are removed in their corresponding
+slice. A retained adapter may remain only where the workflow boundary is the
+reason for its existence.
 
 ## Retained artifact generators and format transformers
 
@@ -64,6 +66,14 @@ release staging, deployment targets or external report formats:
 - `verify-quality-publication.py`
 - `check-codeql-sarif.py`
 - `check-observability-performance-scope.py`
+
+`check-version-state.py` is retained because `release.sh` copies it to a temporary
+location and invokes it while switching between a detached immutable release tag
+and the next-development `main`. `VersionStateAdapterContractTest` owns its
+positive and negative fixture contract, while `VersionStateRepositoryTest` owns
+the canonical checkout decision and publishes `target/version-state-report.txt`.
+The separate release workflow guard is transitional and must be removed once the
+release-flow contract tests are migrated together.
 
 This list is a temporary classification, not an allow-list for new Python.
 Core validation logic should move to JUnit/Maven-native contracts where the same

--- a/taxonomy-build/src/test/java/com/taxonomy/build/VersionStateAdapterContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/VersionStateAdapterContractTest.java
@@ -1,0 +1,247 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JUnit-owned contract tests for the retained release-state Python adapter.
+ *
+ * <p>The adapter remains because release.sh copies it into a temporary location
+ * and executes it while switching between detached release tags and the next
+ * development main. Test ownership, however, belongs to the Maven reactor.</p>
+ */
+class VersionStateAdapterContractTest {
+
+    @Test
+    void acceptsConsistentDevelopmentState(@TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+
+        AdapterResult result = run(root, "development");
+
+        assertThat(result.exitCode()).as(result.output()).isZero();
+        assertThat(result.output())
+                .contains("Repository version state is consistent")
+                .contains("1.2.9-SNAPSHOT")
+                .contains("development");
+    }
+
+    @Test
+    void acceptsConsistentReleaseStateAndExactTag(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9", true);
+
+        AdapterResult result = run(root, "release", "--tag", "v1.2.9");
+
+        assertThat(result.exitCode()).as(result.output()).isZero();
+        assertThat(result.output())
+                .contains("Repository version state is consistent")
+                .contains("1.2.9")
+                .contains("release");
+    }
+
+    @Test
+    void rejectsSnapshotOnReleasePathAndReleaseTagInDevelopmentMode(
+            @TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+
+        AdapterResult release = run(root, "release");
+        AdapterResult taggedDevelopment = run(
+                root, "development", "--tag", "v1.2.9-SNAPSHOT");
+
+        assertThat(release.exitCode()).isNotZero();
+        assertThat(release.output()).contains("not a valid release version");
+        assertThat(taggedDevelopment.exitCode()).isNotZero();
+        assertThat(taggedDevelopment.output())
+                .contains("release tag is only valid in release mode");
+    }
+
+    @Test
+    void rejectsUnexpectedReleaseTag(@TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9", true);
+
+        AdapterResult result = run(root, "release", "--tag", "v1.2.8");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("Tag 'v1.2.8' != expected 'v1.2.9'");
+    }
+
+    @Test
+    void rejectsRootChildAndHelmVersionDrift(@TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        write(root.resolve("module/pom.xml"), modulePom("1.2.8-SNAPSHOT"));
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "1.2.8-SNAPSHOT"
+                """);
+
+        AdapterResult result = run(root, "development");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("module/pom.xml parent version")
+                .contains("Helm Chart.yaml appVersion");
+    }
+
+    @Test
+    void rejectsCitationArchiveAndReleaseDateDrift(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        write(root.resolve("CITATION.cff"), """
+                version: "1.2.8-SNAPSHOT"
+                date-released: "2026-08-10"
+                """);
+        write(root.resolve(".zenodo.json"), """
+                {"version":"1.2.8-SNAPSHOT","publication_date":"2026-08-10"}
+                """);
+        write(root.resolve("codemeta.json"), """
+                {"version":"1.2.8-SNAPSHOT","datePublished":"2026-08-10"}
+                """);
+
+        AdapterResult result = run(root, "development");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("CITATION.cff version")
+                .contains("CITATION.cff release-date state")
+                .contains(".zenodo.json version")
+                .contains(".zenodo.json release-date state")
+                .contains("codemeta.json version")
+                .contains("codemeta.json release-date state");
+    }
+
+    @Test
+    void rejectsExplicitExpectedVersionMismatch(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+
+        AdapterResult result = run(
+                root,
+                "development",
+                "--expected-version",
+                "1.2.10-SNAPSHOT");
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("Root Maven version '1.2.9-SNAPSHOT'")
+                .contains("expected '1.2.10-SNAPSHOT'");
+    }
+
+    private static AdapterResult run(
+            Path fixtureRoot,
+            String mode,
+            String... extra) throws Exception {
+        Path repositoryRoot = findRepositoryRoot();
+        Path script = repositoryRoot.resolve(".github/scripts/check-version-state.py");
+        List<String> command = new ArrayList<>(List.of(
+                "python3",
+                script.toString(),
+                "--root",
+                fixtureRoot.toString(),
+                "--mode",
+                mode));
+        command.addAll(List.of(extra));
+
+        ProcessBuilder builder = new ProcessBuilder(command)
+                .directory(repositoryRoot.toFile())
+                .redirectErrorStream(true);
+        Process process = builder.start();
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        return new AdapterResult(exitCode, output);
+    }
+
+    private static void writeRepository(
+            Path root,
+            String version,
+            boolean release) throws IOException {
+        write(root.resolve("pom.xml"), rootPom(version));
+        write(root.resolve("module/pom.xml"), modulePom(version));
+
+        String releaseDate = release
+                ? "date-released: \"2026-08-10\"\n"
+                : "";
+        write(root.resolve("CITATION.cff"),
+                "version: \"" + version + "\"\n" + releaseDate);
+
+        String bibtexDate = release
+                ? "  date         = {2026-08-10},\n"
+                : "";
+        write(root.resolve("CITATION.md"),
+                "Carsten Hammer. **Taxonomy Architecture Analyzer**. Version "
+                        + version + ". 2026.\n"
+                        + "  version      = {" + version + "},\n"
+                        + bibtexDate);
+
+        write(root.resolve(".zenodo.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"publication_date\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("codemeta.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"datePublished\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "%s"
+                """.formatted(version));
+    }
+
+    private static String rootPom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version);
+    }
+
+    private static String modulePom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>%s</version>
+                  </parent>
+                  <artifactId>module</artifactId>
+                </project>
+                """.formatted(version);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve(
+                    ".github/scripts/check-version-state.py"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+
+    private static void write(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private record AdapterResult(int exitCode, String output) {
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/VersionStateRepositoryTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/VersionStateRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Executes the retained version-state release adapter against the real checkout. */
+class VersionStateRepositoryTest {
+
+    @Test
+    void repositoryMetadataMatchesTheRequestedBuildState() throws Exception {
+        Path root = findRepositoryRoot();
+        String mode = environmentOrDefault("VERSION_STATE_MODE", "development");
+        String expectedVersion = environmentOrNull("VERSION_STATE_EXPECTED_VERSION");
+        String tag = environmentOrNull("VERSION_STATE_TAG");
+
+        List<String> command = new ArrayList<>(List.of(
+                "python3",
+                root.resolve(".github/scripts/check-version-state.py").toString(),
+                "--root",
+                root.toString(),
+                "--mode",
+                mode));
+        if (expectedVersion != null) {
+            command.add("--expected-version");
+            command.add(expectedVersion);
+        }
+        if (tag != null) {
+            command.add("--tag");
+            command.add(tag);
+        }
+
+        Process process = new ProcessBuilder(command)
+                .directory(root.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+
+        Path report = root.resolve("target/version-state-report.txt");
+        Files.createDirectories(report.getParent());
+        Files.writeString(report, output, StandardCharsets.UTF_8);
+        System.out.print(output);
+
+        assertThat(exitCode)
+                .as("repository version state; inspect %s%n%s", report, output)
+                .isZero();
+    }
+
+    private static String environmentOrDefault(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? fallback : value.strip();
+    }
+
+    private static String environmentOrNull(String name) {
+        String value = System.getenv(name);
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve(
+                    ".github/scripts/check-version-state.py"))
+                    && Files.isRegularFile(current.resolve("pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Scope

Eighth bounded slice of #673, stacked on #687. The retained `check-version-state.py` release adapter is tested and invoked in canonical verification under JUnit authority rather than by a Python `unittest` preflight.

### Changes

- adds `VersionStateAdapterContractTest` with isolated development/release fixtures;
- covers exact release tags, snapshot rejection on release paths, release tags in development mode, unexpected tags, root/child POM drift, Helm drift, citation/archive version and date drift, and explicit expected-version mismatch;
- adds `VersionStateRepositoryTest`, which executes the same adapter against the real checkout from canonical Maven/JUnit verification;
- passes `VERSION_STATE_MODE` and optional `VERSION_STATE_TAG` into the canonical Maven step;
- writes `target/version-state-report.txt` and stages it with verified quality evidence;
- removes the separate Python version-state test/check step from ordinary CI;
- documents the bounded adapter rationale and JUnit ownership in `PYTHON_TOOLING_POLICY.md`.

### Why the adapter remains

`release.sh` copies the helper into a temporary directory and executes it while moving between a detached immutable release tag and the next-development `main`. Keeping a standalone adapter at this workflow boundary is currently less fragile than bootstrapping a project JAR after each metadata transition. The Python test suite is not retained as the authority.

### Stack integrity

The branch was merged forward without rewriting history onto final #687 exact head `98b05a2ac12f005c9bb16ff4210c1906776f1831`. Current exact head `a15354132c9b92eddadcc3862be64785ebcf0c33` adds only four intended files relative to #687:

- `.github/workflows/ci-cd.yml`;
- `docs/dev/PYTHON_TOOLING_POLICY.md`;
- `VersionStateAdapterContractTest`;
- `VersionStateRepositoryTest`.

The earlier CodeMirror regression remains excluded. #687's complete evidence correction is present, including zero-count files, deleted JavaScript/template files, and the `index.html` transport ratchet. No review thread is open.

### Transitional release boundary

The release workflow still invokes its historic Python unit guard before the release state machine. Separate bounded follow-up #712 removes that duplicate invocation and test file while retaining the productive adapter and adding a JUnit ratchet. This PR does not make that release-path change implicitly.

### Verification

Checkpoint #690 tests the exact combined head against current `1.4.0-SNAPSHOT` main `d59cfca21794113778c8791dfe7dcdbf126d97e1`. All earlier results are historical after the stack refresh.

Merge only after #687 exact head `98b05a2ac12f005c9bb16ff4210c1906776f1831` is integrated, this PR is retargeted to the resulting `main`, and a fresh exact-head matrix is fully green.

Advances #673.