### PR TITLE
CI checkpoint: repaired release ancestry and 1.4.0-SNAPSHOT transition

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -3,6 +3,6 @@
   "next_development_version": "1.3.2-SNAPSHOT",
   "skip_tests": false,
   "dry_run": false,
-  "request_revision": 8,
-  "requested_after_commit": "849efaab47a7f17814cb0fab08a30bc25f03f352"
+  "request_revision": 7,
+  "requested_after_commit": "64a6a7227a8cf13c1b349004bdd911cdffcf3f45"
 }

--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -3,6 +3,6 @@
   "next_development_version": "1.3.2-SNAPSHOT",
   "skip_tests": false,
   "dry_run": false,
-  "request_revision": 7,
-  "requested_after_commit": "64a6a7227a8cf13c1b349004bdd911cdffcf3f45"
+  "request_revision": 8,
+  "requested_after_commit": "849efaab47a7f17814cb0fab08a30bc25f03f352"
 }

--- a/.github/scripts/resolve-release-parameters.py
+++ b/.github/scripts/resolve-release-parameters.py
@@ -7,6 +7,7 @@ import json
 import os
 from pathlib import Path
 import re
+import subprocess
 import sys
 from typing import Mapping
 import xml.etree.ElementTree as ET
@@ -210,6 +211,58 @@ def resolve_parameters(
     return parameters
 
 
+def validate_staged_release_ancestry(
+    root: Path,
+    parameters: Mapping[str, str],
+    current_version: str,
+) -> None:
+    """Reject a staged tag that is not part of an already-advanced main history."""
+    next_version = parameters["next_development_version"]
+    if not next_version or current_version != next_version:
+        return
+
+    root = root.resolve()
+    git_repository = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    # Pure unit invocations may deliberately use a directory without Git. The
+    # real workflow always checks out a full repository before this guard runs.
+    if git_repository.returncode != 0:
+        return
+
+    tag = f"v{parameters['release_version']}"
+    tag_commit = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{tag}^{{commit}}"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if tag_commit.returncode != 0:
+        return
+
+    ancestry = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tag_commit.stdout.strip(), "HEAD"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if ancestry.returncode == 0:
+        return
+    if ancestry.returncode == 1:
+        raise ValueError(
+            f"staged release tag {tag} is not an ancestor of the current "
+            f"{current_version} checkout; repair release ancestry before publication"
+        )
+    detail = ancestry.stderr.strip() or "unknown git merge-base error"
+    raise ValueError(f"cannot verify staged release ancestry for {tag}: {detail}")
+
+
 def append_outputs(output_path: Path, parameters: Mapping[str, str]) -> None:
     with output_path.open("a", encoding="utf-8") as output:
         for key in _OUTPUT_KEYS:
@@ -225,9 +278,10 @@ def require_env(name: str) -> str:
 
 def main() -> int:
     try:
+        root = Path(".")
         event_name = require_env("EVENT_NAME")
         request = None
-        current_version = None
+        current_version = repository_version(root)
         if event_name == "push":
             request_path = Path(
                 os.environ.get("RELEASE_REQUEST_PATH", ".github/release-request.json")
@@ -236,8 +290,6 @@ def main() -> int:
             if not isinstance(loaded, dict):
                 raise ValueError("release request must contain a JSON object")
             request = loaded
-        elif event_name == "workflow_dispatch":
-            current_version = repository_version(Path("."))
 
         parameters = resolve_parameters(
             event_name,
@@ -245,6 +297,7 @@ def main() -> int:
             request,
             current_version=current_version,
         )
+        validate_staged_release_ancestry(root, parameters, current_version)
         append_outputs(Path(require_env("GITHUB_OUTPUT")), parameters)
     except (OSError, ET.ParseError, json.JSONDecodeError, ValueError) as error:
         print(f"::error::{error}", file=sys.stderr)

--- a/.github/workflows/prepare-development-version.yml
+++ b/.github/workflows/prepare-development-version.yml
@@ -1,0 +1,149 @@
+name: Prepare Development Version
+
+run-name: Prepare ${{ inputs.next_version }} from main
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: Exact canonical development version, for example 1.4.0-SNAPSHOT
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-development-version
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Create verified version-advance pull request
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Set up Java 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Validate and prepare exact development version
+        id: version
+        env:
+          NEXT_VERSION_INPUT: ${{ inputs.next_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          next_version="$NEXT_VERSION_INPUT"
+          if [[ "$next_version" != "${next_version# }" \
+                || "$next_version" != "${next_version% }" \
+                || "$next_version" == *$'\n'* \
+                || "$next_version" == *$'\r'* \
+                || "$next_version" == *$'\t'* ]]; then
+            echo "::error::next_version must be a canonical single-line value without surrounding whitespace"
+            exit 1
+          fi
+          if ! [[ "$next_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-SNAPSHOT$ ]]; then
+            echo "::error::next_version must use canonical X.Y.Z-SNAPSHOT SemVer"
+            exit 1
+          fi
+
+          current_version=$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)
+          if ! [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-SNAPSHOT$ ]]; then
+            echo "::error::Current project version is not a canonical development version: $current_version"
+            exit 1
+          fi
+
+          CURRENT_VERSION="$current_version" NEXT_VERSION="$next_version" python3 - <<'PY'
+          import os
+
+          def version_tuple(value: str) -> tuple[int, int, int]:
+              return tuple(map(int, value.removesuffix("-SNAPSHOT").split(".")))
+
+          current = version_tuple(os.environ["CURRENT_VERSION"])
+          target = version_tuple(os.environ["NEXT_VERSION"])
+          if target <= current:
+              raise SystemExit(
+                  f"next development version {os.environ['NEXT_VERSION']} must be newer than "
+                  f"current {os.environ['CURRENT_VERSION']}"
+              )
+          PY
+
+          branch="prepare-development-${next_version%-SNAPSHOT}"
+          branch=${branch//./-}
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "::error::Remote branch $branch already exists; finish or remove its version-advance PR first"
+            exit 1
+          fi
+
+          echo "current_version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "current_release=${current_version%-SNAPSHOT}" >> "$GITHUB_OUTPUT"
+          echo "next_version=$next_version" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Create coherent version transition
+        env:
+          CURRENT_RELEASE: ${{ steps.version.outputs.current_release }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+
+          ./mvnw -B versions:set \
+            -DnewVersion="$NEXT_VERSION" \
+            -DgenerateBackupPoms=false
+          python3 .github/scripts/update-release-metadata.py "$NEXT_VERSION"
+          python3 .github/scripts/check-version-state.py \
+            --mode development \
+            --expected-version "$NEXT_VERSION"
+          ./mvnw -B -Prelease-check validate \
+            -DreleaseVersion="$CURRENT_RELEASE" \
+            -DnextDevelopmentVersion="$NEXT_VERSION" \
+            -DreleaseCheckCurrentState=advanced \
+            -DreleaseCheckRequireClean=false
+
+          mapfile -d '' tracked_poms < <(
+            git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'
+          )
+          git add -- "${tracked_poms[@]}" \
+            CITATION.cff CITATION.md .zenodo.json codemeta.json
+          if [[ -f deploy/helm/taxonomy/Chart.yaml ]]; then
+            git add -- deploy/helm/taxonomy/Chart.yaml
+          fi
+
+          if git diff --cached --quiet; then
+            echo "::error::Version transition produced no tracked metadata changes"
+            exit 1
+          fi
+          git commit -m "Prepare development version $NEXT_VERSION"
+          git push origin "$BRANCH"
+
+      - name: Open protected main pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current_version }}
+          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Prepare development version $NEXT_VERSION" \
+            --body "Advance Taxonomy from \`$CURRENT_VERSION\` to \`$NEXT_VERSION\` as one coherent Maven/citation/CodeMeta/Zenodo/Helm transition. Merge only after exact-head CI/CD, database compatibility, CodeQL and security gates are green. Tracks #704."

--- a/.mvn/verification-suites.json
+++ b/.mvn/verification-suites.json
@@ -48,6 +48,7 @@
     "delivery.yml": "report, container and deployment delivery",
     "deploy-release.yml": "release state machine",
     "protected-release-main-advance.yml": "protected next-development snapshot verification and pull-request handoff to main",
+    "prepare-development-version.yml": "validated non-release development-version transition through a protected pull request",
     "cleanup-workflow-runs.yml": "Actions retention"
   }
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -37,5 +37,5 @@
   ],
   "communities": [],
   "notes": "The Zenodo archive captures a release of the source code, metadata, citation instructions, and research documentation. Reproducibility instructions are provided in docs/research/reproducibility.md.",
-  "version": "1.3.2-SNAPSHOT"
+  "version": "1.4.0-SNAPSHOT"
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -37,5 +37,6 @@
   ],
   "communities": [],
   "notes": "The Zenodo archive captures a release of the source code, metadata, citation instructions, and research documentation. Reproducibility instructions are provided in docs/research/reproducibility.md.",
-  "version": "1.3.1-SNAPSHOT"
+  "version": "1.3.1",
+  "publication_date": "2026-08-09"
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/carstenartur/Taxonomy"
 url: "https://github.com/carstenartur/Taxonomy"
 license: MIT
-version: "1.3.2-SNAPSHOT"
+version: "1.4.0-SNAPSHOT"
 abstract: >-
   Taxonomy Architecture Analyzer is a Spring Boot web application for mapping
   requirements to architecture taxonomies, producing AI-assisted hierarchical

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 repository-code: "https://github.com/carstenartur/Taxonomy"
 url: "https://github.com/carstenartur/Taxonomy"
 license: MIT
-version: "1.3.1-SNAPSHOT"
+version: "1.3.1"
 abstract: >-
   Taxonomy Architecture Analyzer is a Spring Boot web application for mapping
   requirements to architecture taxonomies, producing AI-assisted hierarchical
@@ -24,3 +24,4 @@ keywords:
   - architecture-decision-support
   - spring-boot
   - java
+date-released: "2026-08-09"

--- a/CITATION.md
+++ b/CITATION.md
@@ -13,7 +13,7 @@ For the exact citation text and BibTeX entry, use the citation shown on the Zeno
 
 ## Development version citation
 
-Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.3.2-SNAPSHOT. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
+Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.4.0-SNAPSHOT. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
 
 ## BibTeX template for the active repository
 
@@ -22,7 +22,7 @@ Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.3.2-SNAPSHOT. 2026
   author       = {Hammer, Carsten},
   orcid        = {https://orcid.org/0009-0005-1047-6381},
   title        = {Taxonomy Architecture Analyzer},
-  version      = {1.3.2-SNAPSHOT},
+  version      = {1.4.0-SNAPSHOT},
   publisher    = {GitHub and Zenodo},
   url          = {https://github.com/carstenartur/Taxonomy},
   license      = {MIT}

--- a/CITATION.md
+++ b/CITATION.md
@@ -13,7 +13,7 @@ For the exact citation text and BibTeX entry, use the citation shown on the Zeno
 
 ## Development version citation
 
-Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.3.1-SNAPSHOT. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
+Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.3.1. 2026. Software. GitHub repository: https://github.com/carstenartur/Taxonomy
 
 ## BibTeX template for the active repository
 
@@ -22,7 +22,8 @@ Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.3.1-SNAPSHOT. 2026
   author       = {Hammer, Carsten},
   orcid        = {https://orcid.org/0009-0005-1047-6381},
   title        = {Taxonomy Architecture Analyzer},
-  version      = {1.3.1-SNAPSHOT},
+  version      = {1.3.1},
+  date         = {2026-08-09},
   publisher    = {GitHub and Zenodo},
   url          = {https://github.com/carstenartur/Taxonomy},
   license      = {MIT}

--- a/codemeta.json
+++ b/codemeta.json
@@ -6,7 +6,7 @@
   "codeRepository": "https://github.com/carstenartur/Taxonomy",
   "issueTracker": "https://github.com/carstenartur/Taxonomy/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.2-SNAPSHOT",
+  "version": "1.4.0-SNAPSHOT",
   "dateCreated": "2026-01-01",
   "programmingLanguage": [
     "Java",

--- a/codemeta.json
+++ b/codemeta.json
@@ -6,7 +6,7 @@
   "codeRepository": "https://github.com/carstenartur/Taxonomy",
   "issueTracker": "https://github.com/carstenartur/Taxonomy/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.3.1-SNAPSHOT",
+  "version": "1.3.1",
   "dateCreated": "2026-01-01",
   "programmingLanguage": [
     "Java",
@@ -51,5 +51,6 @@
     "Java 21+",
     "Maven 3.9+",
     "Optional LLM API key or LOCAL_ONNX provider"
-  ]
+  ],
+  "datePublished": "2026-08-09"
 }

--- a/deploy/helm/taxonomy/Chart.yaml
+++ b/deploy/helm/taxonomy/Chart.yaml
@@ -3,7 +3,7 @@ name: taxonomy
 description: Production-oriented Helm chart for Taxonomy on Rancher and Kubernetes
 type: application
 version: 0.1.0
-appVersion: "1.3.1-SNAPSHOT"
+appVersion: "1.3.1"
 home: https://github.com/carstenartur/Taxonomy
 sources:
   - https://github.com/carstenartur/Taxonomy

--- a/deploy/helm/taxonomy/Chart.yaml
+++ b/deploy/helm/taxonomy/Chart.yaml
@@ -3,7 +3,7 @@ name: taxonomy
 description: Production-oriented Helm chart for Taxonomy on Rancher and Kubernetes
 type: application
 version: 0.1.0
-appVersion: "1.3.2-SNAPSHOT"
+appVersion: "1.4.0-SNAPSHOT"
 home: https://github.com/carstenartur/Taxonomy
 sources:
   - https://github.com/carstenartur/Taxonomy

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.taxonomy</groupId>
     <artifactId>taxonomy</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1</version>
     <packaging>pom</packaging>
     <name>Taxonomy Architecture Analyzer</name>
     <description>Spring Boot web application that loads a C3-taxonomy catalogue and provides full-text search, KNN vector search, architecture-overlay DSL editing, and LLM-assisted analysis.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.taxonomy</groupId>
     <artifactId>taxonomy</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Taxonomy Architecture Analyzer</name>
     <description>Spring Boot web application that loads a C3-taxonomy catalogue and provides full-text search, KNN vector search, architecture-overlay DSL editing, and LLM-assisted analysis.</description>

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>taxonomy-app</artifactId>
     <name>Taxonomy Application</name>

--- a/taxonomy-app/pom.xml
+++ b/taxonomy-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <artifactId>taxonomy-app</artifactId>
     <name>Taxonomy Application</name>

--- a/taxonomy-build/pom.xml
+++ b/taxonomy-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>taxonomy-build</artifactId>

--- a/taxonomy-build/pom.xml
+++ b/taxonomy-build/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>taxonomy-build</artifactId>

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,8 +40,8 @@ class ReleaseParameterAncestryContractTest {
 
         assertThat(result.exitCode()).isZero();
         assertThat(result.stderr()).isEmpty();
-        assertThat(repository.resolve("github-output"))
-                .content(StandardCharsets.UTF_8)
+        assertThat(Files.readString(
+                repository.resolve("github-output"), StandardCharsets.UTF_8))
                 .contains(
                         "release_version=1.3.1",
                         "next_development_version=1.3.2-SNAPSHOT",
@@ -59,9 +57,9 @@ class ReleaseParameterAncestryContractTest {
         Path repository = temporaryDirectory.resolve("repository");
         Files.createDirectories(repository);
         run(repository, "git", "init");
+        run(repository, "git", "symbolic-ref", "HEAD", "refs/heads/main");
         run(repository, "git", "config", "user.name", "Release Contract");
         run(repository, "git", "config", "user.email", "release-contract@taxonomy.local");
-        run(repository, "git", "checkout", "-b", "main");
 
         writePom(repository, "1.3.1-SNAPSHOT");
         commitAll(repository, "Development base");
@@ -155,9 +153,13 @@ class ReleaseParameterAncestryContractTest {
     }
 
     private static boolean isExpectedFailure(String[] command) {
-        List<String> arguments = new ArrayList<>(List.of(command));
-        return arguments.contains("resolve-release-parameters.py")
-                || arguments.contains("--is-ancestor");
+        for (String argument : command) {
+            if (argument.endsWith("resolve-release-parameters.py")
+                    || "--is-ancestor".equals(argument)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Path repositoryRoot() {

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
@@ -1,0 +1,179 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Process-level contract for staged release-tag ancestry validation. */
+class ReleaseParameterAncestryContractTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void rejectsAnAlreadyAdvancedDevelopmentTreeWhoseReleaseTagDiverged() throws Exception {
+        Path repository = createDivergedReleaseRepository();
+
+        ProcessResult result = runResolver(repository);
+
+        assertThat(result.exitCode()).isEqualTo(1);
+        assertThat(result.stderr())
+                .contains("staged release tag v1.3.1 is not an ancestor")
+                .contains("repair release ancestry before publication");
+        assertThat(Files.exists(repository.resolve("github-output"))).isFalse();
+    }
+
+    @Test
+    void acceptsTheSameDevelopmentTreeAfterAHistoryOnlyAncestryMerge() throws Exception {
+        Path repository = createDivergedReleaseRepository();
+        run(repository, "git", "merge", "-s", "ours", "--no-ff", "release/1.3.1",
+                "-m", "Repair v1.3.1 ancestry");
+
+        ProcessResult result = runResolver(repository);
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.stderr()).isEmpty();
+        assertThat(repository.resolve("github-output"))
+                .content(StandardCharsets.UTF_8)
+                .contains(
+                        "release_version=1.3.1",
+                        "next_development_version=1.3.2-SNAPSHOT",
+                        "skip_tests=false",
+                        "dry_run=false",
+                        "resume_staged_release=false");
+        assertThat(run(repository, "git", "merge-base", "--is-ancestor",
+                "v1.3.1", "HEAD").exitCode()).isZero();
+        assertThat(readProjectVersion(repository)).isEqualTo("1.3.2-SNAPSHOT");
+    }
+
+    private Path createDivergedReleaseRepository() throws Exception {
+        Path repository = temporaryDirectory.resolve("repository");
+        Files.createDirectories(repository);
+        run(repository, "git", "init");
+        run(repository, "git", "config", "user.name", "Release Contract");
+        run(repository, "git", "config", "user.email", "release-contract@taxonomy.local");
+        run(repository, "git", "checkout", "-b", "main");
+
+        writePom(repository, "1.3.1-SNAPSHOT");
+        commitAll(repository, "Development base");
+
+        run(repository, "git", "checkout", "-b", "release/1.3.1");
+        writePom(repository, "1.3.1");
+        commitAll(repository, "Release version 1.3.1");
+        run(repository, "git", "tag", "v1.3.1");
+
+        run(repository, "git", "checkout", "main");
+        writePom(repository, "1.3.2-SNAPSHOT");
+        commitAll(repository, "Prepare next development version 1.3.2-SNAPSHOT");
+        writeReleaseRequest(repository);
+        return repository;
+    }
+
+    private ProcessResult runResolver(Path repository) throws Exception {
+        Path output = repository.resolve("github-output");
+        Files.deleteIfExists(output);
+        return run(
+                repository,
+                Map.of(
+                        "EVENT_NAME", "push",
+                        "RELEASE_REQUEST_PATH", repository.resolve("release-request.json").toString(),
+                        "GITHUB_OUTPUT", output.toString()),
+                "python3",
+                repositoryRoot().resolve(".github/scripts/resolve-release-parameters.py").toString());
+    }
+
+    private static void writeReleaseRequest(Path repository) throws IOException {
+        Files.writeString(
+                repository.resolve("release-request.json"),
+                """
+                        {
+                          "release_version": "1.3.1",
+                          "next_development_version": "1.3.2-SNAPSHOT",
+                          "skip_tests": false,
+                          "dry_run": false
+                        }
+                        """,
+                StandardCharsets.UTF_8);
+    }
+
+    private static void writePom(Path repository, String version) throws IOException {
+        Files.writeString(
+                repository.resolve("pom.xml"),
+                """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>com.taxonomy</groupId>
+                          <artifactId>release-contract</artifactId>
+                          <version>%s</version>
+                        </project>
+                        """.formatted(version),
+                StandardCharsets.UTF_8);
+    }
+
+    private static String readProjectVersion(Path repository) throws IOException {
+        String pom = Files.readString(repository.resolve("pom.xml"), StandardCharsets.UTF_8);
+        int start = pom.indexOf("<version>") + "<version>".length();
+        return pom.substring(start, pom.indexOf("</version>", start));
+    }
+
+    private static void commitAll(Path repository, String message) throws Exception {
+        run(repository, "git", "add", "pom.xml");
+        run(repository, "git", "commit", "-m", message);
+    }
+
+    private static ProcessResult run(Path directory, String... command) throws Exception {
+        return run(directory, Map.of(), command);
+    }
+
+    private static ProcessResult run(
+            Path directory,
+            Map<String, String> environment,
+            String... command) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(command)
+                .directory(directory.toFile());
+        builder.environment().putAll(environment);
+        Process process = builder.start();
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        ProcessResult result = new ProcessResult(exitCode, stdout, stderr);
+        if (exitCode != 0 && !isExpectedFailure(command)) {
+            throw new AssertionError("Command failed: " + String.join(" ", command)
+                    + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
+        }
+        return result;
+    }
+
+    private static boolean isExpectedFailure(String[] command) {
+        List<String> arguments = new ArrayList<>(List.of(command));
+        return arguments.contains("resolve-release-parameters.py")
+                || arguments.contains("--is-ancestor");
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            ".github/scripts/resolve-release-parameters.py"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Cannot locate Taxonomy repository root");
+    }
+
+    private record ProcessResult(int exitCode, String stdout, String stderr) {
+    }
+}

--- a/taxonomy-coverage/pom.xml
+++ b/taxonomy-coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>taxonomy-coverage</artifactId>

--- a/taxonomy-coverage/pom.xml
+++ b/taxonomy-coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
 
     <artifactId>taxonomy-coverage</artifactId>

--- a/taxonomy-domain/pom.xml
+++ b/taxonomy-domain/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>taxonomy-domain</artifactId>
     <name>Taxonomy Domain</name>

--- a/taxonomy-domain/pom.xml
+++ b/taxonomy-domain/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <artifactId>taxonomy-domain</artifactId>
     <name>Taxonomy Domain</name>

--- a/taxonomy-dsl/pom.xml
+++ b/taxonomy-dsl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <artifactId>taxonomy-dsl</artifactId>
     <name>Taxonomy DSL</name>

--- a/taxonomy-dsl/pom.xml
+++ b/taxonomy-dsl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>taxonomy-dsl</artifactId>
     <name>Taxonomy DSL</name>

--- a/taxonomy-export/pom.xml
+++ b/taxonomy-export/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <artifactId>taxonomy-export</artifactId>
     <name>Taxonomy Export</name>

--- a/taxonomy-export/pom.xml
+++ b/taxonomy-export/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>taxonomy-export</artifactId>
     <name>Taxonomy Export</name>

--- a/taxonomy-extension-api/pom.xml
+++ b/taxonomy-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <artifactId>taxonomy-extension-api</artifactId>
     <name>Taxonomy Extension API</name>

--- a/taxonomy-extension-api/pom.xml
+++ b/taxonomy-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.taxonomy</groupId>
         <artifactId>taxonomy</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.1</version>
     </parent>
     <artifactId>taxonomy-extension-api</artifactId>
     <name>Taxonomy Extension API</name>


### PR DESCRIPTION
Temporary verification-only checkpoint for #703 and #705.

Purpose: run the authoritative pull-request-to-main gates on the exact combined tree that:

- records the immutable v1.3.1 release commit in development ancestry without publishing it;
- rejects future already-advanced staged releases with divergent tag ancestry;
- advances every Maven module and release metadata surface to `1.4.0-SNAPSHOT`;
- adds the protected non-release development-version workflow;
- leaves `.github/release-request.json` unchanged, so no obsolete 1.3.1 release is triggered.

**Do not merge this PR.** Integrate #703 with a merge commit first, then retarget and verify #705 against the resulting `main`.

Tracks release train #704 and build-policy issue #673.