### PR TITLE
Bind release requests to the exact verified main parent

### DIFF
--- a/.github/scripts/resolve-release-parameters.py
+++ b/.github/scripts/resolve-release-parameters.py
@@ -14,6 +14,7 @@ import xml.etree.ElementTree as ET
 
 _RELEASE_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 _DEVELOPMENT_VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$")
+_COMMIT_ID = re.compile(r"^[0-9a-f]{40}$")
 _INCREMENT_VALUES = {"patch", "minor", "major"}
 _OUTPUT_KEYS = (
     "release_version",
@@ -58,6 +59,13 @@ def normalize_boolean(value: object, field: str) -> str:
         if normalized in {"true", "false"}:
             return normalized
     raise ValueError(f"{field} must be true or false")
+
+
+def normalize_request_revision(value: object) -> int:
+    """Require a positive, non-boolean release-request revision."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError("request_revision must be a positive integer")
+    return value
 
 
 def repository_version(root: Path) -> str:
@@ -211,6 +219,107 @@ def resolve_parameters(
     return parameters
 
 
+def git_output(root: Path, *arguments: str) -> str:
+    """Run one read-only Git command and return its standard output."""
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown Git error"
+        raise ValueError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def validate_release_request_anchor(
+    root: Path,
+    request_path: Path,
+    request: Mapping[str, object],
+) -> None:
+    """Bind a push-triggered request to the immediately preceding verified tree."""
+    root = root.resolve()
+    absolute_request = (
+        request_path if request_path.is_absolute() else root / request_path
+    ).resolve()
+    try:
+        relative_request = absolute_request.relative_to(root).as_posix()
+    except ValueError as error:
+        raise ValueError("release request path must stay inside the repository") from error
+
+    requested_after = request.get("requested_after_commit")
+    if not isinstance(requested_after, str):
+        raise ValueError("requested_after_commit must be a full Git commit ID")
+    requested_after = requested_after.strip()
+    if not _COMMIT_ID.fullmatch(requested_after):
+        raise ValueError("requested_after_commit must be a full Git commit ID")
+    request_revision = normalize_request_revision(request.get("request_revision"))
+
+    parent = git_output(root, "rev-parse", "HEAD^1").strip()
+    if parent != requested_after:
+        raise ValueError(
+            "requested_after_commit must equal the release-request commit's "
+            f"first parent {parent}, got {requested_after}"
+        )
+
+    changed_paths = [
+        path
+        for path in git_output(
+            root,
+            "diff",
+            "--name-only",
+            "--diff-filter=ACDMRTUXB",
+            requested_after,
+            "HEAD",
+            "--",
+        ).splitlines()
+        if path
+    ]
+    if changed_paths != [relative_request]:
+        changed = ", ".join(changed_paths) if changed_paths else "<none>"
+        raise ValueError(
+            f"release request commit must change only {relative_request}; "
+            f"changed paths: {changed}"
+        )
+
+    previous_exists = subprocess.run(
+        ["git", "cat-file", "-e", f"{requested_after}:{relative_request}"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if previous_exists.returncode == 0:
+        previous_text = git_output(
+            root, "show", f"{requested_after}:{relative_request}"
+        )
+        try:
+            previous_request = json.loads(previous_text)
+        except json.JSONDecodeError as error:
+            raise ValueError(
+                "previous release request is not valid JSON"
+            ) from error
+        if not isinstance(previous_request, dict):
+            raise ValueError("previous release request must contain a JSON object")
+        previous_revision = normalize_request_revision(
+            previous_request.get("request_revision")
+        )
+    elif previous_exists.returncode in {1, 128}:
+        previous_revision = 0
+    else:
+        detail = previous_exists.stderr.strip() or "unknown Git error"
+        raise ValueError(f"cannot inspect previous release request: {detail}")
+
+    expected_revision = previous_revision + 1
+    if request_revision != expected_revision:
+        raise ValueError(
+            f"request_revision must advance from {previous_revision} to "
+            f"{expected_revision}, got {request_revision}"
+        )
+
+
 def validate_staged_release_ancestry(
     root: Path,
     parameters: Mapping[str, str],
@@ -289,6 +398,7 @@ def main() -> int:
             loaded = json.loads(request_path.read_text(encoding="utf-8"))
             if not isinstance(loaded, dict):
                 raise ValueError("release request must contain a JSON object")
+            validate_release_request_anchor(root, request_path, loaded)
             request = loaded
 
         parameters = resolve_parameters(

--- a/docs/dev/PYTHON_TOOLING_POLICY.md
+++ b/docs/dev/PYTHON_TOOLING_POLICY.md
@@ -67,6 +67,14 @@ release staging, deployment targets or external report formats:
 - `check-codeql-sarif.py`
 - `check-observability-performance-scope.py`
 
+`resolve-release-parameters.py` remains the small adapter between GitHub event
+inputs, reviewed JSON and stable workflow outputs. For push-triggered releases it
+also verifies that the request commit names its exact first parent, increments
+`request_revision` exactly once, and changes no path except
+`.github/release-request.json`. `ReleaseRequestAnchorContractTest` owns positive
+and negative Git fixtures for this boundary; no Python `unittest` is added for
+the new policy.
+
 `check-version-state.py` is retained because `release.sh` copies it to a temporary
 location and invokes it while switching between a detached immutable release tag
 and the next-development `main`. `VersionStateAdapterContractTest` owns its

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java
@@ -18,8 +18,9 @@ class ReleaseParameterAncestryContractTest {
     Path temporaryDirectory;
 
     @Test
-    void rejectsAnAlreadyAdvancedDevelopmentTreeWhoseReleaseTagDiverged() throws Exception {
-        Path repository = createDivergedReleaseRepository();
+    void rejectsAnAlreadyAdvancedDevelopmentTreeWhoseReleaseTagDiverged()
+            throws Exception {
+        Path repository = createReleaseRepository(false);
 
         ProcessResult result = runResolver(repository);
 
@@ -31,10 +32,9 @@ class ReleaseParameterAncestryContractTest {
     }
 
     @Test
-    void acceptsTheSameDevelopmentTreeAfterAHistoryOnlyAncestryMerge() throws Exception {
-        Path repository = createDivergedReleaseRepository();
-        run(repository, "git", "merge", "-s", "ours", "--no-ff", "release/1.3.1",
-                "-m", "Repair v1.3.1 ancestry");
+    void acceptsTheSameDevelopmentTreeAfterAHistoryOnlyAncestryMerge()
+            throws Exception {
+        Path repository = createReleaseRepository(true);
 
         ProcessResult result = runResolver(repository);
 
@@ -53,13 +53,15 @@ class ReleaseParameterAncestryContractTest {
         assertThat(readProjectVersion(repository)).isEqualTo("1.3.2-SNAPSHOT");
     }
 
-    private Path createDivergedReleaseRepository() throws Exception {
+    private Path createReleaseRepository(boolean repairAncestry)
+            throws Exception {
         Path repository = temporaryDirectory.resolve("repository");
         Files.createDirectories(repository);
         run(repository, "git", "init");
         run(repository, "git", "symbolic-ref", "HEAD", "refs/heads/main");
         run(repository, "git", "config", "user.name", "Release Contract");
-        run(repository, "git", "config", "user.email", "release-contract@taxonomy.local");
+        run(repository, "git", "config", "user.email",
+                "release-contract@taxonomy.local");
 
         writePom(repository, "1.3.1-SNAPSHOT");
         commitAll(repository, "Development base");
@@ -72,7 +74,11 @@ class ReleaseParameterAncestryContractTest {
         run(repository, "git", "checkout", "main");
         writePom(repository, "1.3.2-SNAPSHOT");
         commitAll(repository, "Prepare next development version 1.3.2-SNAPSHOT");
-        writeReleaseRequest(repository);
+        if (repairAncestry) {
+            run(repository, "git", "merge", "-s", "ours", "--no-ff",
+                    "release/1.3.1", "-m", "Repair v1.3.1 ancestry");
+        }
+        commitReleaseRequest(repository);
         return repository;
     }
 
@@ -83,13 +89,26 @@ class ReleaseParameterAncestryContractTest {
                 repository,
                 Map.of(
                         "EVENT_NAME", "push",
-                        "RELEASE_REQUEST_PATH", repository.resolve("release-request.json").toString(),
+                        "RELEASE_REQUEST_PATH",
+                        repository.resolve("release-request.json").toString(),
                         "GITHUB_OUTPUT", output.toString()),
                 "python3",
-                repositoryRoot().resolve(".github/scripts/resolve-release-parameters.py").toString());
+                repositoryRoot().resolve(
+                        ".github/scripts/resolve-release-parameters.py").toString());
     }
 
-    private static void writeReleaseRequest(Path repository) throws IOException {
+    private static void commitReleaseRequest(Path repository) throws Exception {
+        String requestedAfter = run(
+                repository, "git", "rev-parse", "HEAD").stdout().strip();
+        writeReleaseRequest(repository, requestedAfter, 1);
+        run(repository, "git", "add", "release-request.json");
+        run(repository, "git", "commit", "-m", "Request staged release resume");
+    }
+
+    private static void writeReleaseRequest(
+            Path repository,
+            String requestedAfter,
+            int requestRevision) throws IOException {
         Files.writeString(
                 repository.resolve("release-request.json"),
                 """
@@ -97,13 +116,17 @@ class ReleaseParameterAncestryContractTest {
                           "release_version": "1.3.1",
                           "next_development_version": "1.3.2-SNAPSHOT",
                           "skip_tests": false,
-                          "dry_run": false
+                          "dry_run": false,
+                          "resume_staged_release": false,
+                          "request_revision": %d,
+                          "requested_after_commit": "%s"
                         }
-                        """,
+                        """.formatted(requestRevision, requestedAfter),
                 StandardCharsets.UTF_8);
     }
 
-    private static void writePom(Path repository, String version) throws IOException {
+    private static void writePom(Path repository, String version)
+            throws IOException {
         Files.writeString(
                 repository.resolve("pom.xml"),
                 """
@@ -118,18 +141,22 @@ class ReleaseParameterAncestryContractTest {
                 StandardCharsets.UTF_8);
     }
 
-    private static String readProjectVersion(Path repository) throws IOException {
-        String pom = Files.readString(repository.resolve("pom.xml"), StandardCharsets.UTF_8);
+    private static String readProjectVersion(Path repository)
+            throws IOException {
+        String pom = Files.readString(
+                repository.resolve("pom.xml"), StandardCharsets.UTF_8);
         int start = pom.indexOf("<version>") + "<version>".length();
         return pom.substring(start, pom.indexOf("</version>", start));
     }
 
-    private static void commitAll(Path repository, String message) throws Exception {
+    private static void commitAll(Path repository, String message)
+            throws Exception {
         run(repository, "git", "add", "pom.xml");
         run(repository, "git", "commit", "-m", message);
     }
 
-    private static ProcessResult run(Path directory, String... command) throws Exception {
+    private static ProcessResult run(Path directory, String... command)
+            throws Exception {
         return run(directory, Map.of(), command);
     }
 
@@ -141,12 +168,15 @@ class ReleaseParameterAncestryContractTest {
                 .directory(directory.toFile());
         builder.environment().putAll(environment);
         Process process = builder.start();
-        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stdout = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stderr = new String(
+                process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
         int exitCode = process.waitFor();
         ProcessResult result = new ProcessResult(exitCode, stdout, stderr);
         if (exitCode != 0 && !isExpectedFailure(command)) {
-            throw new AssertionError("Command failed: " + String.join(" ", command)
+            throw new AssertionError("Command failed: "
+                    + String.join(" ", command)
                     + "\nstdout:\n" + stdout + "\nstderr:\n" + stderr);
         }
         return result;

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseRequestAnchorContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseRequestAnchorContractTest.java
@@ -1,0 +1,186 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** JUnit-owned contract for push-triggered release-request ancestry. */
+class ReleaseRequestAnchorContractTest {
+
+    @Test
+    void acceptsOneRevisionChangingOnlyTheRequestAfterItsExactParent(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 8, false);
+
+        AdapterResult result = runAdapter(root);
+
+        assertThat(result.exitCode()).as(result.output()).isZero();
+        assertThat(result.output()).doesNotContain("::error::");
+        assertThat(Files.readAllLines(
+                root.resolve("github-output"), StandardCharsets.UTF_8))
+                .containsExactly(
+                        "release_version=1.4.0",
+                        "next_development_version=1.4.1-SNAPSHOT",
+                        "skip_tests=false",
+                        "dry_run=true",
+                        "resume_staged_release=false");
+    }
+
+    @Test
+    void rejectsARequestNotAnchoredToItsImmediateFirstParent(
+            @TempDir Path root) throws Exception {
+        initializeRepository(root);
+        commitRequest(root, "0".repeat(40), 8, false);
+
+        AdapterResult result = runAdapter(root);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("requested_after_commit must equal")
+                .contains("first parent");
+    }
+
+    @Test
+    void rejectsAReleaseCommitContainingAnyOtherPath(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 8, true);
+
+        AdapterResult result = runAdapter(root);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("release request commit must change only")
+                .contains("README.md");
+    }
+
+    @Test
+    void rejectsARequestRevisionThatDoesNotAdvanceExactlyOnce(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 9, false);
+
+        AdapterResult result = runAdapter(root);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("request_revision must advance from 7 to 8")
+                .contains("got 9");
+    }
+
+    private static String initializeRepository(Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.4.0-SNAPSHOT</version>
+                </project>
+                """);
+        write(root.resolve(".github/release-request.json"), request(
+                "f".repeat(40), 7));
+
+        git(root, "init");
+        git(root, "branch", "-M", "main");
+        git(root, "config", "user.name", "Release Contract Test");
+        git(root, "config", "user.email", "release-contract@example.invalid");
+        git(root, "add", ".");
+        git(root, "commit", "-m", "Verified release base");
+        return git(root, "rev-parse", "HEAD").strip();
+    }
+
+    private static void commitRequest(
+            Path root,
+            String requestedAfter,
+            int revision,
+            boolean includeOtherPath) throws Exception {
+        write(root.resolve(".github/release-request.json"), request(
+                requestedAfter, revision));
+        if (includeOtherPath) {
+            write(root.resolve("README.md"), "unreviewed release content\n");
+        }
+        git(root, "add", ".");
+        git(root, "commit", "-m", "Request release dry run");
+    }
+
+    private static AdapterResult runAdapter(Path fixtureRoot) throws Exception {
+        Path repositoryRoot = findRepositoryRoot();
+        Path output = fixtureRoot.resolve("github-output");
+        List<String> command = new ArrayList<>(List.of(
+                "python3",
+                repositoryRoot.resolve(
+                        ".github/scripts/resolve-release-parameters.py").toString()));
+        ProcessBuilder builder = new ProcessBuilder(command)
+                .directory(fixtureRoot.toFile())
+                .redirectErrorStream(true);
+        builder.environment().put("EVENT_NAME", "push");
+        builder.environment().put("GITHUB_OUTPUT", output.toString());
+        builder.environment().put(
+                "RELEASE_REQUEST_PATH", ".github/release-request.json");
+
+        Process process = builder.start();
+        String text = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        return new AdapterResult(process.waitFor(), text);
+    }
+
+    private static String git(Path root, String... arguments) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(arguments));
+        Process process = new ProcessBuilder(command)
+                .directory(root.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        assertThat(exitCode).as("%s%n%s", command, output).isZero();
+        return output;
+    }
+
+    private static String request(String requestedAfter, int revision) {
+        return """
+                {
+                  "release_version": "1.4.0",
+                  "next_development_version": "1.4.1-SNAPSHOT",
+                  "skip_tests": false,
+                  "dry_run": true,
+                  "resume_staged_release": false,
+                  "request_revision": %d,
+                  "requested_after_commit": "%s"
+                }
+                """.formatted(revision, requestedAfter);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve(
+                    ".github/scripts/resolve-release-parameters.py"))
+                    && Files.isRegularFile(current.resolve("pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private record AdapterResult(int exitCode, String output) {
+    }
+}


### PR DESCRIPTION
## Problem

`.github/release-request.json` records `requested_after_commit` and `request_revision`, but the release workflow previously ignored both fields. A reviewed request therefore claimed to be bound to an exact verified `main` commit without enforcing that claim.

## Changes

- extend the retained `resolve-release-parameters.py` workflow adapter so every push-triggered release request must:
  - name one canonical full Git commit in `requested_after_commit`;
  - name the exact first parent of the triggering request commit;
  - change only `.github/release-request.json` relative to that parent;
  - increment `request_revision` by exactly one from the parent tree;
- add `ReleaseRequestAnchorContractTest` with isolated real-Git fixtures proving:
  - a correctly anchored one-file revision is accepted;
  - a stale or fabricated anchor is rejected;
  - any additional changed path is rejected;
  - skipped request revisions are rejected;
- update the pre-existing staged-release ancestry fixtures so they construct real anchored request commits before testing divergent and repaired tag history;
- document JUnit ownership of the retained adapter boundary in `PYTHON_TOOLING_POLICY.md`.

No new Python `unittest` is introduced. The workflow adapter remains productive glue between GitHub events, reviewed JSON and stable outputs; JUnit owns its positive and negative contract.

## Matrix correction

The first combined #717 database run proved the new anchor fixtures themselves green but exposed that `ReleaseParameterAncestryContractTest` still generated the old uncommitted request shape. The corrected fixture commits a real revision-1 request after either the divergent next-development commit or the repaired history-only merge. The original staged-tag ancestry assertions remain unchanged; no production validation was weakened or bypassed.

## Clean integration head

After #714 merged, directly retargeting the original feature history to `main` produced a nine-file merge-base artefact. The PR head was therefore rebuilt from the exact current `main` commit rather than merging that unrelated history.

Base: `6ef7c596366cd4641ba867bef934df4603ca3e66`.

Head: `e7214946071371ecc7fb9e8ddbc07c5188148e27`.

The head is exactly one commit ahead, zero behind, and changes exactly four files:

- `.github/scripts/resolve-release-parameters.py`;
- `taxonomy-build/src/test/java/com/taxonomy/build/ReleaseRequestAnchorContractTest.java`;
- `taxonomy-build/src/test/java/com/taxonomy/build/ReleaseParameterAncestryContractTest.java`;
- `docs/dev/PYTHON_TOOLING_POLICY.md`.

All checks attached to earlier heads `46b4173217770c4c79f4a1cb4ee0700c0a12c2f6` and `d947a6b29cbac368bb534aa8842390248056c268` are historical only. Require fresh exact-head CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan and no unresolved review thread before merge.

## Release ordering

This correction must be integrated before staged dry-run request #715 is allowed to target `main`. After integration, #715 must be rebuilt directly from the exact verified `main` SHA so its request commit satisfies the new first-parent, one-file and revision checks.

Verification-only #717 completed its purpose and was closed unmerged.

Advances #673 and #711.