### PR TITLE
Execute relation commands against the explicit repository context

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
@@ -34,11 +34,8 @@ public final class ExpectedHeadDslCommitter {
 
         Repository repository = dslRepository.getGitRepository();
         String refName = Constants.R_HEADS + request.branch();
-        Ref branchRef = repository.getRefDatabase().exactRef(refName);
-        ObjectId actualHead = branchRef == null || branchRef.getObjectId() == null
-                ? ObjectId.zeroId()
-                : branchRef.getObjectId();
         ObjectId expectedHead = request.expectedHeadObjectId();
+        ObjectId actualHead = currentHead(repository, refName);
         if (!actualHead.equals(expectedHead)) {
             throw conflict(request.branch(), expectedHead, actualHead, null);
         }
@@ -90,6 +87,55 @@ public final class ExpectedHeadDslCommitter {
         }
     }
 
+    /**
+     * Verifies that a semantic no-op still refers to the exact selected branch
+     * head and therefore may safely return that commit as the authority token.
+     *
+     * <p>For an existing branch the verification uses a no-change ref update
+     * with an expected-old-object precondition, so a concurrent writer cannot be
+     * silently accepted. For an expected absent branch JGit has no object ID to
+     * lock; the method performs a fail-closed exact-ref check and returns
+     * {@code null} only while the branch remains absent.</p>
+     */
+    public String verifyExpectedHead(
+            DslGitRepository dslRepository,
+            String branch,
+            String expectedHeadCommit) throws IOException {
+        Objects.requireNonNull(dslRepository, "dslRepository");
+        String normalizedBranch = normalizeBranch(branch);
+        ObjectId expectedHead = expectedHeadObjectId(expectedHeadCommit);
+        Repository repository = dslRepository.getGitRepository();
+        String refName = Constants.R_HEADS + normalizedBranch;
+        ObjectId actualHead = currentHead(repository, refName);
+        if (!actualHead.equals(expectedHead)) {
+            throw conflict(normalizedBranch, expectedHead, actualHead, null);
+        }
+        if (ObjectId.zeroId().equals(expectedHead)) {
+            return null;
+        }
+
+        RefUpdate update = repository.updateRef(refName);
+        update.setNewObjectId(expectedHead);
+        update.setExpectedOldObjectId(expectedHead);
+        update.setForceUpdate(false);
+        update.disableRefLog();
+        RefUpdate.Result result = update.update();
+        if (result == RefUpdate.Result.NO_CHANGE) {
+            return expectedHead.name();
+        }
+        if (result == RefUpdate.Result.LOCK_FAILURE
+                || result == RefUpdate.Result.REJECTED
+                || result == RefUpdate.Result.REJECTED_CURRENT_BRANCH) {
+            throw conflict(
+                    normalizedBranch,
+                    expectedHead,
+                    currentHead(repository, refName),
+                    result);
+        }
+        throw new IOException(
+                "Expected-head verification failed for " + refName + ": " + result);
+    }
+
     private static ObjectId currentHead(
             Repository repository,
             String refName) throws IOException {
@@ -128,6 +174,30 @@ public final class ExpectedHeadDslCommitter {
         return new PersonIdent(normalized, email);
     }
 
+    private static String normalizeBranch(String branch) {
+        if (branch == null || branch.isBlank()) {
+            throw new IllegalArgumentException("branch must not be blank");
+        }
+        String normalized = branch.strip();
+        if (!Repository.isValidRefName(Constants.R_HEADS + normalized)) {
+            throw new IllegalArgumentException(
+                    "invalid branch name: " + normalized);
+        }
+        return normalized;
+    }
+
+    private static ObjectId expectedHeadObjectId(String expectedHeadCommit) {
+        if (expectedHeadCommit == null) {
+            return ObjectId.zeroId();
+        }
+        String normalized = expectedHeadCommit.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "expectedHeadCommit must be null or a full commit ID");
+        }
+        return ObjectId.fromString(normalized);
+    }
+
     public record CommitRequest(
             String branch,
             String expectedHeadCommit,
@@ -136,21 +206,10 @@ public final class ExpectedHeadDslCommitter {
             String message) {
 
         public CommitRequest {
-            if (branch == null || branch.isBlank()) {
-                throw new IllegalArgumentException("branch must not be blank");
-            }
-            branch = branch.strip();
-            if (!Repository.isValidRefName(Constants.R_HEADS + branch)) {
-                throw new IllegalArgumentException(
-                        "invalid branch name: " + branch);
-            }
+            branch = normalizeBranch(branch);
             if (expectedHeadCommit != null) {
                 expectedHeadCommit = expectedHeadCommit.strip();
-                if (expectedHeadCommit.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "expectedHeadCommit must be null or a full commit ID");
-                }
-                ObjectId.fromString(expectedHeadCommit);
+                expectedHeadObjectId(expectedHeadCommit);
             }
             dslText = Objects.requireNonNull(dslText, "dslText");
             author = author == null || author.isBlank()
@@ -162,9 +221,8 @@ public final class ExpectedHeadDslCommitter {
         }
 
         ObjectId expectedHeadObjectId() {
-            return expectedHeadCommit == null
-                    ? ObjectId.zeroId()
-                    : ObjectId.fromString(expectedHeadCommit);
+            return ExpectedHeadDslCommitter.expectedHeadObjectId(
+                    expectedHeadCommit);
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/ExpectedHeadDslCommitter.java
@@ -209,7 +209,8 @@ public final class ExpectedHeadDslCommitter {
             branch = normalizeBranch(branch);
             if (expectedHeadCommit != null) {
                 expectedHeadCommit = expectedHeadCommit.strip();
-                expectedHeadObjectId(expectedHeadCommit);
+                ExpectedHeadDslCommitter.expectedHeadObjectId(
+                        expectedHeadCommit);
             }
             dslText = Objects.requireNonNull(dslText, "dslText");
             author = author == null || author.isBlank()

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandService.java
@@ -1,0 +1,253 @@
+package com.taxonomy.relations.command;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeResult;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.CommitRequest;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.eclipse.jgit.lib.ObjectId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Executes one relation command against the exact repository context and makes
+ * the resulting JGit commit the authority token.
+ *
+ * <p>This service deliberately has no relational repository dependency. A later
+ * projection stage may consume {@link CommandResult#authoritativeCommitId()},
+ * but a database write can never precede or substitute the Git command here.</p>
+ */
+@Service
+public class ArchitectureRelationGitCommandService {
+
+    private final DslGitRepositoryFactory repositoryFactory;
+    private final ArchitectureRelationDslTransformer transformer;
+    private final ExpectedHeadDslCommitter committer;
+
+    @Autowired
+    public ArchitectureRelationGitCommandService(
+            DslGitRepositoryFactory repositoryFactory) {
+        this(repositoryFactory,
+                new ArchitectureRelationDslTransformer(),
+                new ExpectedHeadDslCommitter());
+    }
+
+    ArchitectureRelationGitCommandService(
+            DslGitRepositoryFactory repositoryFactory,
+            ArchitectureRelationDslTransformer transformer,
+            ExpectedHeadDslCommitter committer) {
+        this.repositoryFactory = Objects.requireNonNull(
+                repositoryFactory, "repositoryFactory");
+        this.transformer = Objects.requireNonNull(transformer, "transformer");
+        this.committer = Objects.requireNonNull(committer, "committer");
+    }
+
+    /**
+     * Applies and commits one command using only the supplied request-stable
+     * repository context.
+     */
+    public CommandResult execute(
+            RepositoryContext context,
+            String expectedHeadCommit,
+            RelationCommand command) throws IOException {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(command, "command");
+        requireMutable(context);
+        String normalizedExpectedHead = normalizeExpectedHead(expectedHeadCommit);
+
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        String sourceDsl = normalizedExpectedHead == null
+                ? ""
+                : repository.getDslAtCommit(normalizedExpectedHead);
+        if (sourceDsl == null) {
+            sourceDsl = "";
+        }
+
+        ChangeResult change = apply(sourceDsl, command);
+        if (!change.changed()) {
+            String authoritativeHead = committer.verifyExpectedHead(
+                    repository,
+                    context.branch(),
+                    normalizedExpectedHead);
+            return result(
+                    context,
+                    normalizedExpectedHead,
+                    authoritativeHead,
+                    change.kind(),
+                    false,
+                    command.metadata().causationId());
+        }
+
+        ExpectedHeadDslCommitter.CommitResult commit = committer.commit(
+                repository,
+                new CommitRequest(
+                        context.branch(),
+                        normalizedExpectedHead,
+                        change.dsl(),
+                        context.username(),
+                        commitMessage(command, change.kind())));
+        return result(
+                context,
+                commit.previousHeadCommit(),
+                commit.commitId(),
+                change.kind(),
+                true,
+                command.metadata().causationId());
+    }
+
+    private ChangeResult apply(String sourceDsl, RelationCommand command) {
+        if (command instanceof UpsertRelation upsert) {
+            return transformer.upsert(sourceDsl, upsert.definition());
+        }
+        if (command instanceof RemoveRelation remove) {
+            return transformer.remove(sourceDsl, remove.identity());
+        }
+        throw new IllegalArgumentException(
+                "Unsupported relation command: " + command.getClass().getName());
+    }
+
+    private String commitMessage(RelationCommand command, ChangeKind changeKind) {
+        RelationIdentity identity = command.identity();
+        StringBuilder message = new StringBuilder("relation: ")
+                .append(changeKind.name().toLowerCase(Locale.ROOT))
+                .append(' ')
+                .append(identity.sourceId()).append(' ')
+                .append(identity.relationType()).append(' ')
+                .append(identity.targetId())
+                .append("\n\nCausation-Id: ")
+                .append(command.metadata().causationId());
+        if (command.metadata().rationale() != null) {
+            message.append("\nRationale: ")
+                    .append(command.metadata().rationale());
+        }
+        return message.toString();
+    }
+
+    private CommandResult result(
+            RepositoryContext context,
+            String previousHead,
+            String authoritativeHead,
+            ChangeKind changeKind,
+            boolean commitCreated,
+            String causationId) {
+        return new CommandResult(
+                context.repositoryId(),
+                context.workspaceId(),
+                context.branch(),
+                context.scope(),
+                previousHead,
+                authoritativeHead,
+                changeKind,
+                commitCreated,
+                causationId);
+    }
+
+    private static void requireMutable(RepositoryContext context) {
+        if (context.scope() == RepositoryScope.CENTRAL_READ) {
+            throw new ReadOnlyRepositoryContextException(
+                    "Relation commands require CENTRAL_WRITE, WORKSPACE or FORK scope");
+        }
+    }
+
+    private static String normalizeExpectedHead(String expectedHeadCommit) {
+        if (expectedHeadCommit == null) {
+            return null;
+        }
+        String normalized = expectedHeadCommit.strip();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "expectedHeadCommit must be null or a full commit ID");
+        }
+        ObjectId.fromString(normalized);
+        return normalized;
+    }
+
+    public sealed interface RelationCommand
+            permits UpsertRelation, RemoveRelation {
+        RelationIdentity identity();
+        CommandMetadata metadata();
+    }
+
+    public record UpsertRelation(
+            RelationDefinition definition,
+            CommandMetadata metadata) implements RelationCommand {
+        public UpsertRelation {
+            definition = Objects.requireNonNull(definition, "definition");
+            metadata = Objects.requireNonNull(metadata, "metadata");
+        }
+
+        @Override
+        public RelationIdentity identity() {
+            return definition.identity();
+        }
+    }
+
+    public record RemoveRelation(
+            RelationIdentity identity,
+            CommandMetadata metadata) implements RelationCommand {
+        public RemoveRelation {
+            identity = Objects.requireNonNull(identity, "identity");
+            metadata = Objects.requireNonNull(metadata, "metadata");
+        }
+    }
+
+    public record CommandMetadata(
+            String causationId,
+            String rationale) {
+        public CommandMetadata {
+            causationId = requireSingleLine(causationId, "causationId");
+            rationale = normalizeRationale(rationale);
+        }
+
+        public CommandMetadata(String causationId) {
+            this(causationId, null);
+        }
+    }
+
+    public record CommandResult(
+            String repositoryId,
+            String workspaceId,
+            String branch,
+            RepositoryScope scope,
+            String previousHeadCommit,
+            String authoritativeCommitId,
+            ChangeKind changeKind,
+            boolean commitCreated,
+            String causationId) {
+    }
+
+    public static final class ReadOnlyRepositoryContextException
+            extends IllegalStateException {
+        public ReadOnlyRepositoryContextException(String message) {
+            super(message);
+        }
+    }
+
+    private static String requireSingleLine(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        String normalized = value.strip();
+        if (normalized.indexOf('\n') >= 0 || normalized.indexOf('\r') >= 0) {
+            throw new IllegalArgumentException(field + " must be one line");
+        }
+        return normalized;
+    }
+
+    private static String normalizeRationale(String rationale) {
+        if (rationale == null || rationale.isBlank()) {
+            return null;
+        }
+        return rationale.strip().replaceAll("\\s+", " ");
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandService.java
@@ -79,6 +79,11 @@ public class ArchitectureRelationGitCommandService {
                     repository,
                     context.branch(),
                     normalizedExpectedHead);
+            if (authoritativeHead == null) {
+                throw new MissingAuthoritativeHeadException(
+                        "Semantic no-op has no existing Git commit on branch '"
+                                + context.branch() + "'");
+            }
             return result(
                     context,
                     normalizedExpectedHead,
@@ -224,11 +229,27 @@ public class ArchitectureRelationGitCommandService {
             ChangeKind changeKind,
             boolean commitCreated,
             String causationId) {
+        public CommandResult {
+            repositoryId = Objects.requireNonNull(repositoryId, "repositoryId");
+            branch = Objects.requireNonNull(branch, "branch");
+            scope = Objects.requireNonNull(scope, "scope");
+            authoritativeCommitId = Objects.requireNonNull(
+                    authoritativeCommitId, "authoritativeCommitId");
+            changeKind = Objects.requireNonNull(changeKind, "changeKind");
+            causationId = Objects.requireNonNull(causationId, "causationId");
+        }
     }
 
     public static final class ReadOnlyRepositoryContextException
             extends IllegalStateException {
         public ReadOnlyRepositoryContextException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class MissingAuthoritativeHeadException
+            extends IllegalStateException {
+        public MissingAuthoritativeHeadException(String message) {
             super(message);
         }
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandMissingHeadTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandMissingHeadTest.java
@@ -1,0 +1,44 @@
+package com.taxonomy.relations.command;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.MissingAuthoritativeHeadException;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RemoveRelation;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ArchitectureRelationGitCommandMissingHeadTest {
+
+    @Test
+    void absentRelationOnAbsentBranchIsNotReportedAsAuthoritativeSuccess()
+            throws Exception {
+        try (DslGitRepositoryFactory repositoryFactory =
+                     new DslGitRepositoryFactory(null)) {
+            ArchitectureRelationGitCommandService service =
+                    new ArchitectureRelationGitCommandService(
+                            repositoryFactory,
+                            new ArchitectureRelationDslTransformer(),
+                            new ExpectedHeadDslCommitter());
+            RepositoryContext context = RepositoryContext.workspace(
+                    "repo-a", "workspace-a", "draft", "alice");
+
+            assertThatThrownBy(() -> service.execute(
+                    context,
+                    null,
+                    new RemoveRelation(
+                            new RelationIdentity("APP-1", "USES", "SVC-1"),
+                            new CommandMetadata("remove-missing"))))
+                    .isInstanceOf(MissingAuthoritativeHeadException.class)
+                    .hasMessageContaining("no existing Git commit");
+
+            assertThat(repositoryFactory.resolveRepository(context)
+                    .getHeadCommit("draft")).isNull();
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandServiceTest.java
@@ -1,0 +1,300 @@
+package com.taxonomy.relations.command;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.ReadOnlyRepositoryContextException;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RemoveRelation;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.UpsertRelation;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class ArchitectureRelationGitCommandServiceTest {
+
+    private DslGitRepositoryFactory repositoryFactory;
+
+    @AfterEach
+    void closeRepositories() {
+        if (repositoryFactory != null) {
+            repositoryFactory.close();
+        }
+    }
+
+    @Test
+    void workspaceCommandCommitsOnlyToTheExplicitSelectedWorkspace()
+            throws Exception {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext workspaceA = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+        RepositoryContext workspaceB = RepositoryContext.workspace(
+                "repo-a", "workspace-b", "draft", "bob");
+        DslGitRepository repositoryA = repositoryFactory.resolveRepository(workspaceA);
+        DslGitRepository repositoryB = repositoryFactory.resolveRepository(workspaceB);
+        String seed = """
+                element APP-1 type Application {
+                  title: "Payments";
+                }
+
+                element SVC-1 type Service {
+                  title: "Payment service";
+                }
+                """;
+        String headA = repositoryA.commitDsl(
+                "draft", seed, "system", "Seed workspace A");
+        String headB = repositoryB.commitDsl(
+                "draft", seed, "system", "Seed workspace B");
+
+        var result = service.execute(
+                workspaceA,
+                headA,
+                new UpsertRelation(
+                        definition("accepted", 0.9, "manual"),
+                        new CommandMetadata(
+                                "proposal-17",
+                                " Accepted after architecture review. ")));
+
+        assertThat(result.repositoryId()).isEqualTo("repo-a");
+        assertThat(result.workspaceId()).isEqualTo("workspace-a");
+        assertThat(result.branch()).isEqualTo("draft");
+        assertThat(result.scope()).isEqualTo(RepositoryScope.WORKSPACE);
+        assertThat(result.previousHeadCommit()).isEqualTo(headA);
+        assertThat(result.authoritativeCommitId())
+                .isEqualTo(repositoryA.getHeadCommit("draft"));
+        assertThat(result.changeKind()).isEqualTo(ChangeKind.ADDED);
+        assertThat(result.commitCreated()).isTrue();
+        assertThat(result.causationId()).isEqualTo("proposal-17");
+        assertThat(repositoryA.getDslAtHead("draft"))
+                .contains("relation APP-1 USES SVC-1")
+                .contains("status: accepted;");
+        assertThat(repositoryA.getHeadCommitInfo("draft").message())
+                .contains("relation: added APP-1 USES SVC-1")
+                .contains("Causation-Id: proposal-17")
+                .contains("Rationale: Accepted after architecture review.");
+
+        assertThat(repositoryB.getHeadCommit("draft")).isEqualTo(headB);
+        assertThat(repositoryB.getDslAtHead("draft"))
+                .doesNotContain("relation APP-1 USES SVC-1");
+        assertThat(repositoryB.getCommitCount("draft")).isEqualTo(1);
+    }
+
+    @Test
+    void centralReadIsRejectedBeforeRepositoryResolution() {
+        DslGitRepositoryFactory factory = mock(DslGitRepositoryFactory.class);
+        ArchitectureRelationGitCommandService service =
+                new ArchitectureRelationGitCommandService(
+                        factory,
+                        new ArchitectureRelationDslTransformer(),
+                        new ExpectedHeadDslCommitter());
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-a", "accepted", "reader");
+
+        assertThatThrownBy(() -> service.execute(
+                context,
+                null,
+                new UpsertRelation(
+                        definition("accepted", 0.9, "manual"),
+                        new CommandMetadata("manual-1"))))
+                .isInstanceOf(ReadOnlyRepositoryContextException.class)
+                .hasMessageContaining("CENTRAL_WRITE, WORKSPACE or FORK");
+        verifyNoInteractions(factory);
+    }
+
+    @Test
+    void centralWriteCreatesTheInitialAuthoritativeCommit() throws Exception {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext context = RepositoryContext.centralWrite(
+                "repo-central", "accepted", "maintainer");
+
+        var result = service.execute(
+                context,
+                null,
+                new UpsertRelation(
+                        definition("accepted", 1.0, "manual"),
+                        new CommandMetadata("manual-central")));
+
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        assertThat(result.previousHeadCommit()).isNull();
+        assertThat(result.authoritativeCommitId())
+                .isEqualTo(repository.getHeadCommit("accepted"));
+        assertThat(result.commitCreated()).isTrue();
+        assertThat(repository.getCommitCount("accepted")).isEqualTo(1);
+        assertThat(repository.getDslAtHead("accepted"))
+                .contains("relation APP-1 USES SVC-1");
+    }
+
+    @Test
+    void equivalentCommandReturnsTheExistingCommitWithoutAddingHistory()
+            throws Exception {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        String head = repository.commitDsl(
+                "draft",
+                """
+                        relation APP-1 USES SVC-1 {
+                          status: accepted;
+                          confidence: 0.8;
+                          provenance: manual;
+                        }
+                        """,
+                "system",
+                "Seed relation");
+
+        var result = service.execute(
+                context,
+                head,
+                new UpsertRelation(
+                        definition("accepted", 0.8, "manual"),
+                        new CommandMetadata("duplicate-review")));
+
+        assertThat(result.changeKind()).isEqualTo(ChangeKind.UNCHANGED);
+        assertThat(result.commitCreated()).isFalse();
+        assertThat(result.previousHeadCommit()).isEqualTo(head);
+        assertThat(result.authoritativeCommitId()).isEqualTo(head);
+        assertThat(repository.getHeadCommit("draft")).isEqualTo(head);
+        assertThat(repository.getCommitCount("draft")).isEqualTo(1);
+    }
+
+    @Test
+    void staleNoOpCommandFailsInsteadOfReturningAnObsoleteAuthorityToken()
+            throws Exception {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        String dsl = """
+                relation APP-1 USES SVC-1 {
+                  status: accepted;
+                  confidence: 0.8;
+                  provenance: manual;
+                }
+                """;
+        String expected = repository.commitDsl(
+                "draft", dsl, "system", "Seed relation");
+        String competing = repository.commitDsl(
+                "draft",
+                dsl + "\n# concurrent metadata update\n",
+                "bob",
+                "Concurrent edit");
+
+        assertThatThrownBy(() -> service.execute(
+                context,
+                expected,
+                new UpsertRelation(
+                        definition("accepted", 0.8, "manual"),
+                        new CommandMetadata("stale-review"))))
+                .isInstanceOfSatisfying(
+                        BranchHeadConflictException.class,
+                        conflict -> {
+                            assertThat(conflict.getExpectedHeadCommit())
+                                    .isEqualTo(expected);
+                            assertThat(conflict.getActualHeadCommit())
+                                    .isEqualTo(competing);
+                        });
+        assertThat(repository.getHeadCommit("draft")).isEqualTo(competing);
+        assertThat(repository.getCommitCount("draft")).isEqualTo(2);
+    }
+
+    @Test
+    void commandUsesTheBranchEmbeddedInRepositoryContext() throws Exception {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        String reviewHead = repository.commitDsl(
+                "review",
+                """
+                        relation APP-1 USES SVC-1 {
+                          status: proposed;
+                        }
+                        """,
+                "system",
+                "Seed review branch");
+        String draftHead = repository.commitDsl(
+                "draft",
+                "element APP-1 type Application {\n}\n",
+                "system",
+                "Seed draft branch");
+
+        var result = service.execute(
+                context,
+                reviewHead,
+                new RemoveRelation(
+                        identity(),
+                        new CommandMetadata(
+                                "remove-9",
+                                "No longer part of the reviewed architecture")));
+
+        assertThat(result.branch()).isEqualTo("review");
+        assertThat(result.changeKind()).isEqualTo(ChangeKind.REMOVED);
+        assertThat(repository.getDslAtHead("review"))
+                .doesNotContain("relation APP-1 USES SVC-1");
+        assertThat(repository.getHeadCommit("draft")).isEqualTo(draftHead);
+        assertThat(repository.getDslAtHead("draft"))
+                .contains("element APP-1 type Application");
+    }
+
+    @Test
+    void validatesExpectedHeadAndCommandMetadata() {
+        ArchitectureRelationGitCommandService service = service();
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.execute(
+                        context,
+                        " ",
+                        new RemoveRelation(
+                                identity(),
+                                new CommandMetadata("remove-1"))))
+                .withMessageContaining("expectedHeadCommit");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new CommandMetadata("line-1\nline-2"))
+                .withMessageContaining("must be one line");
+        assertThat(new CommandMetadata(
+                "decision-1",
+                "  reviewed\nby   architecture  ").rationale())
+                .isEqualTo("reviewed by architecture");
+    }
+
+    private ArchitectureRelationGitCommandService service() {
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        return new ArchitectureRelationGitCommandService(
+                repositoryFactory,
+                new ArchitectureRelationDslTransformer(),
+                new ExpectedHeadDslCommitter());
+    }
+
+    private static RelationIdentity identity() {
+        return new RelationIdentity("APP-1", "USES", "SVC-1");
+    }
+
+    private static RelationDefinition definition(
+            String status,
+            Double confidence,
+            String provenance) {
+        return new RelationDefinition(
+                identity(),
+                status,
+                confidence,
+                provenance,
+                Map.of("x-command-source", "relation-review"));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/command/ArchitectureRelationGitCommandServiceTest.java
@@ -152,6 +152,7 @@ class ArchitectureRelationGitCommandServiceTest {
                           status: accepted;
                           confidence: 0.8;
                           provenance: manual;
+                          x-command-source: relation-review;
                         }
                         """,
                 "system",
@@ -184,6 +185,7 @@ class ArchitectureRelationGitCommandServiceTest {
                   status: accepted;
                   confidence: 0.8;
                   provenance: manual;
+                  x-command-source: relation-review;
                 }
                 """;
         String expected = repository.commitDsl(


### PR DESCRIPTION
## Scope

Third bounded slice of #691, stacked on #694. It combines the deterministic TaxDSL transformer and expected-head JGit boundary into the first real relation command service.

### Changes

- adds `ArchitectureRelationGitCommandService` with an explicit `RepositoryContext` input;
- resolves exactly that repository/workspace through `DslGitRepositoryFactory` and uses only `context.branch()` and `context.username()`;
- rejects mutation from `CENTRAL_READ` before repository resolution;
- supports typed upsert and remove commands with required one-line causation IDs and normalized optional rationale;
- reads the DSL from the caller's expected commit, transforms it deterministically, and commits only through `ExpectedHeadDslCommitter`;
- returns repository, workspace, branch, scope, previous head, authoritative commit ID, change kind, commit-created flag and causation ID;
- gives semantic no-ops the existing expected commit as authority without adding history;
- extends the JGit boundary with a no-change expected-head ref verification so a stale no-op cannot return an obsolete authority token;
- keeps the service free of relational repositories and transactions: no database projection can precede the authoritative Git result;
- adds JUnit coverage for workspace isolation, central-write creation, pre-resolution read-only rejection, semantic no-op history, stale no-op conflict, exact branch routing, removal, metadata normalization and validation.

### Remaining boundary

This PR does not yet replace proposal/hypothesis review call sites and does not materialise database/search projections. Those follow only after the command service and expected-head contract are verified, so Git-first failure semantics remain independently provable.

## Stacking and merge policy

Base: #694 (`feat/git-authoritative-relation-jgit-precondition`). Retarget only after #692 and #694 are integrated into #610. This PR remains draft until exact-head verification is green.

Advances #691 and #609.