### PR TITLE
Expose Git-first proposal accept, reject and revert commands

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitProposalReviewApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitProposalReviewApiController.java
@@ -1,0 +1,308 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.ReadOnlyRepositoryContextException;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.PendingPhase;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ProposalReviewPendingException;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewAction;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewResult;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+/** Git-authoritative accept, reject and revert commands for relation proposals. */
+@RestController
+@RequestMapping("/api/architecture/proposals")
+@Tag(name = "Git-authoritative proposal review")
+public class GitProposalReviewApiController {
+
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
+    private final GitAuthoritativeProposalReviewService reviewService;
+    private final WorkspaceResolver workspaceResolver;
+    private final SystemRepositoryService repositoryService;
+    private final RepositoryMembershipService membershipService;
+
+    public GitProposalReviewApiController(
+            GitAuthoritativeProposalReviewService reviewService,
+            WorkspaceResolver workspaceResolver,
+            SystemRepositoryService repositoryService,
+            RepositoryMembershipService membershipService) {
+        this.reviewService = reviewService;
+        this.workspaceResolver = workspaceResolver;
+        this.repositoryService = repositoryService;
+        this.membershipService = membershipService;
+    }
+
+    @Operation(summary = "Accept a proposal through an exact Git commit")
+    @PostMapping("/{proposalId}/accept")
+    public ResponseEntity<ReviewResponse> accept(
+            @PathVariable Long proposalId,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = true)
+            String causationId,
+            @RequestBody(required = false) ReviewBody body) {
+        return review(
+                proposalId,
+                ReviewAction.ACCEPT,
+                ifMatch,
+                ifNoneMatch,
+                causationId,
+                body);
+    }
+
+    @Operation(summary = "Reject a proposal through an exact Git commit")
+    @PostMapping("/{proposalId}/reject")
+    public ResponseEntity<ReviewResponse> reject(
+            @PathVariable Long proposalId,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = true)
+            String causationId,
+            @RequestBody(required = false) ReviewBody body) {
+        return review(
+                proposalId,
+                ReviewAction.REJECT,
+                ifMatch,
+                ifNoneMatch,
+                causationId,
+                body);
+    }
+
+    @Operation(summary = "Revert a reviewed proposal through an exact Git commit")
+    @PostMapping("/{proposalId}/revert")
+    public ResponseEntity<ReviewResponse> revert(
+            @PathVariable Long proposalId,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = true)
+            String causationId,
+            @RequestBody(required = false) ReviewBody body) {
+        return review(
+                proposalId,
+                ReviewAction.REVERT,
+                ifMatch,
+                ifNoneMatch,
+                causationId,
+                body);
+    }
+
+    private ResponseEntity<ReviewResponse> review(
+            Long proposalId,
+            ReviewAction action,
+            String ifMatch,
+            String ifNoneMatch,
+            String causationId,
+            ReviewBody body) {
+        try {
+            RepositoryContext context = writableContext(
+                    workspaceResolver.resolveCurrentRepositoryContext());
+            if (context == null) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            String expectedHead = GitHttpPrecondition.expectedHead(
+                    ifMatch, ifNoneMatch);
+            String rationale = body == null ? null : body.rationale();
+            ReviewResult result = switch (action) {
+                case ACCEPT -> reviewService.accept(
+                        proposalId,
+                        context,
+                        expectedHead,
+                        new CommandMetadata(causationId, rationale));
+                case REJECT -> reviewService.reject(
+                        proposalId,
+                        context,
+                        expectedHead,
+                        new CommandMetadata(causationId, rationale));
+                case REVERT -> reviewService.revert(
+                        proposalId,
+                        context,
+                        expectedHead,
+                        new CommandMetadata(causationId, rationale));
+            };
+            return projected(result);
+        } catch (GitHttpPrecondition.PreconditionRequiredException error) {
+            return ResponseEntity.status(HttpStatus.PRECONDITION_REQUIRED).build();
+        } catch (BranchHeadConflictException error) {
+            return preconditionFailed(proposalId, action, error);
+        } catch (ProposalReviewPendingException error) {
+            return pending(error);
+        } catch (ReadOnlyRepositoryContextException error) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IOException error) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+    }
+
+    private static ResponseEntity<ReviewResponse> projected(
+            ReviewResult result) {
+        CommandResult authority = result.mutation().authority();
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.ETAG,
+                        GitHttpPrecondition.etag(
+                                authority.authoritativeCommitId()))
+                .body(ReviewResponse.projected(result));
+    }
+
+    private static ResponseEntity<ReviewResponse> pending(
+            ProposalReviewPendingException error) {
+        CommandResult authority = error.getAuthority();
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .header(
+                        HttpHeaders.ETAG,
+                        GitHttpPrecondition.etag(
+                                authority.authoritativeCommitId()))
+                .body(ReviewResponse.pending(error));
+    }
+
+    private static ResponseEntity<ReviewResponse> preconditionFailed(
+            Long proposalId,
+            ReviewAction action,
+            BranchHeadConflictException error) {
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(
+                HttpStatus.PRECONDITION_FAILED);
+        if (error.getActualHeadCommit() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            error.getActualHeadCommit()));
+        }
+        return response.body(ReviewResponse.conflict(
+                proposalId, action, error));
+    }
+
+    /** Convert a central read context into an explicitly authorized write context. */
+    private RepositoryContext writableContext(RepositoryContext context) {
+        if (context.workspaceId() != null) {
+            return context;
+        }
+        SystemRepository repository = repositoryService.getRepository(
+                context.repositoryId());
+        if (!isApplicationAdmin()
+                && !membershipService.canMaintain(
+                        repository, context.username())) {
+            return null;
+        }
+        return new RepositoryContext(
+                context.repositoryId(),
+                null,
+                context.branch(),
+                context.username(),
+                RepositoryScope.CENTRAL_WRITE);
+    }
+
+    private static boolean isApplicationAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        return authentication != null
+                && authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_ADMIN".equals(
+                        authority.getAuthority()));
+    }
+
+    public record ReviewBody(String rationale) {
+    }
+
+    public record ReviewResponse(
+            Long proposalId,
+            String action,
+            String intendedProposalStatus,
+            String authoritativeCommitId,
+            String changeKind,
+            boolean commitCreated,
+            String projectionStatus,
+            String projectionOutcome,
+            Boolean relationPresent,
+            String pendingPhase,
+            String expectedHeadCommit,
+            String actualHeadCommit) {
+
+        static ReviewResponse projected(ReviewResult result) {
+            CommandResult authority = result.mutation().authority();
+            return new ReviewResponse(
+                    result.proposalId(),
+                    result.action().name(),
+                    result.proposalStatus().name(),
+                    authority.authoritativeCommitId(),
+                    authority.changeKind().name(),
+                    authority.commitCreated(),
+                    "PROJECTED",
+                    result.mutation().projection().outcome().name(),
+                    result.mutation().projection().relationPresent(),
+                    null,
+                    null,
+                    null);
+        }
+
+        static ReviewResponse pending(
+                ProposalReviewPendingException error) {
+            CommandResult authority = error.getAuthority();
+            PendingPhase phase = error.getPhase();
+            return new ReviewResponse(
+                    error.getProposalId(),
+                    null,
+                    error.getIntendedStatus().name(),
+                    authority.authoritativeCommitId(),
+                    authority.changeKind().name(),
+                    authority.commitCreated(),
+                    "PENDING_RECOVERY",
+                    null,
+                    null,
+                    phase.name(),
+                    null,
+                    null);
+        }
+
+        static ReviewResponse conflict(
+                Long proposalId,
+                ReviewAction action,
+                BranchHeadConflictException error) {
+            return new ReviewResponse(
+                    proposalId,
+                    action.name(),
+                    null,
+                    null,
+                    null,
+                    false,
+                    "PRECONDITION_FAILED",
+                    null,
+                    null,
+                    null,
+                    error.getExpectedHeadCommit(),
+                    error.getActualHeadCommit());
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
@@ -3,7 +3,9 @@ package com.taxonomy.relations.repository;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.model.RelationProposal;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -94,6 +96,20 @@ public interface RelationProposalRepository extends JpaRepository<RelationPropos
                    OR p.workspaceId = :workspaceId)
             """)
     Optional<RelationProposal> findByIdInRepositoryWorkspace(
+            @Param("repositoryId") String repositoryId,
+            @Param("id") Long id,
+            @Param("workspaceId") String workspaceId);
+
+    /** Locks one exact mutable proposal row for the final review-state transition. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p FROM RelationProposal p
+            WHERE p.repositoryId = :repositoryId
+              AND p.id = :id
+              AND ((:workspaceId IS NULL AND p.workspaceId IS NULL)
+                   OR p.workspaceId = :workspaceId)
+            """)
+    Optional<RelationProposal> findByIdInRepositoryWorkspaceForUpdate(
             @Param("repositoryId") String repositoryId,
             @Param("id") Long id,
             @Param("workspaceId") String workspaceId);

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeProposalReviewService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeProposalReviewService.java
@@ -1,0 +1,277 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.relations.service.ProposalReviewStateStore.ProposalSnapshot;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Reviews one proposal by committing the relation decision to Git first and
+ * advancing relational proposal bookkeeping only after projection succeeds.
+ */
+@Service
+public class GitAuthoritativeProposalReviewService {
+
+    private static final String PROPOSAL_PROVENANCE = "proposal-review";
+
+    private final ProposalReviewStateStore stateStore;
+    private final GitAuthoritativeRelationMutationService mutationService;
+
+    public GitAuthoritativeProposalReviewService(
+            ProposalReviewStateStore stateStore,
+            GitAuthoritativeRelationMutationService mutationService) {
+        this.stateStore = Objects.requireNonNull(stateStore, "stateStore");
+        this.mutationService = Objects.requireNonNull(
+                mutationService, "mutationService");
+    }
+
+    public ReviewResult accept(
+            Long proposalId,
+            RepositoryContext context,
+            String expectedHeadCommit,
+            CommandMetadata metadata) throws IOException {
+        return review(
+                proposalId,
+                context,
+                expectedHeadCommit,
+                metadata,
+                ReviewAction.ACCEPT);
+    }
+
+    public ReviewResult reject(
+            Long proposalId,
+            RepositoryContext context,
+            String expectedHeadCommit,
+            CommandMetadata metadata) throws IOException {
+        return review(
+                proposalId,
+                context,
+                expectedHeadCommit,
+                metadata,
+                ReviewAction.REJECT);
+    }
+
+    public ReviewResult revert(
+            Long proposalId,
+            RepositoryContext context,
+            String expectedHeadCommit,
+            CommandMetadata metadata) throws IOException {
+        return review(
+                proposalId,
+                context,
+                expectedHeadCommit,
+                metadata,
+                ReviewAction.REVERT);
+    }
+
+    private ReviewResult review(
+            Long proposalId,
+            RepositoryContext context,
+            String expectedHeadCommit,
+            CommandMetadata metadata,
+            ReviewAction action) throws IOException {
+        RepositoryContext tenant = ProposalReviewStateStore
+                .requireWritableContext(context);
+        Objects.requireNonNull(metadata, "metadata");
+        ProposalSnapshot proposal = stateStore.require(proposalId, tenant);
+        action.requireCurrentStatus(proposal.id(), proposal.status());
+
+        MutationResult mutation;
+        try {
+            mutation = mutate(
+                    proposal,
+                    tenant,
+                    expectedHeadCommit,
+                    metadata,
+                    action);
+        } catch (ProjectionPendingException error) {
+            throw ProposalReviewPendingException.projection(
+                    proposal.id(), action.targetStatus(), error);
+        }
+
+        try {
+            ProposalStatus status = stateStore.transition(
+                    proposal.id(),
+                    tenant,
+                    proposal.status(),
+                    action.targetStatus());
+            return new ReviewResult(
+                    proposal.id(), action, status, mutation);
+        } catch (RuntimeException bookkeepingFailure) {
+            throw ProposalReviewPendingException.bookkeeping(
+                    proposal.id(),
+                    action.targetStatus(),
+                    mutation.authority(),
+                    bookkeepingFailure);
+        }
+    }
+
+    private MutationResult mutate(
+            ProposalSnapshot proposal,
+            RepositoryContext context,
+            String expectedHeadCommit,
+            CommandMetadata metadata,
+            ReviewAction action) throws IOException {
+        RelationIdentity identity = new RelationIdentity(
+                proposal.sourceCode(),
+                proposal.relationType().name(),
+                proposal.targetCode());
+        if (action == ReviewAction.REVERT) {
+            return mutationService.remove(
+                    context, expectedHeadCommit, identity, metadata);
+        }
+        return mutationService.upsert(
+                context,
+                expectedHeadCommit,
+                new RelationDefinition(
+                        identity,
+                        action.dslStatus(),
+                        proposal.confidence(),
+                        PROPOSAL_PROVENANCE,
+                        Map.of(
+                                "x-proposal-id",
+                                proposal.id().toString())),
+                metadata);
+    }
+
+    public enum ReviewAction {
+        ACCEPT(ProposalStatus.PENDING, ProposalStatus.ACCEPTED, "accepted"),
+        REJECT(ProposalStatus.PENDING, ProposalStatus.REJECTED, "rejected"),
+        REVERT(null, ProposalStatus.PENDING, null);
+
+        private final ProposalStatus requiredStatus;
+        private final ProposalStatus targetStatus;
+        private final String dslStatus;
+
+        ReviewAction(
+                ProposalStatus requiredStatus,
+                ProposalStatus targetStatus,
+                String dslStatus) {
+            this.requiredStatus = requiredStatus;
+            this.targetStatus = targetStatus;
+            this.dslStatus = dslStatus;
+        }
+
+        void requireCurrentStatus(Long proposalId, ProposalStatus current) {
+            if (this == REVERT) {
+                if (current == ProposalStatus.PENDING) {
+                    throw new IllegalStateException(
+                            "Proposal " + proposalId + " is already PENDING");
+                }
+                return;
+            }
+            if (current != requiredStatus) {
+                throw new IllegalStateException(
+                        "Proposal " + proposalId + " is already " + current);
+            }
+        }
+
+        ProposalStatus targetStatus() {
+            return targetStatus;
+        }
+
+        String dslStatus() {
+            return dslStatus;
+        }
+    }
+
+    public record ReviewResult(
+            Long proposalId,
+            ReviewAction action,
+            ProposalStatus proposalStatus,
+            MutationResult mutation) {
+        public ReviewResult {
+            proposalId = Objects.requireNonNull(proposalId, "proposalId");
+            action = Objects.requireNonNull(action, "action");
+            proposalStatus = Objects.requireNonNull(
+                    proposalStatus, "proposalStatus");
+            mutation = Objects.requireNonNull(mutation, "mutation");
+        }
+    }
+
+    public static final class ProposalReviewPendingException
+            extends IllegalStateException {
+        private final Long proposalId;
+        private final ProposalStatus intendedStatus;
+        private final CommandResult authority;
+        private final PendingPhase phase;
+
+        private ProposalReviewPendingException(
+                Long proposalId,
+                ProposalStatus intendedStatus,
+                CommandResult authority,
+                PendingPhase phase,
+                Throwable cause) {
+            super("Git proposal review succeeded at "
+                    + authority.authoritativeCommitId()
+                    + ", but " + phase.description + " requires recovery", cause);
+            this.proposalId = Objects.requireNonNull(proposalId, "proposalId");
+            this.intendedStatus = Objects.requireNonNull(
+                    intendedStatus, "intendedStatus");
+            this.authority = Objects.requireNonNull(authority, "authority");
+            this.phase = Objects.requireNonNull(phase, "phase");
+        }
+
+        static ProposalReviewPendingException projection(
+                Long proposalId,
+                ProposalStatus intendedStatus,
+                ProjectionPendingException error) {
+            return new ProposalReviewPendingException(
+                    proposalId,
+                    intendedStatus,
+                    error.getAuthority(),
+                    PendingPhase.PROJECTION,
+                    error);
+        }
+
+        static ProposalReviewPendingException bookkeeping(
+                Long proposalId,
+                ProposalStatus intendedStatus,
+                CommandResult authority,
+                Throwable cause) {
+            return new ProposalReviewPendingException(
+                    proposalId,
+                    intendedStatus,
+                    authority,
+                    PendingPhase.PROPOSAL_BOOKKEEPING,
+                    cause);
+        }
+
+        public Long getProposalId() {
+            return proposalId;
+        }
+
+        public ProposalStatus getIntendedStatus() {
+            return intendedStatus;
+        }
+
+        public CommandResult getAuthority() {
+            return authority;
+        }
+
+        public PendingPhase getPhase() {
+            return phase;
+        }
+    }
+
+    public enum PendingPhase {
+        PROJECTION("relation projection"),
+        PROPOSAL_BOOKKEEPING("proposal bookkeeping");
+
+        private final String description;
+
+        PendingPhase(String description) {
+            this.description = description;
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
@@ -32,7 +32,7 @@ public class ProposalReviewStateStore {
             Long proposalId,
             RepositoryContext context) {
         RepositoryContext tenant = requireWritableContext(context);
-        RelationProposal proposal = find(proposalId, tenant);
+        RelationProposal proposal = find(proposalId, tenant, false);
         return new ProposalSnapshot(
                 proposal.getId(),
                 proposal.getSourceNode().getCode(),
@@ -51,7 +51,7 @@ public class ProposalReviewStateStore {
             ProposalStatus expected,
             ProposalStatus target) {
         RepositoryContext tenant = requireWritableContext(context);
-        RelationProposal proposal = find(proposalId, tenant);
+        RelationProposal proposal = find(proposalId, tenant, true);
         if (proposal.getStatus() != expected) {
             throw new ProposalStateConflictException(
                     "Proposal " + proposalId + " is " + proposal.getStatus()
@@ -66,14 +66,20 @@ public class ProposalReviewStateStore {
 
     private RelationProposal find(
             Long proposalId,
-            RepositoryContext context) {
+            RepositoryContext context,
+            boolean forUpdate) {
         if (proposalId == null) {
             throw new IllegalArgumentException("proposalId must not be null");
         }
-        return proposalRepository.findByIdInRepositoryWorkspace(
+        return (forUpdate
+                ? proposalRepository.findByIdInRepositoryWorkspaceForUpdate(
                         context.repositoryId(),
                         proposalId,
                         context.workspaceId())
+                : proposalRepository.findByIdInRepositoryWorkspace(
+                        context.repositoryId(),
+                        proposalId,
+                        context.workspaceId()))
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Proposal not found in active repository/workspace: "
                                 + proposalId));

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
@@ -1,0 +1,126 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Reads and advances proposal bookkeeping in short transactions around an
+ * independently authoritative Git command.
+ */
+@Service
+public class ProposalReviewStateStore {
+
+    private final RelationProposalRepository proposalRepository;
+
+    public ProposalReviewStateStore(
+            RelationProposalRepository proposalRepository) {
+        this.proposalRepository = Objects.requireNonNull(
+                proposalRepository, "proposalRepository");
+    }
+
+    @Transactional(readOnly = true)
+    public ProposalSnapshot require(
+            Long proposalId,
+            RepositoryContext context) {
+        RepositoryContext tenant = requireWritableContext(context);
+        RelationProposal proposal = find(proposalId, tenant);
+        return new ProposalSnapshot(
+                proposal.getId(),
+                proposal.getSourceNode().getCode(),
+                proposal.getTargetNode().getCode(),
+                proposal.getRelationType(),
+                proposal.getStatus(),
+                proposal.getConfidence(),
+                proposal.getRationale(),
+                proposal.getProvenance());
+    }
+
+    @Transactional
+    public ProposalStatus transition(
+            Long proposalId,
+            RepositoryContext context,
+            ProposalStatus expected,
+            ProposalStatus target) {
+        RepositoryContext tenant = requireWritableContext(context);
+        RelationProposal proposal = find(proposalId, tenant);
+        if (proposal.getStatus() != expected) {
+            throw new ProposalStateConflictException(
+                    "Proposal " + proposalId + " is " + proposal.getStatus()
+                            + ", expected " + expected);
+        }
+        proposal.setStatus(target);
+        proposal.setReviewedAt(target == ProposalStatus.PENDING
+                ? null : Instant.now());
+        proposalRepository.save(proposal);
+        return target;
+    }
+
+    private RelationProposal find(
+            Long proposalId,
+            RepositoryContext context) {
+        if (proposalId == null) {
+            throw new IllegalArgumentException("proposalId must not be null");
+        }
+        return proposalRepository.findByIdInRepositoryWorkspace(
+                        context.repositoryId(),
+                        proposalId,
+                        context.workspaceId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Proposal not found in active repository/workspace: "
+                                + proposalId));
+    }
+
+    static RepositoryContext requireWritableContext(
+            RepositoryContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException(
+                    "RepositoryContext must not be null");
+        }
+        if (context.workspaceId() == null
+                && context.scope() != RepositoryScope.CENTRAL_WRITE) {
+            throw new IllegalArgumentException(
+                    "Central proposal review requires CENTRAL_WRITE scope");
+        }
+        if (context.workspaceId() != null
+                && context.scope() != RepositoryScope.WORKSPACE
+                && context.scope() != RepositoryScope.FORK) {
+            throw new IllegalArgumentException(
+                    "Workspace proposal review requires WORKSPACE or FORK scope");
+        }
+        return context;
+    }
+
+    public record ProposalSnapshot(
+            Long id,
+            String sourceCode,
+            String targetCode,
+            RelationType relationType,
+            ProposalStatus status,
+            double confidence,
+            String rationale,
+            String provenance) {
+        public ProposalSnapshot {
+            id = Objects.requireNonNull(id, "id");
+            sourceCode = Objects.requireNonNull(sourceCode, "sourceCode");
+            targetCode = Objects.requireNonNull(targetCode, "targetCode");
+            relationType = Objects.requireNonNull(relationType, "relationType");
+            status = Objects.requireNonNull(status, "status");
+        }
+    }
+
+    public static final class ProposalStateConflictException
+            extends IllegalStateException {
+        public ProposalStateConflictException(String message) {
+            super(message);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitProposalReviewApiControllerHttpContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitProposalReviewApiControllerHttpContractTest.java
@@ -1,0 +1,67 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.relations.service.RelationReviewService;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Source-level contract for the Git-authoritative proposal review boundary. */
+class GitProposalReviewApiControllerHttpContractTest {
+
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
+    @Test
+    void exposesASeparateArchitectureProposalReviewRoute() {
+        RequestMapping mapping = GitProposalReviewApiController.class
+                .getAnnotation(RequestMapping.class);
+
+        assertThat(mapping).isNotNull();
+        assertThat(mapping.value())
+                .containsExactly("/api/architecture/proposals");
+    }
+
+    @Test
+    void requiresAnIdempotencyKeyForEveryReviewMutation() {
+        assertRequiredIdempotencyKey(method("accept"));
+        assertRequiredIdempotencyKey(method("reject"));
+        assertRequiredIdempotencyKey(method("revert"));
+    }
+
+    @Test
+    void newBoundaryCannotCallTheLegacyDbFirstReviewService() {
+        assertThat(Arrays.stream(GitProposalReviewApiController.class
+                        .getDeclaredFields())
+                .map(Field::getType))
+                .doesNotContain(RelationReviewService.class);
+    }
+
+    private static Method method(String name) {
+        return Arrays.stream(GitProposalReviewApiController.class
+                        .getDeclaredMethods())
+                .filter(candidate -> candidate.getName().equals(name))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static void assertRequiredIdempotencyKey(Method method) {
+        RequestHeader header = Arrays.stream(method.getParameters())
+                .map(parameter -> parameter.getAnnotation(RequestHeader.class))
+                .filter(Objects::nonNull)
+                .filter(annotation -> IDEMPOTENCY_KEY.equals(annotation.value())
+                        || IDEMPOTENCY_KEY.equals(annotation.name()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(header.required())
+                .as("%s must reject a missing Idempotency-Key before invocation",
+                        method.getName())
+                .isTrue();
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeProposalReviewServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeProposalReviewServiceTest.java
@@ -1,0 +1,237 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.PendingPhase;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ProposalReviewPendingException;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.relations.service.ProposalReviewStateStore.ProposalSnapshot;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GitAuthoritativeProposalReviewServiceTest {
+
+    private static final String PREVIOUS = "a".repeat(40);
+    private static final String AUTHORITY = "b".repeat(40);
+
+    @Mock
+    private ProposalReviewStateStore stateStore;
+
+    @Mock
+    private GitAuthoritativeRelationMutationService mutationService;
+
+    private GitAuthoritativeProposalReviewService service;
+    private RepositoryContext context;
+    private CommandMetadata metadata;
+
+    @BeforeEach
+    void setUp() {
+        service = new GitAuthoritativeProposalReviewService(
+                stateStore, mutationService);
+        context = new RepositoryContext(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "alice",
+                RepositoryScope.WORKSPACE);
+        metadata = new CommandMetadata("proposal-review-17", "human review");
+    }
+
+    @Test
+    void acceptCommitsAndProjectsBeforeAdvancingProposalBookkeeping()
+            throws Exception {
+        ProposalSnapshot proposal = snapshot(ProposalStatus.PENDING);
+        MutationResult mutation = mutation(true);
+        when(stateStore.require(17L, context)).thenReturn(proposal);
+        when(mutationService.upsert(
+                eq(context), eq(PREVIOUS), any(), eq(metadata)))
+                .thenReturn(mutation);
+        when(stateStore.transition(
+                17L, context, ProposalStatus.PENDING, ProposalStatus.ACCEPTED))
+                .thenReturn(ProposalStatus.ACCEPTED);
+
+        var result = service.accept(17L, context, PREVIOUS, metadata);
+
+        ArgumentCaptor<RelationDefinition> definition =
+                ArgumentCaptor.forClass(RelationDefinition.class);
+        verify(mutationService).upsert(
+                eq(context), eq(PREVIOUS), definition.capture(), eq(metadata));
+        assertThat(definition.getValue().status()).isEqualTo("accepted");
+        assertThat(definition.getValue().confidence()).isEqualTo(0.83);
+        assertThat(definition.getValue().provenance())
+                .isEqualTo("proposal-review");
+        assertThat(definition.getValue().extensions())
+                .isEqualTo(Map.of("x-proposal-id", "17"));
+        assertThat(result.proposalStatus()).isEqualTo(ProposalStatus.ACCEPTED);
+        assertThat(result.mutation().authority().authoritativeCommitId())
+                .isEqualTo(AUTHORITY);
+
+        InOrder order = inOrder(mutationService, stateStore);
+        order.verify(stateStore).require(17L, context);
+        order.verify(mutationService).upsert(
+                eq(context), eq(PREVIOUS), any(), eq(metadata));
+        order.verify(stateStore).transition(
+                17L, context, ProposalStatus.PENDING, ProposalStatus.ACCEPTED);
+    }
+
+    @Test
+    void rejectPersistsARejectedGitDecisionAndInactiveProjection()
+            throws Exception {
+        when(stateStore.require(17L, context))
+                .thenReturn(snapshot(ProposalStatus.PENDING));
+        when(mutationService.upsert(
+                eq(context), eq(PREVIOUS), any(), eq(metadata)))
+                .thenReturn(mutation(false));
+        when(stateStore.transition(
+                17L, context, ProposalStatus.PENDING, ProposalStatus.REJECTED))
+                .thenReturn(ProposalStatus.REJECTED);
+
+        var result = service.reject(17L, context, PREVIOUS, metadata);
+
+        ArgumentCaptor<RelationDefinition> definition =
+                ArgumentCaptor.forClass(RelationDefinition.class);
+        verify(mutationService).upsert(
+                eq(context), eq(PREVIOUS), definition.capture(), eq(metadata));
+        assertThat(definition.getValue().status()).isEqualTo("rejected");
+        assertThat(result.mutation().projection().relationPresent()).isFalse();
+        assertThat(result.proposalStatus()).isEqualTo(ProposalStatus.REJECTED);
+    }
+
+    @Test
+    void revertRemovesTheCurrentDecisionBeforeReturningProposalToPending()
+            throws Exception {
+        when(stateStore.require(17L, context))
+                .thenReturn(snapshot(ProposalStatus.ACCEPTED));
+        when(mutationService.remove(
+                eq(context), eq(PREVIOUS), any(), eq(metadata)))
+                .thenReturn(mutation(false));
+        when(stateStore.transition(
+                17L, context, ProposalStatus.ACCEPTED, ProposalStatus.PENDING))
+                .thenReturn(ProposalStatus.PENDING);
+
+        var result = service.revert(17L, context, PREVIOUS, metadata);
+
+        ArgumentCaptor<RelationIdentity> identity =
+                ArgumentCaptor.forClass(RelationIdentity.class);
+        verify(mutationService).remove(
+                eq(context), eq(PREVIOUS), identity.capture(), eq(metadata));
+        assertThat(identity.getValue())
+                .extracting(
+                        RelationIdentity::sourceId,
+                        RelationIdentity::relationType,
+                        RelationIdentity::targetId)
+                .containsExactly("APP-1", "USES", "SVC-1");
+        assertThat(result.proposalStatus()).isEqualTo(ProposalStatus.PENDING);
+    }
+
+    @Test
+    void projectionFailureExposesAuthorityAndNeverAdvancesProposalStatus()
+            throws Exception {
+        CommandResult authority = authority();
+        when(stateStore.require(17L, context))
+                .thenReturn(snapshot(ProposalStatus.PENDING));
+        when(mutationService.upsert(
+                eq(context), eq(PREVIOUS), any(), eq(metadata)))
+                .thenThrow(new ProjectionPendingException(
+                        authority,
+                        new IllegalStateException("database unavailable")));
+
+        assertThatThrownBy(() -> service.accept(
+                17L, context, PREVIOUS, metadata))
+                .isInstanceOfSatisfying(
+                        ProposalReviewPendingException.class,
+                        error -> {
+                            assertThat(error.getAuthority()).isEqualTo(authority);
+                            assertThat(error.getIntendedStatus())
+                                    .isEqualTo(ProposalStatus.ACCEPTED);
+                            assertThat(error.getPhase())
+                                    .isEqualTo(PendingPhase.PROJECTION);
+                        });
+        verify(stateStore, never()).transition(
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void bookkeepingFailureRemainsRecoverableAfterProjectedGitSuccess()
+            throws Exception {
+        MutationResult mutation = mutation(true);
+        when(stateStore.require(17L, context))
+                .thenReturn(snapshot(ProposalStatus.PENDING));
+        when(mutationService.upsert(
+                eq(context), eq(PREVIOUS), any(), eq(metadata)))
+                .thenReturn(mutation);
+        when(stateStore.transition(
+                17L, context, ProposalStatus.PENDING, ProposalStatus.ACCEPTED))
+                .thenThrow(new IllegalStateException("proposal row unavailable"));
+
+        assertThatThrownBy(() -> service.accept(
+                17L, context, PREVIOUS, metadata))
+                .isInstanceOfSatisfying(
+                        ProposalReviewPendingException.class,
+                        error -> {
+                            assertThat(error.getAuthority())
+                                    .isEqualTo(mutation.authority());
+                            assertThat(error.getPhase())
+                                    .isEqualTo(PendingPhase.PROPOSAL_BOOKKEEPING);
+                        });
+    }
+
+    private static ProposalSnapshot snapshot(ProposalStatus status) {
+        return new ProposalSnapshot(
+                17L,
+                "APP-1",
+                "SVC-1",
+                RelationType.USES,
+                status,
+                0.83,
+                "reviewed evidence",
+                "llm");
+    }
+
+    private static MutationResult mutation(boolean relationPresent) {
+        return new MutationResult(
+                authority(),
+                new RelationDecisionProjectionService.ProjectionResult(
+                        RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
+                        AUTHORITY,
+                        relationPresent));
+    }
+
+    private static CommandResult authority() {
+        return new CommandResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                RepositoryScope.WORKSPACE,
+                PREVIOUS,
+                AUTHORITY,
+                ChangeKind.UPDATED,
+                true,
+                "proposal-review-17");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalReviewStateStoreTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalReviewStateStoreTest.java
@@ -1,0 +1,98 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProposalReviewStateStoreTest {
+
+    private final RelationProposalRepository repository =
+            mock(RelationProposalRepository.class);
+    private final ProposalReviewStateStore store =
+            new ProposalReviewStateStore(repository);
+    private final RepositoryContext context = new RepositoryContext(
+            "repo-a",
+            "workspace-a",
+            "review",
+            "alice",
+            RepositoryScope.WORKSPACE);
+
+    @Test
+    void transitionLocksTheExactTenantRowAndRechecksItsStatus() {
+        RelationProposal proposal = proposal(ProposalStatus.PENDING);
+        when(repository.findByIdInRepositoryWorkspaceForUpdate(
+                "repo-a", 17L, "workspace-a"))
+                .thenReturn(Optional.of(proposal));
+
+        ProposalStatus result = store.transition(
+                17L,
+                context,
+                ProposalStatus.PENDING,
+                ProposalStatus.ACCEPTED);
+
+        assertThat(result).isEqualTo(ProposalStatus.ACCEPTED);
+        assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.ACCEPTED);
+        assertThat(proposal.getReviewedAt()).isNotNull();
+        verify(repository).save(proposal);
+        verify(repository, never()).findByIdInRepositoryWorkspace(
+                "repo-a", 17L, "workspace-a");
+    }
+
+    @Test
+    void transitionRejectsAConcurrentProposalStatusChange() {
+        RelationProposal proposal = proposal(ProposalStatus.REJECTED);
+        when(repository.findByIdInRepositoryWorkspaceForUpdate(
+                "repo-a", 17L, "workspace-a"))
+                .thenReturn(Optional.of(proposal));
+
+        assertThatThrownBy(() -> store.transition(
+                17L,
+                context,
+                ProposalStatus.PENDING,
+                ProposalStatus.ACCEPTED))
+                .isInstanceOf(
+                        ProposalReviewStateStore.ProposalStateConflictException.class)
+                .hasMessageContaining("is REJECTED, expected PENDING");
+        verify(repository, never()).save(proposal);
+    }
+
+    @Test
+    void revertingToPendingClearsTheReviewTimestamp() {
+        RelationProposal proposal = proposal(ProposalStatus.ACCEPTED);
+        proposal.setReviewedAt(java.time.Instant.parse(
+                "2026-08-12T10:00:00Z"));
+        when(repository.findByIdInRepositoryWorkspaceForUpdate(
+                "repo-a", 17L, "workspace-a"))
+                .thenReturn(Optional.of(proposal));
+
+        store.transition(
+                17L,
+                context,
+                ProposalStatus.ACCEPTED,
+                ProposalStatus.PENDING);
+
+        assertThat(proposal.getStatus()).isEqualTo(ProposalStatus.PENDING);
+        assertThat(proposal.getReviewedAt()).isNull();
+    }
+
+    private static RelationProposal proposal(ProposalStatus status) {
+        RelationProposal proposal = new RelationProposal();
+        proposal.setId(17L);
+        proposal.setRepositoryId("repo-a");
+        proposal.setWorkspaceId("workspace-a");
+        proposal.setStatus(status);
+        return proposal;
+    }
+}


### PR DESCRIPTION
## Scope

Next bounded #691 slice on WIP #610. It adds an additive Git-authoritative proposal-review boundary without silently changing or deleting the legacy `/api/proposals/**` compatibility endpoints.

## Changes

- add POST `/api/architecture/proposals/{id}/accept`, `/reject` and `/revert`;
- require one exact strong `If-Match` commit ETag or `If-None-Match: *` plus a required `Idempotency-Key`;
- resolve the exact writable repository/workspace/branch context before review;
- map proposal accept to a Git relation upsert with `status accepted`;
- map proposal reject to a Git relation upsert with `status rejected`, preserving the decision in TaxDSL while #709 keeps it out of active projections;
- map revert of either reviewed state to exact relation removal, retaining the old decision in Git history while returning the proposal to `PENDING`;
- run the existing Git command and rebuildable relation projection before changing relational proposal bookkeeping;
- return the authoritative commit as a strong response `ETag`;
- return HTTP 202 with the immutable authority and an explicit pending phase when relation projection or proposal bookkeeping needs recovery;
- return HTTP 412 and the actual branch ETag for stale expected-head conflicts;
- lock the exact tenant proposal row with `PESSIMISTIC_WRITE` for the final short status transition and recheck its prior status.

## Authority boundary

No transaction spans Git and the database. A successful Git commit cannot be rolled back or hidden by projection or proposal-row failure. Proposal status advances only after Git and projection succeed. The new controller has a source-level ratchet preventing dependency on the legacy DB-first `RelationReviewService`.

The historic `/api/proposals/{id}/accept|reject|revert` endpoints remain unchanged temporarily for compatibility. Their removal or delegation is a later migration step after clients adopt the architecture endpoint and recovery/read operations exist.

## Verification

Focused JUnit coverage proves:

- Git mutation precedes proposal-state transition;
- accepted/rejected DSL decisions and proposal provenance metadata;
- rejected projections remain inactive;
- revert uses exact relation removal;
- projection and bookkeeping failures expose recoverable authority without status advancement;
- exact tenant row locking and concurrent status conflict detection;
- public route and required idempotency headers;
- new controller cannot call the legacy DB-first review service.

Base: #610 exact head `104a6dd35ac5da63ff18089793c0d69ce355cfd9`.

Head: `a560f22d65f1ed6b5cf02d3f19e7dd31919e5abe`.

The branch is eight commits ahead, zero behind and changes exactly seven files. Merge only into #610 after CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security Scan are green and no review thread remains open.

Advances #691, #698, #609 and #610.