### PR TITLE
Persist relation projection recovery and expose rebuild operations

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
@@ -1,0 +1,310 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.BranchProjectionSourceException;
+import com.taxonomy.relations.service.RelationProjectionOperationsService;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.ProjectionStatus;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildHeadConflictException;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildOperation;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RecoveryReconciliationPendingException;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+/** Authorized operator API for rebuildable relation branch projections. */
+@RestController
+@RequestMapping("/api/architecture/relations/projection")
+@Tag(name = "Relation projection operations")
+public class RelationProjectionOperationsApiController {
+
+    private final RelationProjectionOperationsService operationsService;
+    private final WorkspaceResolver workspaceResolver;
+    private final SystemRepositoryService repositoryService;
+    private final RepositoryMembershipService membershipService;
+
+    public RelationProjectionOperationsApiController(
+            RelationProjectionOperationsService operationsService,
+            WorkspaceResolver workspaceResolver,
+            SystemRepositoryService repositoryService,
+            RepositoryMembershipService membershipService) {
+        this.operationsService = operationsService;
+        this.workspaceResolver = workspaceResolver;
+        this.repositoryService = repositoryService;
+        this.membershipService = membershipService;
+    }
+
+    @Operation(summary = "Inspect exact-branch projection readiness and recovery")
+    @GetMapping("/readiness")
+    public ResponseEntity<ProjectionOperationResponse> readiness() {
+        RepositoryContext context = writableContext(
+                workspaceResolver.resolveCurrentRepositoryContext());
+        if (context == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        ProjectionStatus status = operationsService.inspect(context);
+        ResponseEntity.BodyBuilder response = ResponseEntity.ok();
+        if (status.readiness().currentHeadCommit() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            status.readiness().currentHeadCommit()));
+        }
+        return response.body(ProjectionOperationResponse.status(
+                context, status));
+    }
+
+    @Operation(summary = "Rebuild an exact branch projection from Git")
+    @PostMapping("/rebuild")
+    public ResponseEntity<ProjectionOperationResponse> rebuild(
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false)
+            String ifNoneMatch) {
+        try {
+            RepositoryContext context = writableContext(
+                    workspaceResolver.resolveCurrentRepositoryContext());
+            if (context == null) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            String expectedHead = GitHttpPrecondition.expectedHead(
+                    ifMatch, ifNoneMatch);
+            RebuildOperation operation = operationsService.rebuild(
+                    context, expectedHead);
+            return ResponseEntity.ok()
+                    .header(
+                            HttpHeaders.ETAG,
+                            GitHttpPrecondition.etag(
+                                    operation.rebuild()
+                                            .authoritativeCommitId()))
+                    .body(ProjectionOperationResponse.rebuilt(
+                            context, operation));
+        } catch (GitHttpPrecondition.PreconditionRequiredException error) {
+            return ResponseEntity.status(HttpStatus.PRECONDITION_REQUIRED).build();
+        } catch (BranchHeadConflictException error) {
+            return preconditionFailed(
+                    error.getExpectedHeadCommit(),
+                    error.getActualHeadCommit());
+        } catch (RebuildHeadConflictException error) {
+            return preconditionFailed(
+                    error.getExpectedHeadCommit(),
+                    error.getActualHeadCommit());
+        } catch (RecoveryReconciliationPendingException error) {
+            String commit = error.getRebuild().authoritativeCommitId();
+            return ResponseEntity.status(HttpStatus.ACCEPTED)
+                    .header(HttpHeaders.ETAG, GitHttpPrecondition.etag(commit))
+                    .body(ProjectionOperationResponse.reconciliationPending(
+                            error.getRebuild().repositoryId(),
+                            error.getRebuild().workspaceId(),
+                            error.getRebuild().branch(),
+                            commit,
+                            error.getRebuild().relationCount()));
+        } catch (BranchProjectionSourceException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IOException error) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+    }
+
+    private static ResponseEntity<ProjectionOperationResponse>
+            preconditionFailed(
+                    String expectedHeadCommit,
+                    String actualHeadCommit) {
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(
+                HttpStatus.PRECONDITION_FAILED);
+        if (actualHeadCommit != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(actualHeadCommit));
+        }
+        return response.body(ProjectionOperationResponse.conflict(
+                expectedHeadCommit, actualHeadCommit));
+    }
+
+    /** Central projection operations require repository-maintainer authority. */
+    private RepositoryContext writableContext(RepositoryContext context) {
+        if (context.workspaceId() != null) {
+            return context;
+        }
+        SystemRepository repository = repositoryService.getRepository(
+                context.repositoryId());
+        if (!isApplicationAdmin()
+                && !membershipService.canMaintain(
+                        repository, context.username())) {
+            return null;
+        }
+        return new RepositoryContext(
+                context.repositoryId(),
+                null,
+                context.branch(),
+                context.username(),
+                RepositoryScope.CENTRAL_WRITE);
+    }
+
+    private static boolean isApplicationAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        return authentication != null
+                && authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_ADMIN".equals(
+                        authority.getAuthority()));
+    }
+
+    public record RecoveryResponse(
+            Long id,
+            String authoritativeCommitId,
+            String previousHeadCommit,
+            String causationId,
+            String status,
+            int attemptCount,
+            String failureType,
+            String failureMessage,
+            Instant firstObservedAt,
+            Instant lastObservedAt) {
+
+        static RecoveryResponse from(RecoveryRecord recovery) {
+            return new RecoveryResponse(
+                    recovery.id(),
+                    recovery.authoritativeCommitId(),
+                    recovery.previousHeadCommit(),
+                    recovery.causationId(),
+                    recovery.status().name(),
+                    recovery.attemptCount(),
+                    recovery.failureType(),
+                    recovery.failureMessage(),
+                    recovery.firstObservedAt(),
+                    recovery.lastObservedAt());
+        }
+    }
+
+    public record ProjectionOperationResponse(
+            String repositoryId,
+            String workspaceId,
+            String branch,
+            String operationStatus,
+            String readinessState,
+            String currentHeadCommit,
+            String projectedCommit,
+            int relationCount,
+            List<RecoveryResponse> pendingRecoveries,
+            Integer recoveredCount,
+            Integer supersededCount,
+            Integer remainingPendingCount,
+            String expectedHeadCommit,
+            String actualHeadCommit) {
+
+        public ProjectionOperationResponse {
+            pendingRecoveries = pendingRecoveries == null
+                    ? List.of()
+                    : List.copyOf(pendingRecoveries);
+        }
+
+        static ProjectionOperationResponse status(
+                RepositoryContext context,
+                ProjectionStatus status) {
+            return new ProjectionOperationResponse(
+                    context.repositoryId(),
+                    context.workspaceId(),
+                    context.branch(),
+                    "INSPECTED",
+                    status.readiness().state().name(),
+                    status.readiness().currentHeadCommit(),
+                    status.readiness().projectedCommit(),
+                    status.readiness().rows().size(),
+                    status.pendingRecoveries().stream()
+                            .map(RecoveryResponse::from)
+                            .toList(),
+                    null,
+                    null,
+                    status.pendingRecoveries().size(),
+                    null,
+                    null);
+        }
+
+        static ProjectionOperationResponse rebuilt(
+                RepositoryContext context,
+                RebuildOperation operation) {
+            return new ProjectionOperationResponse(
+                    context.repositoryId(),
+                    context.workspaceId(),
+                    context.branch(),
+                    "REBUILT",
+                    operation.readiness().state().name(),
+                    operation.readiness().currentHeadCommit(),
+                    operation.readiness().projectedCommit(),
+                    operation.rebuild().relationCount(),
+                    List.of(),
+                    operation.reconciliation().recoveredCount(),
+                    operation.reconciliation().supersededCount(),
+                    operation.reconciliation().remainingPendingCount(),
+                    null,
+                    null);
+        }
+
+        static ProjectionOperationResponse reconciliationPending(
+                String repositoryId,
+                String workspaceId,
+                String branch,
+                String commit,
+                int relationCount) {
+            return new ProjectionOperationResponse(
+                    repositoryId,
+                    workspaceId,
+                    branch,
+                    "RECOVERY_RECONCILIATION_PENDING",
+                    null,
+                    commit,
+                    commit,
+                    relationCount,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+        }
+
+        static ProjectionOperationResponse conflict(
+                String expectedHeadCommit,
+                String actualHeadCommit) {
+            return new ProjectionOperationResponse(
+                    null,
+                    null,
+                    null,
+                    "PRECONDITION_FAILED",
+                    null,
+                    actualHeadCommit,
+                    null,
+                    0,
+                    List.of(),
+                    null,
+                    null,
+                    null,
+                    expectedHeadCommit,
+                    actualHeadCommit);
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
@@ -146,7 +146,8 @@ public class RelationProjectionOperationsApiController {
 
     /** Central projection operations require repository-maintainer authority. */
     private RepositoryContext writableContext(RepositoryContext context) {
-        if (context.workspaceId() != null) {
+        if (context.scope() == RepositoryScope.WORKSPACE
+                || context.scope() == RepositoryScope.FORK) {
             return context;
         }
         SystemRepository repository = repositoryService.getRepository(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiController.java
@@ -6,6 +6,7 @@ import com.taxonomy.relations.service.RelationProjectionOperationsService;
 import com.taxonomy.relations.service.RelationProjectionOperationsService.ProjectionStatus;
 import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildHeadConflictException;
 import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildOperation;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildVerificationException;
 import com.taxonomy.relations.service.RelationProjectionOperationsService.RecoveryReconciliationPendingException;
 import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
 import com.taxonomy.workspace.model.SystemRepository;
@@ -108,6 +109,8 @@ public class RelationProjectionOperationsApiController {
             return preconditionFailed(
                     error.getExpectedHeadCommit(),
                     error.getActualHeadCommit());
+        } catch (RebuildVerificationException error) {
+            return verificationFailed(error);
         } catch (RecoveryReconciliationPendingException error) {
             String commit = error.getRebuild().authoritativeCommitId();
             return ResponseEntity.status(HttpStatus.ACCEPTED)
@@ -142,6 +145,20 @@ public class RelationProjectionOperationsApiController {
         }
         return response.body(ProjectionOperationResponse.conflict(
                 expectedHeadCommit, actualHeadCommit));
+    }
+
+    private static ResponseEntity<ProjectionOperationResponse>
+            verificationFailed(RebuildVerificationException error) {
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(
+                HttpStatus.CONFLICT);
+        String currentHead = error.getReadiness().currentHeadCommit();
+        if (currentHead != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(currentHead));
+        }
+        return response.body(
+                ProjectionOperationResponse.verificationFailed(error));
     }
 
     /** Central projection operations require repository-maintainer authority. */
@@ -261,6 +278,25 @@ public class RelationProjectionOperationsApiController {
                     operation.reconciliation().recoveredCount(),
                     operation.reconciliation().supersededCount(),
                     operation.reconciliation().remainingPendingCount(),
+                    null,
+                    null);
+        }
+
+        static ProjectionOperationResponse verificationFailed(
+                RebuildVerificationException error) {
+            return new ProjectionOperationResponse(
+                    error.getRebuild().repositoryId(),
+                    error.getRebuild().workspaceId(),
+                    error.getRebuild().branch(),
+                    "VERIFICATION_FAILED",
+                    error.getReadiness().state().name(),
+                    error.getReadiness().currentHeadCommit(),
+                    error.getReadiness().projectedCommit(),
+                    error.getRebuild().relationCount(),
+                    List.of(),
+                    null,
+                    null,
+                    null,
                     null,
                     null);
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProjectionRecovery.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationProjectionRecovery.java
@@ -1,0 +1,313 @@
+package com.taxonomy.relations.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Durable recovery record for a Git-authoritative relation commit whose
+ * database projection did not complete.
+ *
+ * <p>The authoritative commit is immutable. Rebuild reconciliation may only
+ * complete or supersede the record after the selected branch has been rebuilt
+ * from a commit that contains that authority.</p>
+ */
+@Entity
+@Table(name = "relation_projection_recovery",
+        indexes = {
+                @Index(
+                        name = "idx_rel_projection_recovery_repository",
+                        columnList = "repository_id"),
+                @Index(
+                        name = "idx_rel_projection_recovery_pending",
+                        columnList = "repository_id, workspace_scope_key, branch, status, id")
+        },
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_rel_projection_recovery_authority",
+                columnNames = {
+                        "repository_id",
+                        "workspace_scope_key",
+                        "branch",
+                        "authoritative_commit_id"
+                }))
+public class RelationProjectionRecovery {
+
+    private static final int FAILURE_TYPE_LIMIT = 255;
+    private static final int FAILURE_MESSAGE_LIMIT = 2000;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "repository_id", nullable = false, length = 255)
+    private String repositoryId;
+
+    @Column(name = "workspace_id", length = 255)
+    private String workspaceId;
+
+    @Column(name = "workspace_scope_key", nullable = false, length = 255)
+    private String workspaceScopeKey = RelationDecisionProjection.CENTRAL_SCOPE_KEY;
+
+    @Column(name = "branch", nullable = false, length = 255)
+    private String branch;
+
+    @Column(name = "previous_head_commit", length = 40)
+    private String previousHeadCommit;
+
+    @Column(name = "authoritative_commit_id", nullable = false, length = 40)
+    private String authoritativeCommitId;
+
+    @Column(name = "causation_id", nullable = false, length = 255)
+    private String causationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private RecoveryStatus status = RecoveryStatus.PENDING;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "failure_type", nullable = false, length = FAILURE_TYPE_LIMIT)
+    private String failureType;
+
+    @Column(name = "failure_message", nullable = false, length = FAILURE_MESSAGE_LIMIT)
+    private String failureMessage;
+
+    @Column(name = "first_observed_at", nullable = false)
+    private Instant firstObservedAt;
+
+    @Column(name = "last_observed_at", nullable = false)
+    private Instant lastObservedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private long version;
+
+    @PrePersist
+    void onCreate() {
+        synchronize();
+        Instant now = Instant.now();
+        if (firstObservedAt == null) {
+            firstObservedAt = now;
+        }
+        if (lastObservedAt == null) {
+            lastObservedAt = firstObservedAt;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        synchronize();
+    }
+
+    private void synchronize() {
+        repositoryId = requireText(repositoryId, "repositoryId");
+        workspaceId = normalizeOptional(workspaceId);
+        workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(workspaceId);
+        branch = requireText(branch, "branch");
+        previousHeadCommit = normalizeCommitId(
+                previousHeadCommit, "previousHeadCommit", true);
+        authoritativeCommitId = normalizeCommitId(
+                authoritativeCommitId, "authoritativeCommitId", false);
+        causationId = requireText(causationId, "causationId");
+        status = Objects.requireNonNull(status, "status");
+        failureType = limit(requireText(failureType, "failureType"), FAILURE_TYPE_LIMIT);
+        failureMessage = limit(
+                requireText(failureMessage, "failureMessage"),
+                FAILURE_MESSAGE_LIMIT);
+        if (attemptCount < 1) {
+            throw new IllegalArgumentException("attemptCount must be positive");
+        }
+        if (status == RecoveryStatus.PENDING && completedAt != null) {
+            throw new IllegalArgumentException(
+                    "pending recovery must not have completedAt");
+        }
+        if (status != RecoveryStatus.PENDING && completedAt == null) {
+            throw new IllegalArgumentException(
+                    "completed recovery requires completedAt");
+        }
+    }
+
+    public void recordFailure(Throwable failure) {
+        Objects.requireNonNull(failure, "failure");
+        Instant now = Instant.now();
+        if (firstObservedAt == null) {
+            firstObservedAt = now;
+        }
+        lastObservedAt = now;
+        status = RecoveryStatus.PENDING;
+        completedAt = null;
+        attemptCount = Math.addExact(attemptCount, 1);
+        failureType = limit(failure.getClass().getName(), FAILURE_TYPE_LIMIT);
+        String message = normalizeOptional(failure.getMessage());
+        failureMessage = limit(
+                message == null ? failure.getClass().getSimpleName() : message,
+                FAILURE_MESSAGE_LIMIT);
+    }
+
+    public void complete(RecoveryStatus completion) {
+        if (completion == null || completion == RecoveryStatus.PENDING) {
+            throw new IllegalArgumentException(
+                    "completion must be RECOVERED or SUPERSEDED");
+        }
+        status = completion;
+        completedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = requireText(repositoryId, "repositoryId");
+    }
+
+    public String getWorkspaceId() {
+        return workspaceId;
+    }
+
+    public void setWorkspaceId(String workspaceId) {
+        this.workspaceId = normalizeOptional(workspaceId);
+        this.workspaceScopeKey = RelationDecisionProjection.scopeKeyFor(
+                this.workspaceId);
+    }
+
+    public String getWorkspaceScopeKey() {
+        return workspaceScopeKey;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = requireText(branch, "branch");
+    }
+
+    public String getPreviousHeadCommit() {
+        return previousHeadCommit;
+    }
+
+    public void setPreviousHeadCommit(String previousHeadCommit) {
+        this.previousHeadCommit = normalizeCommitId(
+                previousHeadCommit, "previousHeadCommit", true);
+    }
+
+    public String getAuthoritativeCommitId() {
+        return authoritativeCommitId;
+    }
+
+    public void setAuthoritativeCommitId(String authoritativeCommitId) {
+        this.authoritativeCommitId = normalizeCommitId(
+                authoritativeCommitId, "authoritativeCommitId", false);
+    }
+
+    public String getCausationId() {
+        return causationId;
+    }
+
+    public void setCausationId(String causationId) {
+        this.causationId = requireText(causationId, "causationId");
+    }
+
+    public RecoveryStatus getStatus() {
+        return status;
+    }
+
+    public int getAttemptCount() {
+        return attemptCount;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public Instant getFirstObservedAt() {
+        return firstObservedAt;
+    }
+
+    public Instant getLastObservedAt() {
+        return lastObservedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    private static String normalizeCommitId(
+            String value,
+            String field,
+            boolean optional) {
+        String normalized = normalizeOptional(value);
+        if (normalized == null && optional) {
+            return null;
+        }
+        if (normalized == null
+                || normalized.length() != 40
+                || !normalized.chars().allMatch(RelationProjectionRecovery::isHex)) {
+            throw new IllegalArgumentException(
+                    field + " must be a full Git object ID");
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isHex(int value) {
+        return value >= '0' && value <= '9'
+                || value >= 'a' && value <= 'f'
+                || value >= 'A' && value <= 'F';
+    }
+
+    private static String limit(String value, int limit) {
+        return value.length() <= limit ? value : value.substring(0, limit);
+    }
+
+    private static String normalizeOptional(String value) {
+        return value == null || value.isBlank() ? null : value.strip();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.strip();
+    }
+
+    public enum RecoveryStatus {
+        PENDING,
+        RECOVERED,
+        SUPERSEDED
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProjectionRecoveryRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProjectionRecoveryRepository.java
@@ -1,0 +1,70 @@
+package com.taxonomy.relations.repository;
+
+import com.taxonomy.relations.model.RelationProjectionRecovery;
+import com.taxonomy.relations.model.RelationProjectionRecovery.RecoveryStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Exact repository/workspace/branch access to durable projection recovery state. */
+@Repository
+public interface RelationProjectionRecoveryRepository
+        extends JpaRepository<RelationProjectionRecovery, Long> {
+
+    Optional<RelationProjectionRecovery>
+            findByRepositoryIdAndWorkspaceScopeKeyAndBranchAndAuthoritativeCommitId(
+                    String repositoryId,
+                    String workspaceScopeKey,
+                    String branch,
+                    String authoritativeCommitId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT recovery
+            FROM RelationProjectionRecovery recovery
+            WHERE recovery.repositoryId = :repositoryId
+              AND recovery.workspaceScopeKey = :workspaceScopeKey
+              AND recovery.branch = :branch
+              AND recovery.authoritativeCommitId = :authoritativeCommitId
+            """)
+    Optional<RelationProjectionRecovery> findAuthorityForUpdate(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceScopeKey") String workspaceScopeKey,
+            @Param("branch") String branch,
+            @Param("authoritativeCommitId") String authoritativeCommitId);
+
+    List<RelationProjectionRecovery>
+            findByRepositoryIdAndWorkspaceScopeKeyAndBranchAndStatusOrderByIdAsc(
+                    String repositoryId,
+                    String workspaceScopeKey,
+                    String branch,
+                    RecoveryStatus status);
+
+    long countByRepositoryIdAndWorkspaceScopeKeyAndBranchAndStatus(
+            String repositoryId,
+            String workspaceScopeKey,
+            String branch,
+            RecoveryStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT recovery
+            FROM RelationProjectionRecovery recovery
+            WHERE recovery.repositoryId = :repositoryId
+              AND recovery.workspaceScopeKey = :workspaceScopeKey
+              AND recovery.branch = :branch
+              AND recovery.status = :status
+            ORDER BY recovery.id
+            """)
+    List<RelationProjectionRecovery> findStatusForUpdate(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceScopeKey") String workspaceScopeKey,
+            @Param("branch") String branch,
+            @Param("status") RecoveryStatus status);
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
@@ -102,6 +102,17 @@ public class GitAuthoritativeRelationMutationService {
         private final CommandResult authority;
         private final RecoveryRecord recovery;
 
+        /**
+         * Compatibility form for callers that know the Git authority but do
+         * not have a durable recovery record, for example isolated tests or a
+         * secondary recovery-store failure.
+         */
+        public ProjectionPendingException(
+                CommandResult authority,
+                Throwable cause) {
+            this(authority, null, cause);
+        }
+
         public ProjectionPendingException(
                 CommandResult authority,
                 RecoveryRecord recovery,

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
@@ -1,13 +1,14 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RemoveRelation;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.UpsertRelation;
-import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
-import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
 import com.taxonomy.workspace.service.RepositoryContext;
 import org.springframework.stereotype.Service;
 
@@ -19,23 +20,27 @@ import java.util.Objects;
  * relational projection.
  *
  * <p>The method is deliberately not transactional: a failed projection must
- * never roll back or hide the already successful Git command. Callers receive
- * the authoritative commit through {@link ProjectionPendingException} and can
- * report an accepted/pending-rebuild outcome.</p>
+ * never roll back or hide the already successful Git command. Recovery is
+ * persisted in an independent transaction and callers always receive the
+ * immutable authority, even when that secondary persistence also fails.</p>
  */
 @Service
 public class GitAuthoritativeRelationMutationService {
 
     private final ArchitectureRelationGitCommandService commandService;
     private final RelationDecisionProjectionService projectionService;
+    private final RelationProjectionRecoveryService recoveryService;
 
     public GitAuthoritativeRelationMutationService(
             ArchitectureRelationGitCommandService commandService,
-            RelationDecisionProjectionService projectionService) {
+            RelationDecisionProjectionService projectionService,
+            RelationProjectionRecoveryService recoveryService) {
         this.commandService = Objects.requireNonNull(
                 commandService, "commandService");
         this.projectionService = Objects.requireNonNull(
                 projectionService, "projectionService");
+        this.recoveryService = Objects.requireNonNull(
+                recoveryService, "recoveryService");
     }
 
     public MutationResult upsert(
@@ -71,7 +76,15 @@ public class GitAuthoritativeRelationMutationService {
                     projectionService.project(context, authority, command);
             return new MutationResult(authority, projection);
         } catch (RuntimeException projectionFailure) {
-            throw new ProjectionPendingException(authority, projectionFailure);
+            RecoveryRecord recovery = null;
+            try {
+                recovery = recoveryService.recordPending(
+                        authority, projectionFailure);
+            } catch (RuntimeException recoveryFailure) {
+                projectionFailure.addSuppressed(recoveryFailure);
+            }
+            throw new ProjectionPendingException(
+                    authority, recovery, projectionFailure);
         }
     }
 
@@ -87,18 +100,29 @@ public class GitAuthoritativeRelationMutationService {
     public static final class ProjectionPendingException
             extends IllegalStateException {
         private final CommandResult authority;
+        private final RecoveryRecord recovery;
 
         public ProjectionPendingException(
                 CommandResult authority,
+                RecoveryRecord recovery,
                 Throwable cause) {
             super("Git relation command succeeded at "
                     + authority.authoritativeCommitId()
                     + ", but its projection requires recovery", cause);
             this.authority = Objects.requireNonNull(authority, "authority");
+            this.recovery = recovery;
         }
 
         public CommandResult getAuthority() {
             return authority;
+        }
+
+        public RecoveryRecord getRecovery() {
+            return recovery;
+        }
+
+        public boolean isRecoveryPersisted() {
+            return recovery != null;
         }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
@@ -88,19 +88,12 @@ public class RelationProjectionOperationsService {
         }
 
         RebuildResult rebuilt = rebuildService.rebuild(selected);
-        ReconciliationResult reconciliation;
-        try {
-            reconciliation = recoveryService.reconcileAfterRebuild(
-                    selected, rebuilt.authoritativeCommitId());
-        } catch (RuntimeException error) {
-            throw new RecoveryReconciliationPendingException(rebuilt, error);
-        }
-
         if (!verifiedHead.equals(rebuilt.authoritativeCommitId())) {
             throw new RebuildHeadConflictException(
                     verifiedHead,
                     rebuilt.authoritativeCommitId());
         }
+
         Readiness readiness = readinessService.inspect(selected);
         if (!rebuilt.authoritativeCommitId().equals(
                 readiness.currentHeadCommit())) {
@@ -114,6 +107,14 @@ public class RelationProjectionOperationsService {
                 && rebuilt.relationCount() == readiness.rows().size();
         if (!verifiedProjection) {
             throw new RebuildVerificationException(rebuilt, readiness);
+        }
+
+        ReconciliationResult reconciliation;
+        try {
+            reconciliation = recoveryService.reconcileAfterRebuild(
+                    selected, rebuilt.authoritativeCommitId());
+        } catch (RuntimeException error) {
+            throw new RecoveryReconciliationPendingException(rebuilt, error);
         }
         return new RebuildOperation(rebuilt, reconciliation, readiness);
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
@@ -68,20 +68,21 @@ public class RelationProjectionOperationsService {
     }
 
     /**
-     * Rebuilds only after proving the caller's exact branch head. A benign
-     * rebuild of a concurrently newer head is reported as a precondition
-     * conflict rather than silently satisfying the stale request.
+     * Rebuilds only after proving the caller's exact existing branch head. A
+     * benign rebuild of a concurrently newer head is reported as a
+     * precondition conflict rather than silently satisfying the stale request.
      */
     public RebuildOperation rebuild(
             RepositoryContext context,
             String expectedHeadCommit) throws IOException {
         RepositoryContext selected = requireMutable(context);
+        String requiredHead = requireExistingHead(expectedHeadCommit);
         DslGitRepository repository = gitRepositoryFactory
                 .resolveRepository(selected);
         String verifiedHead = expectedHeadVerifier.verifyExpectedHead(
                 repository,
                 selected.branch(),
-                expectedHeadCommit);
+                requiredHead);
         if (verifiedHead == null) {
             throw new BranchProjectionSourceException(
                     "Cannot rebuild relation projection for an absent branch");
@@ -117,6 +118,14 @@ public class RelationProjectionOperationsService {
             throw new RecoveryReconciliationPendingException(rebuilt, error);
         }
         return new RebuildOperation(rebuilt, reconciliation, readiness);
+    }
+
+    private static String requireExistingHead(String expectedHeadCommit) {
+        if (expectedHeadCommit == null || expectedHeadCommit.isBlank()) {
+            throw new IllegalArgumentException(
+                    "Projection rebuild requires If-Match with the exact existing branch commit");
+        }
+        return expectedHeadCommit.strip();
     }
 
     private static RepositoryContext requireMutable(RepositoryContext context) {

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
@@ -102,12 +102,18 @@ public class RelationProjectionOperationsService {
                     rebuilt.authoritativeCommitId());
         }
         Readiness readiness = readinessService.inspect(selected);
-        if (readiness.state() != ReadinessState.READY
-                || !rebuilt.authoritativeCommitId().equals(
-                        readiness.currentHeadCommit())) {
+        if (!rebuilt.authoritativeCommitId().equals(
+                readiness.currentHeadCommit())) {
             throw new RebuildHeadConflictException(
                     rebuilt.authoritativeCommitId(),
                     readiness.currentHeadCommit());
+        }
+        boolean verifiedProjection = readiness.state() == ReadinessState.READY
+                && rebuilt.authoritativeCommitId().equals(
+                        readiness.projectedCommit())
+                && rebuilt.relationCount() == readiness.rows().size();
+        if (!verifiedProjection) {
+            throw new RebuildVerificationException(rebuilt, readiness);
         }
         return new RebuildOperation(rebuilt, reconciliation, readiness);
     }
@@ -163,6 +169,31 @@ public class RelationProjectionOperationsService {
 
         public String getActualHeadCommit() {
             return actualHeadCommit;
+        }
+    }
+
+    public static final class RebuildVerificationException
+            extends IllegalStateException {
+        private final RebuildResult rebuild;
+        private final Readiness readiness;
+
+        public RebuildVerificationException(
+                RebuildResult rebuild,
+                Readiness readiness) {
+            super("Relation projection rebuild at "
+                    + rebuild.authoritativeCommitId()
+                    + " did not produce a verified READY projection: "
+                    + readiness.state());
+            this.rebuild = Objects.requireNonNull(rebuild, "rebuild");
+            this.readiness = Objects.requireNonNull(readiness, "readiness");
+        }
+
+        public RebuildResult getRebuild() {
+            return rebuild;
+        }
+
+        public Readiness getReadiness() {
+            return readiness;
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionOperationsService.java
@@ -1,0 +1,186 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.BranchProjectionSourceException;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.ReconciliationResult;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+/** Authorized operational boundary for branch projection readiness and rebuilds. */
+@Service
+public class RelationProjectionOperationsService {
+
+    private final DslGitRepositoryFactory gitRepositoryFactory;
+    private final RelationBranchProjectionReadinessService readinessService;
+    private final RelationBranchProjectionRebuildService rebuildService;
+    private final RelationProjectionRecoveryService recoveryService;
+    private final ExpectedHeadDslCommitter expectedHeadVerifier;
+
+    @Autowired
+    public RelationProjectionOperationsService(
+            DslGitRepositoryFactory gitRepositoryFactory,
+            RelationBranchProjectionReadinessService readinessService,
+            RelationBranchProjectionRebuildService rebuildService,
+            RelationProjectionRecoveryService recoveryService) {
+        this(
+                gitRepositoryFactory,
+                readinessService,
+                rebuildService,
+                recoveryService,
+                new ExpectedHeadDslCommitter());
+    }
+
+    RelationProjectionOperationsService(
+            DslGitRepositoryFactory gitRepositoryFactory,
+            RelationBranchProjectionReadinessService readinessService,
+            RelationBranchProjectionRebuildService rebuildService,
+            RelationProjectionRecoveryService recoveryService,
+            ExpectedHeadDslCommitter expectedHeadVerifier) {
+        this.gitRepositoryFactory = Objects.requireNonNull(
+                gitRepositoryFactory, "gitRepositoryFactory");
+        this.readinessService = Objects.requireNonNull(
+                readinessService, "readinessService");
+        this.rebuildService = Objects.requireNonNull(
+                rebuildService, "rebuildService");
+        this.recoveryService = Objects.requireNonNull(
+                recoveryService, "recoveryService");
+        this.expectedHeadVerifier = Objects.requireNonNull(
+                expectedHeadVerifier, "expectedHeadVerifier");
+    }
+
+    public ProjectionStatus inspect(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        return new ProjectionStatus(
+                readinessService.inspect(selected),
+                recoveryService.pending(selected));
+    }
+
+    /**
+     * Rebuilds only after proving the caller's exact branch head. A benign
+     * rebuild of a concurrently newer head is reported as a precondition
+     * conflict rather than silently satisfying the stale request.
+     */
+    public RebuildOperation rebuild(
+            RepositoryContext context,
+            String expectedHeadCommit) throws IOException {
+        RepositoryContext selected = requireMutable(context);
+        DslGitRepository repository = gitRepositoryFactory
+                .resolveRepository(selected);
+        String verifiedHead = expectedHeadVerifier.verifyExpectedHead(
+                repository,
+                selected.branch(),
+                expectedHeadCommit);
+        if (verifiedHead == null) {
+            throw new BranchProjectionSourceException(
+                    "Cannot rebuild relation projection for an absent branch");
+        }
+
+        RebuildResult rebuilt = rebuildService.rebuild(selected);
+        ReconciliationResult reconciliation;
+        try {
+            reconciliation = recoveryService.reconcileAfterRebuild(
+                    selected, rebuilt.authoritativeCommitId());
+        } catch (RuntimeException error) {
+            throw new RecoveryReconciliationPendingException(rebuilt, error);
+        }
+
+        if (!verifiedHead.equals(rebuilt.authoritativeCommitId())) {
+            throw new RebuildHeadConflictException(
+                    verifiedHead,
+                    rebuilt.authoritativeCommitId());
+        }
+        Readiness readiness = readinessService.inspect(selected);
+        if (readiness.state() != ReadinessState.READY
+                || !rebuilt.authoritativeCommitId().equals(
+                        readiness.currentHeadCommit())) {
+            throw new RebuildHeadConflictException(
+                    rebuilt.authoritativeCommitId(),
+                    readiness.currentHeadCommit());
+        }
+        return new RebuildOperation(rebuilt, reconciliation, readiness);
+    }
+
+    private static RepositoryContext requireMutable(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        if (selected.scope() == RepositoryScope.CENTRAL_READ) {
+            throw new IllegalArgumentException(
+                    "Projection rebuild requires a writable repository context");
+        }
+        return selected;
+    }
+
+    public record ProjectionStatus(
+            Readiness readiness,
+            List<RecoveryRecord> pendingRecoveries) {
+        public ProjectionStatus {
+            readiness = Objects.requireNonNull(readiness, "readiness");
+            pendingRecoveries = List.copyOf(Objects.requireNonNull(
+                    pendingRecoveries, "pendingRecoveries"));
+        }
+    }
+
+    public record RebuildOperation(
+            RebuildResult rebuild,
+            ReconciliationResult reconciliation,
+            Readiness readiness) {
+        public RebuildOperation {
+            rebuild = Objects.requireNonNull(rebuild, "rebuild");
+            reconciliation = Objects.requireNonNull(
+                    reconciliation, "reconciliation");
+            readiness = Objects.requireNonNull(readiness, "readiness");
+        }
+    }
+
+    public static final class RebuildHeadConflictException
+            extends IllegalStateException {
+        private final String expectedHeadCommit;
+        private final String actualHeadCommit;
+
+        public RebuildHeadConflictException(
+                String expectedHeadCommit,
+                String actualHeadCommit) {
+            super("Relation projection rebuild expected "
+                    + expectedHeadCommit + " but observed " + actualHeadCommit);
+            this.expectedHeadCommit = expectedHeadCommit;
+            this.actualHeadCommit = actualHeadCommit;
+        }
+
+        public String getExpectedHeadCommit() {
+            return expectedHeadCommit;
+        }
+
+        public String getActualHeadCommit() {
+            return actualHeadCommit;
+        }
+    }
+
+    public static final class RecoveryReconciliationPendingException
+            extends IllegalStateException {
+        private final RebuildResult rebuild;
+
+        public RecoveryReconciliationPendingException(
+                RebuildResult rebuild,
+                Throwable cause) {
+            super("Relation projection rebuilt at "
+                    + rebuild.authoritativeCommitId()
+                    + ", but recovery reconciliation is pending", cause);
+            this.rebuild = Objects.requireNonNull(rebuild, "rebuild");
+        }
+
+        public RebuildResult getRebuild() {
+            return rebuild;
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionRecoveryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionRecoveryService.java
@@ -1,0 +1,239 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.model.RelationProjectionRecovery;
+import com.taxonomy.relations.model.RelationProjectionRecovery.RecoveryStatus;
+import com.taxonomy.relations.repository.RelationProjectionRecoveryRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/** Durable recovery ledger for failed relation decision projections. */
+@Service
+public class RelationProjectionRecoveryService {
+
+    private final RelationProjectionRecoveryRepository recoveryRepository;
+    private final DslGitRepositoryFactory gitRepositoryFactory;
+
+    public RelationProjectionRecoveryService(
+            RelationProjectionRecoveryRepository recoveryRepository,
+            DslGitRepositoryFactory gitRepositoryFactory) {
+        this.recoveryRepository = Objects.requireNonNull(
+                recoveryRepository, "recoveryRepository");
+        this.gitRepositoryFactory = Objects.requireNonNull(
+                gitRepositoryFactory, "gitRepositoryFactory");
+    }
+
+    /**
+     * Records projection failure in an independent transaction after Git has
+     * already committed the authoritative decision.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RecoveryRecord recordPending(
+            CommandResult authority,
+            Throwable failure) {
+        Objects.requireNonNull(authority, "authority");
+        Objects.requireNonNull(failure, "failure");
+        String scopeKey = RelationDecisionProjection.scopeKeyFor(
+                authority.workspaceId());
+        RelationProjectionRecovery recovery = recoveryRepository
+                .findAuthorityForUpdate(
+                        authority.repositoryId(),
+                        scopeKey,
+                        authority.branch(),
+                        authority.authoritativeCommitId())
+                .orElseGet(RelationProjectionRecovery::new);
+        recovery.setRepositoryId(authority.repositoryId());
+        recovery.setWorkspaceId(authority.workspaceId());
+        recovery.setBranch(authority.branch());
+        recovery.setPreviousHeadCommit(authority.previousHeadCommit());
+        recovery.setAuthoritativeCommitId(authority.authoritativeCommitId());
+        recovery.setCausationId(authority.causationId());
+        recovery.recordFailure(failure);
+        return RecoveryRecord.from(recoveryRepository.save(recovery));
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecoveryRecord> pending(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        return recoveryRepository
+                .findByRepositoryIdAndWorkspaceScopeKeyAndBranchAndStatusOrderByIdAsc(
+                        selected.repositoryId(),
+                        RelationDecisionProjection.scopeKeyFor(
+                                selected.workspaceId()),
+                        selected.branch(),
+                        RecoveryStatus.PENDING)
+                .stream()
+                .map(RecoveryRecord::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public long pendingCount(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        return recoveryRepository
+                .countByRepositoryIdAndWorkspaceScopeKeyAndBranchAndStatus(
+                        selected.repositoryId(),
+                        RelationDecisionProjection.scopeKeyFor(
+                                selected.workspaceId()),
+                        selected.branch(),
+                        RecoveryStatus.PENDING);
+    }
+
+    /**
+     * Completes pending records only when the rebuilt commit is the same commit
+     * or demonstrably descends from the failed authoritative commit.
+     */
+    @Transactional
+    public ReconciliationResult reconcileAfterRebuild(
+            RepositoryContext context,
+            String rebuiltCommitId) {
+        RepositoryContext selected = requireMutable(context);
+        String rebuilt = requireCommitId(rebuiltCommitId);
+        String scopeKey = RelationDecisionProjection.scopeKeyFor(
+                selected.workspaceId());
+        List<RelationProjectionRecovery> pending = recoveryRepository
+                .findStatusForUpdate(
+                        selected.repositoryId(),
+                        scopeKey,
+                        selected.branch(),
+                        RecoveryStatus.PENDING);
+        if (pending.isEmpty()) {
+            return new ReconciliationResult(rebuilt, 0, 0, 0);
+        }
+
+        DslGitRepository dslRepository = gitRepositoryFactory
+                .resolveRepository(selected);
+        int recovered = 0;
+        int superseded = 0;
+        try (RevWalk walk = new RevWalk(dslRepository.getGitRepository())) {
+            RevCommit rebuiltCommit = walk.parseCommit(ObjectId.fromString(rebuilt));
+            for (RelationProjectionRecovery recovery : pending) {
+                RecoveryStatus completion = completion(
+                        walk,
+                        rebuiltCommit,
+                        recovery.getAuthoritativeCommitId());
+                if (completion == null) {
+                    continue;
+                }
+                recovery.complete(completion);
+                recoveryRepository.save(recovery);
+                if (completion == RecoveryStatus.RECOVERED) {
+                    recovered++;
+                } else {
+                    superseded++;
+                }
+            }
+        } catch (IOException error) {
+            throw new ProjectionRecoveryReconciliationException(
+                    "Unable to reconcile relation projection recovery at "
+                            + rebuilt,
+                    error);
+        }
+        return new ReconciliationResult(
+                rebuilt,
+                recovered,
+                superseded,
+                pending.size() - recovered - superseded);
+    }
+
+    private static RecoveryStatus completion(
+            RevWalk walk,
+            RevCommit rebuiltCommit,
+            String pendingCommitId) {
+        try {
+            RevCommit pendingCommit = walk.parseCommit(
+                    ObjectId.fromString(pendingCommitId));
+            if (pendingCommit.equals(rebuiltCommit)) {
+                return RecoveryStatus.RECOVERED;
+            }
+            return walk.isMergedInto(pendingCommit, rebuiltCommit)
+                    ? RecoveryStatus.SUPERSEDED
+                    : null;
+        } catch (IOException | IllegalArgumentException error) {
+            return null;
+        }
+    }
+
+    private static RepositoryContext requireMutable(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        if (selected.scope() == RepositoryScope.CENTRAL_READ) {
+            throw new IllegalArgumentException(
+                    "Projection recovery reconciliation requires a writable context");
+        }
+        return selected;
+    }
+
+    private static String requireCommitId(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(
+                    "rebuiltCommitId must not be blank");
+        }
+        return ObjectId.fromString(value.strip()).name()
+                .toLowerCase(Locale.ROOT);
+    }
+
+    public record RecoveryRecord(
+            Long id,
+            String repositoryId,
+            String workspaceId,
+            String branch,
+            String previousHeadCommit,
+            String authoritativeCommitId,
+            String causationId,
+            RecoveryStatus status,
+            int attemptCount,
+            String failureType,
+            String failureMessage,
+            java.time.Instant firstObservedAt,
+            java.time.Instant lastObservedAt,
+            java.time.Instant completedAt) {
+
+        static RecoveryRecord from(RelationProjectionRecovery recovery) {
+            return new RecoveryRecord(
+                    recovery.getId(),
+                    recovery.getRepositoryId(),
+                    recovery.getWorkspaceId(),
+                    recovery.getBranch(),
+                    recovery.getPreviousHeadCommit(),
+                    recovery.getAuthoritativeCommitId(),
+                    recovery.getCausationId(),
+                    recovery.getStatus(),
+                    recovery.getAttemptCount(),
+                    recovery.getFailureType(),
+                    recovery.getFailureMessage(),
+                    recovery.getFirstObservedAt(),
+                    recovery.getLastObservedAt(),
+                    recovery.getCompletedAt());
+        }
+    }
+
+    public record ReconciliationResult(
+            String rebuiltCommitId,
+            int recoveredCount,
+            int supersededCount,
+            int remainingPendingCount) {
+    }
+
+    public static final class ProjectionRecoveryReconciliationException
+            extends IllegalStateException {
+        public ProjectionRecoveryReconciliationException(
+                String message,
+                Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V11__relation_projection_recovery.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V11__relation_projection_recovery.sql
@@ -1,0 +1,59 @@
+-- A Git-authoritative relation commit remains visible to operators even when
+-- its rebuildable database projection cannot be updated immediately.
+
+create table relation_projection_recovery (
+    id bigserial primary key,
+    repository_id varchar(255) not null,
+    workspace_id varchar(255),
+    workspace_scope_key varchar(255) not null,
+    branch varchar(255) not null,
+    previous_head_commit varchar(40),
+    authoritative_commit_id varchar(40) not null,
+    causation_id varchar(255) not null,
+    status varchar(32) not null,
+    attempt_count integer not null,
+    failure_type varchar(255) not null,
+    failure_message varchar(2000) not null,
+    first_observed_at timestamp with time zone not null,
+    last_observed_at timestamp with time zone not null,
+    completed_at timestamp with time zone,
+    version bigint not null default 0,
+    constraint fk_rel_projection_recovery_repository
+        foreign key (repository_id)
+        references system_repository (repository_id),
+    constraint uq_rel_projection_recovery_authority
+        unique (
+            repository_id,
+            workspace_scope_key,
+            branch,
+            authoritative_commit_id
+        ),
+    constraint ck_rel_projection_recovery_scope
+        check (
+            (workspace_id is null and workspace_scope_key = '__shared__')
+            or
+            (workspace_id is not null and workspace_scope_key = workspace_id)
+        ),
+    constraint ck_rel_projection_recovery_status
+        check (status in ('PENDING', 'RECOVERED', 'SUPERSEDED')),
+    constraint ck_rel_projection_recovery_attempts
+        check (attempt_count >= 1),
+    constraint ck_rel_projection_recovery_completion
+        check (
+            (status = 'PENDING' and completed_at is null)
+            or
+            (status <> 'PENDING' and completed_at is not null)
+        )
+);
+
+create index idx_rel_projection_recovery_repository
+    on relation_projection_recovery (repository_id);
+
+create index idx_rel_projection_recovery_pending
+    on relation_projection_recovery (
+        repository_id,
+        workspace_scope_key,
+        branch,
+        status,
+        id
+    );

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -115,11 +115,30 @@ class TaxonomySchemaPostgresMigrationIT {
                 "relation_decision_projection_checkpoint",
                 "relation_count"))
                 .isTrue();
+        assertThat(tableExists(dataSource, "relation_projection_recovery")).isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "repository_id"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "workspace_scope_key"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "branch"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "authoritative_commit_id"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "status"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "attempt_count"))
+                .isTrue();
         assertThat(tableExists(dataSource, TaxonomySchemaMigrationConfig.HISTORY_TABLE)).isTrue();
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "0", "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10");
+                        "6", "7", "8", "9", "10", "11");
     }
 
     @Test
@@ -184,10 +203,17 @@ class TaxonomySchemaPostgresMigrationIT {
                 "relation_decision_projection_checkpoint",
                 "authoritative_commit_id"))
                 .isTrue();
+        assertThat(tableExists(dataSource, "relation_projection_recovery")).isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "authoritative_commit_id"))
+                .isTrue();
+        assertThat(columnExists(
+                dataSource, "relation_projection_recovery", "status"))
+                .isTrue();
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10");
+                        "6", "7", "8", "9", "10", "11");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiControllerHttpContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationProjectionOperationsApiControllerHttpContractTest.java
@@ -1,0 +1,60 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.repository.RelationProjectionRecoveryRepository;
+import com.taxonomy.relations.service.RelationProjectionOperationsService;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Source-level contract for the authorized projection operations boundary. */
+class RelationProjectionOperationsApiControllerHttpContractTest {
+
+    @Test
+    void exposesTheArchitectureProjectionOperationsRoute() {
+        RequestMapping mapping = RelationProjectionOperationsApiController.class
+                .getAnnotation(RequestMapping.class);
+
+        assertThat(mapping).isNotNull();
+        assertThat(mapping.value())
+                .containsExactly("/api/architecture/relations/projection");
+    }
+
+    @Test
+    void rebuildUsesHttpPreconditionsAtThePublicBoundary() {
+        Method rebuild = Arrays.stream(
+                        RelationProjectionOperationsApiController.class
+                                .getDeclaredMethods())
+                .filter(method -> method.getName().equals("rebuild"))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(rebuild.getAnnotation(PostMapping.class).value())
+                .containsExactly("/rebuild");
+        assertThat(Arrays.stream(rebuild.getParameters())
+                .map(parameter -> parameter.getAnnotation(RequestHeader.class))
+                .filter(Objects::nonNull)
+                .map(RequestHeader::value))
+                .contains("If-Match", "If-None-Match");
+    }
+
+    @Test
+    void controllerDelegatesWithoutWritingProjectionTablesDirectly() {
+        assertThat(Arrays.stream(
+                        RelationProjectionOperationsApiController.class
+                                .getDeclaredFields())
+                .map(Field::getType))
+                .contains(RelationProjectionOperationsService.class)
+                .doesNotContain(
+                        RelationDecisionProjectionRepository.class,
+                        RelationProjectionRecoveryRepository.class);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
@@ -7,7 +7,9 @@ import com.taxonomy.relations.command.ArchitectureRelationGitCommandService;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
+import com.taxonomy.relations.model.RelationProjectionRecovery.RecoveryStatus;
 import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryScope;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Instant;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +40,9 @@ class GitAuthoritativeRelationMutationServiceTest {
 
     @Mock
     private RelationDecisionProjectionService projectionService;
+
+    @Mock
+    private RelationProjectionRecoveryService recoveryService;
 
     @Test
     void commitsBeforeProjectingAndReturnsBothResults() throws Exception {
@@ -67,18 +74,25 @@ class GitAuthoritativeRelationMutationServiceTest {
                 eq(context), eq(PREVIOUS), any(RelationCommand.class));
         order.verify(projectionService).project(
                 eq(context), eq(authority), any(RelationCommand.class));
+        verifyNoInteractions(recoveryService);
     }
 
     @Test
-    void exposesAuthoritativeCommitWhenProjectionNeedsRecovery() throws Exception {
+    void persistsRecoveryAfterProjectionFailureAndExposesAuthority()
+            throws Exception {
         RepositoryContext context = context();
         CommandResult authority = authority();
+        IllegalStateException projectionFailure =
+                new IllegalStateException("database unavailable");
+        RecoveryRecord recovery = recovery();
         when(commandService.execute(
                 eq(context), eq(PREVIOUS), any(RelationCommand.class)))
                 .thenReturn(authority);
         when(projectionService.project(
                 eq(context), eq(authority), any(RelationCommand.class)))
-                .thenThrow(new IllegalStateException("database unavailable"));
+                .thenThrow(projectionFailure);
+        when(recoveryService.recordPending(authority, projectionFailure))
+                .thenReturn(recovery);
         GitAuthoritativeRelationMutationService service = service();
 
         assertThatThrownBy(() -> service.remove(
@@ -86,16 +100,63 @@ class GitAuthoritativeRelationMutationServiceTest {
                 PREVIOUS,
                 definition().identity(),
                 new CommandMetadata("request-17")))
-                .isInstanceOf(ProjectionPendingException.class)
-                .satisfies(error -> assertThat(
-                        ((ProjectionPendingException) error).getAuthority())
-                        .isSameAs(authority))
+                .isInstanceOfSatisfying(
+                        ProjectionPendingException.class,
+                        error -> {
+                            assertThat(error.getAuthority()).isSameAs(authority);
+                            assertThat(error.getRecovery()).isSameAs(recovery);
+                            assertThat(error.isRecoveryPersisted()).isTrue();
+                        })
                 .hasMessageContaining(AUTHORITY);
+
+        InOrder order = inOrder(
+                commandService, projectionService, recoveryService);
+        order.verify(commandService).execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class));
+        order.verify(projectionService).project(
+                eq(context), eq(authority), any(RelationCommand.class));
+        order.verify(recoveryService).recordPending(
+                authority, projectionFailure);
+    }
+
+    @Test
+    void secondaryRecoveryFailureNeverMasksTheImmutableGitAuthority()
+            throws Exception {
+        RepositoryContext context = context();
+        CommandResult authority = authority();
+        IllegalStateException projectionFailure =
+                new IllegalStateException("projection unavailable");
+        IllegalStateException recoveryFailure =
+                new IllegalStateException("recovery table unavailable");
+        when(commandService.execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class)))
+                .thenReturn(authority);
+        when(projectionService.project(
+                eq(context), eq(authority), any(RelationCommand.class)))
+                .thenThrow(projectionFailure);
+        when(recoveryService.recordPending(authority, projectionFailure))
+                .thenThrow(recoveryFailure);
+
+        assertThatThrownBy(() -> service().upsert(
+                context,
+                PREVIOUS,
+                definition(),
+                new CommandMetadata("request-17")))
+                .isInstanceOfSatisfying(
+                        ProjectionPendingException.class,
+                        error -> {
+                            assertThat(error.getAuthority()).isSameAs(authority);
+                            assertThat(error.isRecoveryPersisted()).isFalse();
+                            assertThat(error.getCause())
+                                    .isSameAs(projectionFailure);
+                            assertThat(error.getCause().getSuppressed())
+                                    .containsExactly(recoveryFailure);
+                        });
     }
 
     private GitAuthoritativeRelationMutationService service() {
         return new GitAuthoritativeRelationMutationService(
-                commandService, projectionService);
+                commandService, projectionService, recoveryService);
     }
 
     private static RepositoryContext context() {
@@ -127,5 +188,24 @@ class GitAuthoritativeRelationMutationServiceTest {
                 ChangeKind.UPDATED,
                 true,
                 "request-17");
+    }
+
+    private static RecoveryRecord recovery() {
+        Instant observed = Instant.parse("2026-08-12T12:00:00Z");
+        return new RecoveryRecord(
+                23L,
+                "repo-a",
+                "workspace-a",
+                "review",
+                PREVIOUS,
+                AUTHORITY,
+                "request-17",
+                RecoveryStatus.PENDING,
+                1,
+                IllegalStateException.class.getName(),
+                "database unavailable",
+                observed,
+                observed,
+                null);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
@@ -11,12 +11,15 @@ import com.taxonomy.relations.service.RelationProjectionRecoveryService.Reconcil
 import com.taxonomy.workspace.service.RepositoryContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +35,7 @@ class RelationProjectionOperationsServiceTest {
     }
 
     @Test
-    void rebuildRequiresTheExactHeadThenReconcilesAndProvesReadiness()
+    void rebuildRequiresTheExactHeadThenProvesReadinessBeforeReconciliation()
             throws Exception {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a", "review", "alice");
@@ -55,9 +58,9 @@ class RelationProjectionOperationsServiceTest {
         Readiness readiness = new Readiness(
                 ReadinessState.READY, head, head, List.of());
         when(rebuildService.rebuild(context)).thenReturn(rebuilt);
+        when(readinessService.inspect(context)).thenReturn(readiness);
         when(recoveryService.reconcileAfterRebuild(context, head))
                 .thenReturn(reconciliation);
-        when(readinessService.inspect(context)).thenReturn(readiness);
 
         var operation = new RelationProjectionOperationsService(
                 repositoryFactory,
@@ -68,9 +71,11 @@ class RelationProjectionOperationsServiceTest {
         assertThat(operation.rebuild()).isSameAs(rebuilt);
         assertThat(operation.reconciliation()).isSameAs(reconciliation);
         assertThat(operation.readiness()).isSameAs(readiness);
-        verify(rebuildService).rebuild(context);
-        verify(recoveryService).reconcileAfterRebuild(context, head);
-        verify(readinessService).inspect(context);
+        InOrder order = inOrder(
+                rebuildService, readinessService, recoveryService);
+        order.verify(rebuildService).rebuild(context);
+        order.verify(readinessService).inspect(context);
+        order.verify(recoveryService).reconcileAfterRebuild(context, head);
     }
 
     @Test
@@ -99,11 +104,11 @@ class RelationProjectionOperationsServiceTest {
         assertThatThrownBy(() -> service.rebuild(
                 context, "a".repeat(40)))
                 .isInstanceOf(BranchHeadConflictException.class);
-        verify(rebuildService, org.mockito.Mockito.never()).rebuild(context);
+        verify(rebuildService, never()).rebuild(context);
     }
 
     @Test
-    void sameHeadButCorruptReadModelIsNotReportedAsAHeadConflict()
+    void corruptReadModelNeverCompletesRecoveryAndIsNotAHeadConflict()
             throws Exception {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a", "review", "alice");
@@ -121,13 +126,9 @@ class RelationProjectionOperationsServiceTest {
                 mock(RelationProjectionRecoveryService.class);
         RebuildResult rebuilt = new RebuildResult(
                 "repo-a", "workspace-a", "review", head, 1);
-        ReconciliationResult reconciliation = new ReconciliationResult(
-                head, 0, 0, 0);
         Readiness corrupt = new Readiness(
                 ReadinessState.CORRUPT, head, head, List.of());
         when(rebuildService.rebuild(context)).thenReturn(rebuilt);
-        when(recoveryService.reconcileAfterRebuild(context, head))
-                .thenReturn(reconciliation);
         when(readinessService.inspect(context)).thenReturn(corrupt);
 
         assertThatThrownBy(() -> new RelationProjectionOperationsService(
@@ -141,10 +142,11 @@ class RelationProjectionOperationsServiceTest {
                             assertThat(error.getRebuild()).isSameAs(rebuilt);
                             assertThat(error.getReadiness()).isSameAs(corrupt);
                         });
+        verify(recoveryService, never()).reconcileAfterRebuild(context, head);
     }
 
     @Test
-    void reconciliationFailureStillExposesTheSuccessfulRebuildCommit()
+    void reconciliationFailureStillExposesTheVerifiedRebuildCommit()
             throws Exception {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a", "review", "alice");
@@ -161,8 +163,11 @@ class RelationProjectionOperationsServiceTest {
         RelationProjectionRecoveryService recoveryService =
                 mock(RelationProjectionRecoveryService.class);
         RebuildResult rebuilt = new RebuildResult(
-                "repo-a", "workspace-a", "review", head, 1);
+                "repo-a", "workspace-a", "review", head, 0);
+        Readiness readiness = new Readiness(
+                ReadinessState.READY, head, head, List.of());
         when(rebuildService.rebuild(context)).thenReturn(rebuilt);
+        when(readinessService.inspect(context)).thenReturn(readiness);
         when(recoveryService.reconcileAfterRebuild(context, head))
                 .thenThrow(new IllegalStateException("recovery unavailable"));
 

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
@@ -1,0 +1,137 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RecoveryReconciliationPendingException;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.ReconciliationResult;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationProjectionOperationsServiceTest {
+
+    private DslGitRepositoryFactory repositoryFactory;
+
+    @AfterEach
+    void closeRepositories() {
+        if (repositoryFactory != null) {
+            repositoryFactory.close();
+        }
+    }
+
+    @Test
+    void rebuildRequiresTheExactHeadThenReconcilesAndProvesReadiness()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        String head = repositoryFactory.resolveRepository(context).commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "Seed branch");
+        RelationBranchProjectionReadinessService readinessService =
+                mock(RelationBranchProjectionReadinessService.class);
+        RelationBranchProjectionRebuildService rebuildService =
+                mock(RelationBranchProjectionRebuildService.class);
+        RelationProjectionRecoveryService recoveryService =
+                mock(RelationProjectionRecoveryService.class);
+        RebuildResult rebuilt = new RebuildResult(
+                "repo-a", "workspace-a", "review", head, 2);
+        ReconciliationResult reconciliation = new ReconciliationResult(
+                head, 1, 1, 0);
+        Readiness readiness = new Readiness(
+                ReadinessState.READY, head, head, List.of());
+        when(rebuildService.rebuild(context)).thenReturn(rebuilt);
+        when(recoveryService.reconcileAfterRebuild(context, head))
+                .thenReturn(reconciliation);
+        when(readinessService.inspect(context)).thenReturn(readiness);
+
+        var operation = new RelationProjectionOperationsService(
+                repositoryFactory,
+                readinessService,
+                rebuildService,
+                recoveryService).rebuild(context, head);
+
+        assertThat(operation.rebuild()).isSameAs(rebuilt);
+        assertThat(operation.reconciliation()).isSameAs(reconciliation);
+        assertThat(operation.readiness()).isSameAs(readiness);
+        verify(rebuildService).rebuild(context);
+        verify(recoveryService).reconcileAfterRebuild(context, head);
+        verify(readinessService).inspect(context);
+    }
+
+    @Test
+    void staleExpectedHeadIsRejectedBeforeAnyProjectionWrite() throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        repositoryFactory.resolveRepository(context).commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "Seed branch");
+        RelationBranchProjectionReadinessService readinessService =
+                mock(RelationBranchProjectionReadinessService.class);
+        RelationBranchProjectionRebuildService rebuildService =
+                mock(RelationBranchProjectionRebuildService.class);
+        RelationProjectionRecoveryService recoveryService =
+                mock(RelationProjectionRecoveryService.class);
+        RelationProjectionOperationsService service =
+                new RelationProjectionOperationsService(
+                        repositoryFactory,
+                        readinessService,
+                        rebuildService,
+                        recoveryService);
+
+        assertThatThrownBy(() -> service.rebuild(
+                context, "a".repeat(40)))
+                .isInstanceOf(BranchHeadConflictException.class);
+        verify(rebuildService, org.mockito.Mockito.never()).rebuild(context);
+    }
+
+    @Test
+    void reconciliationFailureStillExposesTheSuccessfulRebuildCommit()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        String head = repositoryFactory.resolveRepository(context).commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "Seed branch");
+        RelationBranchProjectionReadinessService readinessService =
+                mock(RelationBranchProjectionReadinessService.class);
+        RelationBranchProjectionRebuildService rebuildService =
+                mock(RelationBranchProjectionRebuildService.class);
+        RelationProjectionRecoveryService recoveryService =
+                mock(RelationProjectionRecoveryService.class);
+        RebuildResult rebuilt = new RebuildResult(
+                "repo-a", "workspace-a", "review", head, 1);
+        when(rebuildService.rebuild(context)).thenReturn(rebuilt);
+        when(recoveryService.reconcileAfterRebuild(context, head))
+                .thenThrow(new IllegalStateException("recovery unavailable"));
+
+        assertThatThrownBy(() -> new RelationProjectionOperationsService(
+                repositoryFactory,
+                readinessService,
+                rebuildService,
+                recoveryService).rebuild(context, head))
+                .isInstanceOfSatisfying(
+                        RecoveryReconciliationPendingException.class,
+                        error -> assertThat(error.getRebuild())
+                                .isSameAs(rebuilt));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
@@ -5,6 +5,7 @@ import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictExcep
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationProjectionOperationsService.RebuildVerificationException;
 import com.taxonomy.relations.service.RelationProjectionOperationsService.RecoveryReconciliationPendingException;
 import com.taxonomy.relations.service.RelationProjectionRecoveryService.ReconciliationResult;
 import com.taxonomy.workspace.service.RepositoryContext;
@@ -48,7 +49,7 @@ class RelationProjectionOperationsServiceTest {
         RelationProjectionRecoveryService recoveryService =
                 mock(RelationProjectionRecoveryService.class);
         RebuildResult rebuilt = new RebuildResult(
-                "repo-a", "workspace-a", "review", head, 2);
+                "repo-a", "workspace-a", "review", head, 0);
         ReconciliationResult reconciliation = new ReconciliationResult(
                 head, 1, 1, 0);
         Readiness readiness = new Readiness(
@@ -99,6 +100,47 @@ class RelationProjectionOperationsServiceTest {
                 context, "a".repeat(40)))
                 .isInstanceOf(BranchHeadConflictException.class);
         verify(rebuildService, org.mockito.Mockito.never()).rebuild(context);
+    }
+
+    @Test
+    void sameHeadButCorruptReadModelIsNotReportedAsAHeadConflict()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        String head = repositoryFactory.resolveRepository(context).commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "Seed branch");
+        RelationBranchProjectionReadinessService readinessService =
+                mock(RelationBranchProjectionReadinessService.class);
+        RelationBranchProjectionRebuildService rebuildService =
+                mock(RelationBranchProjectionRebuildService.class);
+        RelationProjectionRecoveryService recoveryService =
+                mock(RelationProjectionRecoveryService.class);
+        RebuildResult rebuilt = new RebuildResult(
+                "repo-a", "workspace-a", "review", head, 1);
+        ReconciliationResult reconciliation = new ReconciliationResult(
+                head, 0, 0, 0);
+        Readiness corrupt = new Readiness(
+                ReadinessState.CORRUPT, head, head, List.of());
+        when(rebuildService.rebuild(context)).thenReturn(rebuilt);
+        when(recoveryService.reconcileAfterRebuild(context, head))
+                .thenReturn(reconciliation);
+        when(readinessService.inspect(context)).thenReturn(corrupt);
+
+        assertThatThrownBy(() -> new RelationProjectionOperationsService(
+                repositoryFactory,
+                readinessService,
+                rebuildService,
+                recoveryService).rebuild(context, head))
+                .isInstanceOfSatisfying(
+                        RebuildVerificationException.class,
+                        error -> {
+                            assertThat(error.getRebuild()).isSameAs(rebuilt);
+                            assertThat(error.getReadiness()).isSameAs(corrupt);
+                        });
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionOperationsServiceTest.java
@@ -79,6 +79,34 @@ class RelationProjectionOperationsServiceTest {
     }
 
     @Test
+    void branchCreationPreconditionIsRejectedBeforeRepositoryOrProjectionAccess()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = mock(DslGitRepositoryFactory.class);
+        RelationBranchProjectionReadinessService readinessService =
+                mock(RelationBranchProjectionReadinessService.class);
+        RelationBranchProjectionRebuildService rebuildService =
+                mock(RelationBranchProjectionRebuildService.class);
+        RelationProjectionRecoveryService recoveryService =
+                mock(RelationProjectionRecoveryService.class);
+
+        assertThatThrownBy(() -> new RelationProjectionOperationsService(
+                repositoryFactory,
+                readinessService,
+                rebuildService,
+                recoveryService).rebuild(context, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("requires If-Match");
+
+        verify(repositoryFactory, never()).resolveRepository(context);
+        verify(rebuildService, never()).rebuild(context);
+        verify(readinessService, never()).inspect(context);
+        verify(recoveryService, never()).reconcileAfterRebuild(
+                context, null);
+    }
+
+    @Test
     void staleExpectedHeadIsRejectedBeforeAnyProjectionWrite() throws Exception {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a", "review", "alice");

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionRecoveryServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionRecoveryServiceTest.java
@@ -1,0 +1,134 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.storage.DslGitRepository;
+import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.model.RelationProjectionRecovery;
+import com.taxonomy.relations.model.RelationProjectionRecovery.RecoveryStatus;
+import com.taxonomy.relations.repository.RelationProjectionRecoveryRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationProjectionRecoveryServiceTest {
+
+    private DslGitRepositoryFactory repositoryFactory;
+
+    @AfterEach
+    void closeRepositories() {
+        if (repositoryFactory != null) {
+            repositoryFactory.close();
+        }
+    }
+
+    @Test
+    void recordsTheImmutableAuthorityInAnIndependentRecoveryRow() {
+        RelationProjectionRecoveryRepository repository =
+                mock(RelationProjectionRecoveryRepository.class);
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        CommandResult authority = authority("a".repeat(40), "b".repeat(40));
+        IllegalStateException failure =
+                new IllegalStateException("projection unavailable");
+        when(repository.findAuthorityForUpdate(
+                "repo-a", "workspace-a", "review", "b".repeat(40)))
+                .thenReturn(Optional.empty());
+        when(repository.save(any(RelationProjectionRecovery.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var record = new RelationProjectionRecoveryService(
+                repository, repositoryFactory).recordPending(authority, failure);
+
+        ArgumentCaptor<RelationProjectionRecovery> saved =
+                ArgumentCaptor.forClass(RelationProjectionRecovery.class);
+        verify(repository).save(saved.capture());
+        assertThat(saved.getValue().getRepositoryId()).isEqualTo("repo-a");
+        assertThat(saved.getValue().getWorkspaceId()).isEqualTo("workspace-a");
+        assertThat(saved.getValue().getPreviousHeadCommit())
+                .isEqualTo("a".repeat(40));
+        assertThat(saved.getValue().getAuthoritativeCommitId())
+                .isEqualTo("b".repeat(40));
+        assertThat(saved.getValue().getStatus())
+                .isEqualTo(RecoveryStatus.PENDING);
+        assertThat(saved.getValue().getAttemptCount()).isEqualTo(1);
+        assertThat(record.failureMessage()).isEqualTo("projection unavailable");
+    }
+
+    @Test
+    void rebuildCompletesExactAuthorityAndSupersedesItsAncestor()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "review", "alice");
+        repositoryFactory = new DslGitRepositoryFactory(null);
+        DslGitRepository git = repositoryFactory.resolveRepository(context);
+        String first = git.commitDsl(
+                "review",
+                "element APP-1 type Application {\n}\n",
+                "alice",
+                "First authority");
+        String second = git.commitDsl(
+                "review",
+                "element APP-2 type Application {\n}\n",
+                "alice",
+                "Second authority");
+        RelationProjectionRecovery ancestor = pending(first, "request-1");
+        RelationProjectionRecovery exact = pending(second, "request-2");
+        RelationProjectionRecoveryRepository repository =
+                mock(RelationProjectionRecoveryRepository.class);
+        when(repository.findStatusForUpdate(
+                "repo-a", "workspace-a", "review", RecoveryStatus.PENDING))
+                .thenReturn(List.of(ancestor, exact));
+        when(repository.save(any(RelationProjectionRecovery.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = new RelationProjectionRecoveryService(
+                repository, repositoryFactory)
+                .reconcileAfterRebuild(context, second);
+
+        assertThat(ancestor.getStatus()).isEqualTo(RecoveryStatus.SUPERSEDED);
+        assertThat(exact.getStatus()).isEqualTo(RecoveryStatus.RECOVERED);
+        assertThat(result.recoveredCount()).isEqualTo(1);
+        assertThat(result.supersededCount()).isEqualTo(1);
+        assertThat(result.remainingPendingCount()).isZero();
+        verify(repository, times(2)).save(any(RelationProjectionRecovery.class));
+    }
+
+    private static RelationProjectionRecovery pending(
+            String authority,
+            String causationId) {
+        RelationProjectionRecovery recovery = new RelationProjectionRecovery();
+        recovery.setRepositoryId("repo-a");
+        recovery.setWorkspaceId("workspace-a");
+        recovery.setBranch("review");
+        recovery.setPreviousHeadCommit(null);
+        recovery.setAuthoritativeCommitId(authority);
+        recovery.setCausationId(causationId);
+        recovery.recordFailure(new IllegalStateException("pending"));
+        return recovery;
+    }
+
+    private static CommandResult authority(String previous, String authority) {
+        return new CommandResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                RepositoryScope.WORKSPACE,
+                previous,
+                authority,
+                ChangeKind.UPDATED,
+                true,
+                "request-17");
+    }
+}


### PR DESCRIPTION
## Scope

Next bounded #698 slice on the exact integrated #610 head. It makes failed relation projections durably observable and adds authorized readiness/rebuild operations without switching productive reads or removing the legacy projection.

## Durable recovery

- add `relation_projection_recovery` with exact repository/workspace/branch/authority uniqueness, optimistic versioning and explicit `PENDING`, `RECOVERED` and `SUPERSEDED` states;
- record immutable Git authority, previous head, causation, failure details, attempts and timestamps in an independent `REQUIRES_NEW` transaction after projection failure;
- preserve the authoritative commit even when the secondary recovery write also fails;
- list pending records only in the selected repository/workspace/branch;
- reconcile only after a full rebuild proves `READY`; exact failed commits become `RECOVERED`, proven ancestors become `SUPERSEDED`, and missing/unrelated commits remain pending fail-closed.

## Operator boundary

Under `/api/architecture/relations/projection`:

- `GET /readiness` reports live Git head, checkpoint/readiness state, projected commit, safe relation count and ordered pending recoveries;
- `POST /rebuild` requires a strong `If-Match` for an existing full commit and rejects `If-None-Match: *` before repository access;
- rebuild proves the requested head, rebuild result, live head, projected commit and relation count before reconciliation;
- stale/concurrently changed heads return HTTP 412 with the actual ETag;
- same-head but corrupt/stale projections return an explicit HTTP 409 verification failure and never complete recovery;
- a verified rebuild whose recovery reconciliation still fails returns HTTP 202 with the rebuilt commit ETag;
- central operations require application-admin or repository-maintainer authority; resolved workspace and fork scopes are preserved.

The endpoint never writes Git. It only reconstructs database state from the selected Git branch.

## Migration and verification

- PostgreSQL V11 creates the durable recovery ledger and exact-scope indexes/constraints;
- the migration contract verifies fresh and adopted schemas through V11 plus the recovery table and core columns;
- focused tests cover authority preservation, independent recovery persistence, exact/ancestor reconciliation with real JGit history, strict operation ordering, invalid/stale preconditions, corrupt read models, pending reconciliation, route/header contracts and absence of direct controller repository writes.

## Stack integrity

Base: `75ef6cc4e31f83f53ca05d3762234575eac149cd`.

Head: `39db13e0479dddc04c4a16be8c38a35d9b41d6ba`.

The branch is 21 commits ahead, zero behind and changes exactly twelve files. All checks on earlier heads are historical. Merge only into `copilot/architecture-epic-multi-repo` after fresh exact-head CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL, Security Scan and no unresolved review thread.

Advances #698, #609 and #610.