### PR TITLE
Keep rejected relation decisions in Git but out of active projections

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionRebuildWriter.java
@@ -33,6 +33,8 @@ public class RelationBranchProjectionRebuildWriter {
     /**
      * Replaces the exact repository/workspace/branch rows and checkpoint in one
      * transaction. Failure leaves the previously complete projection untouched.
+     * Rejected decisions stay in authoritative TaxDSL but are omitted from the
+     * complete active-relation projection.
      */
     @Transactional
     public RebuildResult replace(
@@ -60,6 +62,8 @@ public class RelationBranchProjectionRebuildWriter {
         projectionRepository.flush();
 
         List<RelationDecisionProjection> replacements = snapshots.stream()
+                .filter(snapshot -> RelationDecisionStatusPolicy
+                        .isRelationPresent(snapshot.status()))
                 .sorted(Comparator
                         .comparing(RelationSnapshot::sourceCode)
                         .thenComparing(snapshot -> snapshot.relationType().name())

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
@@ -41,8 +41,9 @@ public class RelationDecisionProjectionWriter {
     @Transactional
     public ProjectionResult write(ProjectionRequest request) {
         Objects.requireNonNull(request, "request");
+        ProjectionRequest effectiveRequest = effectiveState(request);
         String workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(
-                request.workspaceId());
+                effectiveRequest.workspaceId());
 
         // An incremental command proves only one relation identity. Even when it
         // is a semantic no-op, it must not leave a previous full-branch checkpoint
@@ -50,47 +51,68 @@ public class RelationDecisionProjectionWriter {
         // Runtime failures roll this deletion back with the relation write.
         if (checkpointRepository != null) {
             checkpointRepository.deleteExact(
-                    request.repositoryId(),
+                    effectiveRequest.repositoryId(),
                     workspaceScopeKey,
-                    request.branch());
+                    effectiveRequest.branch());
         }
 
         RelationDecisionProjection existing = projectionRepository
                 .findExactForUpdate(
-                        request.repositoryId(),
+                        effectiveRequest.repositoryId(),
                         workspaceScopeKey,
-                        request.branch(),
-                        request.sourceCode(),
-                        request.relationType(),
-                        request.targetCode())
+                        effectiveRequest.branch(),
+                        effectiveRequest.sourceCode(),
+                        effectiveRequest.relationType(),
+                        effectiveRequest.targetCode())
                 .orElse(null);
 
         if (existing == null) {
             RelationDecisionProjection created = new RelationDecisionProjection();
-            applyIdentity(created, request);
-            applyState(created, request);
-            applyAuthority(created, request);
+            applyIdentity(created, effectiveRequest);
+            applyState(created, effectiveRequest);
+            applyAuthority(created, effectiveRequest);
             projectionRepository.save(created);
-            return result(ProjectionOutcome.CREATED, request);
+            return result(ProjectionOutcome.CREATED, effectiveRequest);
         }
 
-        if (request.authoritativeCommitId().equals(
+        if (effectiveRequest.authoritativeCommitId().equals(
                 existing.getAuthoritativeCommitId())) {
-            if (!sameState(existing, request)
-                    || !request.causationId().equals(
+            if (!sameState(existing, effectiveRequest)
+                    || !effectiveRequest.causationId().equals(
                             existing.getCausationId())) {
                 throw new ProjectionConflictException(
                         "Authoritative commit "
-                                + request.authoritativeCommitId()
+                                + effectiveRequest.authoritativeCommitId()
                                 + " is already projected with different relation state");
             }
-            return result(ProjectionOutcome.REPLAYED, request);
+            return result(ProjectionOutcome.REPLAYED, effectiveRequest);
         }
 
-        applyState(existing, request);
-        applyAuthority(existing, request);
+        applyState(existing, effectiveRequest);
+        applyAuthority(existing, effectiveRequest);
         projectionRepository.save(existing);
-        return result(ProjectionOutcome.UPDATED, request);
+        return result(ProjectionOutcome.UPDATED, effectiveRequest);
+    }
+
+    private static ProjectionRequest effectiveState(ProjectionRequest request) {
+        boolean relationPresent = request.relationPresent()
+                && RelationDecisionStatusPolicy.isRelationPresent(request.status());
+        if (relationPresent == request.relationPresent()) {
+            return request;
+        }
+        return new ProjectionRequest(
+                request.repositoryId(),
+                request.workspaceId(),
+                request.branch(),
+                request.sourceCode(),
+                request.relationType(),
+                request.targetCode(),
+                false,
+                request.status(),
+                request.confidence(),
+                request.provenance(),
+                request.authoritativeCommitId(),
+                request.causationId());
     }
 
     private static void applyIdentity(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionStatusPolicy.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionStatusPolicy.java
@@ -1,0 +1,20 @@
+package com.taxonomy.relations.service;
+
+/**
+ * Defines whether one Git-authoritative relation decision represents an active
+ * relation in the rebuildable branch projection.
+ *
+ * <p>Historic DSL documents may omit {@code status}; proposed and provisional
+ * relations are also retained for compatibility with existing branch views.
+ * A rejected relation remains in TaxDSL as audit evidence but is never exposed
+ * as an active projected relation.</p>
+ */
+final class RelationDecisionStatusPolicy {
+
+    private RelationDecisionStatusPolicy() {
+    }
+
+    static boolean isRelationPresent(String status) {
+        return status == null || !"rejected".equalsIgnoreCase(status.strip());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RejectedRelationProjectionSemanticsTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RejectedRelationProjectionSemanticsTest.java
@@ -1,0 +1,120 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RelationSnapshot;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionRequest;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RejectedRelationProjectionSemanticsTest {
+
+    private static final String COMMIT = "a".repeat(40);
+
+    @Test
+    void onlyRejectedDecisionsAreInactiveForCompatibility() {
+        assertThat(RelationDecisionStatusPolicy.isRelationPresent(null)).isTrue();
+        assertThat(RelationDecisionStatusPolicy.isRelationPresent("accepted")).isTrue();
+        assertThat(RelationDecisionStatusPolicy.isRelationPresent("PROPOSED")).isTrue();
+        assertThat(RelationDecisionStatusPolicy.isRelationPresent(" provisional ")).isTrue();
+        assertThat(RelationDecisionStatusPolicy.isRelationPresent(" rejected ")).isFalse();
+    }
+
+    @Test
+    void incrementalRejectedUpsertBecomesAnExplicitInactiveTombstone() {
+        RelationDecisionProjectionRepository repository =
+                mock(RelationDecisionProjectionRepository.class);
+        when(repository.findExactForUpdate(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1"))
+                .thenReturn(Optional.empty());
+        ProjectionRequest request = new ProjectionRequest(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1",
+                true,
+                "rejected",
+                0.8,
+                "human-review",
+                COMMIT,
+                "proposal-17");
+
+        var result = new RelationDecisionProjectionWriter(repository)
+                .write(request);
+
+        ArgumentCaptor<RelationDecisionProjection> saved =
+                ArgumentCaptor.forClass(RelationDecisionProjection.class);
+        verify(repository).save(saved.capture());
+        assertThat(result.relationPresent()).isFalse();
+        assertThat(saved.getValue().isRelationPresent()).isFalse();
+        assertThat(saved.getValue().getStatus()).isEqualTo("rejected");
+        assertThat(saved.getValue().getAuthoritativeCommitId())
+                .isEqualTo(COMMIT);
+    }
+
+    @Test
+    void completeRebuildKeepsRejectedDecisionsInGitButNotInReadyRows() {
+        RelationDecisionProjectionRepository projections =
+                mock(RelationDecisionProjectionRepository.class);
+        RelationDecisionProjectionCheckpointRepository checkpoints =
+                mock(RelationDecisionProjectionCheckpointRepository.class);
+        when(checkpoints.findExactForUpdate(
+                "repo-a", "workspace-a", "review"))
+                .thenReturn(Optional.empty());
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        List<RelationSnapshot> snapshots = List.of(
+                new RelationSnapshot(
+                        "APP-1", RelationType.USES, "SVC-1",
+                        "accepted", 0.9, "human-review"),
+                new RelationSnapshot(
+                        "APP-2", RelationType.DEPENDS_ON, "SVC-2",
+                        "rejected", 0.7, "human-review"));
+
+        var result = new RelationBranchProjectionRebuildWriter(
+                projections, checkpoints)
+                .replace(context, COMMIT, snapshots);
+
+        @SuppressWarnings("rawtypes")
+        ArgumentCaptor<Iterable> savedRows =
+                ArgumentCaptor.forClass(Iterable.class);
+        verify(projections).saveAll(savedRows.capture());
+        List<RelationDecisionProjection> rows = StreamSupport.stream(
+                        savedRows.getValue().spliterator(), false)
+                .map(RelationDecisionProjection.class::cast)
+                .toList();
+        ArgumentCaptor<RelationDecisionProjectionCheckpoint> checkpoint =
+                ArgumentCaptor.forClass(
+                        RelationDecisionProjectionCheckpoint.class);
+        verify(checkpoints).saveAndFlush(checkpoint.capture());
+
+        assertThat(rows).hasSize(1);
+        assertThat(rows.getFirst().getSourceCode()).isEqualTo("APP-1");
+        assertThat(rows.getFirst().isRelationPresent()).isTrue();
+        assertThat(result.relationCount()).isEqualTo(1);
+        assertThat(checkpoint.getValue().getRelationCount()).isEqualTo(1);
+        assertThat(checkpoint.getValue().getAuthoritativeCommitId())
+                .isEqualTo(COMMIT);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RejectedRelationProjectionSemanticsTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RejectedRelationProjectionSemanticsTest.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## Scope

Seventh bounded slice of #691, now based directly on the WIP multi-repository integration branch after corrected #706 was integrated.

A rejected proposal or hypothesis must remain reconstructable from authoritative TaxDSL, but it must not be exposed as an active relation. This PR defines and enforces that distinction at both incremental and complete transactional projection boundaries.

## Changes

- adds one compatibility-preserving status policy:
  - missing, `accepted`, `proposed` and `provisional` statuses remain active;
  - `rejected` is inactive, case-insensitively;
- incremental upserts whose authoritative TaxDSL status is `rejected` are written as explicit inactive tombstones while retaining status, provenance, causation and authoritative commit;
- complete branch rebuilds omit rejected rows and store a checkpoint count containing only active relations;
- rejected decision blocks remain in `architecture.taxdsl` as Git audit evidence;
- readiness therefore never treats a rejected relation as an active row and never marks a full rebuild corrupt merely because the authoritative branch contains rejected decision history;
- adds JUnit coverage for compatibility status behavior, incremental rejection tombstones, complete rebuild filtering and checkpoint counts;
- removes the reviewed unused Mockito matcher import.

## Authority boundary

No controller-specific shortcut is involved. The transactional writers enforce the policy for every caller. Duplicate or malformed TaxDSL validation still occurs before the writers; this slice changes only active-projection semantics.

## Stack integrity

- #610 base exact head: `1aae488064f53319272bc140012e8f7e73eae8df`.
- #706 is already integrated in that head, including the corrected `/api/architecture/relations` route and required `Idempotency-Key` contract.
- Current #709 exact head: `38088bd8f4d848bf3c6887ec9b2829516b8e5d53`.
- The branch was merged forward without rewriting history.
- The diff relative to #610 remains limited to four intended projection-semantics files.
- The only #709 review thread is resolved.

## Verification and integration

A fresh exact-head matrix is running for `38088bd8f4d848bf3c6887ec9b2829516b8e5d53`:

- CI/CD;
- PostgreSQL, Oracle and SQL Server;
- JGit storage consumer contract;
- CodeQL;
- Security Scan.

Merge this PR only into #610, never directly into `main`, and only after all exact-head gates are green and no review thread is open. Checkpoint #710 remains verification-only and must be closed unmerged after successful integration.

Advances proposal/hypothesis Git-first review work in #691, projection recovery #698, multi-repository epic #609/#610 and release train #704.