### PR TITLE
Request non-publishing Taxonomy 1.4.0 release dry run

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -1,8 +1,9 @@
 {
-  "release_version": "1.3.1",
-  "next_development_version": "1.3.2-SNAPSHOT",
+  "release_version": "1.4.0",
+  "next_development_version": "1.4.1-SNAPSHOT",
   "skip_tests": false,
-  "dry_run": false,
-  "request_revision": 7,
-  "requested_after_commit": "64a6a7227a8cf13c1b349004bdd911cdffcf3f45"
+  "dry_run": true,
+  "resume_staged_release": false,
+  "request_revision": 8,
+  "requested_after_commit": "b4f2847f0d940803c4d666b5986197362ee04e78"
 }


### PR DESCRIPTION
## Purpose

Request a **non-publishing** Taxonomy 1.4.0 dry run from the exact release-policy-protected `main` commit.

## Requested transition

- current development state: `1.4.0-SNAPSHOT`;
- dry-run release state: `1.4.0`;
- next development state: `1.4.1-SNAPSHOT`;
- tests: enabled;
- `dry_run`: `true`;
- staged-release resume: disabled;
- remote refs, GitHub releases, container images and deployment hooks must remain unchanged.

## Commit-bound request

Base and `requested_after_commit`:

`b4f2847f0d940803c4d666b5986197362ee04e78`

Request commit:

`5e2975c4b15f93e8703b34b141b74b1efd9d74c0`

Integrity proof:

- exactly one commit ahead and zero behind `main`;
- the request commit's first parent is exactly `requested_after_commit`;
- exactly one changed path: `.github/release-request.json`;
- `request_revision` advances exactly once, from 7 to 8;
- requested versions are `1.4.0` and `1.4.1-SNAPSHOT`;
- `skip_tests` is false;
- `dry_run` is true.

## Safety and ordering

#716 is integrated in the base, so the push-triggered release workflow will reject this request unless all parent, path and revision invariants hold. Keep this PR draft until its exact-head CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan and review are green. After merge, inspect the dry-run logs and artifacts before preparing any publishing request.

Tracks #711.