### PR TITLE
Enforce expected branch heads for authoritative DSL commits

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
@@ -1,0 +1,205 @@
+package com.taxonomy.dsl.storage;
+
+import org.eclipse.jgit.lib.CommitBuilder;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectInserter;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.TreeFormatter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Creates one DSL commit only when the selected branch still has the caller's
+ * expected head.
+ *
+ * <p>The comparison is performed both before object insertion and atomically by
+ * JGit's ref update. A concurrent change can therefore never be adopted as an
+ * implicit parent of a relation command. Inserted objects may become unreachable
+ * after a race, which is normal Git behaviour; the branch remains untouched.</p>
+ */
+public final class ExpectedHeadDslCommitter {
+
+    public CommitResult commit(
+            DslGitRepository dslRepository,
+            CommitRequest request) throws IOException {
+        Objects.requireNonNull(dslRepository, "dslRepository");
+        Objects.requireNonNull(request, "request");
+
+        Repository repository = dslRepository.getGitRepository();
+        String refName = Constants.R_HEADS + request.branch();
+        Ref branchRef = repository.getRefDatabase().exactRef(refName);
+        ObjectId actualHead = branchRef == null || branchRef.getObjectId() == null
+                ? ObjectId.zeroId()
+                : branchRef.getObjectId();
+        ObjectId expectedHead = request.expectedHeadObjectId();
+        if (!actualHead.equals(expectedHead)) {
+            throw conflict(request.branch(), expectedHead, actualHead, null);
+        }
+
+        PersonIdent actor = personIdent(request.author());
+        try (ObjectInserter inserter = repository.newObjectInserter()) {
+            ObjectId blobId = inserter.insert(
+                    Constants.OBJ_BLOB,
+                    request.dslText().getBytes(StandardCharsets.UTF_8));
+            TreeFormatter tree = new TreeFormatter();
+            tree.append(DslGitRepository.DSL_FILENAME,
+                    FileMode.REGULAR_FILE, blobId);
+            ObjectId treeId = inserter.insert(tree);
+
+            CommitBuilder commit = new CommitBuilder();
+            commit.setTreeId(treeId);
+            commit.setAuthor(actor);
+            commit.setCommitter(actor);
+            commit.setMessage(request.message());
+            if (!ObjectId.zeroId().equals(expectedHead)) {
+                commit.setParentId(expectedHead);
+            }
+
+            ObjectId commitId = inserter.insert(commit);
+            inserter.flush();
+
+            RefUpdate update = repository.updateRef(refName);
+            update.setNewObjectId(commitId);
+            update.setExpectedOldObjectId(expectedHead);
+            update.setForceUpdate(false);
+            update.setRefLogIdent(actor);
+            update.setRefLogMessage("commit: " + request.message(), true);
+            RefUpdate.Result result = update.update();
+            switch (result) {
+                case NEW, FAST_FORWARD, FORCED -> {
+                    return new CommitResult(
+                            commitId.name(),
+                            headName(expectedHead),
+                            result);
+                }
+                case LOCK_FAILURE, REJECTED, REJECTED_CURRENT_BRANCH -> {
+                    ObjectId currentHead = currentHead(repository, refName);
+                    throw conflict(
+                            request.branch(), expectedHead, currentHead, result);
+                }
+                default -> throw new IOException(
+                        "Ref update failed for " + refName + ": " + result);
+            }
+        }
+    }
+
+    private static ObjectId currentHead(
+            Repository repository,
+            String refName) throws IOException {
+        Ref current = repository.getRefDatabase().exactRef(refName);
+        return current == null || current.getObjectId() == null
+                ? ObjectId.zeroId()
+                : current.getObjectId();
+    }
+
+    private static BranchHeadConflictException conflict(
+            String branch,
+            ObjectId expected,
+            ObjectId actual,
+            RefUpdate.Result result) {
+        String suffix = result == null ? "" : " (ref update: " + result + ")";
+        return new BranchHeadConflictException(
+                branch,
+                headName(expected),
+                headName(actual),
+                "Branch '" + branch + "' moved: expected "
+                        + headName(expected) + ", actual " + headName(actual)
+                        + suffix);
+    }
+
+    private static String headName(ObjectId id) {
+        return id == null || ObjectId.zeroId().equals(id) ? null : id.name();
+    }
+
+    private static PersonIdent personIdent(String author) {
+        String normalized = author == null || author.isBlank()
+                ? "taxonomy"
+                : author.strip();
+        String email = normalized.contains("@")
+                ? normalized
+                : normalized + "@taxonomy.local";
+        return new PersonIdent(normalized, email);
+    }
+
+    public record CommitRequest(
+            String branch,
+            String expectedHeadCommit,
+            String dslText,
+            String author,
+            String message) {
+
+        public CommitRequest {
+            if (branch == null || branch.isBlank()) {
+                throw new IllegalArgumentException("branch must not be blank");
+            }
+            branch = branch.strip();
+            if (!Repository.isValidRefName(Constants.R_HEADS + branch)) {
+                throw new IllegalArgumentException(
+                        "invalid branch name: " + branch);
+            }
+            if (expectedHeadCommit != null) {
+                expectedHeadCommit = expectedHeadCommit.strip();
+                if (expectedHeadCommit.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "expectedHeadCommit must be null or a full commit ID");
+                }
+                ObjectId.fromString(expectedHeadCommit);
+            }
+            dslText = Objects.requireNonNull(dslText, "dslText");
+            author = author == null || author.isBlank()
+                    ? "taxonomy"
+                    : author.strip();
+            message = message == null || message.isBlank()
+                    ? "DSL update"
+                    : message.strip();
+        }
+
+        ObjectId expectedHeadObjectId() {
+            return expectedHeadCommit == null
+                    ? ObjectId.zeroId()
+                    : ObjectId.fromString(expectedHeadCommit);
+        }
+    }
+
+    public record CommitResult(
+            String commitId,
+            String previousHeadCommit,
+            RefUpdate.Result refUpdateResult) {
+    }
+
+    public static final class BranchHeadConflictException extends IOException {
+        private final String branch;
+        private final String expectedHeadCommit;
+        private final String actualHeadCommit;
+
+        BranchHeadConflictException(
+                String branch,
+                String expectedHeadCommit,
+                String actualHeadCommit,
+                String message) {
+            super(message);
+            this.branch = branch;
+            this.expectedHeadCommit = expectedHeadCommit;
+            this.actualHeadCommit = actualHeadCommit;
+        }
+
+        public String getBranch() {
+            return branch;
+        }
+
+        public String getExpectedHeadCommit() {
+            return expectedHeadCommit;
+        }
+
+        public String getActualHeadCommit() {
+            return actualHeadCommit;
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitterTest.java
@@ -1,0 +1,166 @@
+package com.taxonomy.dsl.storage;
+
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.CommitRequest;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.RefUpdate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ExpectedHeadDslCommitterTest {
+
+    private final ExpectedHeadDslCommitter committer =
+            new ExpectedHeadDslCommitter();
+
+    @Test
+    void createsInitialAndChildCommitsOnlyAtTheExpectedHead() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            var initial = committer.commit(repository, new CommitRequest(
+                    "draft",
+                    null,
+                    "meta {\n  language: \"taxdsl\";\n}\n",
+                    "alice",
+                    "Initialize architecture"));
+
+            assertThat(initial.previousHeadCommit()).isNull();
+            assertThat(initial.refUpdateResult()).isEqualTo(RefUpdate.Result.NEW);
+            assertThat(repository.getHeadCommit("draft"))
+                    .isEqualTo(initial.commitId());
+
+            var child = committer.commit(repository, new CommitRequest(
+                    "draft",
+                    initial.commitId(),
+                    "element APP-1 type Application {\n}\n",
+                    "alice",
+                    "Add APP-1"));
+
+            assertThat(child.previousHeadCommit())
+                    .isEqualTo(initial.commitId());
+            assertThat(child.refUpdateResult())
+                    .isEqualTo(RefUpdate.Result.FAST_FORWARD);
+            assertThat(repository.getHeadCommit("draft"))
+                    .isEqualTo(child.commitId());
+            assertThat(repository.getDslAtHead("draft"))
+                    .contains("element APP-1 type Application");
+            assertThat(repository.getCommitCount("draft")).isEqualTo(2);
+            assertThat(repository.getHeadCommitInfo("draft").author())
+                    .isEqualTo("alice");
+        }
+    }
+
+    @Test
+    void rejectsAStaleExpectedHeadWithoutChangingTheBranch() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            String initial = committer.commit(repository, new CommitRequest(
+                    "draft", null, "meta {\n}\n", "alice", "Initial"))
+                    .commitId();
+            String competing = repository.commitDsl(
+                    "draft",
+                    "element OTHER-1 type Application {\n}\n",
+                    "bob",
+                    "Concurrent edit");
+
+            assertThatThrownBy(() -> committer.commit(repository, new CommitRequest(
+                    "draft",
+                    initial,
+                    "element APP-1 type Application {\n}\n",
+                    "alice",
+                    "Stale command")))
+                    .isInstanceOfSatisfying(
+                            BranchHeadConflictException.class,
+                            conflict -> {
+                                assertThat(conflict.getBranch()).isEqualTo("draft");
+                                assertThat(conflict.getExpectedHeadCommit())
+                                        .isEqualTo(initial);
+                                assertThat(conflict.getActualHeadCommit())
+                                        .isEqualTo(competing);
+                            });
+
+            assertThat(repository.getHeadCommit("draft")).isEqualTo(competing);
+            assertThat(repository.getDslAtHead("draft"))
+                    .contains("OTHER-1")
+                    .doesNotContain("APP-1");
+            assertThat(repository.getCommitCount("draft")).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void distinguishesAbsentBranchFromAnExistingBranch() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            String nonexistentExpected = ObjectId.fromString(
+                    "1111111111111111111111111111111111111111").name();
+
+            assertThatThrownBy(() -> committer.commit(repository, new CommitRequest(
+                    "draft",
+                    nonexistentExpected,
+                    "meta {\n}\n",
+                    "alice",
+                    "Unexpected parent")))
+                    .isInstanceOfSatisfying(
+                            BranchHeadConflictException.class,
+                            conflict -> {
+                                assertThat(conflict.getExpectedHeadCommit())
+                                        .isEqualTo(nonexistentExpected);
+                                assertThat(conflict.getActualHeadCommit()).isNull();
+                            });
+
+            String initial = committer.commit(repository, new CommitRequest(
+                    "draft", null, "meta {\n}\n", "alice", "Initial"))
+                    .commitId();
+            assertThatThrownBy(() -> committer.commit(repository, new CommitRequest(
+                    "draft",
+                    null,
+                    "element APP-1 type Application {\n}\n",
+                    "alice",
+                    "Unexpected initial command")))
+                    .isInstanceOfSatisfying(
+                            BranchHeadConflictException.class,
+                            conflict -> {
+                                assertThat(conflict.getExpectedHeadCommit()).isNull();
+                                assertThat(conflict.getActualHeadCommit())
+                                        .isEqualTo(initial);
+                            });
+        }
+    }
+
+    @Test
+    void validatesBranchExpectedCommitAndRequiredContent() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CommitRequest(
+                        " ", null, "dsl", "alice", "message"))
+                .withMessageContaining("branch must not be blank");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CommitRequest(
+                        "bad branch", null, "dsl", "alice", "message"))
+                .withMessageContaining("invalid branch name");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CommitRequest(
+                        "draft", " ", "dsl", "alice", "message"))
+                .withMessageContaining("must be null or a full commit ID");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CommitRequest(
+                        "draft", "not-a-commit", "dsl", "alice", "message"));
+        assertThatThrownBy(() -> new CommitRequest(
+                "draft", null, null, "alice", "message"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("dslText");
+    }
+
+    @Test
+    void normalizesDefaultAuthorAndMessage() throws Exception {
+        try (DslGitRepository repository = new DslGitRepository()) {
+            var result = committer.commit(repository, new CommitRequest(
+                    " draft ", null, "meta {\n}\n", " ", " "));
+
+            assertThat(repository.getHeadCommit("draft"))
+                    .isEqualTo(result.commitId());
+            assertThat(repository.getHeadCommitInfo("draft").author())
+                    .isEqualTo("taxonomy");
+            assertThat(repository.getHeadCommitInfo("draft").message())
+                    .isEqualTo("DSL update");
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Second bounded slice of #691, stacked on #692. It adds the atomic JGit precondition required before relation commands can safely commit transformed `architecture.taxdsl` content.

### Changes

- adds `ExpectedHeadDslCommitter` around the selected `DslGitRepository`;
- distinguishes an absent branch (`expectedHeadCommit == null`) from an existing branch with an exact full commit ID;
- checks the expected head before object insertion and again atomically through `RefUpdate.setExpectedOldObjectId`;
- never adopts a concurrent branch update as an implicit parent;
- returns the new commit ID, previous head and JGit ref-update result;
- exposes a typed `BranchHeadConflictException` carrying branch, expected head and actual head for later HTTP 409 mapping;
- validates branch names, expected commit IDs, required DSL content, author and commit message defaults;
- adds in-memory JGit tests for initial and child commits, stale commands, absent/existing branch distinctions, validation and persisted author/message metadata.

### Failure boundary

A conflict leaves the branch and its reachable history unchanged. Git may retain unreachable inserted objects after a race, which is normal and garbage-collectable; no projection or relational mutation is introduced in this slice.

## Stacking and merge policy

Base: #692 (`feat/git-authoritative-relation-commands`). Retarget only after the deterministic transformer slice is integrated into #610. This PR remains draft until exact-head verification is green.

Advances #691 and #609; projection materialisation and DB-first call-site replacement remain separate slices.