### PR TITLE
Rebuild complete relation projections from the exact Git branch head

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationDecisionProjectionCheckpoint.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationDecisionProjectionCheckpoint.java
@@ -1,0 +1,191 @@
+package com.taxonomy.relations.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+
+/**
+ * Completion token for one fully rebuilt repository/workspace/branch relation projection.
+ *
+ * <p>A checkpoint is valid only while its authoritative commit remains the exact
+ * selected branch head. Incremental command projections invalidate the checkpoint;
+ * user-facing reads may consume decision rows only after a complete rebuild has
+ * atomically replaced the branch rows and checkpoint in one database transaction.</p>
+ */
+@Entity
+@Table(name = "relation_decision_projection_checkpoint",
+        indexes = {
+                @Index(
+                        name = "idx_rel_projection_checkpoint_repository",
+                        columnList = "repository_id"),
+                @Index(
+                        name = "idx_rel_projection_checkpoint_scope",
+                        columnList = "repository_id, workspace_scope_key, branch")
+        },
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_rel_projection_checkpoint_scope",
+                columnNames = {
+                        "repository_id",
+                        "workspace_scope_key",
+                        "branch"
+                }))
+public class RelationDecisionProjectionCheckpoint {
+
+    public static final String CENTRAL_SCOPE_KEY = "__shared__";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "repository_id", nullable = false, length = 255)
+    private String repositoryId;
+
+    @Column(name = "workspace_id", length = 255)
+    private String workspaceId;
+
+    @Column(name = "workspace_scope_key", nullable = false, length = 255)
+    private String workspaceScopeKey = CENTRAL_SCOPE_KEY;
+
+    @Column(name = "branch", nullable = false, length = 255)
+    private String branch;
+
+    @Column(name = "authoritative_commit_id", nullable = false, length = 40)
+    private String authoritativeCommitId;
+
+    @Column(name = "relation_count", nullable = false)
+    private int relationCount;
+
+    @Column(name = "completed_at", nullable = false)
+    private Instant completedAt;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
+    @PrePersist
+    void onCreate() {
+        synchronize();
+        if (completedAt == null) {
+            completedAt = Instant.now();
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        synchronize();
+        completedAt = Instant.now();
+    }
+
+    private void synchronize() {
+        repositoryId = requireText(repositoryId, "repositoryId");
+        workspaceId = normalizeOptional(workspaceId);
+        workspaceScopeKey = scopeKeyFor(workspaceId);
+        branch = requireText(branch, "branch");
+        authoritativeCommitId = requireCommitId(authoritativeCommitId);
+        if (relationCount < 0) {
+            throw new IllegalArgumentException("relationCount must not be negative");
+        }
+    }
+
+    public static String scopeKeyFor(String workspaceId) {
+        String normalized = normalizeOptional(workspaceId);
+        return normalized == null ? CENTRAL_SCOPE_KEY : normalized;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = requireText(repositoryId, "repositoryId");
+    }
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = normalizeOptional(workspaceId);
+        this.workspaceScopeKey = scopeKeyFor(this.workspaceId);
+    }
+
+    public String getWorkspaceScopeKey() {
+        return workspaceScopeKey;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = requireText(branch, "branch");
+    }
+
+    public String getAuthoritativeCommitId() {
+        return authoritativeCommitId;
+    }
+
+    public void setAuthoritativeCommitId(String authoritativeCommitId) {
+        this.authoritativeCommitId = requireCommitId(authoritativeCommitId);
+    }
+
+    public int getRelationCount() {
+        return relationCount;
+    }
+
+    public void setRelationCount(int relationCount) {
+        if (relationCount < 0) {
+            throw new IllegalArgumentException("relationCount must not be negative");
+        }
+        this.relationCount = relationCount;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    private static String requireCommitId(String value) {
+        String normalized = requireText(value, "authoritativeCommitId");
+        if (normalized.length() != 40
+                || !normalized.chars().allMatch(RelationDecisionProjectionCheckpoint::isHex)) {
+            throw new IllegalArgumentException(
+                    "authoritativeCommitId must be a full Git object ID");
+        }
+        return normalized.toLowerCase(java.util.Locale.ROOT);
+    }
+
+    private static boolean isHex(int value) {
+        return value >= '0' && value <= '9'
+                || value >= 'a' && value <= 'f'
+                || value >= 'A' && value <= 'F';
+    }
+
+    private static String normalizeOptional(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.strip();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationDecisionProjectionCheckpointRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationDecisionProjectionCheckpointRepository.java
@@ -1,0 +1,49 @@
+package com.taxonomy.relations.repository;
+
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/** Exact repository/workspace/branch access to relation projection checkpoints. */
+@Repository
+public interface RelationDecisionProjectionCheckpointRepository
+        extends JpaRepository<RelationDecisionProjectionCheckpoint, Long> {
+
+    Optional<RelationDecisionProjectionCheckpoint>
+            findByRepositoryIdAndWorkspaceScopeKeyAndBranch(
+                    String repositoryId,
+                    String workspaceScopeKey,
+                    String branch);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT checkpoint
+            FROM RelationDecisionProjectionCheckpoint checkpoint
+            WHERE checkpoint.repositoryId = :repositoryId
+              AND checkpoint.workspaceScopeKey = :workspaceScopeKey
+              AND checkpoint.branch = :branch
+            """)
+    Optional<RelationDecisionProjectionCheckpoint> findExactForUpdate(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceScopeKey") String workspaceScopeKey,
+            @Param("branch") String branch);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("""
+            DELETE FROM RelationDecisionProjectionCheckpoint checkpoint
+            WHERE checkpoint.repositoryId = :repositoryId
+              AND checkpoint.workspaceScopeKey = :workspaceScopeKey
+              AND checkpoint.branch = :branch
+            """)
+    int deleteExact(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceScopeKey") String workspaceScopeKey,
+            @Param("branch") String branch);
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationDecisionProjectionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationDecisionProjectionRepository.java
@@ -5,6 +5,7 @@ import com.taxonomy.relations.model.RelationDecisionProjection;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -46,4 +47,16 @@ public interface RelationDecisionProjectionRepository
             String repositoryId,
             String workspaceScopeKey,
             String branch);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = false)
+    @Query("""
+            DELETE FROM RelationDecisionProjection projection
+            WHERE projection.repositoryId = :repositoryId
+              AND projection.workspaceScopeKey = :workspaceScopeKey
+              AND projection.branch = :branch
+            """)
+    int deleteExactBranch(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceScopeKey") String workspaceScopeKey,
+            @Param("branch") String branch);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessService.java
@@ -1,0 +1,184 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Proves whether one branch projection is complete for the current Git head.
+ *
+ * <p>This service is intentionally not wired into user-facing relation reads yet.
+ * It establishes the fail-closed boundary required for that later switch: missing,
+ * stale, partial, tombstone-contaminated or concurrently advanced projections are
+ * never returned as ready.</p>
+ */
+@Service
+public class RelationBranchProjectionReadinessService {
+
+    private final DslGitRepositoryFactory gitRepositoryFactory;
+    private final RelationDecisionProjectionRepository projectionRepository;
+    private final RelationDecisionProjectionCheckpointRepository checkpointRepository;
+
+    public RelationBranchProjectionReadinessService(
+            DslGitRepositoryFactory gitRepositoryFactory,
+            RelationDecisionProjectionRepository projectionRepository,
+            RelationDecisionProjectionCheckpointRepository checkpointRepository) {
+        this.gitRepositoryFactory = Objects.requireNonNull(
+                gitRepositoryFactory, "gitRepositoryFactory");
+        this.projectionRepository = Objects.requireNonNull(
+                projectionRepository, "projectionRepository");
+        this.checkpointRepository = Objects.requireNonNull(
+                checkpointRepository, "checkpointRepository");
+    }
+
+    @Transactional(readOnly = true)
+    public Readiness inspect(RepositoryContext context) {
+        Objects.requireNonNull(context, "context");
+        DslGitRepository repository = gitRepositoryFactory.resolveRepository(context);
+        String headBefore = readHead(repository, context.branch());
+        if (headBefore == null) {
+            return Readiness.notReady(
+                    ReadinessState.BRANCH_MISSING,
+                    null,
+                    null,
+                    List.of());
+        }
+
+        String workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(
+                context.workspaceId());
+        RelationDecisionProjectionCheckpoint checkpoint = checkpointRepository
+                .findByRepositoryIdAndWorkspaceScopeKeyAndBranch(
+                        context.repositoryId(),
+                        workspaceScopeKey,
+                        context.branch())
+                .orElse(null);
+        if (checkpoint == null) {
+            return Readiness.notReady(
+                    ReadinessState.NOT_BUILT,
+                    headBefore,
+                    null,
+                    List.of());
+        }
+        if (!headBefore.equals(checkpoint.getAuthoritativeCommitId())) {
+            return Readiness.notReady(
+                    ReadinessState.STALE,
+                    headBefore,
+                    checkpoint.getAuthoritativeCommitId(),
+                    List.of());
+        }
+
+        List<RelationDecisionProjection> rows = projectionRepository
+                .findByRepositoryIdAndWorkspaceScopeKeyAndBranchOrderBySourceCodeAscTargetCodeAsc(
+                        context.repositoryId(),
+                        workspaceScopeKey,
+                        context.branch());
+        boolean inconsistent = rows.size() != checkpoint.getRelationCount()
+                || rows.stream().anyMatch(row -> !row.isRelationPresent()
+                        || !headBefore.equals(row.getAuthoritativeCommitId()));
+        if (inconsistent) {
+            return Readiness.notReady(
+                    ReadinessState.CORRUPT,
+                    headBefore,
+                    checkpoint.getAuthoritativeCommitId(),
+                    List.of());
+        }
+
+        String headAfter = readHead(repository, context.branch());
+        if (!Objects.equals(headBefore, headAfter)) {
+            return Readiness.notReady(
+                    ReadinessState.STALE,
+                    headAfter,
+                    checkpoint.getAuthoritativeCommitId(),
+                    List.of());
+        }
+        return new Readiness(
+                ReadinessState.READY,
+                headBefore,
+                checkpoint.getAuthoritativeCommitId(),
+                List.copyOf(rows));
+    }
+
+    public List<RelationDecisionProjection> requireReady(RepositoryContext context) {
+        Readiness readiness = inspect(context);
+        if (readiness.state() != ReadinessState.READY) {
+            throw new RelationProjectionNotReadyException(
+                    "Relation projection is not ready for "
+                            + context.repositoryId() + "/" + context.branch()
+                            + ": " + readiness.state());
+        }
+        return readiness.rows();
+    }
+
+    private static String readHead(
+            DslGitRepository repository,
+            String branch) {
+        try {
+            Ref ref = repository.getGitRepository().getRefDatabase()
+                    .exactRef(Constants.R_HEADS + branch);
+            return ref == null || ref.getObjectId() == null
+                    ? null
+                    : ref.getObjectId().name();
+        } catch (IOException error) {
+            throw new RelationProjectionNotReadyException(
+                    "Unable to read selected relation projection branch head",
+                    error);
+        }
+    }
+
+    public enum ReadinessState {
+        READY,
+        NOT_BUILT,
+        STALE,
+        CORRUPT,
+        BRANCH_MISSING
+    }
+
+    public record Readiness(
+            ReadinessState state,
+            String currentHeadCommit,
+            String projectedCommit,
+            List<RelationDecisionProjection> rows) {
+        public Readiness {
+            state = Objects.requireNonNull(state, "state");
+            rows = List.copyOf(Objects.requireNonNull(rows, "rows"));
+            if (state != ReadinessState.READY && !rows.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Non-ready projection must not expose relation rows");
+            }
+        }
+
+        private static Readiness notReady(
+                ReadinessState state,
+                String currentHeadCommit,
+                String projectedCommit,
+                List<RelationDecisionProjection> rows) {
+            return new Readiness(
+                    state, currentHeadCommit, projectedCommit, rows);
+        }
+    }
+
+    public static final class RelationProjectionNotReadyException
+            extends IllegalStateException {
+        public RelationProjectionNotReadyException(String message) {
+            super(message);
+        }
+
+        public RelationProjectionNotReadyException(
+                String message,
+                Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildService.java
@@ -1,0 +1,300 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.ast.BlockAst;
+import com.taxonomy.dsl.ast.DocumentAst;
+import com.taxonomy.dsl.parser.TaxDslParser;
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Rebuilds one complete branch relation projection from authoritative TaxDSL.
+ *
+ * <p>Repository resolution, branch-head capture, DSL parsing and semantic
+ * validation happen before the transactional writer replaces any database rows.
+ * The branch head is verified again immediately before the writer is invoked.
+ * A later read boundary still compares the persisted checkpoint with the live
+ * branch head, so a commit that arrives after the rebuild cannot expose stale
+ * rows as current.</p>
+ */
+@Service
+public class RelationBranchProjectionRebuildService {
+
+    private static final String RELATION_KIND = "relation";
+
+    private final DslGitRepositoryFactory gitRepositoryFactory;
+    private final RelationBranchProjectionRebuildWriter rebuildWriter;
+    private final TaxDslParser parser;
+    private final ExpectedHeadDslCommitter expectedHeadVerifier;
+
+    @Autowired
+    public RelationBranchProjectionRebuildService(
+            DslGitRepositoryFactory gitRepositoryFactory,
+            RelationBranchProjectionRebuildWriter rebuildWriter) {
+        this(
+                gitRepositoryFactory,
+                rebuildWriter,
+                new TaxDslParser(),
+                new ExpectedHeadDslCommitter());
+    }
+
+    RelationBranchProjectionRebuildService(
+            DslGitRepositoryFactory gitRepositoryFactory,
+            RelationBranchProjectionRebuildWriter rebuildWriter,
+            TaxDslParser parser,
+            ExpectedHeadDslCommitter expectedHeadVerifier) {
+        this.gitRepositoryFactory = Objects.requireNonNull(
+                gitRepositoryFactory, "gitRepositoryFactory");
+        this.rebuildWriter = Objects.requireNonNull(
+                rebuildWriter, "rebuildWriter");
+        this.parser = Objects.requireNonNull(parser, "parser");
+        this.expectedHeadVerifier = Objects.requireNonNull(
+                expectedHeadVerifier, "expectedHeadVerifier");
+    }
+
+    /** Replaces the exact branch projection and writes its completion checkpoint atomically. */
+    public RebuildResult rebuild(RepositoryContext context) {
+        Objects.requireNonNull(context, "context");
+        requireMutable(context);
+        DslGitRepository repository = gitRepositoryFactory.resolveRepository(context);
+        String head = readHead(repository, context.branch());
+        String dsl = readDsl(repository, head);
+        List<RelationSnapshot> relations = parseRelations(dsl, head);
+        verifyHead(repository, context.branch(), head);
+        return rebuildWriter.replace(context, head, relations);
+    }
+
+    private String readHead(DslGitRepository repository, String branch) {
+        try {
+            Ref ref = repository.getGitRepository().getRefDatabase()
+                    .exactRef(Constants.R_HEADS + branch);
+            if (ref == null || ref.getObjectId() == null) {
+                throw new BranchProjectionSourceException(
+                        "Cannot rebuild relation projection: branch '"
+                                + branch + "' does not exist");
+            }
+            return ref.getObjectId().name();
+        } catch (IOException error) {
+            throw new BranchProjectionSourceException(
+                    "Unable to read relation projection branch head '"
+                            + branch + "'",
+                    error);
+        }
+    }
+
+    private String readDsl(DslGitRepository repository, String commitId) {
+        try {
+            String dsl = repository.getDslAtCommit(commitId);
+            if (dsl == null) {
+                throw new BranchProjectionSourceException(
+                        "Authoritative commit has no architecture.taxdsl: "
+                                + commitId);
+            }
+            return dsl;
+        } catch (IOException error) {
+            throw new BranchProjectionSourceException(
+                    "Unable to read authoritative relation projection commit "
+                            + commitId,
+                    error);
+        }
+    }
+
+    private void verifyHead(
+            DslGitRepository repository,
+            String branch,
+            String expectedHead) {
+        try {
+            String verified = expectedHeadVerifier.verifyExpectedHead(
+                    repository, branch, expectedHead);
+            if (!expectedHead.equals(verified)) {
+                throw new BranchProjectionSourceException(
+                        "Selected branch no longer has the captured projection head");
+            }
+        } catch (IOException error) {
+            throw new BranchProjectionSourceException(
+                    "Selected branch moved during relation projection rebuild",
+                    error);
+        }
+    }
+
+    private List<RelationSnapshot> parseRelations(String dsl, String commitId) {
+        DocumentAst document;
+        try {
+            document = parser.parse(dsl, "architecture.taxdsl");
+        } catch (RuntimeException error) {
+            throw new BranchProjectionSourceException(
+                    "Cannot rebuild relation projection from invalid TaxDSL commit "
+                            + commitId,
+                    error);
+        }
+
+        Map<RelationIdentity, RelationSnapshot> relations = new LinkedHashMap<>();
+        for (BlockAst block : document.getBlocks()) {
+            if (!RELATION_KIND.equals(block.getKind())) {
+                continue;
+            }
+            List<String> tokens = block.getHeaderTokens();
+            if (tokens.size() != 3) {
+                throw new BranchProjectionSourceException(
+                        "Relation block must contain exactly source, type and target at commit "
+                                + commitId);
+            }
+            RelationType relationType;
+            try {
+                relationType = RelationType.valueOf(
+                        tokens.get(1).toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException error) {
+                throw new BranchProjectionSourceException(
+                        "Unsupported relation type '" + tokens.get(1)
+                                + "' at commit " + commitId,
+                        error);
+            }
+            RelationIdentity identity = new RelationIdentity(
+                    requireToken(tokens.get(0), "source code"),
+                    relationType,
+                    requireToken(tokens.get(2), "target code"));
+            RelationSnapshot snapshot = new RelationSnapshot(
+                    identity.sourceCode(),
+                    identity.relationType(),
+                    identity.targetCode(),
+                    uniqueProperty(block, "status", identity),
+                    confidence(block, identity),
+                    uniqueProperty(block, "provenance", identity));
+            if (relations.putIfAbsent(identity, snapshot) != null) {
+                throw new BranchProjectionSourceException(
+                        "Duplicate relation in authoritative branch projection: "
+                                + identity.display());
+            }
+        }
+        return List.copyOf(relations.values());
+    }
+
+    private static String uniqueProperty(
+            BlockAst block,
+            String property,
+            RelationIdentity identity) {
+        List<String> values = block.propertyValues(property);
+        if (values.size() > 1) {
+            throw new BranchProjectionSourceException(
+                    "Duplicate " + property + " property on relation "
+                            + identity.display());
+        }
+        return values.isEmpty() ? null : normalizeOptional(values.getFirst());
+    }
+
+    private static Double confidence(
+            BlockAst block,
+            RelationIdentity identity) {
+        String value = uniqueProperty(block, "confidence", identity);
+        if (value == null) {
+            return null;
+        }
+        try {
+            double parsed = Double.parseDouble(value);
+            if (!Double.isFinite(parsed) || parsed < 0.0 || parsed > 1.0) {
+                throw new NumberFormatException("outside [0,1]");
+            }
+            return parsed;
+        } catch (NumberFormatException error) {
+            throw new BranchProjectionSourceException(
+                    "Invalid confidence on relation " + identity.display(),
+                    error);
+        }
+    }
+
+    private static void requireMutable(RepositoryContext context) {
+        if (context.scope() == RepositoryScope.CENTRAL_READ) {
+            throw new BranchProjectionContextException(
+                    "Relation projection rebuild requires a writable repository context");
+        }
+    }
+
+    private static String requireToken(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new BranchProjectionSourceException(field + " must not be blank");
+        }
+        String normalized = value.strip();
+        if (normalized.chars().anyMatch(Character::isWhitespace)) {
+            throw new BranchProjectionSourceException(
+                    field + " must be one TaxDSL token: " + normalized);
+        }
+        return normalized;
+    }
+
+    private static String normalizeOptional(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    public record RelationSnapshot(
+            String sourceCode,
+            RelationType relationType,
+            String targetCode,
+            String status,
+            Double confidence,
+            String provenance) {
+        public RelationSnapshot {
+            sourceCode = requireToken(sourceCode, "sourceCode");
+            relationType = Objects.requireNonNull(relationType, "relationType");
+            targetCode = requireToken(targetCode, "targetCode");
+            status = normalizeOptional(status);
+            provenance = normalizeOptional(provenance);
+            if (confidence != null
+                    && (!Double.isFinite(confidence)
+                    || confidence < 0.0
+                    || confidence > 1.0)) {
+                throw new IllegalArgumentException(
+                        "confidence must be finite and between 0.0 and 1.0");
+            }
+        }
+    }
+
+    public record RebuildResult(
+            String repositoryId,
+            String workspaceId,
+            String branch,
+            String authoritativeCommitId,
+            int relationCount) {
+    }
+
+    private record RelationIdentity(
+            String sourceCode,
+            RelationType relationType,
+            String targetCode) {
+        private String display() {
+            return sourceCode + " " + relationType + " " + targetCode;
+        }
+    }
+
+    public static final class BranchProjectionContextException
+            extends IllegalArgumentException {
+        public BranchProjectionContextException(String message) {
+            super(message);
+        }
+    }
+
+    public static final class BranchProjectionSourceException
+            extends IllegalStateException {
+        public BranchProjectionSourceException(String message) {
+            super(message);
+        }
+
+        public BranchProjectionSourceException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriter.java
@@ -1,0 +1,109 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RelationSnapshot;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/** Transactional replacement boundary for one fully validated branch projection. */
+@Service
+public class RelationBranchProjectionRebuildWriter {
+
+    private final RelationDecisionProjectionRepository projectionRepository;
+    private final RelationDecisionProjectionCheckpointRepository checkpointRepository;
+
+    public RelationBranchProjectionRebuildWriter(
+            RelationDecisionProjectionRepository projectionRepository,
+            RelationDecisionProjectionCheckpointRepository checkpointRepository) {
+        this.projectionRepository = Objects.requireNonNull(
+                projectionRepository, "projectionRepository");
+        this.checkpointRepository = Objects.requireNonNull(
+                checkpointRepository, "checkpointRepository");
+    }
+
+    /**
+     * Replaces the exact repository/workspace/branch rows and checkpoint in one
+     * transaction. Failure leaves the previously complete projection untouched.
+     */
+    @Transactional
+    public RebuildResult replace(
+            RepositoryContext context,
+            String authoritativeCommitId,
+            List<RelationSnapshot> relations) {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(authoritativeCommitId, "authoritativeCommitId");
+        List<RelationSnapshot> snapshots = List.copyOf(
+                Objects.requireNonNull(relations, "relations"));
+        String workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(
+                context.workspaceId());
+
+        RelationDecisionProjectionCheckpoint checkpoint = checkpointRepository
+                .findExactForUpdate(
+                        context.repositoryId(),
+                        workspaceScopeKey,
+                        context.branch())
+                .orElseGet(RelationDecisionProjectionCheckpoint::new);
+
+        projectionRepository.deleteExactBranch(
+                context.repositoryId(),
+                workspaceScopeKey,
+                context.branch());
+        projectionRepository.flush();
+
+        List<RelationDecisionProjection> replacements = snapshots.stream()
+                .sorted(Comparator
+                        .comparing(RelationSnapshot::sourceCode)
+                        .thenComparing(snapshot -> snapshot.relationType().name())
+                        .thenComparing(RelationSnapshot::targetCode))
+                .map(snapshot -> projection(
+                        context,
+                        authoritativeCommitId,
+                        snapshot))
+                .toList();
+        projectionRepository.saveAll(replacements);
+        projectionRepository.flush();
+
+        checkpoint.setRepositoryId(context.repositoryId());
+        checkpoint.setWorkspaceId(context.workspaceId());
+        checkpoint.setBranch(context.branch());
+        checkpoint.setAuthoritativeCommitId(authoritativeCommitId);
+        checkpoint.setRelationCount(replacements.size());
+        checkpointRepository.saveAndFlush(checkpoint);
+
+        return new RebuildResult(
+                context.repositoryId(),
+                context.workspaceId(),
+                context.branch(),
+                authoritativeCommitId,
+                replacements.size());
+    }
+
+    private static RelationDecisionProjection projection(
+            RepositoryContext context,
+            String authoritativeCommitId,
+            RelationSnapshot snapshot) {
+        RelationDecisionProjection projection = new RelationDecisionProjection();
+        projection.setRepositoryId(context.repositoryId());
+        projection.setWorkspaceId(context.workspaceId());
+        projection.setBranch(context.branch());
+        projection.setSourceCode(snapshot.sourceCode());
+        projection.setRelationType(snapshot.relationType());
+        projection.setTargetCode(snapshot.targetCode());
+        projection.setRelationPresent(true);
+        projection.setStatus(snapshot.status());
+        projection.setConfidence(snapshot.confidence());
+        projection.setProvenance(snapshot.provenance());
+        projection.setAuthoritativeCommitId(authoritativeCommitId);
+        projection.setCausationId("rebuild:" + authoritativeCommitId);
+        return projection;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
@@ -7,6 +7,7 @@ import com.taxonomy.relations.service.RelationDecisionProjectionService.Projecti
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionOutcome;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionRequest;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionResult;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class RelationDecisionProjectionWriter {
     private final RelationDecisionProjectionRepository projectionRepository;
     private final RelationDecisionProjectionCheckpointRepository checkpointRepository;
 
+    @Autowired
     public RelationDecisionProjectionWriter(
             RelationDecisionProjectionRepository projectionRepository,
             RelationDecisionProjectionCheckpointRepository checkpointRepository) {
@@ -26,6 +28,14 @@ public class RelationDecisionProjectionWriter {
                 projectionRepository, "projectionRepository");
         this.checkpointRepository = Objects.requireNonNull(
                 checkpointRepository, "checkpointRepository");
+    }
+
+    /** Compatibility constructor for focused pre-checkpoint unit tests in this package. */
+    RelationDecisionProjectionWriter(
+            RelationDecisionProjectionRepository projectionRepository) {
+        this.projectionRepository = Objects.requireNonNull(
+                projectionRepository, "projectionRepository");
+        this.checkpointRepository = null;
     }
 
     @Transactional
@@ -38,10 +48,12 @@ public class RelationDecisionProjectionWriter {
         // is a semantic no-op, it must not leave a previous full-branch checkpoint
         // available as an assurance that every row was rebuilt at this commit.
         // Runtime failures roll this deletion back with the relation write.
-        checkpointRepository.deleteExact(
-                request.repositoryId(),
-                workspaceScopeKey,
-                request.branch());
+        if (checkpointRepository != null) {
+            checkpointRepository.deleteExact(
+                    request.repositoryId(),
+                    workspaceScopeKey,
+                    request.branch());
+        }
 
         RelationDecisionProjection existing = projectionRepository
                 .findExactForUpdate(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
@@ -1,6 +1,7 @@
 package com.taxonomy.relations.service;
 
 import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
 import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionConflictException;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionOutcome;
@@ -11,16 +12,20 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
-/** Transactional writer for one already Git-verified projection state. */
+/** Transactional writer for one already Git-verified incremental projection state. */
 @Service
 public class RelationDecisionProjectionWriter {
 
     private final RelationDecisionProjectionRepository projectionRepository;
+    private final RelationDecisionProjectionCheckpointRepository checkpointRepository;
 
     public RelationDecisionProjectionWriter(
-            RelationDecisionProjectionRepository projectionRepository) {
+            RelationDecisionProjectionRepository projectionRepository,
+            RelationDecisionProjectionCheckpointRepository checkpointRepository) {
         this.projectionRepository = Objects.requireNonNull(
                 projectionRepository, "projectionRepository");
+        this.checkpointRepository = Objects.requireNonNull(
+                checkpointRepository, "checkpointRepository");
     }
 
     @Transactional
@@ -28,6 +33,16 @@ public class RelationDecisionProjectionWriter {
         Objects.requireNonNull(request, "request");
         String workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(
                 request.workspaceId());
+
+        // An incremental command proves only one relation identity. Even when it
+        // is a semantic no-op, it must not leave a previous full-branch checkpoint
+        // available as an assurance that every row was rebuilt at this commit.
+        // Runtime failures roll this deletion back with the relation write.
+        checkpointRepository.deleteExact(
+                request.repositoryId(),
+                workspaceScopeKey,
+                request.branch());
+
         RelationDecisionProjection existing = projectionRepository
                 .findExactForUpdate(
                         request.repositoryId(),

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V10__relation_projection_checkpoint.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V10__relation_projection_checkpoint.sql
@@ -1,0 +1,37 @@
+-- A relation decision projection becomes readable only after one complete branch
+-- rebuild has atomically replaced every row and recorded the exact Git head.
+
+create table relation_decision_projection_checkpoint (
+    id bigserial primary key,
+    repository_id varchar(255) not null,
+    workspace_id varchar(255),
+    workspace_scope_key varchar(255) not null,
+    branch varchar(255) not null,
+    authoritative_commit_id varchar(40) not null,
+    relation_count integer not null,
+    completed_at timestamp with time zone not null,
+    version bigint not null default 0,
+    constraint fk_rel_projection_checkpoint_repository
+        foreign key (repository_id)
+        references system_repository (repository_id),
+    constraint uq_rel_projection_checkpoint_scope
+        unique (repository_id, workspace_scope_key, branch),
+    constraint ck_rel_projection_checkpoint_scope
+        check (
+            (workspace_id is null and workspace_scope_key = '__shared__')
+            or
+            (workspace_id is not null and workspace_scope_key = workspace_id)
+        ),
+    constraint ck_rel_projection_checkpoint_count
+        check (relation_count >= 0)
+);
+
+create index idx_rel_projection_checkpoint_repository
+    on relation_decision_projection_checkpoint (repository_id);
+
+create index idx_rel_projection_checkpoint_scope
+    on relation_decision_projection_checkpoint (
+        repository_id,
+        workspace_scope_key,
+        branch
+    );

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/RelationProjectionCheckpointPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/RelationProjectionCheckpointPostgresMigrationIT.java
@@ -1,0 +1,261 @@
+package com.taxonomy.dsl.storage;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Real PostgreSQL evidence for the exact relation branch projection checkpoint. */
+@Testcontainers
+@Tag("db-postgres")
+class RelationProjectionCheckpointPostgresMigrationIT {
+
+    @Container
+    @SuppressWarnings("rawtypes")
+    static PostgreSQLContainer database = new PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("taxonomy")
+            .withUsername("taxonomy")
+            .withPassword("taxonomy");
+
+    @Test
+    void enforcesRepositoryScopeBranchIdentityAndCheckpointIntegrity()
+            throws Exception {
+        DataSource dataSource = isolatedDataSource(
+                "relation_projection_checkpoint");
+        migrateJgit(dataSource);
+        migrateApplicationTo(dataSource, "9");
+        insertRepository(dataSource, "repo-a", true);
+        insertRepository(dataSource, "repo-b", false);
+
+        migrateApplicationTo(dataSource, "10");
+
+        insertCheckpoint(
+                dataSource,
+                "repo-a",
+                null,
+                "__shared__",
+                "accepted",
+                "a".repeat(40),
+                2);
+        insertCheckpoint(
+                dataSource,
+                "repo-a",
+                "workspace-a",
+                "workspace-a",
+                "accepted",
+                "b".repeat(40),
+                1);
+        insertCheckpoint(
+                dataSource,
+                "repo-a",
+                null,
+                "__shared__",
+                "review",
+                "c".repeat(40),
+                0);
+
+        assertThat(singleLong(dataSource, """
+                select count(*)
+                from relation_decision_projection_checkpoint
+                """))
+                .isEqualTo(3L);
+
+        assertThatThrownBy(() -> insertCheckpoint(
+                dataSource,
+                "repo-a",
+                null,
+                "__shared__",
+                "accepted",
+                "d".repeat(40),
+                4))
+                .isInstanceOf(SQLException.class);
+        assertThatThrownBy(() -> insertCheckpoint(
+                dataSource,
+                "missing-repository",
+                null,
+                "__shared__",
+                "accepted",
+                "e".repeat(40),
+                1))
+                .isInstanceOf(SQLException.class);
+        assertThatThrownBy(() -> insertCheckpoint(
+                dataSource,
+                "repo-b",
+                "workspace-b",
+                "wrong-scope",
+                "draft",
+                "f".repeat(40),
+                1))
+                .isInstanceOf(SQLException.class);
+        assertThatThrownBy(() -> insertCheckpoint(
+                dataSource,
+                "repo-b",
+                null,
+                "__shared__",
+                "draft",
+                "1".repeat(40),
+                -1))
+                .isInstanceOf(SQLException.class);
+    }
+
+    private static void insertRepository(
+            DataSource dataSource,
+            String repositoryId,
+            boolean primary) throws SQLException {
+        execute(dataSource, """
+                insert into system_repository (
+                    repository_id,
+                    display_name,
+                    topology_mode,
+                    default_branch,
+                    primary_repo,
+                    created_at,
+                    storage_repository_name,
+                    slug,
+                    visibility,
+                    lifecycle_state,
+                    owner_type,
+                    owner_id,
+                    created_by,
+                    updated_at)
+                values (
+                    '%s',
+                    '%s',
+                    'INTERNAL_SHARED',
+                    'draft',
+                    %s,
+                    current_timestamp,
+                    'storage-%s',
+                    '%s',
+                    'ORGANIZATION',
+                    'ACTIVE',
+                    'SYSTEM',
+                    'system',
+                    'system',
+                    current_timestamp)
+                """.formatted(
+                        repositoryId,
+                        repositoryId,
+                        primary,
+                        repositoryId,
+                        repositoryId));
+    }
+
+    private static void insertCheckpoint(
+            DataSource dataSource,
+            String repositoryId,
+            String workspaceId,
+            String workspaceScopeKey,
+            String branch,
+            String commitId,
+            int relationCount) throws SQLException {
+        String workspace = workspaceId == null
+                ? "null"
+                : "'" + workspaceId + "'";
+        execute(dataSource, """
+                insert into relation_decision_projection_checkpoint (
+                    repository_id,
+                    workspace_id,
+                    workspace_scope_key,
+                    branch,
+                    authoritative_commit_id,
+                    relation_count,
+                    completed_at,
+                    version)
+                values (
+                    '%s',
+                    %s,
+                    '%s',
+                    '%s',
+                    '%s',
+                    %d,
+                    current_timestamp,
+                    0)
+                """.formatted(
+                        repositoryId,
+                        workspace,
+                        workspaceScopeKey,
+                        branch,
+                        commitId,
+                        relationCount));
+    }
+
+    private static void migrateJgit(DataSource dataSource) {
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.POSTGRESQL_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false);
+    }
+
+    private static void migrateApplicationTo(
+            DataSource dataSource,
+            String version) {
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(TaxonomySchemaMigrationConfig.POSTGRES_LOCATION)
+                .table(TaxonomySchemaMigrationConfig.HISTORY_TABLE)
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .baselineDescription("before Taxonomy application schema")
+                .target(version)
+                .load()
+                .migrate();
+    }
+
+    private static DataSource isolatedDataSource(String schema)
+            throws SQLException {
+        DataSource admin = baseDataSource();
+        execute(admin, "drop schema if exists " + schema + " cascade");
+        execute(admin, "create schema " + schema);
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(database.getJdbcUrl()
+                + (database.getJdbcUrl().contains("?") ? "&" : "?")
+                + "currentSchema=" + schema);
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static DataSource baseDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(database.getJdbcUrl());
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static long singleLong(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getLong(1);
+        }
+    }
+
+    private static void execute(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -87,9 +87,39 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(columnExists(
                 dataSource, "relation_decision_projection", "authoritative_commit_id"))
                 .isTrue();
+        assertThat(tableExists(
+                dataSource, "relation_decision_projection_checkpoint"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "repository_id"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "workspace_scope_key"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "branch"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "authoritative_commit_id"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "relation_count"))
+                .isTrue();
         assertThat(tableExists(dataSource, TaxonomySchemaMigrationConfig.HISTORY_TABLE)).isTrue();
         assertThat(successfulVersions(dataSource))
-                .containsExactly("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
+                .containsExactly(
+                        "0", "1", "2", "3", "4", "5",
+                        "6", "7", "8", "9", "10");
     }
 
     @Test
@@ -141,8 +171,23 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(columnExists(
                 dataSource, "relation_decision_projection", "authoritative_commit_id"))
                 .isTrue();
+        assertThat(tableExists(
+                dataSource, "relation_decision_projection_checkpoint"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "branch"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "authoritative_commit_id"))
+                .isTrue();
         assertThat(successfulVersions(dataSource))
-                .containsExactly("1", "2", "3", "4", "5", "6", "7", "8", "9");
+                .containsExactly(
+                        "1", "2", "3", "4", "5",
+                        "6", "7", "8", "9", "10");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessServiceTest.java
@@ -1,0 +1,185 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.RelationProjectionNotReadyException;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RelationBranchProjectionReadinessServiceTest {
+
+    private DslGitRepositoryFactory repositoryFactory;
+
+    @AfterEach
+    void closeRepositories() {
+        if (repositoryFactory != null) {
+            repositoryFactory.close();
+        }
+    }
+
+    @Test
+    void returnsRowsOnlyWhenCheckpointCountAndLiveGitHeadMatch() throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        DslGitRepository git = repositoryFactory.resolveRepository(context);
+        String head = git.commitDsl(
+                "review",
+                "relation APP-1 USES SVC-1 {\n  status: accepted;\n}\n",
+                "alice",
+                "Seed ready projection");
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpoint checkpoint = checkpoint(
+                context, head, 1);
+        RelationDecisionProjection row = projection(context, head, true);
+        when(checkpoints.findByRepositoryIdAndWorkspaceScopeKeyAndBranch(
+                "repo-a", "workspace-a", "review"))
+                .thenReturn(Optional.of(checkpoint));
+        when(projections
+                .findByRepositoryIdAndWorkspaceScopeKeyAndBranchOrderBySourceCodeAscTargetCodeAsc(
+                        "repo-a", "workspace-a", "review"))
+                .thenReturn(List.of(row));
+
+        RelationBranchProjectionReadinessService service =
+                new RelationBranchProjectionReadinessService(
+                        repositoryFactory, projections, checkpoints);
+        var readiness = service.inspect(context);
+
+        assertThat(readiness.state()).isEqualTo(ReadinessState.READY);
+        assertThat(readiness.currentHeadCommit()).isEqualTo(head);
+        assertThat(readiness.projectedCommit()).isEqualTo(head);
+        assertThat(readiness.rows()).containsExactly(row);
+        assertThat(service.requireReady(context)).containsExactly(row);
+    }
+
+    @Test
+    void staleCheckpointNeverExposesRows() throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        DslGitRepository git = repositoryFactory.resolveRepository(context);
+        String head = git.commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "Advance branch");
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        when(checkpoints.findByRepositoryIdAndWorkspaceScopeKeyAndBranch(
+                "repo-a", "workspace-a", "review"))
+                .thenReturn(Optional.of(checkpoint(
+                        context, "a".repeat(40), 1)));
+
+        RelationBranchProjectionReadinessService service =
+                new RelationBranchProjectionReadinessService(
+                        repositoryFactory, projections, checkpoints);
+        var readiness = service.inspect(context);
+
+        assertThat(readiness.state()).isEqualTo(ReadinessState.STALE);
+        assertThat(readiness.currentHeadCommit()).isEqualTo(head);
+        assertThat(readiness.rows()).isEmpty();
+        verifyNoInteractions(projections);
+        assertThatThrownBy(() -> service.requireReady(context))
+                .isInstanceOf(RelationProjectionNotReadyException.class)
+                .hasMessageContaining("STALE");
+    }
+
+    @Test
+    void rowCountMismatchOrTombstoneMakesProjectionCorrupt() throws Exception {
+        RepositoryContext context = RepositoryContext.centralWrite(
+                "repo-a", "accepted", "maintainer");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        String head = repositoryFactory.resolveRepository(context).commitDsl(
+                "accepted",
+                "element APP-1 type Application {\n}\n",
+                "maintainer",
+                "Seed central branch");
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        when(checkpoints.findByRepositoryIdAndWorkspaceScopeKeyAndBranch(
+                "repo-a", "__shared__", "accepted"))
+                .thenReturn(Optional.of(checkpoint(context, head, 1)));
+        when(projections
+                .findByRepositoryIdAndWorkspaceScopeKeyAndBranchOrderBySourceCodeAscTargetCodeAsc(
+                        "repo-a", "__shared__", "accepted"))
+                .thenReturn(List.of(projection(context, head, false)));
+
+        var readiness = new RelationBranchProjectionReadinessService(
+                repositoryFactory, projections, checkpoints).inspect(context);
+
+        assertThat(readiness.state()).isEqualTo(ReadinessState.CORRUPT);
+        assertThat(readiness.rows()).isEmpty();
+    }
+
+    @Test
+    void missingBranchShortCircuitsBeforeDatabaseAccess() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "missing", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+
+        var readiness = new RelationBranchProjectionReadinessService(
+                repositoryFactory, projections, checkpoints).inspect(context);
+
+        assertThat(readiness.state()).isEqualTo(ReadinessState.BRANCH_MISSING);
+        assertThat(readiness.rows()).isEmpty();
+        verifyNoInteractions(checkpoints, projections);
+    }
+
+    private static RelationDecisionProjectionCheckpoint checkpoint(
+            RepositoryContext context,
+            String commit,
+            int count) {
+        RelationDecisionProjectionCheckpoint checkpoint =
+                new RelationDecisionProjectionCheckpoint();
+        checkpoint.setRepositoryId(context.repositoryId());
+        checkpoint.setWorkspaceId(context.workspaceId());
+        checkpoint.setBranch(context.branch());
+        checkpoint.setAuthoritativeCommitId(commit);
+        checkpoint.setRelationCount(count);
+        return checkpoint;
+    }
+
+    private static RelationDecisionProjection projection(
+            RepositoryContext context,
+            String commit,
+            boolean present) {
+        RelationDecisionProjection projection = new RelationDecisionProjection();
+        projection.setRepositoryId(context.repositoryId());
+        projection.setWorkspaceId(context.workspaceId());
+        projection.setBranch(context.branch());
+        projection.setSourceCode("APP-1");
+        projection.setRelationType(RelationType.USES);
+        projection.setTargetCode("SVC-1");
+        projection.setRelationPresent(present);
+        projection.setAuthoritativeCommitId(commit);
+        projection.setCausationId("rebuild:" + commit);
+        return projection;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildServiceTest.java
@@ -1,0 +1,151 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.BranchProjectionContextException;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.BranchProjectionSourceException;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RelationSnapshot;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RelationBranchProjectionRebuildServiceTest {
+
+    private DslGitRepositoryFactory repositoryFactory;
+
+    @AfterEach
+    void closeRepositories() {
+        if (repositoryFactory != null) {
+            repositoryFactory.close();
+        }
+    }
+
+    @Test
+    void parsesTheExactBranchHeadBeforeReplacingProjectionRows() throws Exception {
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        RelationBranchProjectionRebuildWriter writer =
+                mock(RelationBranchProjectionRebuildWriter.class);
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        DslGitRepository repository = repositoryFactory.resolveRepository(context);
+        String head = repository.commitDsl(
+                "review",
+                """
+                        element APP-1 type Application {
+                          title: "Application";
+                        }
+
+                        relation APP-1 USES SVC-1 {
+                          status: accepted;
+                          confidence: 0.9;
+                          provenance: manual;
+                        }
+
+                        relation SVC-1 DEPENDS_ON DB-1 {
+                          status: proposed;
+                        }
+                        """,
+                "alice",
+                "Seed review branch");
+        when(writer.replace(any(), anyString(), anyList()))
+                .thenAnswer(invocation -> new RebuildResult(
+                        context.repositoryId(),
+                        context.workspaceId(),
+                        context.branch(),
+                        invocation.getArgument(1),
+                        ((List<?>) invocation.getArgument(2)).size()));
+
+        RelationBranchProjectionRebuildService service =
+                new RelationBranchProjectionRebuildService(
+                        repositoryFactory, writer);
+        RebuildResult result = service.rebuild(context);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RelationSnapshot>> snapshots =
+                ArgumentCaptor.forClass(List.class);
+        verify(writer).replace(
+                org.mockito.ArgumentMatchers.eq(context),
+                org.mockito.ArgumentMatchers.eq(head),
+                snapshots.capture());
+        assertThat(result.authoritativeCommitId()).isEqualTo(head);
+        assertThat(result.relationCount()).isEqualTo(2);
+        assertThat(snapshots.getValue())
+                .extracting(
+                        RelationSnapshot::sourceCode,
+                        RelationSnapshot::relationType,
+                        RelationSnapshot::targetCode)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple(
+                                "APP-1", RelationType.USES, "SVC-1"),
+                        org.assertj.core.groups.Tuple.tuple(
+                                "SVC-1", RelationType.DEPENDS_ON, "DB-1"));
+        assertThat(snapshots.getValue().getFirst().status())
+                .isEqualTo("accepted");
+        assertThat(snapshots.getValue().getFirst().confidence())
+                .isEqualTo(0.9);
+        assertThat(snapshots.getValue().getFirst().provenance())
+                .isEqualTo("manual");
+    }
+
+    @Test
+    void duplicateAuthoritativeRelationsFailBeforeDatabaseAccess() throws Exception {
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        RelationBranchProjectionRebuildWriter writer =
+                mock(RelationBranchProjectionRebuildWriter.class);
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "draft", "alice");
+        repositoryFactory.resolveRepository(context).commitDsl(
+                "draft",
+                """
+                        relation APP-1 USES SVC-1 {
+                          status: proposed;
+                        }
+
+                        relation APP-1 USES SVC-1 {
+                          status: accepted;
+                        }
+                        """,
+                "alice",
+                "Duplicate relation fixture");
+
+        RelationBranchProjectionRebuildService service =
+                new RelationBranchProjectionRebuildService(
+                        repositoryFactory, writer);
+
+        assertThatThrownBy(() -> service.rebuild(context))
+                .isInstanceOf(BranchProjectionSourceException.class)
+                .hasMessageContaining("Duplicate relation");
+        verifyNoInteractions(writer);
+    }
+
+    @Test
+    void centralReadIsRejectedBeforeRepositoryOrDatabaseAccess() {
+        DslGitRepositoryFactory factory = mock(DslGitRepositoryFactory.class);
+        RelationBranchProjectionRebuildWriter writer =
+                mock(RelationBranchProjectionRebuildWriter.class);
+        RelationBranchProjectionRebuildService service =
+                new RelationBranchProjectionRebuildService(factory, writer);
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-a", "accepted", "reader");
+
+        assertThatThrownBy(() -> service.rebuild(context))
+                .isInstanceOf(BranchProjectionContextException.class)
+                .hasMessageContaining("writable repository context");
+        verifyNoInteractions(factory, writer);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriterTest.java
@@ -1,0 +1,123 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RelationSnapshot;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationBranchProjectionRebuildWriterTest {
+
+    @Test
+    void replacesOnlyTheExactBranchAndWritesItsCheckpoint() {
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        String commit = "a".repeat(40);
+        when(checkpoints.findExactForUpdate(
+                "repo-a", "workspace-a", "review"))
+                .thenReturn(Optional.empty());
+
+        RelationBranchProjectionRebuildWriter writer =
+                new RelationBranchProjectionRebuildWriter(
+                        projections, checkpoints);
+        var result = writer.replace(
+                context,
+                commit,
+                List.of(
+                        new RelationSnapshot(
+                                "APP-1",
+                                RelationType.USES,
+                                "SVC-1",
+                                "accepted",
+                                0.9,
+                                "manual"),
+                        new RelationSnapshot(
+                                "SVC-1",
+                                RelationType.DEPENDS_ON,
+                                "DB-1",
+                                null,
+                                null,
+                                null)));
+
+        verify(projections).deleteExactBranch(
+                "repo-a", "workspace-a", "review");
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<RelationDecisionProjection>> replacements =
+                ArgumentCaptor.forClass(List.class);
+        verify(projections).saveAll(replacements.capture());
+        assertThat(replacements.getValue()).hasSize(2);
+        assertThat(replacements.getValue())
+                .allSatisfy(row -> {
+                    assertThat(row.getRepositoryId()).isEqualTo("repo-a");
+                    assertThat(row.getWorkspaceId()).isEqualTo("workspace-a");
+                    assertThat(row.getBranch()).isEqualTo("review");
+                    assertThat(row.isRelationPresent()).isTrue();
+                    assertThat(row.getAuthoritativeCommitId()).isEqualTo(commit);
+                    assertThat(row.getCausationId())
+                            .isEqualTo("rebuild:" + commit);
+                });
+
+        ArgumentCaptor<RelationDecisionProjectionCheckpoint> checkpoint =
+                ArgumentCaptor.forClass(
+                        RelationDecisionProjectionCheckpoint.class);
+        verify(checkpoints).saveAndFlush(checkpoint.capture());
+        assertThat(checkpoint.getValue().getRepositoryId())
+                .isEqualTo("repo-a");
+        assertThat(checkpoint.getValue().getWorkspaceScopeKey())
+                .isEqualTo("workspace-a");
+        assertThat(checkpoint.getValue().getBranch())
+                .isEqualTo("review");
+        assertThat(checkpoint.getValue().getAuthoritativeCommitId())
+                .isEqualTo(commit);
+        assertThat(checkpoint.getValue().getRelationCount()).isEqualTo(2);
+        assertThat(result.authoritativeCommitId()).isEqualTo(commit);
+        assertThat(result.relationCount()).isEqualTo(2);
+    }
+
+    @Test
+    void updatesTheLockedExistingCheckpointInsteadOfCreatingAnotherIdentity() {
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        RepositoryContext context = RepositoryContext.centralWrite(
+                "repo-a", "accepted", "maintainer");
+        RelationDecisionProjectionCheckpoint existing =
+                new RelationDecisionProjectionCheckpoint();
+        existing.setRepositoryId("repo-a");
+        existing.setBranch("accepted");
+        existing.setAuthoritativeCommitId("b".repeat(40));
+        existing.setRelationCount(4);
+        when(checkpoints.findExactForUpdate(
+                "repo-a",
+                RelationDecisionProjection.CENTRAL_SCOPE_KEY,
+                "accepted"))
+                .thenReturn(Optional.of(existing));
+
+        RelationBranchProjectionRebuildWriter writer =
+                new RelationBranchProjectionRebuildWriter(
+                        projections, checkpoints);
+        writer.replace(context, "c".repeat(40), List.of());
+
+        verify(checkpoints).saveAndFlush(existing);
+        assertThat(existing.getAuthoritativeCommitId())
+                .isEqualTo("c".repeat(40));
+        assertThat(existing.getRelationCount()).isZero();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationDecisionProjectionCheckpointInvalidationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationDecisionProjectionCheckpointInvalidationTest.java
@@ -1,0 +1,101 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationDecisionProjectionCheckpointInvalidationTest {
+
+    @Test
+    void incrementalProjectionInvalidatesTheExactFullBranchCheckpointFirst() {
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        ProjectionRequest request = new ProjectionRequest(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1",
+                true,
+                "accepted",
+                0.9,
+                "manual",
+                "a".repeat(40),
+                "proposal-17");
+        when(projections.findExactForUpdate(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1"))
+                .thenReturn(Optional.empty());
+
+        RelationDecisionProjectionWriter writer =
+                new RelationDecisionProjectionWriter(
+                        projections, checkpoints);
+        var result = writer.write(request);
+
+        InOrder order = inOrder(checkpoints, projections);
+        order.verify(checkpoints).deleteExact(
+                "repo-a", "workspace-a", "review");
+        order.verify(projections).findExactForUpdate(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1");
+        verify(projections).save(org.mockito.ArgumentMatchers.any());
+        assertThat(result.authoritativeCommitId()).isEqualTo("a".repeat(40));
+    }
+
+    @Test
+    void centralIncrementalProjectionInvalidatesOnlyTheSelectedRepositoryBranch() {
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        ProjectionRequest request = new ProjectionRequest(
+                "repo-b",
+                null,
+                "accepted",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1",
+                false,
+                null,
+                null,
+                null,
+                "b".repeat(40),
+                "remove-3");
+        when(projections.findExactForUpdate(
+                "repo-b",
+                "__shared__",
+                "accepted",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1"))
+                .thenReturn(Optional.empty());
+
+        new RelationDecisionProjectionWriter(
+                projections, checkpoints).write(request);
+
+        verify(checkpoints).deleteExact(
+                "repo-b", "__shared__", "accepted");
+    }
+}


### PR DESCRIPTION
## Scope

Fifth bounded implementation slice of #691 and second slice of #698, now based on the integrated branch-local projection from #699.

This PR introduces the first complete branch rebuild and readiness checkpoint for Git-authoritative relation projections. It deliberately does not switch existing product reads to the new projection yet.

## Changes

- adds `RelationDecisionProjectionCheckpoint`, uniquely keyed by repository, normalized workspace scope and branch;
- records the exact authoritative branch-head commit, projected relation count and completion time;
- adds exact-scope checkpoint repository access with pessimistic replacement locking;
- adds `RelationBranchProjectionRebuildService`, which resolves only the supplied `RepositoryContext`, captures the exact branch head, reads and validates that commit's `architecture.taxdsl`, rejects malformed/duplicate relations, and verifies the head again before database replacement;
- adds `RelationBranchProjectionRebuildWriter`, which atomically deletes and replaces only the exact repository/workspace/branch rows and writes the matching checkpoint in the same transaction;
- adds `RelationBranchProjectionReadinessService`, which returns rows only when checkpoint commit, live Git head, row count, per-row commit and presence state all agree, with a second head read to fail closed on concurrent movement;
- incremental one-relation projections invalidate the exact full-branch checkpoint in the same transaction, so partial command application can never leave a stale READY assurance;
- adds PostgreSQL Flyway V10 with repository FK, exact scope uniqueness, workspace-scope and non-negative-count checks;
- extends fresh/adopted PostgreSQL migration evidence through V10 and adds a focused real-PostgreSQL checkpoint contract;
- adds JUnit coverage for parsing, duplicate rejection before DB access, writable-scope enforcement, exact transactional replacement, checkpoint reuse, incremental invalidation, ready/stale/corrupt/missing-branch behavior and no row exposure before readiness.

## Authority and read boundary

JGit/TaxDSL remains authoritative. The checkpoint certifies only that one complete relational projection was rebuilt from one exact branch head. A missing, stale, partial or inconsistent projection exposes no rows. Existing user-facing relation reads remain unchanged until a later slice explicitly adopts `requireReady(...)` with a migration/recovery strategy.

## Verification policy

The base now contains #692, #694, #696 and #699. This exact head must pass CI/CD, PostgreSQL/Oracle/SQL Server compatibility, JGit consumer contract, CodeQL and security scan before integration.

Advances #698, #691, #609, #610 and the 1.4.0 release train #704.