### PR TITLE
Expose Git-first relation mutations with If-Match and ETag

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitHttpPrecondition.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitHttpPrecondition.java
@@ -1,0 +1,79 @@
+package com.taxonomy.relations.controller;
+
+import org.eclipse.jgit.lib.ObjectId;
+
+/** Parses strong HTTP entity-tag preconditions into an exact Git branch head. */
+final class GitHttpPrecondition {
+
+    private GitHttpPrecondition() {
+    }
+
+    /**
+     * Returns the expected commit from {@code If-Match}; {@code null} means the
+     * caller supplied {@code If-None-Match: *} and expects an absent branch.
+     */
+    static String expectedHead(String ifMatch, String ifNoneMatch) {
+        String match = normalize(ifMatch);
+        String noneMatch = normalize(ifNoneMatch);
+        if (match != null && noneMatch != null) {
+            throw new InvalidPreconditionException(
+                    "If-Match and If-None-Match must not be combined");
+        }
+        if (match == null && noneMatch == null) {
+            throw new PreconditionRequiredException(
+                    "Supply If-Match with the exact branch commit or If-None-Match: * for a new branch");
+        }
+        if (noneMatch != null) {
+            if (!"*".equals(noneMatch)) {
+                throw new InvalidPreconditionException(
+                        "If-None-Match must be exactly * for Git branch creation");
+            }
+            return null;
+        }
+        if (match.startsWith("W/")) {
+            throw new InvalidPreconditionException(
+                    "If-Match must use a strong Git commit ETag");
+        }
+        if (match.indexOf(',') >= 0 || "*".equals(match)) {
+            throw new InvalidPreconditionException(
+                    "If-Match must contain exactly one quoted Git commit ID");
+        }
+        if (match.length() != 42
+                || match.charAt(0) != '"'
+                || match.charAt(match.length() - 1) != '"') {
+            throw new InvalidPreconditionException(
+                    "If-Match must be a quoted full Git commit ID");
+        }
+        String commit = match.substring(1, match.length() - 1);
+        try {
+            return ObjectId.fromString(commit).name();
+        } catch (IllegalArgumentException error) {
+            throw new InvalidPreconditionException(
+                    "If-Match must be a quoted full Git commit ID", error);
+        }
+    }
+
+    static String etag(String commitId) {
+        return '"' + ObjectId.fromString(commitId).name() + '"';
+    }
+
+    private static String normalize(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    static final class PreconditionRequiredException extends IllegalArgumentException {
+        PreconditionRequiredException(String message) {
+            super(message);
+        }
+    }
+
+    static final class InvalidPreconditionException extends IllegalArgumentException {
+        InvalidPreconditionException(String message) {
+            super(message);
+        }
+
+        InvalidPreconditionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * returned as the response ETag; the database projection can never precede it.</p>
  */
 @RestController
-@RequestMapping("/api/relations/git")
+@RequestMapping("/api/architecture/relations")
 @Tag(name = "Git-authoritative relations")
 public class GitRelationCommandApiController {
 
@@ -76,7 +76,7 @@ public class GitRelationCommandApiController {
             String ifMatch,
             @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
             String ifNoneMatch,
-            @RequestHeader(value = IDEMPOTENCY_KEY, required = false)
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = true)
             String causationId,
             @RequestBody(required = false) MutationBody body) {
         try {
@@ -130,7 +130,7 @@ public class GitRelationCommandApiController {
             String ifMatch,
             @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
             String ifNoneMatch,
-            @RequestHeader(value = IDEMPOTENCY_KEY, required = false)
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = true)
             String causationId) {
         try {
             RepositoryContext context = writableContext(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
@@ -1,0 +1,322 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.ReadOnlyRepositoryContextException;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Git-authoritative relation mutation API.
+ *
+ * <p>Existing branches require one strong {@code If-Match} commit ETag. Branch
+ * creation requires {@code If-None-Match: *}. The authoritative commit is
+ * returned as the response ETag; the database projection can never precede it.</p>
+ */
+@RestController
+@RequestMapping("/api/architecture/relations")
+@Tag(name = "Git-authoritative relations")
+public class GitRelationCommandApiController {
+
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
+    private final GitAuthoritativeRelationMutationService mutationService;
+    private final WorkspaceResolver workspaceResolver;
+    private final SystemRepositoryService repositoryService;
+    private final RepositoryMembershipService membershipService;
+
+    public GitRelationCommandApiController(
+            GitAuthoritativeRelationMutationService mutationService,
+            WorkspaceResolver workspaceResolver,
+            SystemRepositoryService repositoryService,
+            RepositoryMembershipService membershipService) {
+        this.mutationService = mutationService;
+        this.workspaceResolver = workspaceResolver;
+        this.repositoryService = repositoryService;
+        this.membershipService = membershipService;
+    }
+
+    @Operation(summary = "Add or update one relation through an exact Git commit")
+    @PutMapping("/{sourceCode}/{relationType}/{targetCode}")
+    public ResponseEntity<MutationResponse> upsert(
+            @PathVariable String sourceCode,
+            @PathVariable String relationType,
+            @PathVariable String targetCode,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = false)
+            String causationId,
+            @RequestBody(required = false) MutationBody body) {
+        try {
+            RepositoryContext context = writableContext(
+                    workspaceResolver.resolveCurrentRepositoryContext());
+            if (context == null) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            String expectedHead = GitHttpPrecondition.expectedHead(
+                    ifMatch, ifNoneMatch);
+            RelationIdentity identity = identity(
+                    sourceCode, relationType, targetCode);
+            MutationBody payload = body == null ? MutationBody.EMPTY : body;
+            MutationResult result = mutationService.upsert(
+                    context,
+                    expectedHead,
+                    new RelationDefinition(
+                            identity,
+                            payload.status(),
+                            payload.confidence(),
+                            payload.provenance(),
+                            payload.extensions()),
+                    new CommandMetadata(causationId, payload.rationale()));
+            HttpStatus status = result.authority().changeKind() == ChangeKind.ADDED
+                    ? HttpStatus.CREATED : HttpStatus.OK;
+            return authoritative(status, result);
+        } catch (GitHttpPrecondition.PreconditionRequiredException error) {
+            return ResponseEntity.status(HttpStatus.PRECONDITION_REQUIRED).build();
+        } catch (BranchHeadConflictException error) {
+            return preconditionFailed(error);
+        } catch (ProjectionPendingException error) {
+            return projectionPending(error.getAuthority());
+        } catch (ReadOnlyRepositoryContextException error) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IOException error) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+    }
+
+    @Operation(summary = "Remove one relation through an exact Git commit")
+    @DeleteMapping("/{sourceCode}/{relationType}/{targetCode}")
+    public ResponseEntity<MutationResponse> remove(
+            @PathVariable String sourceCode,
+            @PathVariable String relationType,
+            @PathVariable String targetCode,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = false)
+            String causationId) {
+        try {
+            RepositoryContext context = writableContext(
+                    workspaceResolver.resolveCurrentRepositoryContext());
+            if (context == null) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            String expectedHead = GitHttpPrecondition.expectedHead(
+                    ifMatch, ifNoneMatch);
+            MutationResult result = mutationService.remove(
+                    context,
+                    expectedHead,
+                    identity(sourceCode, relationType, targetCode),
+                    new CommandMetadata(causationId));
+            return authoritative(HttpStatus.OK, result);
+        } catch (GitHttpPrecondition.PreconditionRequiredException error) {
+            return ResponseEntity.status(HttpStatus.PRECONDITION_REQUIRED).build();
+        } catch (BranchHeadConflictException error) {
+            return preconditionFailed(error);
+        } catch (ProjectionPendingException error) {
+            return projectionPending(error.getAuthority());
+        } catch (ReadOnlyRepositoryContextException error) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IOException error) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+    }
+
+    private static RelationIdentity identity(
+            String sourceCode,
+            String relationType,
+            String targetCode) {
+        RelationType type = RelationType.valueOf(
+                relationType.strip().toUpperCase(Locale.ROOT));
+        return new RelationIdentity(sourceCode, type.name(), targetCode);
+    }
+
+    private static ResponseEntity<MutationResponse> authoritative(
+            HttpStatus status,
+            MutationResult result) {
+        CommandResult authority = result.authority();
+        return ResponseEntity.status(status)
+                .header(HttpHeaders.ETAG,
+                        GitHttpPrecondition.etag(
+                                authority.authoritativeCommitId()))
+                .body(MutationResponse.projected(result));
+    }
+
+    private static ResponseEntity<MutationResponse> projectionPending(
+            CommandResult authority) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .header(HttpHeaders.ETAG,
+                        GitHttpPrecondition.etag(
+                                authority.authoritativeCommitId()))
+                .body(MutationResponse.pending(authority));
+    }
+
+    private static ResponseEntity<MutationResponse> preconditionFailed(
+            BranchHeadConflictException error) {
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(
+                HttpStatus.PRECONDITION_FAILED);
+        if (error.getActualHeadCommit() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            error.getActualHeadCommit()));
+        }
+        return response.body(MutationResponse.conflict(error));
+    }
+
+    /** Convert a central read context into an explicitly authorized write context. */
+    private RepositoryContext writableContext(RepositoryContext context) {
+        if (context.workspaceId() != null) {
+            return context;
+        }
+        SystemRepository repository = repositoryService.getRepository(
+                context.repositoryId());
+        if (!isApplicationAdmin()
+                && !membershipService.canMaintain(
+                        repository, context.username())) {
+            return null;
+        }
+        return new RepositoryContext(
+                context.repositoryId(),
+                null,
+                context.branch(),
+                context.username(),
+                RepositoryScope.CENTRAL_WRITE);
+    }
+
+    private static boolean isApplicationAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        return authentication != null
+                && authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_ADMIN".equals(
+                        authority.getAuthority()));
+    }
+
+    public record MutationBody(
+            String status,
+            Double confidence,
+            String provenance,
+            Map<String, String> extensions,
+            String rationale) {
+        private static final MutationBody EMPTY = new MutationBody(
+                null, null, null, Map.of(), null);
+
+        public MutationBody {
+            extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+        }
+    }
+
+    public record MutationResponse(
+            String repositoryId,
+            String workspaceId,
+            String branch,
+            String scope,
+            String previousHeadCommit,
+            String authoritativeCommitId,
+            String changeKind,
+            boolean commitCreated,
+            String causationId,
+            String projectionStatus,
+            String projectionOutcome,
+            Boolean relationPresent,
+            String expectedHeadCommit,
+            String actualHeadCommit) {
+
+        static MutationResponse projected(MutationResult result) {
+            CommandResult authority = result.authority();
+            return new MutationResponse(
+                    authority.repositoryId(),
+                    authority.workspaceId(),
+                    authority.branch(),
+                    authority.scope().name(),
+                    authority.previousHeadCommit(),
+                    authority.authoritativeCommitId(),
+                    authority.changeKind().name(),
+                    authority.commitCreated(),
+                    authority.causationId(),
+                    "PROJECTED",
+                    result.projection().outcome().name(),
+                    result.projection().relationPresent(),
+                    null,
+                    null);
+        }
+
+        static MutationResponse pending(CommandResult authority) {
+            return new MutationResponse(
+                    authority.repositoryId(),
+                    authority.workspaceId(),
+                    authority.branch(),
+                    authority.scope().name(),
+                    authority.previousHeadCommit(),
+                    authority.authoritativeCommitId(),
+                    authority.changeKind().name(),
+                    authority.commitCreated(),
+                    authority.causationId(),
+                    "PENDING_REBUILD",
+                    null,
+                    null,
+                    null,
+                    null);
+        }
+
+        static MutationResponse conflict(BranchHeadConflictException error) {
+            return new MutationResponse(
+                    null,
+                    null,
+                    error.getBranch(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    null,
+                    "PRECONDITION_FAILED",
+                    null,
+                    null,
+                    error.getExpectedHeadCommit(),
+                    error.getActualHeadCommit());
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * returned as the response ETag; the database projection can never precede it.</p>
  */
 @RestController
-@RequestMapping("/api/architecture/relations")
+@RequestMapping("/api/relations/git")
 @Tag(name = "Git-authoritative relations")
 public class GitRelationCommandApiController {
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
@@ -1,0 +1,104 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RemoveRelation;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.UpsertRelation;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Makes one exact Git commit authoritative before attempting its rebuildable
+ * relational projection.
+ *
+ * <p>The method is deliberately not transactional: a failed projection must
+ * never roll back or hide the already successful Git command. Callers receive
+ * the authoritative commit through {@link ProjectionPendingException} and can
+ * report an accepted/pending-rebuild outcome.</p>
+ */
+@Service
+public class GitAuthoritativeRelationMutationService {
+
+    private final ArchitectureRelationGitCommandService commandService;
+    private final RelationDecisionProjectionService projectionService;
+
+    public GitAuthoritativeRelationMutationService(
+            ArchitectureRelationGitCommandService commandService,
+            RelationDecisionProjectionService projectionService) {
+        this.commandService = Objects.requireNonNull(
+                commandService, "commandService");
+        this.projectionService = Objects.requireNonNull(
+                projectionService, "projectionService");
+    }
+
+    public MutationResult upsert(
+            RepositoryContext context,
+            String expectedHeadCommit,
+            RelationDefinition definition,
+            CommandMetadata metadata) throws IOException {
+        return execute(
+                context,
+                expectedHeadCommit,
+                new UpsertRelation(definition, metadata));
+    }
+
+    public MutationResult remove(
+            RepositoryContext context,
+            String expectedHeadCommit,
+            RelationIdentity identity,
+            CommandMetadata metadata) throws IOException {
+        return execute(
+                context,
+                expectedHeadCommit,
+                new RemoveRelation(identity, metadata));
+    }
+
+    private MutationResult execute(
+            RepositoryContext context,
+            String expectedHeadCommit,
+            RelationCommand command) throws IOException {
+        CommandResult authority = commandService.execute(
+                context, expectedHeadCommit, command);
+        try {
+            RelationDecisionProjectionService.ProjectionResult projection =
+                    projectionService.project(context, authority, command);
+            return new MutationResult(authority, projection);
+        } catch (RuntimeException projectionFailure) {
+            throw new ProjectionPendingException(authority, projectionFailure);
+        }
+    }
+
+    public record MutationResult(
+            CommandResult authority,
+            RelationDecisionProjectionService.ProjectionResult projection) {
+        public MutationResult {
+            authority = Objects.requireNonNull(authority, "authority");
+            projection = Objects.requireNonNull(projection, "projection");
+        }
+    }
+
+    public static final class ProjectionPendingException
+            extends IllegalStateException {
+        private final CommandResult authority;
+
+        public ProjectionPendingException(
+                CommandResult authority,
+                Throwable cause) {
+            super("Git relation command succeeded at "
+                    + authority.authoritativeCommitId()
+                    + ", but its projection requires recovery", cause);
+            this.authority = Objects.requireNonNull(authority, "authority");
+        }
+
+        public CommandResult getAuthority() {
+            return authority;
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitHttpPreconditionTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitHttpPreconditionTest.java
@@ -1,0 +1,59 @@
+package com.taxonomy.relations.controller;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GitHttpPreconditionTest {
+
+    private static final String COMMIT =
+            "0123456789abcdef0123456789abcdef01234567";
+
+    @Test
+    void parsesOneStrongQuotedCommitEtag() {
+        assertThat(GitHttpPrecondition.expectedHead(
+                '"' + COMMIT + '"', null))
+                .isEqualTo(COMMIT);
+        assertThat(GitHttpPrecondition.etag(COMMIT))
+                .isEqualTo('"' + COMMIT + '"');
+    }
+
+    @Test
+    void mapsIfNoneMatchStarToExpectedAbsentBranch() {
+        assertThat(GitHttpPrecondition.expectedHead(null, "*"))
+                .isNull();
+    }
+
+    @Test
+    void requiresExactlyOneSupportedPrecondition() {
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(null, null))
+                .isInstanceOf(
+                        GitHttpPrecondition.PreconditionRequiredException.class);
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(
+                '"' + COMMIT + '"', "*"))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+    }
+
+    @Test
+    void rejectsWeakWildcardMultipleAndMalformedEtags() {
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(
+                "W/\"" + COMMIT + "\"", null))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead("*", null))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(
+                '"' + COMMIT + "\", \"" + "f".repeat(40) + '"', null))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(COMMIT, null))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+        assertThatThrownBy(() -> GitHttpPrecondition.expectedHead(null, '"' + COMMIT + '"'))
+                .isInstanceOf(
+                        GitHttpPrecondition.InvalidPreconditionException.class);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerHttpContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerHttpContractTest.java
@@ -1,0 +1,56 @@
+package com.taxonomy.relations.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Source-level HTTP contract for the public Git-authoritative relation API. */
+class GitRelationCommandApiControllerHttpContractTest {
+
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
+    @Test
+    void exposesTheDocumentedArchitectureRelationRoute() {
+        RequestMapping mapping = GitRelationCommandApiController.class
+                .getAnnotation(RequestMapping.class);
+
+        assertThat(mapping).isNotNull();
+        assertThat(mapping.value())
+                .containsExactly("/api/architecture/relations");
+    }
+
+    @Test
+    void requiresAnIdempotencyKeyForEveryMutationEndpoint() {
+        assertRequiredIdempotencyKey(method("upsert"));
+        assertRequiredIdempotencyKey(method("remove"));
+    }
+
+    private static Method method(String name) {
+        return Arrays.stream(GitRelationCommandApiController.class
+                        .getDeclaredMethods())
+                .filter(candidate -> candidate.getName().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static void assertRequiredIdempotencyKey(Method method) {
+        RequestHeader header = Arrays.stream(method.getParameters())
+                .map(parameter -> parameter.getAnnotation(RequestHeader.class))
+                .filter(Objects::nonNull)
+                .filter(annotation -> IDEMPOTENCY_KEY.equals(annotation.value())
+                        || IDEMPOTENCY_KEY.equals(annotation.name()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(header.required())
+                .as("%s must reject a missing Idempotency-Key before invocation",
+                        method.getName())
+                .isTrue();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerTest.java
@@ -1,0 +1,207 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.relations.service.RelationDecisionProjectionService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GitRelationCommandApiControllerTest {
+
+    private static final String PREVIOUS = "a".repeat(40);
+    private static final String AUTHORITY = "b".repeat(40);
+
+    @Mock
+    private GitAuthoritativeRelationMutationService mutationService;
+
+    @Mock
+    private WorkspaceResolver workspaceResolver;
+
+    @Mock
+    private SystemRepositoryService repositoryService;
+
+    @Mock
+    private RepositoryMembershipService membershipService;
+
+    private GitRelationCommandApiController controller;
+    private RepositoryContext context;
+
+    @BeforeEach
+    void setUp() {
+        controller = new GitRelationCommandApiController(
+                mutationService,
+                workspaceResolver,
+                repositoryService,
+                membershipService);
+        context = new RepositoryContext(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "alice",
+                RepositoryScope.WORKSPACE);
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+    }
+
+    @Test
+    void returnsAuthoritativeCommitAsStrongEtagAfterProjection() throws Exception {
+        MutationResult result = projectedResult();
+        when(mutationService.upsert(
+                eq(context), eq(PREVIOUS), any(RelationDefinition.class),
+                any(CommandMetadata.class)))
+                .thenReturn(result);
+
+        var response = controller.upsert(
+                "BP-1",
+                "supports",
+                "CP-2",
+                '"' + PREVIOUS + '"',
+                null,
+                "request-17",
+                new GitRelationCommandApiController.MutationBody(
+                        "accepted",
+                        0.9,
+                        "manual-review",
+                        Map.of("x-command-source", "http"),
+                        "reviewed"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo('"' + AUTHORITY + '"');
+        assertThat(response.getBody())
+                .extracting(
+                        GitRelationCommandApiController.MutationResponse::authoritativeCommitId,
+                        GitRelationCommandApiController.MutationResponse::projectionStatus,
+                        GitRelationCommandApiController.MutationResponse::projectionOutcome,
+                        GitRelationCommandApiController.MutationResponse::relationPresent)
+                .containsExactly(
+                        AUTHORITY,
+                        "PROJECTED",
+                        "UPDATED",
+                        true);
+    }
+
+    @Test
+    void requiresAnHttpPreconditionBeforeCallingMutationService() {
+        var response = controller.upsert(
+                "BP-1",
+                "SUPPORTS",
+                "CP-2",
+                null,
+                null,
+                "request-17",
+                null);
+
+        assertThat(response.getStatusCode())
+                .isEqualTo(HttpStatus.PRECONDITION_REQUIRED);
+        verifyNoInteractions(mutationService);
+    }
+
+    @Test
+    void mapsIfNoneMatchStarToNewBranchExpectation() throws Exception {
+        CommandResult authority = new CommandResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                RepositoryScope.WORKSPACE,
+                null,
+                AUTHORITY,
+                ChangeKind.ADDED,
+                true,
+                "request-18");
+        RelationDecisionProjectionService.ProjectionResult projection =
+                new RelationDecisionProjectionService.ProjectionResult(
+                        RelationDecisionProjectionService.ProjectionOutcome.CREATED,
+                        AUTHORITY,
+                        true);
+        when(mutationService.upsert(
+                eq(context), eq(null), any(RelationDefinition.class),
+                any(CommandMetadata.class)))
+                .thenReturn(new MutationResult(authority, projection));
+
+        var response = controller.upsert(
+                "BP-1",
+                "SUPPORTS",
+                "CP-2",
+                null,
+                "*",
+                "request-18",
+                null);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo('"' + AUTHORITY + '"');
+    }
+
+    @Test
+    void returnsAcceptedWithAuthorityWhenProjectionNeedsRecovery()
+            throws Exception {
+        CommandResult authority = authority();
+        when(mutationService.remove(
+                eq(context), eq(PREVIOUS), any(), any(CommandMetadata.class)))
+                .thenThrow(new ProjectionPendingException(
+                        authority,
+                        new IllegalStateException("database unavailable")));
+
+        var response = controller.remove(
+                "BP-1",
+                "SUPPORTS",
+                "CP-2",
+                '"' + PREVIOUS + '"',
+                null,
+                "request-17");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo('"' + AUTHORITY + '"');
+        assertThat(response.getBody().projectionStatus())
+                .isEqualTo("PENDING_REBUILD");
+        assertThat(response.getBody().authoritativeCommitId())
+                .isEqualTo(AUTHORITY);
+    }
+
+    private static MutationResult projectedResult() {
+        return new MutationResult(
+                authority(),
+                new RelationDecisionProjectionService.ProjectionResult(
+                        RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
+                        AUTHORITY,
+                        true));
+    }
+
+    private static CommandResult authority() {
+        return new CommandResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                RepositoryScope.WORKSPACE,
+                PREVIOUS,
+                AUTHORITY,
+                ChangeKind.UPDATED,
+                true,
+                "request-17");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitRelationCommandApiControllerTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -138,7 +139,7 @@ class GitRelationCommandApiControllerTest {
                         AUTHORITY,
                         true);
         when(mutationService.upsert(
-                eq(context), eq(null), any(RelationDefinition.class),
+                eq(context), isNull(), any(RelationDefinition.class),
                 any(CommandMetadata.class)))
                 .thenReturn(new MutationResult(authority, projection));
 

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
@@ -1,0 +1,131 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GitAuthoritativeRelationMutationServiceTest {
+
+    private static final String PREVIOUS = "a".repeat(40);
+    private static final String AUTHORITY = "b".repeat(40);
+
+    @Mock
+    private ArchitectureRelationGitCommandService commandService;
+
+    @Mock
+    private RelationDecisionProjectionService projectionService;
+
+    @Test
+    void commitsBeforeProjectingAndReturnsBothResults() throws Exception {
+        RepositoryContext context = context();
+        CommandResult authority = authority();
+        RelationDecisionProjectionService.ProjectionResult projection =
+                new RelationDecisionProjectionService.ProjectionResult(
+                        RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
+                        AUTHORITY,
+                        true);
+        when(commandService.execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class)))
+                .thenReturn(authority);
+        when(projectionService.project(
+                eq(context), eq(authority), any(RelationCommand.class)))
+                .thenReturn(projection);
+        GitAuthoritativeRelationMutationService service = service();
+
+        var result = service.upsert(
+                context,
+                PREVIOUS,
+                definition(),
+                new CommandMetadata("request-17", "reviewed"));
+
+        assertThat(result.authority()).isSameAs(authority);
+        assertThat(result.projection()).isSameAs(projection);
+        InOrder order = inOrder(commandService, projectionService);
+        order.verify(commandService).execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class));
+        order.verify(projectionService).project(
+                eq(context), eq(authority), any(RelationCommand.class));
+    }
+
+    @Test
+    void exposesAuthoritativeCommitWhenProjectionNeedsRecovery() throws Exception {
+        RepositoryContext context = context();
+        CommandResult authority = authority();
+        when(commandService.execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class)))
+                .thenReturn(authority);
+        when(projectionService.project(
+                eq(context), eq(authority), any(RelationCommand.class)))
+                .thenThrow(new IllegalStateException("database unavailable"));
+        GitAuthoritativeRelationMutationService service = service();
+
+        assertThatThrownBy(() -> service.remove(
+                context,
+                PREVIOUS,
+                definition().identity(),
+                new CommandMetadata("request-17")))
+                .isInstanceOf(ProjectionPendingException.class)
+                .satisfies(error -> assertThat(
+                        ((ProjectionPendingException) error).getAuthority())
+                        .isSameAs(authority))
+                .hasMessageContaining(AUTHORITY);
+    }
+
+    private GitAuthoritativeRelationMutationService service() {
+        return new GitAuthoritativeRelationMutationService(
+                commandService, projectionService);
+    }
+
+    private static RepositoryContext context() {
+        return new RepositoryContext(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "alice",
+                RepositoryScope.WORKSPACE);
+    }
+
+    private static RelationDefinition definition() {
+        return new RelationDefinition(
+                new RelationIdentity("BP-1", "SUPPORTS", "CP-2"),
+                "accepted",
+                0.9,
+                "manual-review",
+                Map.of("x-command-source", "http"));
+    }
+
+    private static CommandResult authority() {
+        return new CommandResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                RepositoryScope.WORKSPACE,
+                PREVIOUS,
+                AUTHORITY,
+                ChangeKind.UPDATED,
+                true,
+                "request-17");
+    }
+}


### PR DESCRIPTION
## Scope

Sixth bounded slice of #691, stacked on the full branch projection/readiness work in #701.

This PR introduces the first public HTTP mutation boundary whose success token is an exact Git commit rather than a relational row. Existing legacy `/api/relations` endpoints remain unchanged until proposal/hypothesis review and productive reads are migrated.

## Changes

- adds a strict strong-ETag parser:
  - existing branches require one quoted full commit in `If-Match`;
  - absent-branch creation requires `If-None-Match: *`;
  - missing preconditions return 428;
  - weak, wildcard, unquoted and multiple `If-Match` values are rejected;
- adds `GitAuthoritativeRelationMutationService`, which executes the Git command first and only then attempts the branch-local projection;
- exposes PUT/DELETE `/api/architecture/relations/{source}/{type}/{target}`;
- requires `Idempotency-Key` as a Spring-required request header and as the command causation ID;
- returns the authoritative commit as a strong response `ETag`;
- maps stale expected-head conflicts to HTTP 412 and returns the actual branch ETag when available;
- returns HTTP 202 plus the authoritative ETag when Git succeeded but projection recovery/rebuild is still required;
- preserves repository/workspace/branch routing and explicit central-write authorization;
- adds JUnit coverage for ETag parsing, missing/creation preconditions, Git-before-projection ordering, successful projected responses, projection-pending authority exposure, the public route and required idempotency headers.

## Authority boundary

A projection failure cannot roll back or hide a successful Git commit. The API reports the commit and `PENDING_REBUILD`; #701 readiness prevents incomplete projections from being treated as readable branch state.

## Review corrections

The post-verification review found two API-contract mismatches. Both are fixed on exact head `c0692acb6438a2bd5d57bdceaeed80a31de3fa1d`:

- the controller now uses the documented `/api/architecture/relations` base route;
- both PUT and DELETE declare `Idempotency-Key` as required;
- `GitRelationCommandApiControllerHttpContractTest` prevents either contract from drifting again.

Because the head changed, all prior green results are treated only as historical evidence. The exact corrected head must pass the complete checkpoint matrix before integration.

## Follow-up

- route proposal acceptance and hypothesis review/revert through the same command boundary;
- persist retry/recovery status for projection-pending operations;
- expose branch rebuild/readiness operations;
- migrate productive relation reads to `requireReady(...)`;
- retire direct DB-authoritative relation mutations after compatibility migration.

## Integration status

- #701 is integrated into the #610 WIP branch as merge commit `2e4501643ef992b1744a5516a31eae355bafbf1e`.
- This PR targets only #610, never `main`.
- Checkpoint #707 verifies the corrected combined stack against the current `main`.
- Merge only after CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and security gates are green for exact head `c0692acb6438a2bd5d57bdceaeed80a31de3fa1d` and no review thread remains open.

Advances #691, #698, #609, #610 and release train #704.