### PR TITLE
Make relation DSL transformations deterministic before Git commands

### DIFF
--- a/taxonomy-dsl/src/main/java/com/taxonomy/dsl/command/ArchitectureRelationDslTransformer.java
+++ b/taxonomy-dsl/src/main/java/com/taxonomy/dsl/command/ArchitectureRelationDslTransformer.java
@@ -1,0 +1,358 @@
+package com.taxonomy.dsl.command;
+
+import com.taxonomy.dsl.ast.BlockAst;
+import com.taxonomy.dsl.ast.DocumentAst;
+import com.taxonomy.dsl.ast.PropertyAst;
+import com.taxonomy.dsl.parser.TaxDslParser;
+import com.taxonomy.dsl.serializer.TaxDslSerializer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Applies one deterministic relation command to an {@code architecture.taxdsl}
+ * document before the result is committed to JGit.
+ *
+ * <p>The transformer is deliberately independent of repositories, transactions,
+ * controllers and projections. It establishes the pure semantic boundary needed
+ * by Git-authoritative relation commands: exact identity, idempotent upsert,
+ * exact removal, duplicate rejection and canonical changed output.</p>
+ */
+public final class ArchitectureRelationDslTransformer {
+
+    private static final String RELATION_KIND = "relation";
+    private static final List<String> MUTABLE_PROPERTY_ORDER = List.of(
+            "status", "confidence", "provenance");
+
+    private final TaxDslParser parser;
+    private final TaxDslSerializer serializer;
+
+    public ArchitectureRelationDslTransformer() {
+        this(new TaxDslParser(), new TaxDslSerializer());
+    }
+
+    ArchitectureRelationDslTransformer(
+            TaxDslParser parser,
+            TaxDslSerializer serializer) {
+        this.parser = Objects.requireNonNull(parser, "parser");
+        this.serializer = Objects.requireNonNull(serializer, "serializer");
+    }
+
+    /**
+     * Adds the relation when absent or updates only the supplied review fields
+     * and extensions when exactly one matching relation exists.
+     */
+    public ChangeResult upsert(String sourceDsl, RelationDefinition definition) {
+        Objects.requireNonNull(definition, "definition");
+        String original = sourceDsl == null ? "" : sourceDsl;
+        DocumentAst document = parser.parse(original, "architecture.taxdsl");
+        List<Integer> matches = matchingIndexes(
+                document.getBlocks(), definition.identity());
+        rejectAmbiguity(definition.identity(), matches.size());
+
+        List<BlockAst> changedBlocks = new ArrayList<>(document.getBlocks());
+        if (matches.isEmpty()) {
+            changedBlocks.add(newRelationBlock(definition));
+            return changed(document, changedBlocks, ChangeKind.ADDED);
+        }
+
+        int index = matches.getFirst();
+        BlockAst existing = changedBlocks.get(index);
+        requireCanonicalHeader(existing, definition.identity());
+        BlockAst replacement = merge(existing, definition);
+        if (canonicalBlock(existing).equals(canonicalBlock(replacement))) {
+            return new ChangeResult(original, ChangeKind.UNCHANGED);
+        }
+        changedBlocks.set(index, replacement);
+        return changed(document, changedBlocks, ChangeKind.UPDATED);
+    }
+
+    /** Removes exactly one matching relation and leaves all other blocks intact. */
+    public ChangeResult remove(String sourceDsl, RelationIdentity identity) {
+        Objects.requireNonNull(identity, "identity");
+        String original = sourceDsl == null ? "" : sourceDsl;
+        DocumentAst document = parser.parse(original, "architecture.taxdsl");
+        List<Integer> matches = matchingIndexes(document.getBlocks(), identity);
+        rejectAmbiguity(identity, matches.size());
+        if (matches.isEmpty()) {
+            return new ChangeResult(original, ChangeKind.UNCHANGED);
+        }
+
+        int index = matches.getFirst();
+        requireCanonicalHeader(document.getBlocks().get(index), identity);
+        List<BlockAst> changedBlocks = new ArrayList<>(document.getBlocks());
+        changedBlocks.remove(index);
+        return changed(document, changedBlocks, ChangeKind.REMOVED);
+    }
+
+    private ChangeResult changed(
+            DocumentAst original,
+            List<BlockAst> blocks,
+            ChangeKind kind) {
+        DocumentAst changed = new DocumentAst(original.getMeta(), blocks);
+        return new ChangeResult(serializer.serialize(changed), kind);
+    }
+
+    private BlockAst newRelationBlock(RelationDefinition definition) {
+        List<PropertyAst> properties = new ArrayList<>();
+        addSuppliedProperties(properties, definition);
+        return new BlockAst(
+                RELATION_KIND,
+                definition.identity().headerTokens(),
+                properties,
+                List.of(),
+                extensionMap(properties),
+                null);
+    }
+
+    private BlockAst merge(
+            BlockAst existing,
+            RelationDefinition definition) {
+        Map<String, String> overrides = suppliedProperties(definition);
+        List<PropertyAst> properties = new ArrayList<>();
+        Set<String> emittedOverrides = new LinkedHashSet<>();
+
+        for (PropertyAst property : existing.getProperties()) {
+            String key = property.key();
+            if (!overrides.containsKey(key)) {
+                properties.add(property);
+                continue;
+            }
+            if (emittedOverrides.add(key)) {
+                properties.add(new PropertyAst(key, overrides.get(key), null));
+            }
+        }
+
+        MUTABLE_PROPERTY_ORDER.stream()
+                .filter(overrides::containsKey)
+                .filter(emittedOverrides::add)
+                .forEach(key -> properties.add(
+                        new PropertyAst(key, overrides.get(key), null)));
+        overrides.keySet().stream()
+                .filter(key -> key.startsWith("x-"))
+                .sorted()
+                .filter(emittedOverrides::add)
+                .forEach(key -> properties.add(
+                        new PropertyAst(key, overrides.get(key), null)));
+
+        return new BlockAst(
+                RELATION_KIND,
+                definition.identity().headerTokens(),
+                properties,
+                existing.getChildren(),
+                extensionMap(properties),
+                existing.getSourceLocation());
+    }
+
+    private void addSuppliedProperties(
+            List<PropertyAst> properties,
+            RelationDefinition definition) {
+        Map<String, String> supplied = suppliedProperties(definition);
+        MUTABLE_PROPERTY_ORDER.stream()
+                .filter(supplied::containsKey)
+                .forEach(key -> properties.add(
+                        new PropertyAst(key, supplied.get(key), null)));
+        supplied.keySet().stream()
+                .filter(key -> key.startsWith("x-"))
+                .sorted()
+                .forEach(key -> properties.add(
+                        new PropertyAst(key, supplied.get(key), null)));
+    }
+
+    private Map<String, String> suppliedProperties(
+            RelationDefinition definition) {
+        Map<String, String> supplied = new LinkedHashMap<>();
+        if (definition.status() != null) {
+            supplied.put("status", definition.status());
+        }
+        if (definition.confidence() != null) {
+            supplied.put("confidence", String.valueOf(definition.confidence()));
+        }
+        if (definition.provenance() != null) {
+            supplied.put("provenance", definition.provenance());
+        }
+        supplied.putAll(definition.extensions());
+        return supplied;
+    }
+
+    private Map<String, String> extensionMap(List<PropertyAst> properties) {
+        Map<String, String> extensions = new LinkedHashMap<>();
+        properties.stream()
+                .filter(PropertyAst::isExtension)
+                .forEach(property -> extensions.put(
+                        property.key(), property.value()));
+        return extensions;
+    }
+
+    private List<Integer> matchingIndexes(
+            List<BlockAst> blocks,
+            RelationIdentity identity) {
+        List<Integer> matches = new ArrayList<>();
+        for (int index = 0; index < blocks.size(); index++) {
+            BlockAst block = blocks.get(index);
+            if (RELATION_KIND.equals(block.getKind())
+                    && headerStartsWith(block, identity)) {
+                matches.add(index);
+            }
+        }
+        return matches;
+    }
+
+    private boolean headerStartsWith(
+            BlockAst block,
+            RelationIdentity identity) {
+        List<String> tokens = block.getHeaderTokens();
+        return tokens.size() >= 3
+                && identity.sourceId().equals(tokens.get(0))
+                && identity.relationType().equals(tokens.get(1))
+                && identity.targetId().equals(tokens.get(2));
+    }
+
+    private void requireCanonicalHeader(
+            BlockAst block,
+            RelationIdentity identity) {
+        if (block.getHeaderTokens().size() != 3) {
+            throw new InvalidRelationBlockException(
+                    "Relation " + identity.asDisplayText()
+                            + " has a malformed header with "
+                            + block.getHeaderTokens().size() + " tokens");
+        }
+    }
+
+    private void rejectAmbiguity(RelationIdentity identity, int matches) {
+        if (matches > 1) {
+            throw new AmbiguousRelationException(
+                    "Relation " + identity.asDisplayText()
+                            + " occurs " + matches + " times");
+        }
+    }
+
+    private String canonicalBlock(BlockAst block) {
+        return serializer.serialize(new DocumentAst(null, List.of(block)));
+    }
+
+    public enum ChangeKind {
+        ADDED,
+        UPDATED,
+        REMOVED,
+        UNCHANGED
+    }
+
+    public record ChangeResult(String dsl, ChangeKind kind) {
+        public ChangeResult {
+            dsl = Objects.requireNonNull(dsl, "dsl");
+            kind = Objects.requireNonNull(kind, "kind");
+        }
+
+        public boolean changed() {
+            return kind != ChangeKind.UNCHANGED;
+        }
+    }
+
+    public record RelationIdentity(
+            String sourceId,
+            String relationType,
+            String targetId) {
+
+        public RelationIdentity {
+            sourceId = requireToken(sourceId, "sourceId");
+            relationType = requireToken(relationType, "relationType")
+                    .toUpperCase(Locale.ROOT);
+            targetId = requireToken(targetId, "targetId");
+        }
+
+        List<String> headerTokens() {
+            return List.of(sourceId, relationType, targetId);
+        }
+
+        String asDisplayText() {
+            return sourceId + " " + relationType + " " + targetId;
+        }
+    }
+
+    public record RelationDefinition(
+            RelationIdentity identity,
+            String status,
+            Double confidence,
+            String provenance,
+            Map<String, String> extensions) {
+
+        public RelationDefinition {
+            identity = Objects.requireNonNull(identity, "identity");
+            status = normalizeOptionalToken(status, "status");
+            provenance = normalizeOptionalToken(provenance, "provenance");
+            if (confidence != null
+                    && (!Double.isFinite(confidence)
+                    || confidence < 0.0
+                    || confidence > 1.0)) {
+                throw new IllegalArgumentException(
+                        "confidence must be finite and between 0.0 and 1.0");
+            }
+            Map<String, String> normalizedExtensions = new TreeMap<>();
+            if (extensions != null) {
+                extensions.forEach((key, value) -> {
+                    String normalizedKey = requireToken(key, "extension key");
+                    if (!normalizedKey.startsWith("x-")) {
+                        throw new IllegalArgumentException(
+                                "extension key must start with x-: " + normalizedKey);
+                    }
+                    normalizedExtensions.put(
+                            normalizedKey,
+                            Objects.requireNonNull(value,
+                                    "extension value for " + normalizedKey));
+                });
+            }
+            extensions = Map.copyOf(normalizedExtensions);
+        }
+
+        public RelationDefinition(
+                RelationIdentity identity,
+                String status,
+                Double confidence,
+                String provenance) {
+            this(identity, status, confidence, provenance, Map.of());
+        }
+    }
+
+    public static final class AmbiguousRelationException
+            extends IllegalStateException {
+        public AmbiguousRelationException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class InvalidRelationBlockException
+            extends IllegalStateException {
+        public InvalidRelationBlockException(String message) {
+            super(message);
+        }
+    }
+
+    private static String requireToken(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        String normalized = value.strip();
+        if (normalized.chars().anyMatch(Character::isWhitespace)) {
+            throw new IllegalArgumentException(
+                    field + " must be one DSL token: " + normalized);
+        }
+        return normalized;
+    }
+
+    private static String normalizeOptionalToken(
+            String value,
+            String field) {
+        if (value == null) {
+            return null;
+        }
+        return requireToken(value, field).toLowerCase(Locale.ROOT);
+    }
+}

--- a/taxonomy-dsl/src/test/java/com/taxonomy/dsl/command/ArchitectureRelationDslTransformerTest.java
+++ b/taxonomy-dsl/src/test/java/com/taxonomy/dsl/command/ArchitectureRelationDslTransformerTest.java
@@ -1,0 +1,217 @@
+package com.taxonomy.dsl.command;
+
+import com.taxonomy.dsl.ast.BlockAst;
+import com.taxonomy.dsl.ast.DocumentAst;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.AmbiguousRelationException;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.InvalidRelationBlockException;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dsl.parser.TaxDslParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ArchitectureRelationDslTransformerTest {
+
+    private final ArchitectureRelationDslTransformer transformer =
+            new ArchitectureRelationDslTransformer();
+    private final TaxDslParser parser = new TaxDslParser();
+
+    @Test
+    void addsRelationAndPreservesUnrelatedAndUnknownBlocks() {
+        String input = """
+                meta {
+                  language: "taxdsl";
+                  version: "2.0";
+                  namespace: "test";
+                }
+
+                element APP-1 type Application {
+                  title: "Payments";
+                }
+
+                futureBlock FUTURE-1 {
+                  x-owner: "architecture";
+                }
+                """;
+        RelationIdentity identity = new RelationIdentity(
+                "APP-1", "uses", "SVC-1");
+        RelationDefinition relation = new RelationDefinition(
+                identity,
+                "accepted",
+                0.8,
+                "manual",
+                Map.of("x-decision-id", "DEC-17"));
+
+        var result = transformer.upsert(input, relation);
+
+        assertThat(result.kind()).isEqualTo(ChangeKind.ADDED);
+        assertThat(result.changed()).isTrue();
+        DocumentAst document = parser.parse(result.dsl());
+        assertThat(document.getMeta().namespace()).isEqualTo("test");
+        assertThat(document.blocksOfKind("element")).hasSize(1);
+        assertThat(document.blocksOfKind("futureBlock")).hasSize(1);
+        BlockAst added = document.blocksOfKind("relation").getFirst();
+        assertThat(added.getHeaderTokens())
+                .containsExactly("APP-1", "USES", "SVC-1");
+        assertThat(added.property("status")).isEqualTo("accepted");
+        assertThat(added.property("confidence")).isEqualTo("0.8");
+        assertThat(added.property("provenance")).isEqualTo("manual");
+        assertThat(added.property("x-decision-id")).isEqualTo("DEC-17");
+    }
+
+    @Test
+    void equivalentUpsertIsANoOpAndReturnsTheOriginalBytes() {
+        String input = """
+                relation APP-1 USES SVC-1 {
+                    provenance: manual;
+                    confidence: 0.8;
+                    status: accepted;
+                }
+                """;
+        RelationDefinition relation = new RelationDefinition(
+                new RelationIdentity("APP-1", "USES", "SVC-1"),
+                "accepted",
+                0.8,
+                "manual");
+
+        var result = transformer.upsert(input, relation);
+
+        assertThat(result.kind()).isEqualTo(ChangeKind.UNCHANGED);
+        assertThat(result.changed()).isFalse();
+        assertThat(result.dsl()).isSameAs(input);
+    }
+
+    @Test
+    void updatesSuppliedReviewFieldsAndPreservesOtherProperties() {
+        String input = """
+                relation APP-1 USES SVC-1 {
+                  status: proposed;
+                  confidence: 0.55;
+                  provenance: imported;
+                  review-note: "retain me";
+                  x-source-id: "proposal-9";
+                }
+                """;
+        RelationDefinition relation = new RelationDefinition(
+                new RelationIdentity("APP-1", "USES", "SVC-1"),
+                "accepted",
+                0.9,
+                "manual",
+                Map.of("x-decision-id", "decision-2"));
+
+        var result = transformer.upsert(input, relation);
+
+        assertThat(result.kind()).isEqualTo(ChangeKind.UPDATED);
+        BlockAst updated = parser.parse(result.dsl())
+                .blocksOfKind("relation").getFirst();
+        assertThat(updated.propertyValues("status"))
+                .containsExactly("accepted");
+        assertThat(updated.propertyValues("confidence"))
+                .containsExactly("0.9");
+        assertThat(updated.property("provenance")).isEqualTo("manual");
+        assertThat(updated.property("review-note")).isEqualTo("retain me");
+        assertThat(updated.property("x-source-id")).isEqualTo("proposal-9");
+        assertThat(updated.property("x-decision-id")).isEqualTo("decision-2");
+    }
+
+    @Test
+    void removesOnlyTheExactRelation() {
+        String input = """
+                relation APP-1 USES SVC-1 {
+                  status: accepted;
+                }
+
+                relation APP-1 USES SVC-2 {
+                  status: accepted;
+                }
+                """;
+
+        var result = transformer.remove(
+                input, new RelationIdentity("APP-1", "USES", "SVC-1"));
+
+        assertThat(result.kind()).isEqualTo(ChangeKind.REMOVED);
+        assertThat(parser.parse(result.dsl()).blocksOfKind("relation"))
+                .singleElement()
+                .extracting(BlockAst::getHeaderTokens)
+                .isEqualTo(java.util.List.of("APP-1", "USES", "SVC-2"));
+    }
+
+    @Test
+    void absentRemovalIsANoOp() {
+        String input = "element APP-1 type Application {\n}\n";
+
+        var result = transformer.remove(
+                input, new RelationIdentity("APP-1", "USES", "SVC-1"));
+
+        assertThat(result.kind()).isEqualTo(ChangeKind.UNCHANGED);
+        assertThat(result.dsl()).isSameAs(input);
+    }
+
+    @Test
+    void rejectsAmbiguousDuplicateRelationsForUpsertAndRemoval() {
+        String input = """
+                relation APP-1 USES SVC-1 {
+                  status: proposed;
+                }
+
+                relation APP-1 USES SVC-1 {
+                  status: accepted;
+                }
+                """;
+        RelationIdentity identity = new RelationIdentity(
+                "APP-1", "USES", "SVC-1");
+
+        assertThatThrownBy(() -> transformer.upsert(
+                input,
+                new RelationDefinition(identity, "accepted", null, null)))
+                .isInstanceOf(AmbiguousRelationException.class)
+                .hasMessageContaining("occurs 2 times");
+        assertThatThrownBy(() -> transformer.remove(input, identity))
+                .isInstanceOf(AmbiguousRelationException.class)
+                .hasMessageContaining("occurs 2 times");
+    }
+
+    @Test
+    void rejectsMalformedMatchingRelationHeader() {
+        String input = """
+                relation APP-1 USES SVC-1 unexpected-token {
+                  status: proposed;
+                }
+                """;
+
+        assertThatThrownBy(() -> transformer.upsert(
+                input,
+                new RelationDefinition(
+                        new RelationIdentity("APP-1", "USES", "SVC-1"),
+                        "accepted",
+                        null,
+                        null)))
+                .isInstanceOf(InvalidRelationBlockException.class)
+                .hasMessageContaining("malformed header");
+    }
+
+    @Test
+    void validatesCommandTokensConfidenceAndExtensionKeys() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RelationIdentity(
+                        "APP 1", "USES", "SVC-1"))
+                .withMessageContaining("one DSL token");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RelationDefinition(
+                        new RelationIdentity("APP-1", "USES", "SVC-1"),
+                        "accepted", 1.1, "manual"))
+                .withMessageContaining("between 0.0 and 1.0");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new RelationDefinition(
+                        new RelationIdentity("APP-1", "USES", "SVC-1"),
+                        "accepted", 0.8, "manual",
+                        Map.of("decision-id", "17")))
+                .withMessageContaining("must start with x-");
+    }
+}


### PR DESCRIPTION
## Scope

First bounded implementation slice of #691, stacked on the #610 multi-repository integration branch. It establishes the pure TaxDSL transformation boundary required before relation review actions can become Git-authoritative.

### Changes

- adds `ArchitectureRelationDslTransformer` in the dependency-light `taxonomy-dsl` module;
- models exact relation identity as source, normalized relation type, and target;
- supports deterministic add, supplied-field update, exact remove, and semantic no-op;
- returns the original bytes for a no-op so an equivalent command cannot create a formatting-only Git commit;
- preserves unrelated, unknown, and extension blocks/properties during changed canonical serialization;
- preserves unsupplied relation properties while replacing duplicate supplied fields with one canonical value;
- rejects duplicate exact relations rather than choosing one arbitrarily;
- rejects malformed matching headers, invalid DSL tokens, out-of-range confidence, and non-`x-` extension keys;
- adds JUnit coverage for add/update/remove/idempotency, preservation, ambiguity, malformed input, and validation.

### Authority boundary

This PR deliberately does **not** touch JGit, controllers, repositories, or relational projections yet. The transformer is the deterministic command kernel that the next slice will combine with expected-head JGit commits and projection materialisation. Database-first relation review paths remain unchanged until that transaction boundary has executable failure and concurrency evidence.

## Stacking and merge policy

Base: `copilot/architecture-epic-multi-repo` (#610). This PR remains draft until its exact head passes the required gates. It advances #691 and #609 but does not complete either issue.