### PR TITLE
Switch product relation reads and UI writes to Git authority

### DIFF
--- a/.github/scripts/ui-primary-relation-workflows.mjs
+++ b/.github/scripts/ui-primary-relation-workflows.mjs
@@ -65,23 +65,49 @@ export async function runRelationWorkflows({ page, evidence }) {
     await page.locator('#newRelDescription').fill('Primary workflow relation');
   }
 
+  async function submitCreateCommand() {
+    const responsePromise = page.waitForResponse(response => {
+      const pathname = new URL(response.url()).pathname;
+      return response.request().method() === 'PUT'
+        && pathname.endsWith('/api/architecture/relations/CP/CONSUMES/IP');
+    }, { timeout: 15_000 });
+    await page.locator('#createRelationSubmit').click();
+    const response = await responsePromise;
+    return {
+      status: response.status(),
+      etag: response.headers().etag || null,
+      body: await response.json()
+    };
+  }
+
   await openCreate();
-  await page.locator('#createRelationSubmit').click();
+  const created = await submitCreateCommand();
+  if (created.status !== 201
+      || created.body.changeKind !== 'ADDED'
+      || created.body.commitCreated !== true
+      || !created.etag) {
+    throw new Error(`Expected a committed ADDED relation, received ${JSON.stringify(created)}`);
+  }
   await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
   await waitForRelation(true);
   await assertBackendRelationCount(1);
   passed('relation create');
 
   await openCreate();
-  await page.locator('#createRelationSubmit').click();
-  await page.locator('#createRelationError').waitFor({ state: 'visible', timeout: 15_000 });
+  const unchanged = await submitCreateCommand();
+  if (unchanged.status !== 200
+      || unchanged.body.changeKind !== 'UNCHANGED'
+      || unchanged.body.commitCreated !== false
+      || unchanged.etag !== created.etag
+      || unchanged.body.authoritativeCommitId !== created.body.authoritativeCommitId) {
+    throw new Error(`Expected an idempotent UNCHANGED upsert, received ${JSON.stringify(unchanged)}`);
+  }
+  await page.locator('#createRelationModal').waitFor({ state: 'hidden', timeout: 15_000 });
+  await waitForRelation(true);
   await assertBackendRelationCount(1);
-  await axeState('relation-duplicate-error', '#createRelationModal');
-  await saveState('relation-duplicate-error', '#createRelationModal');
-  const modal = page.locator('#createRelationModal');
-  await modal.locator('[data-bs-dismiss="modal"]').first().click();
-  await modal.waitFor({ state: 'hidden' });
-  passed('relation duplicate conflict feedback');
+  await axeState('relation-idempotent-upsert', '#relationsBrowser');
+  await saveState('relation-idempotent-upsert', '#relationsBrowser');
+  passed('relation idempotent duplicate upsert');
 
   const row = await exactRelationRow();
   page.once('dialog', dialog => dialog.accept());

--- a/docs/dev/tasks/add-relation-type.md
+++ b/docs/dev/tasks/add-relation-type.md
@@ -2,13 +2,13 @@
 
 ## Goal
 
-Add a new semantic relation type (e.g., `INFLUENCES`, `CONSTRAINS`) to the
-`RelationType` enum and ensure it is handled correctly throughout the
-validation, scoring, and DSL layers.
+Add a new semantic relation type, for example `INFLUENCES` or `CONSTRAINS`, and
+keep its validation, DSL, projected reads, Git-authoritative commands, UI choices,
+and imports consistent.
 
 > Start with the stable extension anchor in
 > [`docs/dev/07-extension-points.md#relation-types-and-compatibility-rules`](../07-extension-points.md#relation-types-and-compatibility-rules).
-> Use this page for the end-to-end file/test/doc checklist.
+> Use this page for the end-to-end file, test, and documentation checklist.
 
 ---
 
@@ -16,107 +16,180 @@ validation, scoring, and DSL layers.
 
 | File | What to do |
 |---|---|
-| `taxonomy-domain/src/main/java/com/taxonomy/model/RelationType.java` | Add the new enum constant |
-| `taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationCompatibilityMatrix.java` | Add the allowed source/target type combinations |
-| `taxonomy-dsl/src/main/java/com/taxonomy/dsl/validation/DslValidator.java` | Add any DSL-level validation rules |
+| `taxonomy-domain/src/main/java/com/taxonomy/model/RelationType.java` | Add the persisted enum constant |
+| `taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationCompatibilityMatrix.java` | Add allowed source/target type combinations |
+| `taxonomy-dsl/src/main/java/com/taxonomy/dsl/validation/DslValidator.java` | Keep the DSL relation-type mirror and compatibility rules aligned |
+| `taxonomy-app/src/main/resources/templates/index.html` | Add the type to both hard-coded relation selectors |
+
+There is currently no relation-type registry and no
+`GET /api/relations/types` endpoint. Adding the enum value alone therefore does
+not populate the UI.
 
 ---
 
 ## Files usually touched
 
-- `taxonomy-domain/…/model/RelationType.java` — new enum constant
-- `taxonomy-app/…/relations/service/RelationCompatibilityMatrix.java` — allowed source/target combinations
-- `taxonomy-app/…/relations/service/RelationValidationService.java` — validation logic that references the compatibility matrix
-- `taxonomy-dsl/…/validation/DslValidator.java` — if DSL blocks use the new type, add validation there
-- `taxonomy-app/src/main/resources/data/relation_seeds.csv` — optional: seed data for typical relations of this type
-- `docs/en/RELATION_SEEDS.md` — document any new seed relations
-- `taxonomy-domain/src/test/java/com/taxonomy/model/RelationTypeTest.java` — add a test asserting the new constant exists
+- `taxonomy-domain/.../model/RelationType.java` — new enum constant
+- `taxonomy-app/.../relations/service/RelationCompatibilityMatrix.java` —
+  allowed source/target combinations
+- `taxonomy-dsl/.../validation/DslValidator.java` — DSL validation mirror
+- `taxonomy-app/src/main/resources/templates/index.html` — both relation-type
+  selectors
+- `taxonomy-domain/src/test/java/com/taxonomy/model/RelationTypeTest.java` —
+  assertion for the new constant
+- compatibility and DSL validation tests for allowed and forbidden combinations
+
+Review these when the new type has special behavior:
+
+- `RelationValidationService`
+- `RelationCandidateService`
+- `RelationProposalService`
+- `AnalysisRelationGenerator`
+- graph traversal, impact, coverage, or materialization services
+- import profiles and seed parsers that map external relation names
+- `taxonomy-app/src/main/resources/data/relations.csv`
+- `docs/en/RELATION_SEEDS.md`
 
 ---
 
 ## Files usually not touched
 
-- `taxonomy-dsl/…/parser/` — the DSL parser uses the `RelationType` enum by string
-  matching; adding the enum constant is sufficient; no parser grammar change needed
-- `taxonomy-export/` — export services handle relation types generically
-- `taxonomy-app/…/controller/` — relation controllers are type-agnostic
-- `taxonomy-app/src/main/resources/templates/index.html` — the relation type
-  dropdown is populated from the enum; no template change needed unless you need
-  a custom label or icon
+- `taxonomy-dsl/.../parser/TaxDslParser.java` — relation type names are carried as
+  strings; adding a simple enum-backed type normally needs no grammar change
+- `taxonomy-export/` — exporters generally handle relation types generically
+- `RelationApiController` — projected read endpoints are type-agnostic
+- `GitRelationCommandApiController` — identity-based commands parse the enum
+  generically
+- `taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations.js` —
+  table rendering is type-agnostic
+- `taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js`
+  — command routing is type-agnostic
+
+Touch these only when the new type changes payload shape, validation semantics,
+or presentation rather than merely adding another enum value.
 
 ---
 
-## Backend endpoint(s)
+## Relation API contract
 
-| Endpoint | Controller |
+### Product reads
+
+| Endpoint | Purpose |
 |---|---|
-| `GET /api/relations` | `RelationApiController` |
-| `POST /api/relations` | `RelationApiController` |
-| `GET /api/relations/types` | `RelationApiController` |
+| `GET /api/relations` | Complete relation projection for the selected repository/workspace; optional `type` filter |
+| `GET /api/node/{code}/relations` | Incoming and outgoing projected relations for one node |
+| `GET /api/relations/count` | Count from the same complete projected snapshot |
 
-The relation endpoints are type-agnostic.
-After adding the enum constant, the new type appears automatically in
-`GET /api/relations/types`.
+These reads return the authoritative branch `ETag` and explicit projection/read
+model headers. Unsafe stale or corrupt projections fail closed.
+
+### Git-authoritative writes
+
+| Endpoint | Purpose |
+|---|---|
+| `PUT /api/architecture/relations/{sourceCode}/{relationType}/{targetCode}` | Add or update one relation identity |
+| `DELETE /api/architecture/relations/{sourceCode}/{relationType}/{targetCode}` | Remove one relation identity |
+
+Existing branches require a strong `If-Match` containing the full quoted commit
+ID. Creating an absent branch requires `If-None-Match: *`. Every command requires
+`Idempotency-Key`.
+
+The old DB-first routes `POST /api/relations` and
+`DELETE /api/relations/{id}` are retired and return HTTP 410. Do not add new
+features or clients to those compatibility routes.
 
 ---
 
-## Frontend module(s)
+## Frontend modules
 
-- `taxonomy-app/src/main/resources/static/js/relations.js` — reads the type list
-  from `/api/relations/types`; no change needed unless you add a custom display label
-- i18n: if the type name needs a German translation, add it to `messages_de.properties`
+- `taxonomy-app/src/main/resources/templates/index.html` — owns the two current
+  hard-coded type selectors
+- `taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations.js` —
+  renders projected relation reads and impact analysis
+- `taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js`
+  — binds Create/Delete to the displayed projection ETag and stable relation
+  identity
+- i18n properties — add labels/help text when the enum name is not an adequate
+  user-facing label
+
+The command adapter intentionally does not maintain its own type list. It submits
+whatever valid enum-backed choice the selectors expose.
 
 ---
 
-## DTOs / domain types
+## DTOs and persisted identity
 
-- `com.taxonomy.model.RelationType` — the source of truth; all other files reference
-  this enum
-- `com.taxonomy.dto.TaxonomyRelationDto` — carries the relation type as a string;
-  no change needed
-- `com.taxonomy.dto.RelationSeedRow` — used for CSV seed data; no structural change needed
+- `RelationType` is the source of truth for persisted names
+- `TaxonomyRelationDto` carries the relation type as a string and needs no
+  structural change
+- Git relation identity is the tuple
+  `(sourceCode, relationType, targetCode)`
+- projection database IDs are rebuild-local implementation details and must not
+  be used as mutation identities
+
+Do not rely on `RelationType.ordinal()`. Persist and compare `name()` values only.
 
 ---
 
 ## Tests to run
 
 ```bash
-# Domain module: verify enum constant is present
+# Domain enum contract
 ./mvnw test -pl taxonomy-domain
 
-# App module: verify compatibility matrix and validation
-./mvnw test -pl taxonomy-app
+# Application validation, Git commands, projected reads, UI contracts
+./mvnw test -pl taxonomy-app -am
+
+# DSL parsing, validation, and round trips
+./mvnw test -pl taxonomy-dsl -am
 ```
 
-Relevant test classes:
-- `RelationTypeTest` — add an assertion for the new constant
-- `RelationValidationServiceTest` — add a test for the new type's allowed combinations
-- `RelationCompatibilityMatrixTest` (if it exists) — add allowed/forbidden pair tests
+Relevant tests include:
+
+- `RelationTypeTest`
+- `RelationValidationServiceTest`
+- `RelationCompatibilityMatrixTest`, when present
+- `GitAuthoritativeRelationMutationServiceTest`
+- `RelationProjectionReadServiceTest`
+- `RelationApiControllerRepositoryScopeTest`
+- `RelationGitCommandUiContractTest`
+- `DslValidatorTest`
+- parser/serializer round-trip tests when DSL behavior changes
+- import/seed tests when mappings or seed data change
+
+Add at least one accepted combination and one rejected combination for the new
+relation type. Also prove that the exact enum name survives DSL and JSON
+round trips.
 
 ---
 
-## Documentation / screenshot updates
+## Documentation and screenshot updates
 
-- `docs/en/RELATION_SEEDS.md` — list any seed relations of the new type
-- `docs/en/API_REFERENCE.md` — update the `RelationType` values table if present
-- Screenshots: not required unless the relation type picker screenshot exists and
-  shows an explicit list
+- `docs/en/RELATION_SEEDS.md` — when seed data or guidance changes
+- `docs/en/API_REFERENCE.md` — when it lists relation-type values or command
+  examples
+- this task and the extension-points page — only if the extension workflow or
+  API architecture changes
+- screenshots — only when a documented picker visibly enumerates all relation
+  types
 
 ---
 
 ## Common pitfalls
 
-1. **Compatibility matrix must be exhaustive:** If you add a new type but do not
-   add it to `RelationCompatibilityMatrix`, the validator will reject all relations
-   of that type as invalid combinations.
-
-2. **DSL serialization order:** If the new type is used in DSL blocks, ensure
-   `TaxDslSerializer.PROPERTY_ORDER` includes any new property names for this type.
-   See [add-dsl-property](add-dsl-property.md) for details.
-
-3. **Existing seed data:** The seed CSV is loaded at startup.
-   If you add seeds for a type that the compatibility matrix rejects, startup
-   will log validation warnings. Add the type to the matrix before adding seeds.
-
-4. **Enum ordinal stability:** Do not rely on `RelationType.ordinal()` — only
-   `name()` (the string value) is persisted in the database.
+1. **Compatibility rules are incomplete.** The enum exists, but the application
+   or DSL validator rejects every use.
+2. **Only one selector was updated.** Manual relation creation and proposal
+   workflows then expose different type sets.
+3. **A fictitious metadata endpoint is assumed.** There is no
+   `/api/relations/types`; the UI list is currently core template data.
+4. **A client uses the retired DB-first route.** New writes must carry Git
+   preconditions and an idempotency key.
+5. **Projection IDs are treated as identities.** Rebuilds may replace those IDs;
+   mutations must use source/type/target.
+6. **Proposal, graph, or import code assumes the old closed set.** Search for
+   switches and type-specific maps before considering the change complete.
+7. **Seed data contradicts the matrix.** Validate new seed/import mappings against
+   both application and DSL compatibility rules.
+8. **Enum ordinals are persisted.** Only stable enum names belong in storage,
+   DSL, and API payloads.

--- a/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyNodeRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/catalog/repository/TaxonomyNodeRepository.java
@@ -4,6 +4,7 @@ import com.taxonomy.catalog.model.TaxonomyNode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,8 @@ import java.util.Optional;
 public interface TaxonomyNodeRepository extends JpaRepository<TaxonomyNode, Long> {
 
     Optional<TaxonomyNode> findByCode(String code);
+
+    List<TaxonomyNode> findByCodeIn(Collection<String> codes);
 
     List<TaxonomyNode> findByParentIsNullOrderByCodeAsc();
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitProposalReviewApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitProposalReviewApiController.java
@@ -204,9 +204,10 @@ public class GitProposalReviewApiController {
                 proposalId, action, error));
     }
 
-    /** Convert a central read context into an explicitly authorized write context. */
+    /** Preserve isolated write scopes; authorize central reads before upgrading. */
     private RepositoryContext writableContext(RepositoryContext context) {
-        if (context.workspaceId() != null) {
+        if (context.scope() == RepositoryScope.WORKSPACE
+                || context.scope() == RepositoryScope.FORK) {
             return context;
         }
         SystemRepository repository = repositoryService.getRepository(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/GitRelationCommandApiController.java
@@ -205,9 +205,10 @@ public class GitRelationCommandApiController {
         return response.body(MutationResponse.conflict(error));
     }
 
-    /** Convert a central read context into an explicitly authorized write context. */
+    /** Preserve isolated write scopes; authorize central reads before upgrading. */
     private RepositoryContext writableContext(RepositoryContext context) {
-        if (context.workspaceId() != null) {
+        if (context.scope() == RepositoryScope.WORKSPACE
+                || context.scope() == RepositoryScope.FORK) {
             return context;
         }
         SystemRepository repository = repositoryService.getRepository(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
@@ -1,21 +1,19 @@
 package com.taxonomy.relations.controller;
 
-import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
-import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadResult;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.workspace.service.RepositoryContext;
-import com.taxonomy.workspace.service.RepositoryMembershipService;
-import com.taxonomy.workspace.service.RepositoryScope;
-import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 @RestController
@@ -33,151 +32,153 @@ import java.util.Map;
 @Tag(name = "Relations")
 public class RelationApiController {
 
-    private final TaxonomyRelationService relationService;
+    public static final String READ_MODEL_HEADER =
+            "X-Taxonomy-Relation-Read-Model";
+    public static final String PROJECTION_STATE_HEADER =
+            "X-Taxonomy-Relation-Projection-State";
+    public static final String PENDING_RECOVERY_HEADER =
+            "X-Taxonomy-Relation-Pending-Recovery";
+
+    private final RelationProjectionReadService relationReadService;
     private final WorkspaceResolver workspaceResolver;
-    private final SystemRepositoryService repositoryService;
-    private final RepositoryMembershipService membershipService;
 
     public RelationApiController(
-            TaxonomyRelationService relationService,
-            WorkspaceResolver workspaceResolver,
-            SystemRepositoryService repositoryService,
-            RepositoryMembershipService membershipService) {
-        this.relationService = relationService;
+            RelationProjectionReadService relationReadService,
+            WorkspaceResolver workspaceResolver) {
+        this.relationReadService = relationReadService;
         this.workspaceResolver = workspaceResolver;
-        this.repositoryService = repositoryService;
-        this.membershipService = membershipService;
     }
 
     @Operation(
             summary = "List relations",
-            description = "Returns relations from the selected repository/workspace, optionally filtered by type")
+            description = "Returns the complete relation projection for the selected repository/workspace, optionally filtered by type")
     @GetMapping("/relations")
     public ResponseEntity<List<TaxonomyRelationDto>> getRelations(
             @Parameter(description = "Filter by relation type")
             @RequestParam(required = false) String type) {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
-        if (type != null && !type.isBlank()) {
-            RelationType relationType;
-            try {
-                relationType = RelationType.valueOf(type.toUpperCase());
-            } catch (IllegalArgumentException exception) {
-                return ResponseEntity.badRequest().build();
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        try {
+            ReadResult result;
+            if (type != null && !type.isBlank()) {
+                RelationType relationType;
+                try {
+                    relationType = RelationType.valueOf(
+                            type.strip().toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException exception) {
+                    return ResponseEntity.badRequest().build();
+                }
+                result = relationReadService.readByType(context, relationType);
+            } else {
+                result = relationReadService.readAll(context);
             }
-            return ResponseEntity.ok(
-                    relationService.getRelationsByTypeInContext(relationType, context));
+            return readResponse(result);
+        } catch (RelationProjectionUnavailableException error) {
+            return unavailable(error).build();
         }
-        return ResponseEntity.ok(relationService.getAllRelationsInContext(context));
     }
 
     @Operation(
             summary = "Get node relations",
-            description = "Returns node relations from the selected repository/workspace")
+            description = "Returns complete incoming and outgoing projected relations for one node in the selected repository/workspace")
     @GetMapping("/node/{code}/relations")
     public ResponseEntity<List<TaxonomyRelationDto>> getRelationsForNode(
             @PathVariable String code) {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
-        return ResponseEntity.ok(
-                relationService.getRelationsForNodeInContext(code, context));
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        try {
+            return readResponse(
+                    relationReadService.readForNode(context, code));
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (RelationProjectionUnavailableException error) {
+            return unavailable(error).build();
+        }
     }
 
+    /**
+     * The historic DB-first write route is deliberately retired. Git-authoritative
+     * callers use PUT /api/architecture/relations/{source}/{type}/{target} with
+     * If-Match/If-None-Match and Idempotency-Key.
+     */
+    @Deprecated(forRemoval = true)
     @Operation(
-            summary = "Create relation",
-            description = "Creates a relation in the active workspace or an explicitly authorized central repository")
+            summary = "Retired DB-first create route",
+            description = "Use the Git-authoritative architecture relation command endpoint")
     @PostMapping("/relations")
     public ResponseEntity<TaxonomyRelationDto> createRelation(
-            @RequestBody Map<String, String> body) {
-        String sourceCode = body.get("sourceCode");
-        String targetCode = body.get("targetCode");
-        String relationTypeStr = body.get("relationType");
-        String description = body.get("description");
-        String provenance = body.get("provenance");
-
-        if (sourceCode == null || sourceCode.isBlank()
-                || targetCode == null || targetCode.isBlank()
-                || relationTypeStr == null || relationTypeStr.isBlank()) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        RelationType relationType;
-        try {
-            relationType = RelationType.valueOf(relationTypeStr.toUpperCase());
-        } catch (IllegalArgumentException exception) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        RepositoryContext context = writableContext(
-                workspaceResolver.resolveCurrentRepositoryContext());
-        if (context == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-
-        try {
-            TaxonomyRelationDto dto = relationService.createRelationInContext(
-                    sourceCode,
-                    targetCode,
-                    relationType,
-                    description,
-                    provenance,
-                    context);
-            return ResponseEntity.ok(dto);
-        } catch (IllegalArgumentException exception) {
-            return ResponseEntity.badRequest().build();
-        }
+            @RequestBody(required = false) Map<String, String> ignored) {
+        return ResponseEntity.status(HttpStatus.GONE).build();
     }
 
-    @Operation(summary = "Delete relation", description = "Deletes a relation in the exact active tenant scope")
+    /**
+     * Projection row IDs are rebuild-local and cannot be authoritative mutation
+     * identities. Call the Git-authoritative identity-based DELETE endpoint.
+     */
+    @Deprecated(forRemoval = true)
+    @Operation(
+            summary = "Retired DB-first delete route",
+            description = "Use DELETE /api/architecture/relations/{source}/{type}/{target}")
     @DeleteMapping("/relations/{id}")
     public ResponseEntity<Void> deleteRelation(@PathVariable Long id) {
-        RepositoryContext context = writableContext(
-                workspaceResolver.resolveCurrentRepositoryContext());
-        if (context == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        try {
-            relationService.deleteRelationInContext(id, context);
-        } catch (IllegalArgumentException exception) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.status(HttpStatus.GONE).build();
     }
 
     @Operation(
             summary = "Count relations",
-            description = "Returns the number of relations visible in the selected repository/workspace")
+            description = "Returns the size of the same complete relation projection used by list and node reads")
     @GetMapping("/relations/count")
     public ResponseEntity<Map<String, Long>> countRelations() {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
-        return ResponseEntity.ok(Map.of(
-                "count", relationService.countRelationsInContext(context)));
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        try {
+            ReadResult result = relationReadService.readAll(context);
+            ResponseEntity.BodyBuilder response = readHeaders(result);
+            return response.body(Map.of(
+                    "count", (long) result.relations().size()));
+        } catch (RelationProjectionUnavailableException error) {
+            return unavailable(error).build();
+        }
     }
 
-    /**
-     * Workspace contexts are writable by their resolved owner. Central contexts
-     * require repository MAINTAINER/OWNER; a global ADMIN remains an explicit
-     * operational compatibility override for the historic primary repository.
-     */
-    private RepositoryContext writableContext(RepositoryContext context) {
-        if (context.workspaceId() != null) {
-            return context;
-        }
-        SystemRepository repository = repositoryService.getRepository(context.repositoryId());
-        if (!isApplicationAdmin()
-                && !membershipService.canMaintain(repository, context.username())) {
-            return null;
-        }
-        return new RepositoryContext(
-                context.repositoryId(),
-                null,
-                context.branch(),
-                context.username(),
-                RepositoryScope.CENTRAL_WRITE);
+    private static ResponseEntity<List<TaxonomyRelationDto>> readResponse(
+            ReadResult result) {
+        return readHeaders(result).body(result.relations());
     }
 
-    private static boolean isApplicationAdmin() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication != null
-                && authentication.getAuthorities().stream()
-                        .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
+    private static ResponseEntity.BodyBuilder readHeaders(ReadResult result) {
+        ResponseEntity.BodyBuilder response = ResponseEntity.ok()
+                .header(READ_MODEL_HEADER, result.readModel().name())
+                .header(PROJECTION_STATE_HEADER,
+                        result.readinessState().name())
+                .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        if (result.authoritativeCommitId() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            result.authoritativeCommitId()));
+        }
+        return response;
+    }
+
+    private static ResponseEntity.BodyBuilder unavailable(
+            RelationProjectionUnavailableException error) {
+        HttpStatus status = error.getReadinessState()
+                == ReadinessState.BRANCH_MISSING
+                ? HttpStatus.NOT_FOUND
+                : HttpStatus.CONFLICT;
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(status)
+                .header(PROJECTION_STATE_HEADER,
+                        error.getReadinessState().name())
+                .header(PENDING_RECOVERY_HEADER,
+                        String.valueOf(error.getPendingRecoveryCount()))
+                .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        if (error.getCurrentHeadCommit() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            error.getCurrentHeadCommit()));
+        }
+        return response;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
@@ -170,9 +170,12 @@ public class RelationApiController {
         ResponseEntity.BodyBuilder response = ResponseEntity.status(status)
                 .header(PROJECTION_STATE_HEADER,
                         error.getReadinessState().name())
-                .header(PENDING_RECOVERY_HEADER,
-                        String.valueOf(error.getPendingRecoveryCount()))
                 .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        if (error.getPendingRecoveryCount() > 0) {
+            response.header(
+                    PENDING_RECOVERY_HEADER,
+                    String.valueOf(error.getPendingRecoveryCount()));
+        }
         if (error.getCurrentHeadCommit() != null) {
             response.header(
                     HttpHeaders.ETAG,

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/RelationApiController.java
@@ -4,6 +4,8 @@ import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationProjectionReadService;
+import com.taxonomy.relations.service.RelationProjectionReadService.CountResult;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
 import com.taxonomy.relations.service.RelationProjectionReadService.ReadResult;
 import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.workspace.service.RepositoryContext;
@@ -126,16 +128,18 @@ public class RelationApiController {
 
     @Operation(
             summary = "Count relations",
-            description = "Returns the size of the same complete relation projection used by list and node reads")
+            description = "Returns the size of the same complete relation projection used by list and node reads without materializing DTOs")
     @GetMapping("/relations/count")
     public ResponseEntity<Map<String, Long>> countRelations() {
         RepositoryContext context = workspaceResolver
                 .resolveCurrentRepositoryContext();
         try {
-            ReadResult result = relationReadService.readAll(context);
-            ResponseEntity.BodyBuilder response = readHeaders(result);
-            return response.body(Map.of(
-                    "count", (long) result.relations().size()));
+            CountResult result = relationReadService.count(context);
+            return readHeaders(
+                    result.readModel(),
+                    result.readinessState(),
+                    result.authoritativeCommitId())
+                    .body(Map.of("count", result.count()));
         } catch (RelationProjectionUnavailableException error) {
             return unavailable(error).build();
         }
@@ -143,20 +147,25 @@ public class RelationApiController {
 
     private static ResponseEntity<List<TaxonomyRelationDto>> readResponse(
             ReadResult result) {
-        return readHeaders(result).body(result.relations());
+        return readHeaders(
+                result.readModel(),
+                result.readinessState(),
+                result.authoritativeCommitId())
+                .body(result.relations());
     }
 
-    private static ResponseEntity.BodyBuilder readHeaders(ReadResult result) {
+    private static ResponseEntity.BodyBuilder readHeaders(
+            ReadModel readModel,
+            ReadinessState readinessState,
+            String authoritativeCommitId) {
         ResponseEntity.BodyBuilder response = ResponseEntity.ok()
-                .header(READ_MODEL_HEADER, result.readModel().name())
-                .header(PROJECTION_STATE_HEADER,
-                        result.readinessState().name())
+                .header(READ_MODEL_HEADER, readModel.name())
+                .header(PROJECTION_STATE_HEADER, readinessState.name())
                 .header(HttpHeaders.CACHE_CONTROL, "no-store");
-        if (result.authoritativeCommitId() != null) {
+        if (authoritativeCommitId != null) {
             response.header(
                     HttpHeaders.ETAG,
-                    GitHttpPrecondition.etag(
-                            result.authoritativeCommitId()));
+                    GitHttpPrecondition.etag(authoritativeCommitId));
         }
         return response;
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationService.java
@@ -8,6 +8,9 @@ import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.Comm
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RemoveRelation;
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.UpsertRelation;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
 import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
 import com.taxonomy.workspace.service.RepositoryContext;
 import org.springframework.stereotype.Service;
@@ -20,25 +23,35 @@ import java.util.Objects;
  * relational projection.
  *
  * <p>The method is deliberately not transactional: a failed projection must
- * never roll back or hide the already successful Git command. Recovery is
- * persisted in an independent transaction and callers always receive the
- * immutable authority, even when that secondary persistence also fails.</p>
+ * never roll back or hide the already successful Git command. The exact command
+ * state is projected first, then the complete branch is rebuilt and proven ready
+ * before any pending recovery is reconciled. Recovery is persisted in an
+ * independent transaction and callers always receive the immutable Git authority,
+ * even when that secondary persistence also fails.</p>
  */
 @Service
 public class GitAuthoritativeRelationMutationService {
 
     private final ArchitectureRelationGitCommandService commandService;
     private final RelationDecisionProjectionService projectionService;
+    private final RelationBranchProjectionRebuildService rebuildService;
+    private final RelationBranchProjectionReadinessService readinessService;
     private final RelationProjectionRecoveryService recoveryService;
 
     public GitAuthoritativeRelationMutationService(
             ArchitectureRelationGitCommandService commandService,
             RelationDecisionProjectionService projectionService,
+            RelationBranchProjectionRebuildService rebuildService,
+            RelationBranchProjectionReadinessService readinessService,
             RelationProjectionRecoveryService recoveryService) {
         this.commandService = Objects.requireNonNull(
                 commandService, "commandService");
         this.projectionService = Objects.requireNonNull(
                 projectionService, "projectionService");
+        this.rebuildService = Objects.requireNonNull(
+                rebuildService, "rebuildService");
+        this.readinessService = Objects.requireNonNull(
+                readinessService, "readinessService");
         this.recoveryService = Objects.requireNonNull(
                 recoveryService, "recoveryService");
     }
@@ -74,6 +87,10 @@ public class GitAuthoritativeRelationMutationService {
         try {
             RelationDecisionProjectionService.ProjectionResult projection =
                     projectionService.project(context, authority, command);
+            RebuildResult rebuild = rebuildService.rebuild(context);
+            verifyCompleteProjection(context, authority, rebuild);
+            recoveryService.reconcileAfterRebuild(
+                    context, authority.authoritativeCommitId());
             return new MutationResult(authority, projection);
         } catch (RuntimeException projectionFailure) {
             RecoveryRecord recovery = null;
@@ -88,12 +105,45 @@ public class GitAuthoritativeRelationMutationService {
         }
     }
 
+    private void verifyCompleteProjection(
+            RepositoryContext context,
+            CommandResult authority,
+            RebuildResult rebuild) {
+        String authoritativeCommit = authority.authoritativeCommitId();
+        if (!authoritativeCommit.equals(rebuild.authoritativeCommitId())) {
+            throw new ProjectionCompletionException(
+                    "Complete relation projection rebuilt commit "
+                            + rebuild.authoritativeCommitId()
+                            + " instead of command authority "
+                            + authoritativeCommit);
+        }
+
+        Readiness readiness = readinessService.inspect(context);
+        boolean complete = readiness.state() == ReadinessState.READY
+                && authoritativeCommit.equals(readiness.currentHeadCommit())
+                && authoritativeCommit.equals(readiness.projectedCommit())
+                && rebuild.relationCount() == readiness.rows().size();
+        if (!complete) {
+            throw new ProjectionCompletionException(
+                    "Relation command at " + authoritativeCommit
+                            + " did not produce a complete readable branch projection: "
+                            + readiness.state());
+        }
+    }
+
     public record MutationResult(
             CommandResult authority,
             RelationDecisionProjectionService.ProjectionResult projection) {
         public MutationResult {
             authority = Objects.requireNonNull(authority, "authority");
             projection = Objects.requireNonNull(projection, "projection");
+        }
+    }
+
+    public static final class ProjectionCompletionException
+            extends IllegalStateException {
+        public ProjectionCompletionException(String message) {
+            super(message);
         }
     }
 
@@ -119,7 +169,7 @@ public class GitAuthoritativeRelationMutationService {
                 Throwable cause) {
             super("Git relation command succeeded at "
                     + authority.authoritativeCommitId()
-                    + ", but its projection requires recovery", cause);
+                    + ", but its complete projection requires recovery", cause);
             this.authority = Objects.requireNonNull(authority, "authority");
             this.recovery = recovery;
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/ProposalReviewStateStore.java
@@ -92,15 +92,15 @@ public class ProposalReviewStateStore {
                     "RepositoryContext must not be null");
         }
         if (context.workspaceId() == null
-                && context.scope() != RepositoryScope.CENTRAL_WRITE) {
-            throw new IllegalArgumentException(
-                    "Central proposal review requires CENTRAL_WRITE scope");
-        }
-        if (context.workspaceId() != null
-                && context.scope() != RepositoryScope.WORKSPACE
+                && context.scope() != RepositoryScope.CENTRAL_WRITE
                 && context.scope() != RepositoryScope.FORK) {
             throw new IllegalArgumentException(
-                    "Workspace proposal review requires WORKSPACE or FORK scope");
+                    "Repository proposal review requires CENTRAL_WRITE or FORK scope");
+        }
+        if (context.workspaceId() != null
+                && context.scope() != RepositoryScope.WORKSPACE) {
+            throw new IllegalArgumentException(
+                    "Workspace proposal review requires WORKSPACE scope");
         }
         return context;
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationDecisionProjectionWriter.java
@@ -77,14 +77,17 @@ public class RelationDecisionProjectionWriter {
 
         if (effectiveRequest.authoritativeCommitId().equals(
                 existing.getAuthoritativeCommitId())) {
-            if (!sameState(existing, effectiveRequest)
-                    || !effectiveRequest.causationId().equals(
-                            existing.getCausationId())) {
+            if (!sameState(existing, effectiveRequest)) {
                 throw new ProjectionConflictException(
                         "Authoritative commit "
                                 + effectiveRequest.authoritativeCommitId()
                                 + " is already projected with different relation state");
             }
+            // Multiple commands may legitimately prove the same semantic no-op
+            // at one unchanged Git head. Their causation IDs identify command
+            // attempts, not different authoritative relation states. A complete
+            // rebuild also records its own rebuild:<commit> causation ID, so
+            // requiring equality here would reject every later unchanged command.
             return result(ProjectionOutcome.REPLAYED, effectiveRequest);
         }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
@@ -1,0 +1,298 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
+import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+/**
+ * Product read boundary for relation decisions.
+ *
+ * <p>A complete branch projection is the normal source. The only compatibility
+ * fallback is the historic primary repository's configured default branch while
+ * no projection has ever been built and no failed Git-authoritative projection
+ * is pending. Stale, corrupt, branch-missing, workspace and fork projections
+ * fail closed instead of exposing an unrelated legacy overlay.</p>
+ */
+@Service
+public class RelationProjectionReadService {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            RelationProjectionReadService.class);
+
+    private final RelationBranchProjectionReadinessService readinessService;
+    private final RelationProjectionRecoveryService recoveryService;
+    private final TaxonomyRelationService legacyRelationService;
+    private final TaxonomyNodeRepository nodeRepository;
+    private final SystemRepositoryService repositoryService;
+    private final Set<String> reportedFallbacks = ConcurrentHashMap.newKeySet();
+
+    public RelationProjectionReadService(
+            RelationBranchProjectionReadinessService readinessService,
+            RelationProjectionRecoveryService recoveryService,
+            TaxonomyRelationService legacyRelationService,
+            TaxonomyNodeRepository nodeRepository,
+            SystemRepositoryService repositoryService) {
+        this.readinessService = Objects.requireNonNull(
+                readinessService, "readinessService");
+        this.recoveryService = Objects.requireNonNull(
+                recoveryService, "recoveryService");
+        this.legacyRelationService = Objects.requireNonNull(
+                legacyRelationService, "legacyRelationService");
+        this.nodeRepository = Objects.requireNonNull(
+                nodeRepository, "nodeRepository");
+        this.repositoryService = Objects.requireNonNull(
+                repositoryService, "repositoryService");
+    }
+
+    public ReadResult readAll(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        Readiness readiness = readinessService.inspect(selected);
+        if (readiness.state() == ReadinessState.READY) {
+            return new ReadResult(
+                    ReadModel.PROJECTION,
+                    readiness.state(),
+                    readiness.currentHeadCommit(),
+                    projectionDtos(readiness.rows()));
+        }
+
+        long pendingRecoveries = recoveryService.pendingCount(selected);
+        if (readiness.state() == ReadinessState.NOT_BUILT
+                && pendingRecoveries == 0
+                && mayUseLegacyFallback(selected)) {
+            reportFallback(selected);
+            return new ReadResult(
+                    ReadModel.LEGACY_FALLBACK,
+                    readiness.state(),
+                    readiness.currentHeadCommit(),
+                    legacyRelationService.getAllRelationsInContext(selected));
+        }
+
+        throw new RelationProjectionUnavailableException(
+                selected,
+                readiness.state(),
+                readiness.currentHeadCommit(),
+                readiness.projectedCommit(),
+                pendingRecoveries);
+    }
+
+    public ReadResult readByType(
+            RepositoryContext context,
+            RelationType relationType) {
+        Objects.requireNonNull(relationType, "relationType");
+        return readAll(context).filter(relation -> relationType.name().equals(
+                relation.getRelationType()));
+    }
+
+    public ReadResult readForNode(
+            RepositoryContext context,
+            String nodeCode) {
+        String code = requireText(nodeCode, "nodeCode");
+        return readAll(context).filter(relation -> code.equals(
+                relation.getSourceCode()) || code.equals(relation.getTargetCode()));
+    }
+
+    public Optional<RelationIdentity> findIdentityById(
+            RepositoryContext context,
+            Long id) {
+        Objects.requireNonNull(id, "id");
+        return readAll(context).relations().stream()
+                .filter(relation -> id.equals(relation.getId()))
+                .findFirst()
+                .map(RelationProjectionReadService::identity);
+    }
+
+    public Optional<TaxonomyRelationDto> findByIdentity(
+            RepositoryContext context,
+            RelationIdentity identity) {
+        Objects.requireNonNull(identity, "identity");
+        return readAll(context).relations().stream()
+                .filter(relation -> identity.sourceId().equals(
+                        relation.getSourceCode()))
+                .filter(relation -> identity.relationType().equals(
+                        relation.getRelationType()))
+                .filter(relation -> identity.targetId().equals(
+                        relation.getTargetCode()))
+                .findFirst();
+    }
+
+    private List<TaxonomyRelationDto> projectionDtos(
+            List<RelationDecisionProjection> rows) {
+        List<RelationDecisionProjection> projections = List.copyOf(rows);
+        Set<String> codes = new LinkedHashSet<>();
+        projections.forEach(row -> {
+            codes.add(row.getSourceCode());
+            codes.add(row.getTargetCode());
+        });
+        Map<String, String> names = names(codes);
+        return projections.stream()
+                .map(row -> projectionDto(row, names))
+                .toList();
+    }
+
+    private Map<String, String> names(Collection<String> codes) {
+        if (codes.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, String> names = new HashMap<>();
+        nodeRepository.findByCodeIn(codes).forEach(node -> names.put(
+                node.getCode(), displayName(node)));
+        return Map.copyOf(names);
+    }
+
+    private static String displayName(TaxonomyNode node) {
+        return node.getNameEn() == null || node.getNameEn().isBlank()
+                ? node.getCode()
+                : node.getNameEn();
+    }
+
+    private static TaxonomyRelationDto projectionDto(
+            RelationDecisionProjection row,
+            Map<String, String> names) {
+        TaxonomyRelationDto dto = new TaxonomyRelationDto();
+        dto.setId(row.getId());
+        dto.setSourceCode(row.getSourceCode());
+        dto.setSourceName(names.getOrDefault(
+                row.getSourceCode(), row.getSourceCode()));
+        dto.setTargetCode(row.getTargetCode());
+        dto.setTargetName(names.getOrDefault(
+                row.getTargetCode(), row.getTargetCode()));
+        dto.setRelationType(row.getRelationType().name());
+        dto.setDescription(null);
+        dto.setProvenance(row.getProvenance());
+        dto.setWeight(null);
+        dto.setBidirectional(false);
+        return dto;
+    }
+
+    private boolean mayUseLegacyFallback(RepositoryContext context) {
+        if (context.scope() != RepositoryScope.CENTRAL_READ
+                && context.scope() != RepositoryScope.CENTRAL_WRITE) {
+            return false;
+        }
+        SystemRepository primary = repositoryService.getPrimaryRepository();
+        return primary.getRepositoryId().equals(context.repositoryId())
+                && primary.getDefaultBranch().equals(context.branch());
+    }
+
+    private void reportFallback(RepositoryContext context) {
+        String key = context.repositoryId() + "/" + context.branch();
+        if (reportedFallbacks.add(key)) {
+            log.warn("Relation reads use the migration-only legacy fallback for {}. "
+                            + "Build the complete Git branch projection to remove this fallback.",
+                    key);
+        }
+    }
+
+    private static RelationIdentity identity(TaxonomyRelationDto relation) {
+        return new RelationIdentity(
+                relation.getSourceCode(),
+                relation.getRelationType(),
+                relation.getTargetCode());
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.strip();
+    }
+
+    public enum ReadModel {
+        PROJECTION,
+        LEGACY_FALLBACK
+    }
+
+    public record ReadResult(
+            ReadModel readModel,
+            ReadinessState readinessState,
+            String authoritativeCommitId,
+            List<TaxonomyRelationDto> relations) {
+        public ReadResult {
+            readModel = Objects.requireNonNull(readModel, "readModel");
+            readinessState = Objects.requireNonNull(
+                    readinessState, "readinessState");
+            relations = List.copyOf(Objects.requireNonNull(
+                    relations, "relations"));
+        }
+
+        public ReadResult filter(Predicate<TaxonomyRelationDto> predicate) {
+            Objects.requireNonNull(predicate, "predicate");
+            return new ReadResult(
+                    readModel,
+                    readinessState,
+                    authoritativeCommitId,
+                    relations.stream().filter(predicate).toList());
+        }
+    }
+
+    public static final class RelationProjectionUnavailableException
+            extends IllegalStateException {
+        private final RepositoryContext context;
+        private final ReadinessState readinessState;
+        private final String currentHeadCommit;
+        private final String projectedCommit;
+        private final long pendingRecoveryCount;
+
+        public RelationProjectionUnavailableException(
+                RepositoryContext context,
+                ReadinessState readinessState,
+                String currentHeadCommit,
+                String projectedCommit,
+                long pendingRecoveryCount) {
+            super("Relation projection is not safely readable for "
+                    + context.repositoryId() + "/" + context.branch()
+                    + ": " + readinessState
+                    + " (pending recovery=" + pendingRecoveryCount + ")");
+            this.context = Objects.requireNonNull(context, "context");
+            this.readinessState = Objects.requireNonNull(
+                    readinessState, "readinessState");
+            this.currentHeadCommit = currentHeadCommit;
+            this.projectedCommit = projectedCommit;
+            this.pendingRecoveryCount = pendingRecoveryCount;
+        }
+
+        public RepositoryContext getContext() {
+            return context;
+        }
+
+        public ReadinessState getReadinessState() {
+            return readinessState;
+        }
+
+        public String getCurrentHeadCommit() {
+            return currentHeadCommit;
+        }
+
+        public String getProjectedCommit() {
+            return projectedCommit;
+        }
+
+        public long getPendingRecoveryCount() {
+            return pendingRecoveryCount;
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
@@ -3,7 +3,6 @@ package com.taxonomy.relations.service;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.catalog.service.TaxonomyRelationService;
-import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationIdentity;
 import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.model.RelationDecisionProjection;
@@ -23,10 +22,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Product read boundary for relation decisions.
@@ -70,13 +69,53 @@ public class RelationProjectionReadService {
 
     public ReadResult readAll(RepositoryContext context) {
         RepositoryContext selected = Objects.requireNonNull(context, "context");
+        return read(
+                selected,
+                ignored -> true,
+                () -> legacyRelationService.getAllRelationsInContext(selected));
+    }
+
+    public ReadResult readByType(
+            RepositoryContext context,
+            RelationType relationType) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        RelationType type = Objects.requireNonNull(
+                relationType, "relationType");
+        return read(
+                selected,
+                row -> row.getRelationType() == type,
+                () -> legacyRelationService.getRelationsByTypeInContext(
+                        type, selected));
+    }
+
+    public ReadResult readForNode(
+            RepositoryContext context,
+            String nodeCode) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        String code = requireText(nodeCode, "nodeCode");
+        return read(
+                selected,
+                row -> code.equals(row.getSourceCode())
+                        || code.equals(row.getTargetCode()),
+                () -> legacyRelationService.getRelationsForNodeInContext(
+                        code, selected));
+    }
+
+    private ReadResult read(
+            RepositoryContext selected,
+            Predicate<RelationDecisionProjection> projectionFilter,
+            Supplier<List<TaxonomyRelationDto>> legacyRead) {
         Readiness readiness = readinessService.inspect(selected);
         if (readiness.state() == ReadinessState.READY) {
+            List<RelationDecisionProjection> selectedRows = readiness.rows()
+                    .stream()
+                    .filter(projectionFilter)
+                    .toList();
             return new ReadResult(
                     ReadModel.PROJECTION,
                     readiness.state(),
                     readiness.currentHeadCommit(),
-                    projectionDtos(readiness.rows()));
+                    projectionDtos(selectedRows));
         }
 
         long pendingRecoveries = recoveryService.pendingCount(selected);
@@ -88,7 +127,7 @@ public class RelationProjectionReadService {
                     ReadModel.LEGACY_FALLBACK,
                     readiness.state(),
                     readiness.currentHeadCommit(),
-                    legacyRelationService.getAllRelationsInContext(selected));
+                    legacyRead.get());
         }
 
         throw new RelationProjectionUnavailableException(
@@ -97,46 +136,6 @@ public class RelationProjectionReadService {
                 readiness.currentHeadCommit(),
                 readiness.projectedCommit(),
                 pendingRecoveries);
-    }
-
-    public ReadResult readByType(
-            RepositoryContext context,
-            RelationType relationType) {
-        Objects.requireNonNull(relationType, "relationType");
-        return readAll(context).filter(relation -> relationType.name().equals(
-                relation.getRelationType()));
-    }
-
-    public ReadResult readForNode(
-            RepositoryContext context,
-            String nodeCode) {
-        String code = requireText(nodeCode, "nodeCode");
-        return readAll(context).filter(relation -> code.equals(
-                relation.getSourceCode()) || code.equals(relation.getTargetCode()));
-    }
-
-    public Optional<RelationIdentity> findIdentityById(
-            RepositoryContext context,
-            Long id) {
-        Objects.requireNonNull(id, "id");
-        return readAll(context).relations().stream()
-                .filter(relation -> id.equals(relation.getId()))
-                .findFirst()
-                .map(RelationProjectionReadService::identity);
-    }
-
-    public Optional<TaxonomyRelationDto> findByIdentity(
-            RepositoryContext context,
-            RelationIdentity identity) {
-        Objects.requireNonNull(identity, "identity");
-        return readAll(context).relations().stream()
-                .filter(relation -> identity.sourceId().equals(
-                        relation.getSourceCode()))
-                .filter(relation -> identity.relationType().equals(
-                        relation.getRelationType()))
-                .filter(relation -> identity.targetId().equals(
-                        relation.getTargetCode()))
-                .findFirst();
     }
 
     private List<TaxonomyRelationDto> projectionDtos(
@@ -207,13 +206,6 @@ public class RelationProjectionReadService {
         }
     }
 
-    private static RelationIdentity identity(TaxonomyRelationDto relation) {
-        return new RelationIdentity(
-                relation.getSourceCode(),
-                relation.getRelationType(),
-                relation.getTargetCode());
-    }
-
     private static String requireText(String value, String field) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException(field + " must not be blank");
@@ -237,15 +229,6 @@ public class RelationProjectionReadService {
                     readinessState, "readinessState");
             relations = List.copyOf(Objects.requireNonNull(
                     relations, "relations"));
-        }
-
-        public ReadResult filter(Predicate<TaxonomyRelationDto> predicate) {
-            Objects.requireNonNull(predicate, "predicate");
-            return new ReadResult(
-                    readModel,
-                    readinessState,
-                    authoritativeCommitId,
-                    relations.stream().filter(predicate).toList());
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
@@ -101,6 +101,33 @@ public class RelationProjectionReadService {
                         code, selected));
     }
 
+    /** Count from the same proven source without allocating relation DTOs. */
+    public CountResult count(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        Readiness readiness = readinessService.inspect(selected);
+        if (readiness.state() == ReadinessState.READY) {
+            return new CountResult(
+                    ReadModel.PROJECTION,
+                    readiness.state(),
+                    readiness.currentHeadCommit(),
+                    readiness.rows().size());
+        }
+
+        long pendingRecoveries = recoveryService.pendingCount(selected);
+        if (readiness.state() == ReadinessState.NOT_BUILT
+                && pendingRecoveries == 0
+                && mayUseLegacyFallback(selected)) {
+            reportFallback(selected);
+            return new CountResult(
+                    ReadModel.LEGACY_FALLBACK,
+                    readiness.state(),
+                    readiness.currentHeadCommit(),
+                    legacyRelationService.countRelationsInContext(selected));
+        }
+
+        throw unavailable(selected, readiness, pendingRecoveries);
+    }
+
     private ReadResult read(
             RepositoryContext selected,
             Predicate<RelationDecisionProjection> projectionFilter,
@@ -130,7 +157,14 @@ public class RelationProjectionReadService {
                     legacyRead.get());
         }
 
-        throw new RelationProjectionUnavailableException(
+        throw unavailable(selected, readiness, pendingRecoveries);
+    }
+
+    private static RelationProjectionUnavailableException unavailable(
+            RepositoryContext selected,
+            Readiness readiness,
+            long pendingRecoveries) {
+        return new RelationProjectionUnavailableException(
                 selected,
                 readiness.state(),
                 readiness.currentHeadCommit(),
@@ -229,6 +263,21 @@ public class RelationProjectionReadService {
                     readinessState, "readinessState");
             relations = List.copyOf(Objects.requireNonNull(
                     relations, "relations"));
+        }
+    }
+
+    public record CountResult(
+            ReadModel readModel,
+            ReadinessState readinessState,
+            String authoritativeCommitId,
+            long count) {
+        public CountResult {
+            readModel = Objects.requireNonNull(readModel, "readModel");
+            readinessState = Objects.requireNonNull(
+                    readinessState, "readinessState");
+            if (count < 0) {
+                throw new IllegalArgumentException("count must not be negative");
+            }
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -45,6 +45,26 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.PUT, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.DELETE, "/api/proposals/**").hasAnyRole("ARCHITECT", "ADMIN");
 
+        // Git-authoritative architecture decisions use identity-based endpoints
+        // outside the historic /api/relations and /api/proposals paths. Keep the
+        // same global role gate here; repository/workspace authority remains an
+        // additional controller-level check.
+        auth.requestMatchers(
+                        HttpMethod.POST,
+                        "/api/architecture/relations/**",
+                        "/api/architecture/proposals/**")
+                .hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(
+                        HttpMethod.PUT,
+                        "/api/architecture/relations/**",
+                        "/api/architecture/proposals/**")
+                .hasAnyRole("ARCHITECT", "ADMIN");
+        auth.requestMatchers(
+                        HttpMethod.DELETE,
+                        "/api/architecture/relations/**",
+                        "/api/architecture/proposals/**")
+                .hasAnyRole("ARCHITECT", "ADMIN");
+
         auth.requestMatchers(HttpMethod.POST, "/api/dsl/parse", "/api/dsl/validate", "/api/dsl/format")
                 .authenticated();
         auth.requestMatchers(HttpMethod.POST, "/api/dsl/**").hasAnyRole("ARCHITECT", "ADMIN");

--- a/taxonomy-app/src/main/resources/static/js/api/relations-api.js
+++ b/taxonomy-app/src/main/resources/static/js/api/relations-api.js
@@ -1,0 +1,46 @@
+/**
+ * Raw-response API boundary for Git-authoritative relation commands.
+ *
+ * Relation mutations need access to HTTP status codes and ETag/projection
+ * headers, including expected 202, 404, 409 and 412 responses. The canonical
+ * fetch wrapper installed by taxonomy-api-client.js still supplies base-path
+ * and CSRF handling; this feature client keeps transport out of UI modules.
+ */
+window.TaxonomyRelationsApi = (function () {
+    'use strict';
+
+    function readSnapshot(relationType) {
+        var url = relationType
+            ? '/api/relations?type=' + encodeURIComponent(relationType)
+            : '/api/relations';
+        return fetch(url, { cache: 'no-store' });
+    }
+
+    function upsertRelation(sourceCode, relationType, targetCode, payload, headers) {
+        return fetch(commandUrl(sourceCode, relationType, targetCode), {
+            method: 'PUT',
+            headers: headers,
+            body: JSON.stringify(payload)
+        });
+    }
+
+    function deleteRelation(sourceCode, relationType, targetCode, headers) {
+        return fetch(commandUrl(sourceCode, relationType, targetCode), {
+            method: 'DELETE',
+            headers: headers
+        });
+    }
+
+    function commandUrl(sourceCode, relationType, targetCode) {
+        return '/api/architecture/relations/'
+            + encodeURIComponent(sourceCode) + '/'
+            + encodeURIComponent(relationType) + '/'
+            + encodeURIComponent(targetCode);
+    }
+
+    return {
+        readSnapshot: readSnapshot,
+        upsertRelation: upsertRelation,
+        deleteRelation: deleteRelation
+    };
+}());

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
@@ -117,14 +117,43 @@
     };
 })();
 
-/* Load the sibling command adapter under the same application context path. */
+/* Load the relation API boundary before its sibling command adapter. */
 (function () {
     'use strict';
     var loader = document.currentScript;
     if (!loader || !loader.src) return;
-    var script = document.createElement('script');
-    script.src = new URL(
-        'taxonomy-relations-git-commands.js', loader.src).href;
-    script.async = false;
-    document.head.appendChild(script);
+
+    function loadCommandAdapter() {
+        if (document.querySelector(
+            'script[data-taxonomy-relation-command-adapter]')) return;
+        var script = document.createElement('script');
+        script.src = new URL(
+            'taxonomy-relations-git-commands.js', loader.src).href;
+        script.async = false;
+        script.setAttribute(
+            'data-taxonomy-relation-command-adapter', 'true');
+        document.head.appendChild(script);
+    }
+
+    if (window.TaxonomyRelationsApi) {
+        loadCommandAdapter();
+        return;
+    }
+
+    var existingApi = document.querySelector(
+        'script[data-taxonomy-relations-api]');
+    if (existingApi) {
+        existingApi.addEventListener('load', loadCommandAdapter, { once: true });
+        return;
+    }
+
+    var apiScript = document.createElement('script');
+    apiScript.src = new URL('../api/relations-api.js', loader.src).href;
+    apiScript.async = false;
+    apiScript.setAttribute('data-taxonomy-relations-api', 'true');
+    apiScript.addEventListener('load', loadCommandAdapter, { once: true });
+    apiScript.addEventListener('error', function () {
+        console.error('[Taxonomy] Failed to load relation API client');
+    }, { once: true });
+    document.head.appendChild(apiScript);
 })();

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
@@ -117,11 +117,14 @@
     };
 })();
 
-/* Load the command adapter before users can invoke relation mutations. */
+/* Load the sibling command adapter under the same application context path. */
 (function () {
     'use strict';
+    var loader = document.currentScript;
+    if (!loader || !loader.src) return;
     var script = document.createElement('script');
-    script.src = '/js/relations/taxonomy-relations-git-commands.js';
+    script.src = new URL(
+        'taxonomy-relations-git-commands.js', loader.src).href;
     script.async = false;
     document.head.appendChild(script);
 })();

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
@@ -117,7 +117,11 @@
     };
 })();
 
-/* Load the relation API boundary before its sibling command adapter. */
+/*
+ * Load the relation API boundary before its sibling command adapter. Expose one
+ * shared readiness promise so the separately loaded browser can safely await
+ * the API even when the dynamic script is slower than parser-inserted scripts.
+ */
 (function () {
     'use strict';
     var loader = document.currentScript;
@@ -135,25 +139,48 @@
         document.head.appendChild(script);
     }
 
-    if (window.TaxonomyRelationsApi) {
-        loadCommandAdapter();
-        return;
+    function createApiPromise() {
+        if (window.TaxonomyRelationsApi) {
+            return Promise.resolve(window.TaxonomyRelationsApi);
+        }
+
+        return new Promise(function (resolve, reject) {
+            var apiScript = document.querySelector(
+                'script[data-taxonomy-relations-api]');
+            var created = false;
+            if (!apiScript) {
+                apiScript = document.createElement('script');
+                apiScript.src = new URL('../api/relations-api.js', loader.src).href;
+                apiScript.async = false;
+                apiScript.setAttribute('data-taxonomy-relations-api', 'true');
+                created = true;
+            }
+
+            apiScript.addEventListener('load', function () {
+                if (window.TaxonomyRelationsApi) {
+                    resolve(window.TaxonomyRelationsApi);
+                } else {
+                    reject(new Error('Relation API client did not initialise.'));
+                }
+            }, { once: true });
+            apiScript.addEventListener('error', function () {
+                reject(new Error('Failed to load relation API client.'));
+            }, { once: true });
+
+            if (created) {
+                document.head.appendChild(apiScript);
+            } else if (window.TaxonomyRelationsApi) {
+                resolve(window.TaxonomyRelationsApi);
+            }
+        });
     }
 
-    var existingApi = document.querySelector(
-        'script[data-taxonomy-relations-api]');
-    if (existingApi) {
-        existingApi.addEventListener('load', loadCommandAdapter, { once: true });
-        return;
+    if (!window.TaxonomyRelationsApiReady) {
+        window.TaxonomyRelationsApiReady = createApiPromise();
     }
-
-    var apiScript = document.createElement('script');
-    apiScript.src = new URL('../api/relations-api.js', loader.src).href;
-    apiScript.async = false;
-    apiScript.setAttribute('data-taxonomy-relations-api', 'true');
-    apiScript.addEventListener('load', loadCommandAdapter, { once: true });
-    apiScript.addEventListener('error', function () {
-        console.error('[Taxonomy] Failed to load relation API client');
-    }, { once: true });
-    document.head.appendChild(apiScript);
+    window.TaxonomyRelationsApiReady
+        .then(loadCommandAdapter)
+        .catch(function (error) {
+            console.error('[Taxonomy] ' + error.message);
+        });
 })();

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-quality.js
@@ -116,3 +116,12 @@
         loadQualityDashboard: loadQualityDashboard
     };
 })();
+
+/* Load the command adapter before users can invoke relation mutations. */
+(function () {
+    'use strict';
+    var script = document.createElement('script');
+    script.src = '/js/relations/taxonomy-relations-git-commands.js';
+    script.async = false;
+    document.head.appendChild(script);
+})();

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -3,8 +3,9 @@
  *
  * The legacy browser remains responsible for rendering and impact analysis.
  * This adapter captures create/delete actions before the retired DB-first
- * handlers, binds them to the ETag of the displayed projection, and addresses
- * relations by the source/type/target identity visible in the same table row.
+ * handlers, refreshes one authoritative snapshot immediately before each
+ * command, and addresses relations by the source/type/target identity visible
+ * in the same table row.
  */
 (function () {
     'use strict';
@@ -77,13 +78,6 @@
             });
     }
 
-    function ensureSnapshot() {
-        if (headEtag || branchMissing) {
-            return Promise.resolve();
-        }
-        return refreshSnapshot();
-    }
-
     function createRelation() {
         var sourceCode = valueOf('newRelSource');
         var targetCode = valueOf('newRelTarget');
@@ -100,7 +94,7 @@
         }
 
         setSpinner(true);
-        ensureSnapshot()
+        refreshSnapshot()
             .then(function () {
                 var extensions = {};
                 if (description) extensions['x-description'] = description;
@@ -146,10 +140,16 @@
             'relations.delete.confirm',
             'Delete this relation?'))) return;
 
-        ensureSnapshot()
-            .then(function () {
+        refreshSnapshot()
+            .then(function (relations) {
                 if (!headEtag) {
                     throw new Error('The selected branch has no relation head.');
+                }
+                if (!(relations || []).some(function (candidate) {
+                    return sameIdentity(candidate, relation);
+                })) {
+                    throw new Error(
+                        'The displayed relation no longer exists in the current branch snapshot.');
                 }
                 return fetch(commandUrl(
                     relation.sourceCode,
@@ -162,6 +162,7 @@
             .then(handleCommandResponse)
             .then(refreshBrowser)
             .catch(function (error) {
+                refreshBrowser();
                 showBrowserError(message(
                     'relations.delete.failed',
                     'Could not delete relation') + ': ' + error.message);
@@ -180,6 +181,13 @@
             relationType: relationType,
             targetCode: targetCode
         };
+    }
+
+    function sameIdentity(left, right) {
+        return left
+            && left.sourceCode === right.sourceCode
+            && left.relationType === right.relationType
+            && left.targetCode === right.targetCode;
     }
 
     function handleCommandResponse(response) {

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -1,0 +1,301 @@
+/**
+ * Git-authoritative command adapter for the existing relation browser.
+ *
+ * The legacy browser remains responsible for rendering and impact analysis.
+ * This adapter captures create/delete actions before the retired DB-first
+ * handlers, binds them to the ETag of the displayed projection, and addresses
+ * relations by their stable source/type/target identity.
+ */
+(function () {
+    'use strict';
+
+    var headEtag = null;
+    var branchMissing = false;
+    var relationsById = new Map();
+    var commandSequence = 0;
+    var initialized = false;
+
+    function init() {
+        if (initialized) return;
+        initialized = true;
+
+        document.addEventListener('click', captureRelationCommand, true);
+
+        var panel = document.getElementById('relationsBrowser');
+        if (panel) {
+            panel.addEventListener('toggle', function () {
+                if (panel.open) refreshSnapshot();
+            });
+            if (panel.open) refreshSnapshot();
+        }
+
+        var typeFilter = document.getElementById('relationsTypeFilter');
+        if (typeFilter) {
+            typeFilter.addEventListener('change', refreshSnapshot);
+        }
+    }
+
+    function captureRelationCommand(event) {
+        var createButton = event.target.closest('#createRelationSubmit');
+        if (createButton) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            createRelation();
+            return;
+        }
+
+        var deleteButton = event.target.closest('.relation-delete-btn');
+        if (deleteButton) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            deleteRelation(deleteButton.getAttribute('data-id'));
+        }
+    }
+
+    function refreshSnapshot() {
+        var typeFilter = document.getElementById('relationsTypeFilter');
+        var type = typeFilter ? typeFilter.value : '';
+        var url = type
+            ? '/api/relations?type=' + encodeURIComponent(type)
+            : '/api/relations';
+
+        return fetch(url, { cache: 'no-store' })
+            .then(function (response) {
+                branchMissing = response.status === 404
+                    && response.headers.get(
+                        'X-Taxonomy-Relation-Projection-State') === 'BRANCH_MISSING';
+                if (branchMissing) {
+                    headEtag = null;
+                    relationsById.clear();
+                    return [];
+                }
+                if (!response.ok) {
+                    headEtag = null;
+                    relationsById.clear();
+                    throw new Error(projectionError(response));
+                }
+                headEtag = response.headers.get('ETag');
+                branchMissing = false;
+                return response.json();
+            })
+            .then(function (relations) {
+                relationsById.clear();
+                (relations || []).forEach(function (relation) {
+                    relationsById.set(String(relation.id), relation);
+                });
+                return relations || [];
+            });
+    }
+
+    function ensureSnapshot() {
+        if (headEtag || branchMissing) {
+            return Promise.resolve();
+        }
+        return refreshSnapshot();
+    }
+
+    function createRelation() {
+        var sourceCode = valueOf('newRelSource');
+        var targetCode = valueOf('newRelTarget');
+        var relationType = valueOf('newRelType');
+        var description = valueOf('newRelDescription');
+        var errorElement = document.getElementById('createRelationError');
+        clearError(errorElement);
+
+        if (!sourceCode || !targetCode || !relationType) {
+            showError(errorElement, message(
+                'relations.create.required',
+                'Source, target and relation type are required.'));
+            return;
+        }
+
+        setSpinner(true);
+        ensureSnapshot()
+            .then(function () {
+                var extensions = {};
+                if (description) extensions['x-description'] = description;
+                return fetch(commandUrl(
+                    sourceCode, relationType, targetCode), {
+                    method: 'PUT',
+                    headers: commandHeaders('relation-create', true),
+                    body: JSON.stringify({
+                        provenance: 'manual',
+                        extensions: extensions,
+                        rationale: description || null
+                    })
+                });
+            })
+            .then(handleCommandResponse)
+            .then(function () {
+                setSpinner(false);
+                var modalElement = document.getElementById(
+                    'createRelationModal');
+                var modal = modalElement && window.bootstrap
+                    ? window.bootstrap.Modal.getInstance(modalElement)
+                    : null;
+                if (modal) modal.hide();
+                refreshBrowser();
+            })
+            .catch(function (error) {
+                setSpinner(false);
+                showError(errorElement, message(
+                    'relations.create.error',
+                    'Could not create relation') + ': ' + error.message);
+            });
+    }
+
+    function deleteRelation(id) {
+        var relation = relationsById.get(String(id));
+        if (!relation) {
+            refreshSnapshot().catch(function () {});
+            showBrowserError(message(
+                'relations.load.failed',
+                'The displayed relation snapshot is no longer available.'));
+            return;
+        }
+        if (!window.confirm(message(
+            'relations.delete.confirm',
+            'Delete this relation?'))) return;
+
+        ensureSnapshot()
+            .then(function () {
+                if (!headEtag) {
+                    throw new Error('The selected branch has no relation head.');
+                }
+                return fetch(commandUrl(
+                    relation.sourceCode,
+                    relation.relationType,
+                    relation.targetCode), {
+                    method: 'DELETE',
+                    headers: commandHeaders('relation-delete', false)
+                });
+            })
+            .then(handleCommandResponse)
+            .then(refreshBrowser)
+            .catch(function (error) {
+                showBrowserError(message(
+                    'relations.delete.failed',
+                    'Could not delete relation') + ': ' + error.message);
+            });
+    }
+
+    function handleCommandResponse(response) {
+        var nextEtag = response.headers.get('ETag');
+        if (nextEtag) {
+            headEtag = nextEtag;
+            branchMissing = false;
+        }
+        if (response.status === 202) {
+            throw new Error(
+                'Git accepted the change, but projection recovery is pending.');
+        }
+        if (response.status === 412) {
+            headEtag = null;
+            refreshSnapshot().catch(function () {});
+            throw new Error(
+                'The selected branch changed. Relations are being reloaded.');
+        }
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status);
+        }
+        if (response.status === 204) return null;
+        return response.json();
+    }
+
+    function commandHeaders(prefix, allowCreation) {
+        var headers = {
+            'Content-Type': 'application/json',
+            'Idempotency-Key': prefix + ':' + Date.now()
+                + ':' + (++commandSequence)
+        };
+        if (allowCreation && branchMissing) {
+            headers['If-None-Match'] = '*';
+        } else if (headEtag) {
+            headers['If-Match'] = headEtag;
+        } else {
+            throw new Error('No authoritative relation ETag is available.');
+        }
+        return headers;
+    }
+
+    function commandUrl(sourceCode, relationType, targetCode) {
+        return '/api/architecture/relations/'
+            + encodeURIComponent(sourceCode) + '/'
+            + encodeURIComponent(relationType) + '/'
+            + encodeURIComponent(targetCode);
+    }
+
+    function refreshBrowser() {
+        return refreshSnapshot()
+            .catch(function (error) {
+                showBrowserError(error.message);
+            })
+            .then(function () {
+                if (window.TaxonomyRelations) {
+                    window.TaxonomyRelations.loadRelations();
+                }
+                if (window.TaxonomyQuality) {
+                    window.TaxonomyQuality.loadQualityDashboard();
+                }
+            });
+    }
+
+    function projectionError(response) {
+        var state = response.headers.get(
+            'X-Taxonomy-Relation-Projection-State');
+        var pending = response.headers.get(
+            'X-Taxonomy-Relation-Pending-Recovery');
+        if (!state) return 'HTTP ' + response.status;
+        return 'Projection ' + state
+            + (pending ? ' (pending recovery: ' + pending + ')' : '');
+    }
+
+    function valueOf(id) {
+        var element = document.getElementById(id);
+        return element && element.value ? element.value.trim() : '';
+    }
+
+    function setSpinner(visible) {
+        var spinner = document.getElementById('createRelationSpinner');
+        if (spinner) spinner.classList.toggle('d-none', !visible);
+        var button = document.getElementById('createRelationSubmit');
+        if (button) button.disabled = visible;
+    }
+
+    function clearError(element) {
+        if (!element) return;
+        element.textContent = '';
+        element.classList.add('d-none');
+    }
+
+    function showError(element, text) {
+        if (!element) return;
+        element.textContent = text;
+        element.classList.remove('d-none');
+    }
+
+    function showBrowserError(text) {
+        var container = document.getElementById(
+            'relationsTableContainer');
+        if (!container) return;
+        var error = document.createElement('div');
+        error.className = 'text-danger small p-1';
+        error.textContent = text;
+        container.prepend(error);
+        window.setTimeout(function () { error.remove(); }, 5000);
+    }
+
+    function message(key, fallback) {
+        if (!window.TaxonomyI18n || !window.TaxonomyI18n.t) {
+            return fallback;
+        }
+        var translated = window.TaxonomyI18n.t(key);
+        return translated && translated !== key ? translated : fallback;
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -61,7 +61,9 @@
                 }
                 if (!response.ok) {
                     headEtag = null;
-                    throw new Error(projectionError(response));
+                    throw commandError(
+                        'PROJECTION_UNAVAILABLE',
+                        projectionError(response));
                 }
                 headEtag = response.headers.get('ETag');
                 branchMissing = false;
@@ -101,22 +103,34 @@
                     commandHeaders('relation-create', true));
             })
             .then(handleCommandResponse)
-            .then(function () {
+            .then(function (outcome) {
                 setSpinner(false);
-                var modalElement = document.getElementById(
-                    'createRelationModal');
-                var modal = modalElement && window.bootstrap
-                    ? window.bootstrap.Modal.getInstance(modalElement)
-                    : null;
-                if (modal) modal.hide();
+                closeCreateModal();
                 refreshBrowser();
+                if (outcome.projectionPending) {
+                    showPendingRecovery(outcome);
+                }
             })
             .catch(function (error) {
                 setSpinner(false);
+                if (error.kind === 'CONFLICT') {
+                    showCommandStatus('warning', error.message);
+                    refreshBrowser();
+                    return;
+                }
                 showError(errorElement, message(
                     'relations.create.error',
                     'Could not create relation') + ': ' + error.message);
             });
+    }
+
+    function closeCreateModal() {
+        var modalElement = document.getElementById(
+            'createRelationModal');
+        var modal = modalElement && window.bootstrap
+            ? window.bootstrap.Modal.getInstance(modalElement)
+            : null;
+        if (modal) modal.hide();
     }
 
     function deleteRelation(button) {
@@ -149,9 +163,18 @@
                     commandHeaders('relation-delete', false));
             })
             .then(handleCommandResponse)
-            .then(refreshBrowser)
+            .then(function (outcome) {
+                refreshBrowser();
+                if (outcome.projectionPending) {
+                    showPendingRecovery(outcome);
+                }
+            })
             .catch(function (error) {
                 refreshBrowser();
+                if (error.kind === 'CONFLICT') {
+                    showCommandStatus('warning', error.message);
+                    return;
+                }
                 showBrowserError(message(
                     'relations.delete.failed',
                     'Could not delete relation') + ': ' + error.message);
@@ -185,20 +208,63 @@
             headEtag = nextEtag;
             branchMissing = false;
         }
-        if (response.status === 202) {
-            throw new Error(
-                'Git accepted the change, but projection recovery is pending.');
+
+        return readJson(response).then(function (body) {
+            if (response.status === 202) {
+                return {
+                    projectionPending: true,
+                    body: body
+                };
+            }
+            if (response.status === 412) {
+                headEtag = null;
+                throw commandError(
+                    'CONFLICT',
+                    'The selected branch changed. Relations are being reloaded.',
+                    body);
+            }
+            if (!response.ok) {
+                throw commandError(
+                    'HTTP',
+                    'HTTP ' + response.status,
+                    body);
+            }
+            return {
+                projectionPending: false,
+                body: body
+            };
+        });
+    }
+
+    function readJson(response) {
+        if (response.status === 204) {
+            return Promise.resolve(null);
         }
-        if (response.status === 412) {
-            headEtag = null;
-            throw new Error(
-                'The selected branch changed. Relations are being reloaded.');
+        var contentType = response.headers.get('Content-Type') || '';
+        if (contentType.indexOf('application/json') < 0) {
+            return Promise.resolve(null);
         }
-        if (!response.ok) {
-            throw new Error('HTTP ' + response.status);
-        }
-        if (response.status === 204) return null;
-        return response.json();
+        return response.json().catch(function () { return null; });
+    }
+
+    function commandError(kind, text, body) {
+        var error = new Error(text);
+        error.kind = kind;
+        error.body = body || null;
+        return error;
+    }
+
+    function showPendingRecovery(outcome) {
+        var body = outcome.body || {};
+        var commit = body.authoritativeCommitId
+            ? ' (' + body.authoritativeCommitId.substring(0, 12) + ')'
+            : '';
+        showCommandStatus(
+            'warning',
+            message(
+                'relations.command.projection.pending',
+                'Git accepted the relation change' + commit
+                    + ', but its readable projection still requires recovery.'));
     }
 
     function commandHeaders(prefix, allowCreation) {
@@ -260,15 +326,25 @@
         element.classList.remove('d-none');
     }
 
-    function showBrowserError(text) {
+    function showCommandStatus(type, text) {
+        if (window.TaxonomyBrowse
+                && typeof window.TaxonomyBrowse.showStatus === 'function') {
+            window.TaxonomyBrowse.showStatus(type, text);
+            return;
+        }
+
         var container = document.getElementById(
             'relationsTableContainer');
         if (!container) return;
-        var error = document.createElement('div');
-        error.className = 'text-danger small p-1';
-        error.textContent = text;
-        container.prepend(error);
-        window.setTimeout(function () { error.remove(); }, 5000);
+        var notice = document.createElement('div');
+        notice.className = 'alert alert-' + type + ' py-1 mb-1';
+        notice.setAttribute('role', type === 'danger' ? 'alert' : 'status');
+        notice.textContent = text;
+        container.prepend(notice);
+    }
+
+    function showBrowserError(text) {
+        showCommandStatus('danger', text);
     }
 
     function message(key, fallback) {

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -22,6 +22,13 @@
         document.addEventListener('click', captureRelationCommand, true);
     }
 
+    function RelationsApi() {
+        if (!window.TaxonomyRelationsApi) {
+            throw new Error('Relation API client is not available.');
+        }
+        return window.TaxonomyRelationsApi;
+    }
+
     function captureRelationCommand(event) {
         var createButton = event.target.closest('#createRelationSubmit');
         if (createButton) {
@@ -42,11 +49,8 @@
     function refreshSnapshot() {
         var typeFilter = document.getElementById('relationsTypeFilter');
         var type = typeFilter ? typeFilter.value : '';
-        var url = type
-            ? '/api/relations?type=' + encodeURIComponent(type)
-            : '/api/relations';
 
-        return fetch(url, { cache: 'no-store' })
+        return RelationsApi().readSnapshot(type)
             .then(function (response) {
                 branchMissing = response.status === 404
                     && response.headers.get(
@@ -85,16 +89,16 @@
             .then(function () {
                 var extensions = {};
                 if (description) extensions['x-description'] = description;
-                return fetch(commandUrl(
-                    sourceCode, relationType, targetCode), {
-                    method: 'PUT',
-                    headers: commandHeaders('relation-create', true),
-                    body: JSON.stringify({
+                return RelationsApi().upsertRelation(
+                    sourceCode,
+                    relationType,
+                    targetCode,
+                    {
                         provenance: 'manual',
                         extensions: extensions,
                         rationale: description || null
-                    })
-                });
+                    },
+                    commandHeaders('relation-create', true));
             })
             .then(handleCommandResponse)
             .then(function () {
@@ -138,13 +142,11 @@
                     throw new Error(
                         'The displayed relation no longer exists in the current branch snapshot.');
                 }
-                return fetch(commandUrl(
+                return RelationsApi().deleteRelation(
                     relation.sourceCode,
                     relation.relationType,
-                    relation.targetCode), {
-                    method: 'DELETE',
-                    headers: commandHeaders('relation-delete', false)
-                });
+                    relation.targetCode,
+                    commandHeaders('relation-delete', false));
             })
             .then(handleCommandResponse)
             .then(refreshBrowser)
@@ -213,13 +215,6 @@
             throw new Error('No authoritative relation ETag is available.');
         }
         return headers;
-    }
-
-    function commandUrl(sourceCode, relationType, targetCode) {
-        return '/api/architecture/relations/'
-            + encodeURIComponent(sourceCode) + '/'
-            + encodeURIComponent(relationType) + '/'
-            + encodeURIComponent(targetCode);
     }
 
     function refreshBrowser() {

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -4,14 +4,13 @@
  * The legacy browser remains responsible for rendering and impact analysis.
  * This adapter captures create/delete actions before the retired DB-first
  * handlers, binds them to the ETag of the displayed projection, and addresses
- * relations by their stable source/type/target identity.
+ * relations by the source/type/target identity visible in the same table row.
  */
 (function () {
     'use strict';
 
     var headEtag = null;
     var branchMissing = false;
-    var relationsById = new Map();
     var commandSequence = 0;
     var initialized = false;
 
@@ -48,7 +47,7 @@
         if (deleteButton) {
             event.preventDefault();
             event.stopImmediatePropagation();
-            deleteRelation(deleteButton.getAttribute('data-id'));
+            deleteRelation(deleteButton);
         }
     }
 
@@ -66,24 +65,15 @@
                         'X-Taxonomy-Relation-Projection-State') === 'BRANCH_MISSING';
                 if (branchMissing) {
                     headEtag = null;
-                    relationsById.clear();
                     return [];
                 }
                 if (!response.ok) {
                     headEtag = null;
-                    relationsById.clear();
                     throw new Error(projectionError(response));
                 }
                 headEtag = response.headers.get('ETag');
                 branchMissing = false;
                 return response.json();
-            })
-            .then(function (relations) {
-                relationsById.clear();
-                (relations || []).forEach(function (relation) {
-                    relationsById.set(String(relation.id), relation);
-                });
-                return relations || [];
             });
     }
 
@@ -144,13 +134,12 @@
             });
     }
 
-    function deleteRelation(id) {
-        var relation = relationsById.get(String(id));
+    function deleteRelation(button) {
+        var relation = relationIdentity(button);
         if (!relation) {
-            refreshSnapshot().catch(function () {});
             showBrowserError(message(
                 'relations.load.failed',
-                'The displayed relation snapshot is no longer available.'));
+                'The displayed relation identity is incomplete.'));
             return;
         }
         if (!window.confirm(message(
@@ -177,6 +166,20 @@
                     'relations.delete.failed',
                     'Could not delete relation') + ': ' + error.message);
             });
+    }
+
+    function relationIdentity(button) {
+        var row = button.closest('tr');
+        if (!row || !row.cells || row.cells.length < 3) return null;
+        var sourceCode = row.cells[0].textContent.trim();
+        var targetCode = row.cells[1].textContent.trim();
+        var relationType = row.cells[2].textContent.trim();
+        if (!sourceCode || !targetCode || !relationType) return null;
+        return {
+            sourceCode: sourceCode,
+            relationType: relationType,
+            targetCode: targetCode
+        };
     }
 
     function handleCommandResponse(response) {

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations-git-commands.js
@@ -5,7 +5,8 @@
  * This adapter captures create/delete actions before the retired DB-first
  * handlers, refreshes one authoritative snapshot immediately before each
  * command, and addresses relations by the source/type/target identity visible
- * in the same table row.
+ * in the same table row. It deliberately does not issue parallel browser-load
+ * requests on panel or filter events.
  */
 (function () {
     'use strict';
@@ -18,21 +19,7 @@
     function init() {
         if (initialized) return;
         initialized = true;
-
         document.addEventListener('click', captureRelationCommand, true);
-
-        var panel = document.getElementById('relationsBrowser');
-        if (panel) {
-            panel.addEventListener('toggle', function () {
-                if (panel.open) refreshSnapshot();
-            });
-            if (panel.open) refreshSnapshot();
-        }
-
-        var typeFilter = document.getElementById('relationsTypeFilter');
-        if (typeFilter) {
-            typeFilter.addEventListener('change', refreshSnapshot);
-        }
     }
 
     function captureRelationCommand(event) {
@@ -202,7 +189,6 @@
         }
         if (response.status === 412) {
             headEtag = null;
-            refreshSnapshot().catch(function () {});
             throw new Error(
                 'The selected branch changed. Relations are being reloaded.');
         }
@@ -237,18 +223,12 @@
     }
 
     function refreshBrowser() {
-        return refreshSnapshot()
-            .catch(function (error) {
-                showBrowserError(error.message);
-            })
-            .then(function () {
-                if (window.TaxonomyRelations) {
-                    window.TaxonomyRelations.loadRelations();
-                }
-                if (window.TaxonomyQuality) {
-                    window.TaxonomyQuality.loadQualityDashboard();
-                }
-            });
+        if (window.TaxonomyRelations) {
+            window.TaxonomyRelations.loadRelations();
+        }
+        if (window.TaxonomyQuality) {
+            window.TaxonomyQuality.loadQualityDashboard();
+        }
     }
 
     function projectionError(response) {

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-relations.js
@@ -44,18 +44,91 @@
     function loadRelations() {
         var content = document.getElementById('relationsTableContainer');
         if (!content) return;
+        content.setAttribute('aria-busy', 'true');
         content.innerHTML = '<div class="text-center text-muted py-2"><div class="spinner-border spinner-border-sm" role="status"></div> ' + t('relations.loading') + '</div>';
 
         var typeFilter = document.getElementById('relationsTypeFilter');
         var type = typeFilter ? typeFilter.value : '';
-        var url = type ? '/api/relations?type=' + encodeURIComponent(type) : '/api/relations';
 
-        fetch(url)
-            .then(function (r) { return r.ok ? r.json() : []; })
-            .then(function (relations) { renderRelationsTable(relations); })
-            .catch(function () {
-                content.innerHTML = '<div class="text-danger small p-2">' + t('relations.load.failed') + '</div>';
+        relationApiReady()
+            .then(function (api) {
+                return api.readSnapshot(type);
+            })
+            .then(function (response) {
+                if (!response.ok) {
+                    throw projectionReadError(response);
+                }
+                return response.json();
+            })
+            .then(function (relations) {
+                content.setAttribute('aria-busy', 'false');
+                renderRelationsTable(relations);
+            })
+            .catch(function (error) {
+                renderRelationsLoadError(content, error);
             });
+    }
+
+    function relationApiReady() {
+        if (window.TaxonomyRelationsApi) {
+            return Promise.resolve(window.TaxonomyRelationsApi);
+        }
+        if (window.TaxonomyRelationsApiReady) {
+            return window.TaxonomyRelationsApiReady;
+        }
+        return Promise.reject(new Error(
+            'Relation API client is not available.'));
+    }
+
+    function projectionReadError(response) {
+        var state = response.headers.get(
+            'X-Taxonomy-Relation-Projection-State');
+        var pending = response.headers.get(
+            'X-Taxonomy-Relation-Pending-Recovery');
+        var detail = 'HTTP ' + response.status;
+        if (state) detail += ', projection=' + state;
+        if (pending && pending !== '0') {
+            detail += ', pending recovery=' + pending;
+        }
+
+        var error = new Error(t('relations.load.failed') + ': ' + detail);
+        error.projectionState = state;
+        error.httpStatus = response.status;
+        return error;
+    }
+
+    function renderRelationsLoadError(content, error) {
+        content.setAttribute('aria-busy', 'false');
+        content.replaceChildren();
+
+        var alert = document.createElement('div');
+        alert.className = error && error.projectionState
+            ? 'alert alert-warning d-flex align-items-center gap-2 mb-0'
+            : 'alert alert-danger d-flex align-items-center gap-2 mb-0';
+        alert.setAttribute('role', 'alert');
+
+        var message = document.createElement('span');
+        message.className = 'flex-grow-1';
+        message.textContent = error && error.message
+            ? error.message
+            : t('relations.load.failed');
+        alert.appendChild(message);
+
+        var retry = document.createElement('button');
+        retry.type = 'button';
+        retry.className = 'btn btn-sm btn-outline-secondary';
+        retry.textContent = translatedOr(
+            'relations.load.retry',
+            translatedOr('workspace.manager.refresh', 'Retry'));
+        retry.addEventListener('click', loadRelations);
+        alert.appendChild(retry);
+
+        content.appendChild(alert);
+    }
+
+    function translatedOr(key, fallback) {
+        var value = t(key);
+        return value && value !== key ? value : fallback;
     }
 
     function renderRelationsTable(relations) {

--- a/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/KeycloakSecurityContainerIT.java
@@ -60,6 +60,8 @@ class KeycloakSecurityContainerIT {
     private static final String ISSUER = KEYCLOAK_ORIGIN + "/realms/" + REALM;
     private static final String CLIENT_ID = "taxonomy-app";
     private static final String CLIENT_SECRET = "taxonomy-test-secret";
+    private static final String GIT_PROPOSAL_REVIEW_PATH =
+            "/api/architecture/proposals/1/accept";
     private static final String KEYCLOAK_IMAGE = System.getProperty(
             "keycloak.container.image", "quay.io/keycloak/keycloak:26.7.0");
 
@@ -180,11 +182,14 @@ class KeycloakSecurityContainerIT {
                 "GET", "/api/relations", userToken, null, null, Map.of())
                 .statusCode()).isEqualTo(200);
 
-        assertThat(jsonPost("/api/relations", userToken, "{}").statusCode())
+        // The Git-authoritative review endpoint requires ARCHITECT/ADMIN. Bearer
+        // clients are CSRF-exempt; missing Idempotency-Key then reaches MVC as 400.
+        assertThat(jsonPost(GIT_PROPOSAL_REVIEW_PATH, userToken, "{}").statusCode())
                 .isEqualTo(403);
-        assertThat(jsonPost("/api/relations", architectToken, "{}").statusCode())
+        assertThat(jsonPost(
+                GIT_PROPOSAL_REVIEW_PATH, architectToken, "{}").statusCode())
                 .isEqualTo(400);
-        assertThat(jsonPost("/api/relations", adminToken, "{}").statusCode())
+        assertThat(jsonPost(GIT_PROPOSAL_REVIEW_PATH, adminToken, "{}").statusCode())
                 .isEqualTo(400);
 
         assertThat(appRequest(
@@ -249,12 +254,14 @@ class KeycloakSecurityContainerIT {
         assertThat(csrfToken).isNotBlank();
 
         HttpResponse<String> withoutCsrf = appRequest(
-                "POST", "/api/relations", null, "application/json", "{}",
+                "POST", GIT_PROPOSAL_REVIEW_PATH,
+                null, "application/json", "{}",
                 Map.of("Cookie", sessionCookie));
         assertThat(withoutCsrf.statusCode()).isEqualTo(403);
 
         HttpResponse<String> withCsrf = appRequest(
-                "POST", "/api/relations", null, "application/json", "{}",
+                "POST", GIT_PROPOSAL_REVIEW_PATH,
+                null, "application/json", "{}",
                 Map.of("Cookie", sessionCookie, csrfHeader, csrfToken));
         assertThat(withCsrf.statusCode()).isEqualTo(400);
 
@@ -381,7 +388,7 @@ class KeycloakSecurityContainerIT {
     private void assertNoApplicationRoles(String token, String expectedUsername)
             throws Exception {
         assertAccount(token, expectedUsername, Set.of());
-        assertThat(jsonPost("/api/relations", token, "{}").statusCode())
+        assertThat(jsonPost(GIT_PROPOSAL_REVIEW_PATH, token, "{}").statusCode())
                 .isEqualTo(403);
         assertThat(appRequest(
                 "GET", "/api/preferences", token, null, null, Map.of())

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -45,30 +45,41 @@ class ProductionPersistenceRestartIT {
         GenericContainer<?> second = null;
 
         try {
-            long countBeforeWrite;
             first = persistentAppContainer(dataVolume);
             first.start();
             URI firstOrigin = origin(first);
             awaitInitialized(client, firstOrigin);
 
-            countBeforeWrite = relationCount(client, firstOrigin);
+            RelationSnapshot beforeWrite = relationSnapshot(client, firstOrigin);
             HttpResponse<String> createResponse = send(client, HttpRequest.newBuilder(
-                    firstOrigin.resolve("/api/relations"))
+                    firstOrigin.resolve(
+                            "/api/architecture/relations/BP/RELATED_TO/BR"))
                     .header("Authorization", AUTHORIZATION)
                     .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString("""
+                    .header("If-Match", beforeWrite.etag())
+                    .header(
+                            "Idempotency-Key",
+                            "production-persistence-restart:"
+                                    + UUID.randomUUID())
+                    .PUT(HttpRequest.BodyPublishers.ofString("""
                             {
-                              "sourceCode": "BP",
-                              "targetCode": "BR",
-                              "relationType": "RELATED_TO",
-                              "description": "Persistence restart proof",
-                              "provenance": "%s"
+                              "status": "accepted",
+                              "provenance": "%s",
+                              "extensions": {
+                                "x-description": "Persistence restart proof"
+                              },
+                              "rationale": "Persistence restart proof"
                             }
                             """.formatted(PERSISTENCE_PROVENANCE)))
                     .build());
-            assertThat(createResponse.statusCode()).isEqualTo(200);
-            assertThat(createResponse.body()).contains(PERSISTENCE_PROVENANCE);
-            assertThat(relationCount(client, firstOrigin)).isGreaterThan(countBeforeWrite);
+            assertThat(createResponse.statusCode()).isIn(200, 201);
+            assertThat(createResponse.headers().firstValue("ETag")).isPresent();
+
+            HttpResponse<String> writtenRelations = relations(client, firstOrigin);
+            assertThat(writtenRelations.statusCode()).isEqualTo(200);
+            assertThat(writtenRelations.body()).contains(PERSISTENCE_PROVENANCE);
+            assertThat(relationCount(client, firstOrigin))
+                    .isGreaterThan(beforeWrite.count());
             first.stop();
             first = null;
 
@@ -77,21 +88,17 @@ class ProductionPersistenceRestartIT {
             URI secondOrigin = origin(second);
             awaitInitialized(client, secondOrigin);
 
-            HttpResponse<String> relations = send(client, HttpRequest.newBuilder(
-                    secondOrigin.resolve("/api/relations"))
-                    .header("Authorization", AUTHORIZATION)
-                    .GET()
-                    .build());
-            assertThat(relations.statusCode()).isEqualTo(200);
-            assertThat(relations.body())
-                    .as("relation written before container replacement must remain present")
+            HttpResponse<String> persistedRelations = relations(client, secondOrigin);
+            assertThat(persistedRelations.statusCode()).isEqualTo(200);
+            assertThat(persistedRelations.body())
+                    .as("Git-authoritative relation written before container replacement must remain present")
                     .contains(PERSISTENCE_PROVENANCE);
 
             // Catalogue-derived relation totals may be normalized during startup. The
-            // persistence contract is that the explicit user relation survives and that
+            // persistence contract is that the explicit Git decision survives and that
             // the repository does not fall below its pre-write baseline.
             assertThat(relationCount(client, secondOrigin))
-                    .isGreaterThanOrEqualTo(countBeforeWrite);
+                    .isGreaterThanOrEqualTo(beforeWrite.count());
         } finally {
             stopQuietly(second);
             stopQuietly(first);
@@ -163,7 +170,23 @@ class ProductionPersistenceRestartIT {
                 });
     }
 
+    private static HttpResponse<String> relations(
+            HttpClient client,
+            URI origin) throws Exception {
+        return send(client, HttpRequest.newBuilder(
+                origin.resolve("/api/relations"))
+                .header("Authorization", AUTHORIZATION)
+                .GET()
+                .build());
+    }
+
     private static long relationCount(HttpClient client, URI origin) throws Exception {
+        return relationSnapshot(client, origin).count();
+    }
+
+    private static RelationSnapshot relationSnapshot(
+            HttpClient client,
+            URI origin) throws Exception {
         HttpResponse<String> response = send(client, HttpRequest.newBuilder(
                 origin.resolve("/api/relations/count"))
                 .header("Authorization", AUTHORIZATION)
@@ -172,10 +195,16 @@ class ProductionPersistenceRestartIT {
         assertThat(response.statusCode()).isEqualTo(200);
         String digits = response.body().replaceAll("[^0-9]", "");
         assertThat(digits).isNotBlank();
-        return Long.parseLong(digits);
+        String etag = response.headers().firstValue("ETag").orElseThrow(
+                () -> new AssertionError(
+                        "relation count response must expose the authoritative Git ETag"));
+        return new RelationSnapshot(Long.parseLong(digits), etag);
     }
 
     private static HttpResponse<String> send(HttpClient client, HttpRequest request) throws Exception {
         return client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private record RelationSnapshot(long count, String etag) {
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/TaxonomyRelationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/TaxonomyRelationTests.java
@@ -1,30 +1,33 @@
 package com.taxonomy;
 
-import com.taxonomy.dto.TaxonomyRelationDto;
-import com.taxonomy.model.RelationType;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.catalog.model.TaxonomyRelation;
 import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
 import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.catalog.service.TaxonomyService;
+import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.repository.RelationDecisionProjectionCheckpointRepository;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.repository.RelationProjectionRecoveryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import org.springframework.security.test.context.support.WithMockUser;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -41,31 +44,48 @@ class TaxonomyRelationTests {
     private TaxonomyRelationRepository relationRepository;
 
     @Autowired
+    private RelationDecisionProjectionRepository projectionRepository;
+
+    @Autowired
+    private RelationDecisionProjectionCheckpointRepository checkpointRepository;
+
+    @Autowired
+    private RelationProjectionRecoveryRepository recoveryRepository;
+
+    @Autowired
     private TaxonomyNodeRepository nodeRepository;
 
     @Autowired
     private TaxonomyService taxonomyService;
 
     @BeforeEach
-    void cleanRelations() {
+    void cleanRelationReadModels() {
+        recoveryRepository.deleteAll();
+        checkpointRepository.deleteAll();
+        projectionRepository.deleteAll();
         relationRepository.deleteAll();
     }
 
     @Test
     void contextLoadsWithRelationService() {
         assertThat(relationService).isNotNull();
+        assertThat(nodeRepository).isNotNull();
     }
 
     @Test
-    void initialRelationCountIsZero() {
+    void initialLegacyRelationCountIsZero() {
         assertThat(relationService.countRelations()).isEqualTo(0);
     }
 
     @Test
-    void createRelationPersistsAndReturnsDto() {
-        TaxonomyRelationDto dto = relationService.createRelation("BP", "CP",
-                RelationType.SUPPORTS, "BP supports CP", "test");
-        assertThat(dto).isNotNull();
+    void legacyCompatibilityServiceStillPersistsAndMapsRows() {
+        TaxonomyRelationDto dto = relationService.createRelation(
+                "BP",
+                "CP",
+                RelationType.SUPPORTS,
+                "BP supports CP",
+                "test");
+
         assertThat(dto.getId()).isNotNull();
         assertThat(dto.getSourceCode()).isEqualTo("BP");
         assertThat(dto.getTargetCode()).isEqualTo("CP");
@@ -75,153 +95,107 @@ class TaxonomyRelationTests {
     }
 
     @Test
-    void getRelationsForNodeReturnsIncomingAndOutgoing() {
-        relationService.createRelation("BP", "CP", RelationType.SUPPORTS, null, "test");
-        relationService.createRelation("CR", "BP", RelationType.DEPENDS_ON, null, "test");
+    void legacyCompatibilityQueriesRemainAvailableDuringMigrationFallback() {
+        relationService.createRelation(
+                "BP", "CP", RelationType.SUPPORTS, null, "test");
+        relationService.createRelation(
+                "CR", "BP", RelationType.DEPENDS_ON, null, "test");
+        relationService.createRelation(
+                "CP", "CR", RelationType.REALIZES, null, "test");
 
-        List<TaxonomyRelationDto> relations = relationService.getRelationsForNode("BP");
-        assertThat(relations).hasSize(2);
+        List<TaxonomyRelationDto> nodeRelations =
+                relationService.getRelationsForNode("BP");
+        List<TaxonomyRelationDto> supports =
+                relationService.getRelationsByType(RelationType.SUPPORTS);
+
+        assertThat(nodeRelations).hasSize(2);
+        assertThat(supports).singleElement()
+                .extracting(TaxonomyRelationDto::getRelationType)
+                .isEqualTo("SUPPORTS");
     }
 
     @Test
-    void getRelationsByTypeFiltersCorrectly() {
-        relationService.createRelation("BP", "CP", RelationType.SUPPORTS, null, "test");
-        relationService.createRelation("CP", "CR", RelationType.REALIZES, null, "test");
-
-        List<TaxonomyRelationDto> supports = relationService.getRelationsByType(RelationType.SUPPORTS);
-        assertThat(supports).hasSize(1);
-        assertThat(supports.get(0).getRelationType()).isEqualTo("SUPPORTS");
-
-        List<TaxonomyRelationDto> realizes = relationService.getRelationsByType(RelationType.REALIZES);
-        assertThat(realizes).hasSize(1);
-        assertThat(realizes.get(0).getRelationType()).isEqualTo("REALIZES");
-    }
-
-    @Test
-    void deleteRelationRemovesIt() {
-        TaxonomyRelationDto dto = relationService.createRelation("BP", "CP",
-                RelationType.SUPPORTS, null, "test");
-        assertThat(relationService.countRelations()).isEqualTo(1);
+    void legacyCompatibilityDeleteAndDuplicateGuardRemainIntact() {
+        TaxonomyRelationDto dto = relationService.createRelation(
+                "BP", "CP", RelationType.SUPPORTS, null, "test");
+        assertThatThrownBy(() -> relationService.createRelation(
+                "BP", "CP", RelationType.SUPPORTS, null, "test"))
+                .isInstanceOf(Exception.class);
 
         relationService.deleteRelation(dto.getId());
-        assertThat(relationService.countRelations()).isEqualTo(0);
+
+        assertThat(relationService.countRelations()).isZero();
     }
 
     @Test
-    void duplicateRelationIsRejected() {
-        relationService.createRelation("BP", "CP", RelationType.SUPPORTS, null, "test");
-        assertThatThrownBy(() -> {
-            relationService.createRelation("BP", "CP", RelationType.SUPPORTS, null, "test");
-        }).isInstanceOf(Exception.class);
-    }
-
-    @Test
-    void relationsApiCountEndpointReturnsZero() throws Exception {
-        mockMvc.perform(get("/api/relations/count").accept(MediaType.APPLICATION_JSON))
+    void productReadCountUsesObservableLegacyFallbackBeforeFirstBuild()
+            throws Exception {
+        mockMvc.perform(get("/api/relations/count")
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(header().string(
+                        "X-Taxonomy-Relation-Read-Model",
+                        "LEGACY_FALLBACK"))
+                .andExpect(header().string(
+                        "X-Taxonomy-Relation-Projection-State",
+                        "NOT_BUILT"))
+                .andExpect(header().exists("ETag"))
                 .andExpect(jsonPath("$.count").value(0));
     }
 
     @Test
-    void relationsApiGetAllReturnsEmptyList() throws Exception {
-        mockMvc.perform(get("/api/relations").accept(MediaType.APPLICATION_JSON))
+    void productReadAllUsesTheSameObservableFallback() throws Exception {
+        mockMvc.perform(get("/api/relations")
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
+                .andExpect(header().string(
+                        "X-Taxonomy-Relation-Read-Model",
+                        "LEGACY_FALLBACK"))
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$.length()").value(0));
     }
 
     @Test
-    void relationsApiPostCreatesRelation() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"BP\",\"targetCode\":\"CP\",\"relationType\":\"SUPPORTS\"}"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.sourceCode").value("BP"))
-                .andExpect(jsonPath("$.targetCode").value("CP"))
-                .andExpect(jsonPath("$.relationType").value("SUPPORTS"));
-    }
+    void typeAndNodeProductReadsFilterOneFallbackSnapshot() throws Exception {
+        relationService.createRelation(
+                "BP", "CP", RelationType.SUPPORTS, null, "test");
+        relationService.createRelation(
+                "CP", "CR", RelationType.REALIZES, null, "test");
+        relationService.createRelation(
+                "CR", "BP", RelationType.DEPENDS_ON, null, "test");
 
-    @Test
-    void relationsApiPostReturnsBadRequestForMissingFields() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"BP\"}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void relationsApiPostReturnsBadRequestForUnknownType() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"BP\",\"targetCode\":\"CP\",\"relationType\":\"UNKNOWN_TYPE\"}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void relationsApiPostReturnsBadRequestForUnknownNode() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"NONEXISTENT\",\"targetCode\":\"CP\",\"relationType\":\"SUPPORTS\"}"))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void relationsApiGetByTypeFilters() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"BP\",\"targetCode\":\"CP\",\"relationType\":\"SUPPORTS\"}"))
-                .andExpect(status().isOk());
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"CP\",\"targetCode\":\"CR\",\"relationType\":\"REALIZES\"}"))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(get("/api/relations").param("type", "SUPPORTS").accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(get("/api/relations")
+                        .param("type", "SUPPORTS")
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].relationType").value("SUPPORTS"));
-    }
-
-    @Test
-    void relationsApiGetForNodeReturnsIncomingAndOutgoing() throws Exception {
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"BP\",\"targetCode\":\"CP\",\"relationType\":\"SUPPORTS\"}"))
-                .andExpect(status().isOk());
-        mockMvc.perform(post("/api/relations")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sourceCode\":\"CR\",\"targetCode\":\"BP\",\"relationType\":\"DEPENDS_ON\"}"))
-                .andExpect(status().isOk());
-
-        mockMvc.perform(get("/api/node/BP/relations").accept(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].relationType")
+                        .value("SUPPORTS"));
+        mockMvc.perform(get("/api/node/BP/relations")
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(2));
     }
 
     @Test
-    void relationsApiDeleteRemovesRelation() throws Exception {
-        String createResponse = mockMvc.perform(post("/api/relations")
+    void dbFirstWriteEndpointsAreExplicitlyRetired() throws Exception {
+        mockMvc.perform(post("/api/relations")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"sourceCode\":\"BP\",\"targetCode\":\"CP\",\"relationType\":\"SUPPORTS\"}"))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString();
-
-        // Extract id from response manually using simple string search
-        int idStart = createResponse.indexOf("\"id\":") + 5;
-        int idEnd = createResponse.indexOf(",", idStart);
-        if (idEnd < 0) idEnd = createResponse.indexOf("}", idStart);
-        long id = Long.parseLong(createResponse.substring(idStart, idEnd).trim());
-
-        mockMvc.perform(delete("/api/relations/" + id))
-                .andExpect(status().isNoContent());
-
-        assertThat(relationService.countRelations()).isEqualTo(0);
+                .andExpect(status().isGone());
+        mockMvc.perform(delete("/api/relations/42"))
+                .andExpect(status().isGone());
     }
 
     @Test
     void relationDtoMappingIsCorrect() {
-        TaxonomyRelationDto dto = relationService.createRelation("BP", "CP",
-                RelationType.SUPPORTS, "A description", "manual");
+        TaxonomyRelationDto dto = relationService.createRelation(
+                "BP",
+                "CP",
+                RelationType.SUPPORTS,
+                "A description",
+                "manual");
+
         assertThat(dto.getSourceCode()).isEqualTo("BP");
         assertThat(dto.getSourceName()).isNotNull();
         assertThat(dto.getTargetCode()).isEqualTo("CP");
@@ -234,18 +208,15 @@ class TaxonomyRelationTests {
 
     @Test
     void nodeDtoContainsRelationFields() {
-        // After loading, the DTO should have outgoing/incoming relation lists (empty by default)
         var tree = taxonomyService.getFullTree();
         assertThat(tree).isNotEmpty();
-        var root = tree.get(0);
+        var root = tree.getFirst();
         assertThat(root.getOutgoingRelations()).isNotNull();
         assertThat(root.getIncomingRelations()).isNotNull();
     }
 
     @Test
     void missingRelationsSheetDoesNotBreakLoader() {
-        // The taxonomy was already loaded without a Relations sheet — all 8 roots should exist
-        var tree = taxonomyService.getFullTree();
-        assertThat(tree).hasSize(8);
+        assertThat(taxonomyService.getFullTree()).hasSize(8);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/TaxonomyRelationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/TaxonomyRelationTests.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-@WithMockUser(roles = "ADMIN")
+@WithMockUser(username = "relation-read-contract-admin", roles = "ADMIN")
 class TaxonomyRelationTests {
 
     @Autowired

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitCommandForkScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/GitCommandForkScopeTest.java
@@ -1,0 +1,135 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.RelationDefinition;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewAction;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.RelationDecisionProjectionService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryScope;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class GitCommandForkScopeTest {
+
+    private static final String PREVIOUS = "a".repeat(40);
+    private static final String AUTHORITY = "b".repeat(40);
+
+    @Test
+    void relationCommandKeepsForkContextInsteadOfUpgradingToCentralWrite()
+            throws Exception {
+        RepositoryContext fork = fork();
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+        GitAuthoritativeRelationMutationService mutationService =
+                mock(GitAuthoritativeRelationMutationService.class);
+        SystemRepositoryService repositoryService =
+                mock(SystemRepositoryService.class);
+        RepositoryMembershipService membershipService =
+                mock(RepositoryMembershipService.class);
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(fork);
+        when(mutationService.upsert(
+                eq(fork), eq(PREVIOUS), any(RelationDefinition.class),
+                any(CommandMetadata.class)))
+                .thenReturn(mutation());
+
+        var response = new GitRelationCommandApiController(
+                mutationService,
+                workspaceResolver,
+                repositoryService,
+                membershipService).upsert(
+                        "BP-1",
+                        "SUPPORTS",
+                        "CP-2",
+                        '"' + PREVIOUS + '"',
+                        null,
+                        "fork-command",
+                        null);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().scope()).isEqualTo("FORK");
+        verifyNoInteractions(repositoryService, membershipService);
+    }
+
+    @Test
+    void proposalReviewKeepsForkContextInsteadOfUpgradingToCentralWrite()
+            throws Exception {
+        RepositoryContext fork = fork();
+        WorkspaceResolver workspaceResolver = mock(WorkspaceResolver.class);
+        GitAuthoritativeProposalReviewService reviewService =
+                mock(GitAuthoritativeProposalReviewService.class);
+        SystemRepositoryService repositoryService =
+                mock(SystemRepositoryService.class);
+        RepositoryMembershipService membershipService =
+                mock(RepositoryMembershipService.class);
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(fork);
+        when(reviewService.accept(
+                eq(42L), eq(fork), eq(PREVIOUS),
+                any(CommandMetadata.class)))
+                .thenReturn(new ReviewResult(
+                        42L,
+                        ReviewAction.ACCEPT,
+                        ProposalStatus.ACCEPTED,
+                        mutation()));
+
+        var response = new GitProposalReviewApiController(
+                reviewService,
+                workspaceResolver,
+                repositoryService,
+                membershipService).accept(
+                        42L,
+                        '"' + PREVIOUS + '"',
+                        null,
+                        "fork-review",
+                        null);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo('"' + AUTHORITY + '"');
+        verifyNoInteractions(repositoryService, membershipService);
+    }
+
+    private static RepositoryContext fork() {
+        return new RepositoryContext(
+                "fork-a",
+                null,
+                "review",
+                "alice",
+                RepositoryScope.FORK);
+    }
+
+    private static MutationResult mutation() {
+        return new MutationResult(
+                new CommandResult(
+                        "fork-a",
+                        null,
+                        "review",
+                        RepositoryScope.FORK,
+                        PREVIOUS,
+                        AUTHORITY,
+                        ChangeKind.UPDATED,
+                        true,
+                        "fork-command"),
+                new RelationDecisionProjectionService.ProjectionResult(
+                        RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
+                        AUTHORITY,
+                        true));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
@@ -1,205 +1,170 @@
 package com.taxonomy.relations.controller;
 
-import com.taxonomy.catalog.service.TaxonomyRelationService;
 import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
-import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadResult;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.workspace.service.RepositoryContext;
-import com.taxonomy.workspace.service.RepositoryMembershipService;
-import com.taxonomy.workspace.service.RepositoryScope;
-import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RelationApiControllerRepositoryScopeTest {
 
-    private TaxonomyRelationService relationService;
+    private RelationProjectionReadService relationReadService;
     private WorkspaceResolver workspaceResolver;
-    private SystemRepositoryService repositoryService;
-    private RepositoryMembershipService membershipService;
     private RelationApiController controller;
 
     @BeforeEach
     void setUp() {
-        relationService = mock(TaxonomyRelationService.class);
+        relationReadService = mock(RelationProjectionReadService.class);
         workspaceResolver = mock(WorkspaceResolver.class);
-        repositoryService = mock(SystemRepositoryService.class);
-        membershipService = mock(RepositoryMembershipService.class);
         controller = new RelationApiController(
-                relationService,
-                workspaceResolver,
-                repositoryService,
-                membershipService);
-    }
-
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
+                relationReadService, workspaceResolver);
     }
 
     @Test
-    void readsUseTheExactResolvedRepositoryContext() {
+    void readsUseTheExactResolvedRepositoryContextAndExposeAuthority() {
         RepositoryContext context = RepositoryContext.centralRead(
                 "repo-b", "main", "alice");
-        when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
-        when(relationService.getAllRelationsInContext(context)).thenReturn(List.of());
+        TaxonomyRelationDto relation = relation(
+                17L, "BP", RelationType.SUPPORTS, "CP");
+        ReadResult result = new ReadResult(
+                ReadModel.PROJECTION,
+                ReadinessState.READY,
+                "a".repeat(40),
+                List.of(relation));
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(relationReadService.readAll(context)).thenReturn(result);
 
         ResponseEntity<List<TaxonomyRelationDto>> response =
                 controller.getRelations(null);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        verify(relationService).getAllRelationsInContext(context);
-        verify(relationService, never()).getAllRelations(any(String.class));
+        assertThat(response.getBody()).containsExactly(relation);
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo("\"" + "a".repeat(40) + "\"");
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.READ_MODEL_HEADER))
+                .isEqualTo("PROJECTION");
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("READY");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("no-store");
+        verify(relationReadService).readAll(context);
     }
 
     @Test
-    void centralReadContextRejectsNonMaintainerWrites() {
-        RepositoryContext context = RepositoryContext.centralRead(
-                "repo-a", "main", "reader");
-        SystemRepository repository = repository("repo-a");
-        when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
-        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
-        when(membershipService.canMaintain(repository, "reader")).thenReturn(false);
+    void typeAndNodeReadsUseTheSameProjectionBoundary() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-b", "workspace-b1", "feature/b1", "alice");
+        ReadResult result = new ReadResult(
+                ReadModel.PROJECTION,
+                ReadinessState.READY,
+                "b".repeat(40),
+                List.of());
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(relationReadService.readByType(
+                context, RelationType.SUPPORTS)).thenReturn(result);
+        when(relationReadService.readForNode(context, "BP"))
+                .thenReturn(result);
 
-        ResponseEntity<TaxonomyRelationDto> response = controller.createRelation(
-                validRelationBody());
+        assertThat(controller.getRelations("supports").getStatusCode().value())
+                .isEqualTo(200);
+        assertThat(controller.getRelationsForNode("BP")
+                .getStatusCode().value()).isEqualTo(200);
 
-        assertThat(response.getStatusCode().value()).isEqualTo(403);
-        verify(relationService, never()).createRelationInContext(
-                any(), any(), any(), any(), any(), any());
+        verify(relationReadService).readByType(
+                context, RelationType.SUPPORTS);
+        verify(relationReadService).readForNode(context, "BP");
     }
 
     @Test
-    void repositoryMaintainerReceivesAnExplicitCentralWriteContext() {
-        RepositoryContext readContext = RepositoryContext.centralRead(
-                "repo-a", "main", "maintainer");
-        SystemRepository repository = repository("repo-a");
-        when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(readContext);
-        when(repositoryService.getRepository("repo-a")).thenReturn(repository);
-        when(membershipService.canMaintain(repository, "maintainer")).thenReturn(true);
-        when(relationService.createRelationInContext(
-                        any(), any(), any(), any(), any(), any()))
-                .thenReturn(new TaxonomyRelationDto());
-
-        ResponseEntity<TaxonomyRelationDto> response = controller.createRelation(
-                validRelationBody());
-
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        ArgumentCaptor<RepositoryContext> contextCaptor =
-                ArgumentCaptor.forClass(RepositoryContext.class);
-        verify(relationService).createRelationInContext(
-                org.mockito.ArgumentMatchers.eq("BP"),
-                org.mockito.ArgumentMatchers.eq("CP"),
-                org.mockito.ArgumentMatchers.eq(RelationType.SUPPORTS),
-                org.mockito.ArgumentMatchers.isNull(),
-                org.mockito.ArgumentMatchers.isNull(),
-                contextCaptor.capture());
-        assertThat(contextCaptor.getValue().repositoryId()).isEqualTo("repo-a");
-        assertThat(contextCaptor.getValue().workspaceId()).isNull();
-        assertThat(contextCaptor.getValue().scope()).isEqualTo(RepositoryScope.CENTRAL_WRITE);
-        assertThat(contextCaptor.getValue().username()).isEqualTo("maintainer");
-    }
-
-    @Test
-    void globalAdminCompatibilityOverrideStillTargetsOnlyTheSelectedRepository() {
-        authenticateAdmin("admin");
-        RepositoryContext readContext = RepositoryContext.centralRead(
-                "repo-b", "draft", "admin");
-        SystemRepository repository = repository("repo-b");
-        when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(readContext);
-        when(repositoryService.getRepository("repo-b")).thenReturn(repository);
-        when(relationService.createRelationInContext(
-                        any(), any(), any(), any(), any(), any()))
-                .thenReturn(new TaxonomyRelationDto());
-
-        ResponseEntity<TaxonomyRelationDto> response = controller.createRelation(
-                validRelationBody());
-
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        ArgumentCaptor<RepositoryContext> contextCaptor =
-                ArgumentCaptor.forClass(RepositoryContext.class);
-        verify(relationService).createRelationInContext(
-                any(), any(), any(), any(), any(), contextCaptor.capture());
-        assertThat(contextCaptor.getValue().repositoryId()).isEqualTo("repo-b");
-        assertThat(contextCaptor.getValue().branch()).isEqualTo("draft");
-        assertThat(contextCaptor.getValue().scope()).isEqualTo(RepositoryScope.CENTRAL_WRITE);
-        verify(membershipService, never()).canMaintain(repository, "admin");
-    }
-
-    @Test
-    void workspaceWritePreservesTheResolvedRepositoryAndWorkspace() {
-        RepositoryContext workspaceContext = RepositoryContext.workspace(
+    void unsafeProjectionReturnsConflictInsteadOfLegacyRows() {
+        RepositoryContext context = RepositoryContext.workspace(
                 "repo-b", "workspace-b1", "feature/b1", "alice");
         when(workspaceResolver.resolveCurrentRepositoryContext())
-                .thenReturn(workspaceContext);
-        when(relationService.createRelationInContext(
-                        any(), any(), any(), any(), any(), any()))
-                .thenReturn(new TaxonomyRelationDto());
+                .thenReturn(context);
+        when(relationReadService.readAll(context)).thenThrow(
+                new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.STALE,
+                        "c".repeat(40),
+                        "d".repeat(40),
+                        2));
 
-        ResponseEntity<TaxonomyRelationDto> response = controller.createRelation(
-                validRelationBody());
+        ResponseEntity<List<TaxonomyRelationDto>> response =
+                controller.getRelations(null);
 
-        assertThat(response.getStatusCode().value()).isEqualTo(200);
-        verify(relationService).createRelationInContext(
-                "BP",
-                "CP",
-                RelationType.SUPPORTS,
-                null,
-                null,
-                workspaceContext);
-        verify(repositoryService, never()).getRepository(any());
-        verify(membershipService, never()).canMaintain(any(), any());
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("STALE");
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PENDING_RECOVERY_HEADER))
+                .isEqualTo("2");
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo("\"" + "c".repeat(40) + "\"");
     }
 
     @Test
-    void deleteCannotFallBackToAnUnscopedIdentifierLookup() {
-        RepositoryContext workspaceContext = RepositoryContext.workspace(
-                "repo-a", "workspace-a", "feature/a", "alice");
+    void countUsesTheExactSameReadResult() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-a", "draft", "alice");
+        ReadResult result = new ReadResult(
+                ReadModel.LEGACY_FALLBACK,
+                ReadinessState.NOT_BUILT,
+                "e".repeat(40),
+                List.of(
+                        relation(1L, "BP", RelationType.SUPPORTS, "CP"),
+                        relation(2L, "CP", RelationType.REALIZES, "CR")));
         when(workspaceResolver.resolveCurrentRepositoryContext())
-                .thenReturn(workspaceContext);
+                .thenReturn(context);
+        when(relationReadService.readAll(context)).thenReturn(result);
 
-        ResponseEntity<Void> response = controller.deleteRelation(42L);
+        ResponseEntity<Map<String, Long>> response = controller.countRelations();
 
-        assertThat(response.getStatusCode().value()).isEqualTo(204);
-        verify(relationService).deleteRelationInContext(42L, workspaceContext);
-        verify(relationService, never()).deleteRelation(42L);
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsEntry("count", 2L);
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.READ_MODEL_HEADER))
+                .isEqualTo("LEGACY_FALLBACK");
     }
 
-    private static Map<String, String> validRelationBody() {
-        return Map.of(
-                "sourceCode", "BP",
-                "targetCode", "CP",
-                "relationType", "SUPPORTS");
+    @Test
+    void dbFirstWriteRoutesAreExplicitlyGone() {
+        assertThat(controller.createRelation(Map.of()).getStatusCode().value())
+                .isEqualTo(410);
+        assertThat(controller.deleteRelation(42L).getStatusCode().value())
+                .isEqualTo(410);
     }
 
-    private static SystemRepository repository(String repositoryId) {
-        SystemRepository repository = new SystemRepository();
-        repository.setRepositoryId(repositoryId);
-        return repository;
-    }
-
-    private static void authenticateAdmin(String username) {
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(
-                        username,
-                        "n/a",
-                        List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+    private static TaxonomyRelationDto relation(
+            Long id,
+            String source,
+            RelationType type,
+            String target) {
+        TaxonomyRelationDto relation = new TaxonomyRelationDto();
+        relation.setId(id);
+        relation.setSourceCode(source);
+        relation.setTargetCode(target);
+        relation.setRelationType(type.name());
+        return relation;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
@@ -142,8 +142,8 @@ class RelationApiControllerRepositoryScopeTest {
                 controller.getRelations(null);
 
         assertThat(response.getStatusCode().value()).isEqualTo(409);
-        assertThat(response.getHeaders().containsKey(
-                RelationApiController.PENDING_RECOVERY_HEADER)).isFalse();
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PENDING_RECOVERY_HEADER)).isNull();
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
@@ -4,6 +4,7 @@ import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationProjectionReadService;
+import com.taxonomy.relations.service.RelationProjectionReadService.CountResult;
 import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
 import com.taxonomy.relations.service.RelationProjectionReadService.ReadResult;
 import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
@@ -146,19 +147,17 @@ class RelationApiControllerRepositoryScopeTest {
     }
 
     @Test
-    void countUsesTheExactSameReadResult() {
+    void countUsesDirectMetadataFromTheSameProvenReadSource() {
         RepositoryContext context = RepositoryContext.centralRead(
                 "repo-a", "draft", "alice");
-        ReadResult result = new ReadResult(
+        CountResult result = new CountResult(
                 ReadModel.LEGACY_FALLBACK,
                 ReadinessState.NOT_BUILT,
                 "e".repeat(40),
-                List.of(
-                        relation(1L, "BP", RelationType.SUPPORTS, "CP"),
-                        relation(2L, "CP", RelationType.REALIZES, "CR")));
+                2L);
         when(workspaceResolver.resolveCurrentRepositoryContext())
                 .thenReturn(context);
-        when(relationReadService.readAll(context)).thenReturn(result);
+        when(relationReadService.count(context)).thenReturn(result);
 
         ResponseEntity<Map<String, Long>> response = controller.countRelations();
 
@@ -167,6 +166,9 @@ class RelationApiControllerRepositoryScopeTest {
         assertThat(response.getHeaders().getFirst(
                 RelationApiController.READ_MODEL_HEADER))
                 .isEqualTo("LEGACY_FALLBACK");
+        assertThat(response.getHeaders().getETag())
+                .isEqualTo("\"" + "e".repeat(40) + "\"");
+        verify(relationReadService).count(context);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/RelationApiControllerRepositoryScopeTest.java
@@ -96,7 +96,7 @@ class RelationApiControllerRepositoryScopeTest {
     }
 
     @Test
-    void unsafeProjectionReturnsConflictInsteadOfLegacyRows() {
+    void unsafeProjectionReturnsConflictAndActualPendingRecoveryCount() {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-b", "workspace-b1", "feature/b1", "alice");
         when(workspaceResolver.resolveCurrentRepositoryContext())
@@ -121,6 +121,28 @@ class RelationApiControllerRepositoryScopeTest {
                 .isEqualTo("2");
         assertThat(response.getHeaders().getETag())
                 .isEqualTo("\"" + "c".repeat(40) + "\"");
+    }
+
+    @Test
+    void unsafeProjectionWithoutPendingRecoveryOmitsRecoveryHeader() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-b", "workspace-b1", "feature/b1", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(relationReadService.readAll(context)).thenThrow(
+                new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.CORRUPT,
+                        "d".repeat(40),
+                        "d".repeat(40),
+                        0));
+
+        ResponseEntity<List<TaxonomyRelationDto>> response =
+                controller.getRelations(null);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(response.getHeaders().containsKey(
+                RelationApiController.PENDING_RECOVERY_HEADER)).isFalse();
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/GitAuthoritativeRelationMutationServiceTest.java
@@ -9,6 +9,10 @@ import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.Comm
 import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.RelationCommand;
 import com.taxonomy.relations.model.RelationProjectionRecovery.RecoveryStatus;
 import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.ProjectionPendingException;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationBranchProjectionRebuildService.RebuildResult;
+import com.taxonomy.relations.service.RelationProjectionRecoveryService.ReconciliationResult;
 import com.taxonomy.relations.service.RelationProjectionRecoveryService.RecoveryRecord;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryScope;
@@ -19,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +31,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -42,26 +49,38 @@ class GitAuthoritativeRelationMutationServiceTest {
     private RelationDecisionProjectionService projectionService;
 
     @Mock
+    private RelationBranchProjectionRebuildService rebuildService;
+
+    @Mock
+    private RelationBranchProjectionReadinessService readinessService;
+
+    @Mock
     private RelationProjectionRecoveryService recoveryService;
 
     @Test
-    void commitsBeforeProjectingAndReturnsBothResults() throws Exception {
+    void commandIsProjectedRebuiltProvenReadyThenReconciled() throws Exception {
         RepositoryContext context = context();
         CommandResult authority = authority();
-        RelationDecisionProjectionService.ProjectionResult projection =
-                new RelationDecisionProjectionService.ProjectionResult(
-                        RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
-                        AUTHORITY,
-                        true);
+        RelationDecisionProjectionService.ProjectionResult projection = projection();
+        RebuildResult rebuild = new RebuildResult(
+                "repo-a", "workspace-a", "review", AUTHORITY, 0);
+        Readiness readiness = new Readiness(
+                ReadinessState.READY,
+                AUTHORITY,
+                AUTHORITY,
+                List.of());
         when(commandService.execute(
                 eq(context), eq(PREVIOUS), any(RelationCommand.class)))
                 .thenReturn(authority);
         when(projectionService.project(
                 eq(context), eq(authority), any(RelationCommand.class)))
                 .thenReturn(projection);
-        GitAuthoritativeRelationMutationService service = service();
+        when(rebuildService.rebuild(context)).thenReturn(rebuild);
+        when(readinessService.inspect(context)).thenReturn(readiness);
+        when(recoveryService.reconcileAfterRebuild(context, AUTHORITY))
+                .thenReturn(new ReconciliationResult(AUTHORITY, 0, 0, 0));
 
-        var result = service.upsert(
+        var result = service().upsert(
                 context,
                 PREVIOUS,
                 definition(),
@@ -69,16 +88,25 @@ class GitAuthoritativeRelationMutationServiceTest {
 
         assertThat(result.authority()).isSameAs(authority);
         assertThat(result.projection()).isSameAs(projection);
-        InOrder order = inOrder(commandService, projectionService);
+        InOrder order = inOrder(
+                commandService,
+                projectionService,
+                rebuildService,
+                readinessService,
+                recoveryService);
         order.verify(commandService).execute(
                 eq(context), eq(PREVIOUS), any(RelationCommand.class));
         order.verify(projectionService).project(
                 eq(context), eq(authority), any(RelationCommand.class));
-        verifyNoInteractions(recoveryService);
+        order.verify(rebuildService).rebuild(context);
+        order.verify(readinessService).inspect(context);
+        order.verify(recoveryService).reconcileAfterRebuild(
+                context, AUTHORITY);
+        verify(recoveryService, never()).recordPending(any(), any());
     }
 
     @Test
-    void persistsRecoveryAfterProjectionFailureAndExposesAuthority()
+    void projectionFailurePersistsRecoveryAndExposesAuthority()
             throws Exception {
         RepositoryContext context = context();
         CommandResult authority = authority();
@@ -93,9 +121,8 @@ class GitAuthoritativeRelationMutationServiceTest {
                 .thenThrow(projectionFailure);
         when(recoveryService.recordPending(authority, projectionFailure))
                 .thenReturn(recovery);
-        GitAuthoritativeRelationMutationService service = service();
 
-        assertThatThrownBy(() -> service.remove(
+        assertThatThrownBy(() -> service().remove(
                 context,
                 PREVIOUS,
                 definition().identity(),
@@ -117,6 +144,70 @@ class GitAuthoritativeRelationMutationServiceTest {
                 eq(context), eq(authority), any(RelationCommand.class));
         order.verify(recoveryService).recordPending(
                 authority, projectionFailure);
+        verifyNoInteractions(rebuildService, readinessService);
+    }
+
+    @Test
+    void rebuildAtAnotherHeadIsRecoveryNotFalseSuccess() throws Exception {
+        RepositoryContext context = context();
+        CommandResult authority = authority();
+        when(commandService.execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class)))
+                .thenReturn(authority);
+        when(projectionService.project(
+                eq(context), eq(authority), any(RelationCommand.class)))
+                .thenReturn(projection());
+        when(rebuildService.rebuild(context)).thenReturn(new RebuildResult(
+                "repo-a",
+                "workspace-a",
+                "review",
+                "c".repeat(40),
+                1));
+        when(recoveryService.recordPending(eq(authority), any()))
+                .thenReturn(recovery());
+
+        assertThatThrownBy(() -> service().upsert(
+                context,
+                PREVIOUS,
+                definition(),
+                new CommandMetadata("request-17")))
+                .isInstanceOfSatisfying(
+                        ProjectionPendingException.class,
+                        error -> assertThat(error.getCause())
+                                .isInstanceOf(
+                                        GitAuthoritativeRelationMutationService
+                                                .ProjectionCompletionException.class));
+        verifyNoInteractions(readinessService);
+        verify(recoveryService, never()).reconcileAfterRebuild(any(), any());
+    }
+
+    @Test
+    void corruptCompleteProjectionNeverReconcilesRecovery() throws Exception {
+        RepositoryContext context = context();
+        CommandResult authority = authority();
+        when(commandService.execute(
+                eq(context), eq(PREVIOUS), any(RelationCommand.class)))
+                .thenReturn(authority);
+        when(projectionService.project(
+                eq(context), eq(authority), any(RelationCommand.class)))
+                .thenReturn(projection());
+        when(rebuildService.rebuild(context)).thenReturn(new RebuildResult(
+                "repo-a", "workspace-a", "review", AUTHORITY, 1));
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.CORRUPT,
+                AUTHORITY,
+                AUTHORITY,
+                List.of()));
+        when(recoveryService.recordPending(eq(authority), any()))
+                .thenReturn(recovery());
+
+        assertThatThrownBy(() -> service().upsert(
+                context,
+                PREVIOUS,
+                definition(),
+                new CommandMetadata("request-17")))
+                .isInstanceOf(ProjectionPendingException.class);
+        verify(recoveryService, never()).reconcileAfterRebuild(any(), any());
     }
 
     @Test
@@ -156,7 +247,18 @@ class GitAuthoritativeRelationMutationServiceTest {
 
     private GitAuthoritativeRelationMutationService service() {
         return new GitAuthoritativeRelationMutationService(
-                commandService, projectionService, recoveryService);
+                commandService,
+                projectionService,
+                rebuildService,
+                readinessService,
+                recoveryService);
+    }
+
+    private static RelationDecisionProjectionService.ProjectionResult projection() {
+        return new RelationDecisionProjectionService.ProjectionResult(
+                RelationDecisionProjectionService.ProjectionOutcome.UPDATED,
+                AUTHORITY,
+                true);
     }
 
     private static RepositoryContext context() {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalReviewStateStoreContextTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalReviewStateStoreContextTest.java
@@ -1,0 +1,43 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryScope;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProposalReviewStateStoreContextTest {
+
+    @Test
+    void acceptsCentralWorkspaceAndRepositoryIsolatedForkWrites() {
+        RepositoryContext central = RepositoryContext.centralWrite(
+                "repo-a", "draft", "alice");
+        RepositoryContext workspace = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RepositoryContext fork = new RepositoryContext(
+                "fork-a", null, "draft", "alice", RepositoryScope.FORK);
+
+        assertThat(ProposalReviewStateStore.requireWritableContext(central))
+                .isSameAs(central);
+        assertThat(ProposalReviewStateStore.requireWritableContext(workspace))
+                .isSameAs(workspace);
+        assertThat(ProposalReviewStateStore.requireWritableContext(fork))
+                .isSameAs(fork);
+    }
+
+    @Test
+    void rejectsCentralReadAndImpossibleScopeWorkspaceCombinations() {
+        RepositoryContext centralRead = RepositoryContext.centralRead(
+                "repo-a", "draft", "alice");
+
+        assertThatThrownBy(() -> ProposalReviewStateStore
+                .requireWritableContext(centralRead))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("CENTRAL_WRITE or FORK");
+        assertThatThrownBy(() -> ProposalReviewStateStore
+                .requireWritableContext(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be null");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationDecisionProjectionWriterSemanticNoOpTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationDecisionProjectionWriterSemanticNoOpTest.java
@@ -1,0 +1,76 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.repository.RelationDecisionProjectionRepository;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionOutcome;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationDecisionProjectionWriterSemanticNoOpTest {
+
+    @Test
+    void sameCommitAndStateWithANewCommandIdIsAReplay() {
+        RelationDecisionProjectionRepository repository =
+                mock(RelationDecisionProjectionRepository.class);
+        String commitId = "a".repeat(40);
+        ProjectionRequest request = new ProjectionRequest(
+                "repo-a",
+                "workspace-a",
+                "draft",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1",
+                true,
+                "accepted",
+                0.9,
+                "manual",
+                commitId,
+                "relation-create:2");
+        RelationDecisionProjection rebuilt = rebuiltProjection(commitId);
+        when(repository.findExactForUpdate(
+                "repo-a",
+                "workspace-a",
+                "draft",
+                "APP-1",
+                RelationType.USES,
+                "SVC-1"))
+                .thenReturn(Optional.of(rebuilt));
+
+        RelationDecisionProjectionWriter writer =
+                new RelationDecisionProjectionWriter(repository);
+        var result = writer.write(request);
+
+        assertThat(result.outcome()).isEqualTo(ProjectionOutcome.REPLAYED);
+        assertThat(result.authoritativeCommitId()).isEqualTo(commitId);
+        assertThat(rebuilt.getCausationId()).isEqualTo("rebuild:" + commitId);
+        verify(repository, never()).save(any());
+    }
+
+    private static RelationDecisionProjection rebuiltProjection(String commitId) {
+        RelationDecisionProjection projection =
+                new RelationDecisionProjection();
+        projection.setRepositoryId("repo-a");
+        projection.setWorkspaceId("workspace-a");
+        projection.setBranch("draft");
+        projection.setSourceCode("APP-1");
+        projection.setRelationType(RelationType.USES);
+        projection.setTargetCode("SVC-1");
+        projection.setRelationPresent(true);
+        projection.setStatus("accepted");
+        projection.setConfidence(0.9);
+        projection.setProvenance("manual");
+        projection.setAuthoritativeCommitId(commitId);
+        projection.setCausationId("rebuild:" + commitId);
+        return projection;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionCountServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionCountServiceTest.java
@@ -1,0 +1,110 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RelationProjectionCountServiceTest {
+
+    private RelationBranchProjectionReadinessService readinessService;
+    private RelationProjectionRecoveryService recoveryService;
+    private TaxonomyRelationService legacyRelationService;
+    private TaxonomyNodeRepository nodeRepository;
+    private SystemRepositoryService repositoryService;
+    private RelationProjectionReadService service;
+
+    @BeforeEach
+    void setUp() {
+        readinessService = mock(RelationBranchProjectionReadinessService.class);
+        recoveryService = mock(RelationProjectionRecoveryService.class);
+        legacyRelationService = mock(TaxonomyRelationService.class);
+        nodeRepository = mock(TaxonomyNodeRepository.class);
+        repositoryService = mock(SystemRepositoryService.class);
+        service = new RelationProjectionReadService(
+                readinessService,
+                recoveryService,
+                legacyRelationService,
+                nodeRepository,
+                repositoryService);
+    }
+
+    @Test
+    void readyCountUsesProjectionRowsWithoutDtoOrNameMaterialization() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "a".repeat(40),
+                "a".repeat(40),
+                List.of(projection(1L), projection(2L))));
+
+        var result = service.count(context);
+
+        assertThat(result.readModel()).isEqualTo(ReadModel.PROJECTION);
+        assertThat(result.readinessState()).isEqualTo(ReadinessState.READY);
+        assertThat(result.authoritativeCommitId()).isEqualTo("a".repeat(40));
+        assertThat(result.count()).isEqualTo(2L);
+        verify(recoveryService, never()).pendingCount(context);
+        verifyNoInteractions(
+                legacyRelationService, nodeRepository, repositoryService);
+    }
+
+    @Test
+    void migrationFallbackUsesRepositoryCountWithoutLoadingDtos() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "primary", "draft", "alice");
+        SystemRepository primary = new SystemRepository();
+        primary.setRepositoryId("primary");
+        primary.setDefaultBranch("draft");
+        primary.setPrimaryRepo(true);
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.NOT_BUILT,
+                "b".repeat(40),
+                null,
+                List.of()));
+        when(recoveryService.pendingCount(context)).thenReturn(0L);
+        when(repositoryService.getPrimaryRepository()).thenReturn(primary);
+        when(legacyRelationService.countRelationsInContext(context))
+                .thenReturn(37L);
+
+        var result = service.count(context);
+
+        assertThat(result.readModel()).isEqualTo(ReadModel.LEGACY_FALLBACK);
+        assertThat(result.count()).isEqualTo(37L);
+        verify(legacyRelationService).countRelationsInContext(context);
+        verifyNoInteractions(nodeRepository);
+    }
+
+    private static RelationDecisionProjection projection(Long id) {
+        RelationDecisionProjection projection = new RelationDecisionProjection();
+        projection.setId(id);
+        projection.setRepositoryId("repo-a");
+        projection.setWorkspaceId("workspace-a");
+        projection.setBranch("feature/a");
+        projection.setSourceCode("BP-" + id);
+        projection.setRelationType(RelationType.SUPPORTS);
+        projection.setTargetCode("CP-" + id);
+        projection.setRelationPresent(true);
+        projection.setAuthoritativeCommitId("a".repeat(40));
+        projection.setCausationId("rebuild:" + id);
+        return projection;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
@@ -15,6 +15,7 @@ import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.SystemRepositoryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collection;
 import java.util.List;
@@ -129,8 +130,6 @@ class RelationProjectionReadServiceTest {
                 null,
                 List.of()));
         when(recoveryService.pendingCount(context)).thenReturn(1L);
-        when(repositoryService.getPrimaryRepository()).thenReturn(
-                primary("primary", "draft"));
 
         assertThatThrownBy(() -> service.readAll(context))
                 .isInstanceOfSatisfying(
@@ -141,7 +140,7 @@ class RelationProjectionReadServiceTest {
                             assertThat(error.getPendingRecoveryCount())
                                     .isEqualTo(1L);
                         });
-        verifyNoInteractions(legacyRelationService);
+        verifyNoInteractions(legacyRelationService, repositoryService);
     }
 
     @Test
@@ -183,15 +182,15 @@ class RelationProjectionReadServiceTest {
     }
 
     @Test
-    void filtersAndIdentityLookupOperateOnOneCompleteSnapshot() {
+    void typeFilterRunsBeforeNameResolutionAndDtoAllocation() {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a", "feature/a", "alice");
         RelationDecisionProjection supports = projection(
                 1L, "BP", RelationType.SUPPORTS, "CP", null,
                 "1".repeat(40));
         RelationDecisionProjection realizes = projection(
-                2L, "CP", RelationType.REALIZES, "CR", null,
-                "1".repeat(40));
+                2L, "UNUSED-SOURCE", RelationType.REALIZES,
+                "UNUSED-TARGET", null, "1".repeat(40));
         when(readinessService.inspect(context)).thenReturn(new Readiness(
                 ReadinessState.READY,
                 "1".repeat(40),
@@ -200,19 +199,44 @@ class RelationProjectionReadServiceTest {
         when(nodeRepository.findByCodeIn(any(Collection.class)))
                 .thenReturn(List.of());
 
-        assertThat(service.readByType(context, RelationType.SUPPORTS)
-                .relations()).extracting(TaxonomyRelationDto::getId)
+        var result = service.readByType(context, RelationType.SUPPORTS);
+
+        assertThat(result.relations())
+                .extracting(TaxonomyRelationDto::getId)
                 .containsExactly(1L);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> codes = ArgumentCaptor.forClass(
+                Collection.class);
+        verify(nodeRepository).findByCodeIn(codes.capture());
+        assertThat(codes.getValue())
+                .containsExactlyInAnyOrder("BP", "CP")
+                .doesNotContain("UNUSED-SOURCE", "UNUSED-TARGET");
+    }
+
+    @Test
+    void nodeFilterReturnsIncomingAndOutgoingRowsFromOneSnapshot() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RelationDecisionProjection supports = projection(
+                1L, "BP", RelationType.SUPPORTS, "CP", null,
+                "1".repeat(40));
+        RelationDecisionProjection realizes = projection(
+                2L, "CP", RelationType.REALIZES, "CR", null,
+                "1".repeat(40));
+        RelationDecisionProjection unrelated = projection(
+                3L, "APP", RelationType.DEPENDS_ON, "TECH", null,
+                "1".repeat(40));
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "1".repeat(40),
+                "1".repeat(40),
+                List.of(supports, realizes, unrelated)));
+        when(nodeRepository.findByCodeIn(any(Collection.class)))
+                .thenReturn(List.of());
+
         assertThat(service.readForNode(context, "CP").relations())
                 .extracting(TaxonomyRelationDto::getId)
                 .containsExactly(1L, 2L);
-        assertThat(service.findIdentityById(context, 2L))
-                .get()
-                .satisfies(identity -> {
-                    assertThat(identity.sourceId()).isEqualTo("CP");
-                    assertThat(identity.relationType()).isEqualTo("REALIZES");
-                    assertThat(identity.targetId()).isEqualTo("CR");
-                });
     }
 
     private static Readiness notBuilt(String digit) {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
@@ -1,0 +1,262 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.catalog.service.TaxonomyRelationService;
+import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationDecisionProjection;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RelationProjectionReadServiceTest {
+
+    private RelationBranchProjectionReadinessService readinessService;
+    private RelationProjectionRecoveryService recoveryService;
+    private TaxonomyRelationService legacyRelationService;
+    private TaxonomyNodeRepository nodeRepository;
+    private SystemRepositoryService repositoryService;
+    private RelationProjectionReadService service;
+
+    @BeforeEach
+    void setUp() {
+        readinessService = mock(RelationBranchProjectionReadinessService.class);
+        recoveryService = mock(RelationProjectionRecoveryService.class);
+        legacyRelationService = mock(TaxonomyRelationService.class);
+        nodeRepository = mock(TaxonomyNodeRepository.class);
+        repositoryService = mock(SystemRepositoryService.class);
+        service = new RelationProjectionReadService(
+                readinessService,
+                recoveryService,
+                legacyRelationService,
+                nodeRepository,
+                repositoryService);
+    }
+
+    @Test
+    void readyProjectionIsTheOnlyNormalProductReadSource() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RelationDecisionProjection projection = projection(
+                17L,
+                "BP-1",
+                RelationType.SUPPORTS,
+                "CP-2",
+                "manual",
+                "a".repeat(40));
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "a".repeat(40),
+                "a".repeat(40),
+                List.of(projection)));
+        when(nodeRepository.findByCodeIn(any(Collection.class)))
+                .thenReturn(List.of(
+                        node("BP-1", "Business Process"),
+                        node("CP-2", "Capability")));
+
+        var result = service.readAll(context);
+
+        assertThat(result.readModel()).isEqualTo(ReadModel.PROJECTION);
+        assertThat(result.readinessState()).isEqualTo(ReadinessState.READY);
+        assertThat(result.authoritativeCommitId()).isEqualTo("a".repeat(40));
+        assertThat(result.relations()).singleElement().satisfies(relation -> {
+            assertThat(relation.getId()).isEqualTo(17L);
+            assertThat(relation.getSourceCode()).isEqualTo("BP-1");
+            assertThat(relation.getSourceName()).isEqualTo("Business Process");
+            assertThat(relation.getTargetCode()).isEqualTo("CP-2");
+            assertThat(relation.getTargetName()).isEqualTo("Capability");
+            assertThat(relation.getRelationType()).isEqualTo("SUPPORTS");
+            assertThat(relation.getProvenance()).isEqualTo("manual");
+        });
+        verifyNoInteractions(legacyRelationService, repositoryService);
+        verify(recoveryService, never()).pendingCount(context);
+    }
+
+    @Test
+    void primaryDefaultBranchMayUseLegacyOnlyBeforeAnyBuildOrFailure() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "primary", "draft", "alice");
+        TaxonomyRelationDto legacy = new TaxonomyRelationDto();
+        legacy.setId(8L);
+        legacy.setSourceCode("BP");
+        legacy.setTargetCode("CP");
+        legacy.setRelationType("SUPPORTS");
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.NOT_BUILT,
+                "b".repeat(40),
+                null,
+                List.of()));
+        when(recoveryService.pendingCount(context)).thenReturn(0L);
+        when(repositoryService.getPrimaryRepository()).thenReturn(
+                primary("primary", "draft"));
+        when(legacyRelationService.getAllRelationsInContext(context))
+                .thenReturn(List.of(legacy));
+
+        var result = service.readAll(context);
+
+        assertThat(result.readModel()).isEqualTo(ReadModel.LEGACY_FALLBACK);
+        assertThat(result.readinessState()).isEqualTo(ReadinessState.NOT_BUILT);
+        assertThat(result.authoritativeCommitId()).isEqualTo("b".repeat(40));
+        assertThat(result.relations()).containsExactly(legacy);
+    }
+
+    @Test
+    void pendingGitProjectionBlocksTheMigrationFallback() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "primary", "draft", "alice");
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.NOT_BUILT,
+                "c".repeat(40),
+                null,
+                List.of()));
+        when(recoveryService.pendingCount(context)).thenReturn(1L);
+        when(repositoryService.getPrimaryRepository()).thenReturn(
+                primary("primary", "draft"));
+
+        assertThatThrownBy(() -> service.readAll(context))
+                .isInstanceOfSatisfying(
+                        RelationProjectionUnavailableException.class,
+                        error -> {
+                            assertThat(error.getReadinessState())
+                                    .isEqualTo(ReadinessState.NOT_BUILT);
+                            assertThat(error.getPendingRecoveryCount())
+                                    .isEqualTo(1L);
+                        });
+        verifyNoInteractions(legacyRelationService);
+    }
+
+    @Test
+    void workspaceAndForkReadsNeverBorrowTheLegacyOverlay() {
+        RepositoryContext workspace = RepositoryContext.workspace(
+                "primary", "workspace-a", "feature/a", "alice");
+        RepositoryContext fork = new RepositoryContext(
+                "fork-a", null, "draft", "alice",
+                com.taxonomy.workspace.service.RepositoryScope.FORK);
+        when(readinessService.inspect(workspace)).thenReturn(notBuilt("d"));
+        when(readinessService.inspect(fork)).thenReturn(notBuilt("e"));
+        when(recoveryService.pendingCount(workspace)).thenReturn(0L);
+        when(recoveryService.pendingCount(fork)).thenReturn(0L);
+
+        assertThatThrownBy(() -> service.readAll(workspace))
+                .isInstanceOf(RelationProjectionUnavailableException.class);
+        assertThatThrownBy(() -> service.readAll(fork))
+                .isInstanceOf(RelationProjectionUnavailableException.class);
+        verifyNoInteractions(legacyRelationService, repositoryService);
+    }
+
+    @Test
+    void staleOrCorruptPrimaryProjectionFailsClosed() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "primary", "draft", "alice");
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.STALE,
+                "f".repeat(40),
+                "0".repeat(40),
+                List.of()));
+        when(recoveryService.pendingCount(context)).thenReturn(0L);
+
+        assertThatThrownBy(() -> service.readAll(context))
+                .isInstanceOfSatisfying(
+                        RelationProjectionUnavailableException.class,
+                        error -> assertThat(error.getReadinessState())
+                                .isEqualTo(ReadinessState.STALE));
+        verifyNoInteractions(legacyRelationService, repositoryService);
+    }
+
+    @Test
+    void filtersAndIdentityLookupOperateOnOneCompleteSnapshot() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RelationDecisionProjection supports = projection(
+                1L, "BP", RelationType.SUPPORTS, "CP", null,
+                "1".repeat(40));
+        RelationDecisionProjection realizes = projection(
+                2L, "CP", RelationType.REALIZES, "CR", null,
+                "1".repeat(40));
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "1".repeat(40),
+                "1".repeat(40),
+                List.of(supports, realizes)));
+        when(nodeRepository.findByCodeIn(any(Collection.class)))
+                .thenReturn(List.of());
+
+        assertThat(service.readByType(context, RelationType.SUPPORTS)
+                .relations()).extracting(TaxonomyRelationDto::getId)
+                .containsExactly(1L);
+        assertThat(service.readForNode(context, "CP").relations())
+                .extracting(TaxonomyRelationDto::getId)
+                .containsExactly(1L, 2L);
+        assertThat(service.findIdentityById(context, 2L))
+                .get()
+                .satisfies(identity -> {
+                    assertThat(identity.sourceId()).isEqualTo("CP");
+                    assertThat(identity.relationType()).isEqualTo("REALIZES");
+                    assertThat(identity.targetId()).isEqualTo("CR");
+                });
+    }
+
+    private static Readiness notBuilt(String digit) {
+        return new Readiness(
+                ReadinessState.NOT_BUILT,
+                digit.repeat(40),
+                null,
+                List.of());
+    }
+
+    private static RelationDecisionProjection projection(
+            Long id,
+            String source,
+            RelationType type,
+            String target,
+            String provenance,
+            String commit) {
+        RelationDecisionProjection projection = new RelationDecisionProjection();
+        projection.setId(id);
+        projection.setRepositoryId("repo-a");
+        projection.setWorkspaceId("workspace-a");
+        projection.setBranch("feature/a");
+        projection.setSourceCode(source);
+        projection.setRelationType(type);
+        projection.setTargetCode(target);
+        projection.setRelationPresent(true);
+        projection.setProvenance(provenance);
+        projection.setAuthoritativeCommitId(commit);
+        projection.setCausationId("rebuild:" + commit);
+        return projection;
+    }
+
+    private static TaxonomyNode node(String code, String name) {
+        TaxonomyNode node = new TaxonomyNode();
+        node.setCode(code);
+        node.setNameEn(name);
+        return node;
+    }
+
+    private static SystemRepository primary(String id, String branch) {
+        SystemRepository repository = new SystemRepository();
+        repository.setRepositoryId(id);
+        repository.setDefaultBranch(branch);
+        repository.setPrimaryRepo(true);
+        return repository;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/GitArchitectureAuthorizationRulesContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/GitArchitectureAuthorizationRulesContractTest.java
@@ -1,0 +1,78 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitArchitectureAuthorizationRulesContractTest {
+
+    private static final Path AUTHORIZATION_RULES = Path.of(
+            "src/main/java/com/taxonomy/security/config/"
+                    + "AuthorizationRulesConfigurer.java");
+
+    @Test
+    void GitDecisionMatchersPrecedeTheFailClosedApiFallback() throws Exception {
+        String source = Files.readString(AUTHORIZATION_RULES);
+
+        int relationMatcher = source.indexOf(
+                "\"/api/architecture/relations/**\"");
+        int proposalMatcher = source.indexOf(
+                "\"/api/architecture/proposals/**\"");
+        int roleGate = source.indexOf(
+                ".hasAnyRole(\"ARCHITECT\", \"ADMIN\")",
+                Math.min(relationMatcher, proposalMatcher));
+        int denyAll = source.indexOf(
+                "auth.requestMatchers(\"/api/**\").denyAll();");
+
+        assertThat(relationMatcher).isGreaterThanOrEqualTo(0);
+        assertThat(proposalMatcher).isGreaterThanOrEqualTo(0);
+        assertThat(roleGate).isGreaterThan(Math.min(
+                relationMatcher, proposalMatcher));
+        assertThat(denyAll).isGreaterThan(roleGate);
+    }
+
+    @Test
+    void GitDecisionPathsHaveEveryStateChangingMethodGate() throws Exception {
+        String source = Files.readString(AUTHORIZATION_RULES);
+        String decisionRules = between(
+                source,
+                "        // Git-authoritative architecture decisions",
+                "        auth.requestMatchers(HttpMethod.POST, \"/api/dsl/parse\"");
+
+        assertThat(decisionRules)
+                .contains("HttpMethod.POST")
+                .contains("HttpMethod.PUT")
+                .contains("HttpMethod.DELETE")
+                .contains("/api/architecture/relations/**")
+                .contains("/api/architecture/proposals/**")
+                .containsOnlyOnce("// Git-authoritative architecture decisions");
+        assertThat(countOccurrences(
+                decisionRules,
+                ".hasAnyRole(\"ARCHITECT\", \"ADMIN\")"))
+                .isEqualTo(3);
+    }
+
+    private static String between(String source, String start, String end) {
+        int startIndex = source.indexOf(start);
+        int endIndex = source.indexOf(end, startIndex + start.length());
+        assertThat(startIndex).isGreaterThanOrEqualTo(0);
+        assertThat(endIndex).isGreaterThan(startIndex);
+        return source.substring(startIndex, endIndex);
+    }
+
+    private static int countOccurrences(String source, String needle) {
+        int count = 0;
+        int fromIndex = 0;
+        while (true) {
+            int index = source.indexOf(needle, fromIndex);
+            if (index < 0) {
+                return count;
+            }
+            count++;
+            fromIndex = index + needle.length();
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -43,20 +43,30 @@ class RelationGitCommandUiContractTest {
     void deleteUsesIdentityFromTheSameVisibleTableRow() throws Exception {
         String adapter = Files.readString(RELATION_ADAPTER);
 
-        int rowLookup = adapter.indexOf("button.closest('tr')");
+        int deleteStart = adapter.indexOf(
+                "    function deleteRelation(button) {");
+        int identityUse = adapter.indexOf(
+                "var relation = relationIdentity(button);", deleteStart);
+        int deleteCommand = adapter.indexOf(
+                "return fetch(commandUrl(", identityUse);
+        int rowFunction = adapter.indexOf(
+                "    function relationIdentity(button) {");
+        int rowLookup = adapter.indexOf(
+                "button.closest('tr')", rowFunction);
         int source = adapter.indexOf(
                 "row.cells[0].textContent.trim()", rowLookup);
         int target = adapter.indexOf(
                 "row.cells[1].textContent.trim()", rowLookup);
         int type = adapter.indexOf(
                 "row.cells[2].textContent.trim()", rowLookup);
-        int command = adapter.indexOf(
-                "return fetch(commandUrl(", type);
 
-        assertThat(rowLookup).isGreaterThanOrEqualTo(0);
+        assertThat(deleteStart).isGreaterThanOrEqualTo(0);
+        assertThat(identityUse).isGreaterThan(deleteStart);
+        assertThat(deleteCommand).isGreaterThan(identityUse);
+        assertThat(rowFunction).isGreaterThan(deleteCommand);
+        assertThat(rowLookup).isGreaterThan(rowFunction);
         assertThat(source).isGreaterThan(rowLookup);
         assertThat(target).isGreaterThan(source);
         assertThat(type).isGreaterThan(target);
-        assertThat(command).isGreaterThan(type);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -39,19 +39,46 @@ class RelationGitCommandUiContractTest {
                 .doesNotContain("fetch('/api/relations', {\n"
                         + "            method: 'POST'")
                 .doesNotContain("'/api/relations/' + id")
-                .doesNotContain("relationsById");
+                .doesNotContain("relationsById")
+                .doesNotContain("function ensureSnapshot");
+    }
+
+    @Test
+    void createAndDeleteRefreshTheAuthoritativeSnapshotImmediately()
+            throws Exception {
+        String adapter = Files.readString(RELATION_ADAPTER);
+
+        int createStart = adapter.indexOf(
+                "    function createRelation() {");
+        int createRefresh = adapter.indexOf(
+                "refreshSnapshot()", createStart);
+        int createCommand = adapter.indexOf(
+                "return fetch(commandUrl(", createRefresh);
+        int deleteStart = adapter.indexOf(
+                "    function deleteRelation(button) {");
+        int identityUse = adapter.indexOf(
+                "var relation = relationIdentity(button);", deleteStart);
+        int deleteRefresh = adapter.indexOf(
+                "refreshSnapshot()", identityUse);
+        int identityProof = adapter.indexOf(
+                "sameIdentity(candidate, relation)", deleteRefresh);
+        int deleteCommand = adapter.indexOf(
+                "return fetch(commandUrl(", identityProof);
+
+        assertThat(createStart).isGreaterThanOrEqualTo(0);
+        assertThat(createRefresh).isGreaterThan(createStart);
+        assertThat(createCommand).isGreaterThan(createRefresh);
+        assertThat(deleteStart).isGreaterThan(createCommand);
+        assertThat(identityUse).isGreaterThan(deleteStart);
+        assertThat(deleteRefresh).isGreaterThan(identityUse);
+        assertThat(identityProof).isGreaterThan(deleteRefresh);
+        assertThat(deleteCommand).isGreaterThan(identityProof);
     }
 
     @Test
     void deleteUsesIdentityFromTheSameVisibleTableRow() throws Exception {
         String adapter = Files.readString(RELATION_ADAPTER);
 
-        int deleteStart = adapter.indexOf(
-                "    function deleteRelation(button) {");
-        int identityUse = adapter.indexOf(
-                "var relation = relationIdentity(button);", deleteStart);
-        int deleteCommand = adapter.indexOf(
-                "return fetch(commandUrl(", identityUse);
         int rowFunction = adapter.indexOf(
                 "    function relationIdentity(button) {");
         int rowLookup = adapter.indexOf(
@@ -62,14 +89,14 @@ class RelationGitCommandUiContractTest {
                 "row.cells[1].textContent.trim()", rowLookup);
         int type = adapter.indexOf(
                 "row.cells[2].textContent.trim()", rowLookup);
+        int sameIdentity = adapter.indexOf(
+                "    function sameIdentity(left, right) {", type);
 
-        assertThat(deleteStart).isGreaterThanOrEqualTo(0);
-        assertThat(identityUse).isGreaterThan(deleteStart);
-        assertThat(deleteCommand).isGreaterThan(identityUse);
-        assertThat(rowFunction).isGreaterThan(deleteCommand);
+        assertThat(rowFunction).isGreaterThanOrEqualTo(0);
         assertThat(rowLookup).isGreaterThan(rowFunction);
         assertThat(source).isGreaterThan(rowLookup);
         assertThat(target).isGreaterThan(source);
         assertThat(type).isGreaterThan(target);
+        assertThat(sameIdentity).isGreaterThan(type);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -21,8 +21,11 @@ class RelationGitCommandUiContractTest {
         String adapter = Files.readString(RELATION_ADAPTER);
         String loader = Files.readString(QUALITY_MODULE);
 
-        assertThat(loader).contains(
-                "/js/relations/taxonomy-relations-git-commands.js");
+        assertThat(loader)
+                .contains("var loader = document.currentScript;")
+                .contains("new URL(")
+                .contains("'taxonomy-relations-git-commands.js', loader.src")
+                .doesNotContain("script.src = '/js/");
         assertThat(adapter)
                 .contains("document.addEventListener('click', "
                         + "captureRelationCommand, true)")

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -79,6 +79,33 @@ class RelationGitCommandUiContractTest {
     }
 
     @Test
+    void acceptedGitCommandPreservesAuthorityAndReportsProjectionRecoverySeparately()
+            throws Exception {
+        String adapter = Files.readString(RELATION_ADAPTER);
+
+        int etagUpdate = adapter.indexOf("headEtag = nextEtag");
+        int accepted = adapter.indexOf("if (response.status === 202)");
+        int pendingOutcome = adapter.indexOf(
+                "projectionPending: true", accepted);
+        int conflict = adapter.indexOf(
+                "if (response.status === 412)", pendingOutcome);
+
+        assertThat(etagUpdate).isGreaterThanOrEqualTo(0);
+        assertThat(accepted).isGreaterThan(etagUpdate);
+        assertThat(pendingOutcome).isGreaterThan(accepted);
+        assertThat(conflict).isGreaterThan(pendingOutcome);
+        assertThat(adapter)
+                .contains("showPendingRecovery(outcome)")
+                .contains("showCommandStatus(")
+                .doesNotContain(
+                        "throw new Error(\n"
+                                + "                'Git accepted the change");
+        assertThat(adapter.split(
+                "showPendingRecovery\\(outcome\\)", -1))
+                .hasSize(4);
+    }
+
+    @Test
     void createAndDeleteRefreshTheAuthoritativeSnapshotImmediately()
             throws Exception {
         String adapter = Files.readString(RELATION_ADAPTER);

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -40,7 +40,9 @@ class RelationGitCommandUiContractTest {
                         + "            method: 'POST'")
                 .doesNotContain("'/api/relations/' + id")
                 .doesNotContain("relationsById")
-                .doesNotContain("function ensureSnapshot");
+                .doesNotContain("function ensureSnapshot")
+                .doesNotContain("addEventListener('toggle'")
+                .doesNotContain("typeFilter.addEventListener");
     }
 
     @Test
@@ -98,5 +100,21 @@ class RelationGitCommandUiContractTest {
         assertThat(target).isGreaterThan(source);
         assertThat(type).isGreaterThan(target);
         assertThat(sameIdentity).isGreaterThan(type);
+    }
+
+    @Test
+    void browserRefreshDelegatesToTheExistingRendererWithoutOwnFetch()
+            throws Exception {
+        String adapter = Files.readString(RELATION_ADAPTER);
+        int refreshStart = adapter.indexOf(
+                "    function refreshBrowser() {");
+        int refreshEnd = adapter.indexOf(
+                "    function projectionError", refreshStart);
+        String refreshBody = adapter.substring(refreshStart, refreshEnd);
+
+        assertThat(refreshBody)
+                .contains("window.TaxonomyRelations.loadRelations()")
+                .doesNotContain("refreshSnapshot()")
+                .doesNotContain("fetch(");
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -35,26 +35,28 @@ class RelationGitCommandUiContractTest {
                 .contains("response.status === 412")
                 .doesNotContain("fetch('/api/relations', {\n"
                         + "            method: 'POST'")
-                .doesNotContain("'/api/relations/' + id");
+                .doesNotContain("'/api/relations/' + id")
+                .doesNotContain("relationsById");
     }
 
     @Test
-    void deleteResolvesTheDisplayedProjectionIdToStableIdentity()
-            throws Exception {
+    void deleteUsesIdentityFromTheSameVisibleTableRow() throws Exception {
         String adapter = Files.readString(RELATION_ADAPTER);
 
-        int lookup = adapter.indexOf(
-                "relationsById.get(String(id))");
+        int rowLookup = adapter.indexOf("button.closest('tr')");
         int source = adapter.indexOf(
-                "relation.sourceCode", lookup);
-        int type = adapter.indexOf(
-                "relation.relationType", lookup);
+                "row.cells[0].textContent.trim()", rowLookup);
         int target = adapter.indexOf(
-                "relation.targetCode", lookup);
+                "row.cells[1].textContent.trim()", rowLookup);
+        int type = adapter.indexOf(
+                "row.cells[2].textContent.trim()", rowLookup);
+        int command = adapter.indexOf(
+                "return fetch(commandUrl(", type);
 
-        assertThat(lookup).isGreaterThanOrEqualTo(0);
-        assertThat(source).isGreaterThan(lookup);
-        assertThat(type).isGreaterThan(source);
-        assertThat(target).isGreaterThan(type);
+        assertThat(rowLookup).isGreaterThanOrEqualTo(0);
+        assertThat(source).isGreaterThan(rowLookup);
+        assertThat(target).isGreaterThan(source);
+        assertThat(type).isGreaterThan(target);
+        assertThat(command).isGreaterThan(type);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -1,0 +1,60 @@
+package com.taxonomy.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelationGitCommandUiContractTest {
+
+    private static final Path RELATION_ADAPTER = Path.of(
+            "src/main/resources/static/js/relations/"
+                    + "taxonomy-relations-git-commands.js");
+    private static final Path QUALITY_MODULE = Path.of(
+            "src/main/resources/static/js/relations/taxonomy-quality.js");
+
+    @Test
+    void loadedAdapterCapturesLegacyButtonsAndUsesIdentityCommands()
+            throws Exception {
+        String adapter = Files.readString(RELATION_ADAPTER);
+        String loader = Files.readString(QUALITY_MODULE);
+
+        assertThat(loader).contains(
+                "/js/relations/taxonomy-relations-git-commands.js");
+        assertThat(adapter)
+                .contains("document.addEventListener('click', "
+                        + "captureRelationCommand, true)")
+                .contains("event.stopImmediatePropagation()")
+                .contains("/api/architecture/relations/")
+                .contains("'If-Match'")
+                .contains("'If-None-Match'")
+                .contains("'Idempotency-Key'")
+                .contains("response.status === 202")
+                .contains("response.status === 412")
+                .doesNotContain("fetch('/api/relations', {\n"
+                        + "            method: 'POST'")
+                .doesNotContain("'/api/relations/' + id");
+    }
+
+    @Test
+    void deleteResolvesTheDisplayedProjectionIdToStableIdentity()
+            throws Exception {
+        String adapter = Files.readString(RELATION_ADAPTER);
+
+        int lookup = adapter.indexOf(
+                "relationsById.get(String(id))");
+        int source = adapter.indexOf(
+                "relation.sourceCode", lookup);
+        int type = adapter.indexOf(
+                "relation.relationType", lookup);
+        int target = adapter.indexOf(
+                "relation.targetCode", lookup);
+
+        assertThat(lookup).isGreaterThanOrEqualTo(0);
+        assertThat(source).isGreaterThan(lookup);
+        assertThat(type).isGreaterThan(source);
+        assertThat(target).isGreaterThan(type);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -14,6 +14,8 @@ class RelationGitCommandUiContractTest {
     private static final Path RELATION_ADAPTER = Path.of(
             "src/main/resources/static/js/relations/"
                     + "taxonomy-relations-git-commands.js");
+    private static final Path RELATION_BROWSER = Path.of(
+            "src/main/resources/static/js/relations/taxonomy-relations.js");
     private static final Path QUALITY_MODULE = Path.of(
             "src/main/resources/static/js/relations/taxonomy-quality.js");
 
@@ -26,8 +28,8 @@ class RelationGitCommandUiContractTest {
 
         assertThat(loader)
                 .contains("var loader = document.currentScript;")
+                .contains("window.TaxonomyRelationsApiReady")
                 .contains("new URL('../api/relations-api.js', loader.src)")
-                .contains("apiScript.addEventListener('load', loadCommandAdapter")
                 .contains("'taxonomy-relations-git-commands.js', loader.src")
                 .doesNotContain("script.src = '/js/");
         assertThat(api)
@@ -54,6 +56,26 @@ class RelationGitCommandUiContractTest {
                 .doesNotContain("function ensureSnapshot")
                 .doesNotContain("addEventListener('toggle'")
                 .doesNotContain("typeFilter.addEventListener");
+    }
+
+    @Test
+    void relationBrowserFailsClosedInsteadOfRenderingUnavailableProjectionAsEmpty()
+            throws Exception {
+        String browser = Files.readString(RELATION_BROWSER);
+
+        assertThat(browser)
+                .contains("relationApiReady()")
+                .contains("api.readSnapshot(type)")
+                .contains("if (!response.ok)")
+                .contains("throw projectionReadError(response)")
+                .contains("X-Taxonomy-Relation-Projection-State")
+                .contains("X-Taxonomy-Relation-Pending-Recovery")
+                .contains("renderRelationsLoadError(content, error)")
+                .contains("retry.addEventListener('click', loadRelations)")
+                .contains("content.setAttribute('aria-busy', 'false')")
+                .doesNotContain("r.ok ? r.json() : []")
+                .doesNotContain(
+                        "var url = type ? '/api/relations?type='");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/RelationGitCommandUiContractTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class RelationGitCommandUiContractTest {
 
+    private static final Path RELATION_API = Path.of(
+            "src/main/resources/static/js/api/relations-api.js");
     private static final Path RELATION_ADAPTER = Path.of(
             "src/main/resources/static/js/relations/"
                     + "taxonomy-relations-git-commands.js");
@@ -18,26 +20,35 @@ class RelationGitCommandUiContractTest {
     @Test
     void loadedAdapterCapturesLegacyButtonsAndUsesIdentityCommands()
             throws Exception {
+        String api = Files.readString(RELATION_API);
         String adapter = Files.readString(RELATION_ADAPTER);
         String loader = Files.readString(QUALITY_MODULE);
 
         assertThat(loader)
                 .contains("var loader = document.currentScript;")
-                .contains("new URL(")
+                .contains("new URL('../api/relations-api.js', loader.src)")
+                .contains("apiScript.addEventListener('load', loadCommandAdapter")
                 .contains("'taxonomy-relations-git-commands.js', loader.src")
                 .doesNotContain("script.src = '/js/");
+        assertThat(api)
+                .contains("window.TaxonomyRelationsApi")
+                .contains("/api/architecture/relations/")
+                .contains("function readSnapshot(relationType)")
+                .contains("function upsertRelation(")
+                .contains("function deleteRelation(");
         assertThat(adapter)
                 .contains("document.addEventListener('click', "
                         + "captureRelationCommand, true)")
                 .contains("event.stopImmediatePropagation()")
-                .contains("/api/architecture/relations/")
+                .contains("RelationsApi().readSnapshot(type)")
+                .contains("RelationsApi().upsertRelation(")
+                .contains("RelationsApi().deleteRelation(")
                 .contains("'If-Match'")
                 .contains("'If-None-Match'")
                 .contains("'Idempotency-Key'")
                 .contains("response.status === 202")
                 .contains("response.status === 412")
-                .doesNotContain("fetch('/api/relations', {\n"
-                        + "            method: 'POST'")
+                .doesNotContain("fetch(")
                 .doesNotContain("'/api/relations/' + id")
                 .doesNotContain("relationsById")
                 .doesNotContain("function ensureSnapshot")
@@ -55,7 +66,7 @@ class RelationGitCommandUiContractTest {
         int createRefresh = adapter.indexOf(
                 "refreshSnapshot()", createStart);
         int createCommand = adapter.indexOf(
-                "return fetch(commandUrl(", createRefresh);
+                "return RelationsApi().upsertRelation(", createRefresh);
         int deleteStart = adapter.indexOf(
                 "    function deleteRelation(button) {");
         int identityUse = adapter.indexOf(
@@ -65,7 +76,7 @@ class RelationGitCommandUiContractTest {
         int identityProof = adapter.indexOf(
                 "sameIdentity(candidate, relation)", deleteRefresh);
         int deleteCommand = adapter.indexOf(
-                "return fetch(commandUrl(", identityProof);
+                "return RelationsApi().deleteRelation(", identityProof);
 
         assertThat(createStart).isGreaterThanOrEqualTo(0);
         assertThat(createRefresh).isGreaterThan(createStart);
@@ -75,6 +86,19 @@ class RelationGitCommandUiContractTest {
         assertThat(deleteRefresh).isGreaterThan(identityUse);
         assertThat(identityProof).isGreaterThan(deleteRefresh);
         assertThat(deleteCommand).isGreaterThan(identityProof);
+    }
+
+    @Test
+    void transportLivesInTheNamedApiLayer() throws Exception {
+        String api = Files.readString(RELATION_API);
+        String adapter = Files.readString(RELATION_ADAPTER);
+
+        assertThat(api)
+                .contains("return fetch(url, { cache: 'no-store' })")
+                .contains("return fetch(commandUrl(")
+                .contains("method: 'PUT'")
+                .contains("method: 'DELETE'");
+        assertThat(adapter).doesNotContain("fetch(");
     }
 
     @Test


### PR DESCRIPTION
## Scope

Next bounded #698 slice on the current integrated multi-repository head `035771053d779178b6e631cb9e4950b65c9aad72`. It switches productive relation reads and browser mutations to the Git-authoritative, complete-branch projection path without deleting the legacy migration model yet.

## Product reads

- add one repository/workspace/branch-sensitive `RelationProjectionReadService`;
- serve relation list, type filter, node relations and count from the same proven read boundary;
- return the authoritative branch ETag plus explicit read-model and readiness headers;
- fail closed for stale, corrupt and missing workspace/fork projections instead of exposing an unrelated central overlay;
- retain one observable migration-only fallback for the historic primary repository default branch only while no projection has ever been built and no failed Git projection is pending;
- filter projection rows before DTO/name materialization and bulk-resolve only the required node names;
- count directly from the proven projection metadata without materializing DTOs.

## Complete mutation boundary

A successful Git relation command now completes this exact sequence before returning success:

1. create or verify the authoritative Git commit;
2. project the exact command state;
3. rebuild the complete selected branch projection;
4. prove rebuilt commit, live head, projected commit and relation count;
5. reconcile durable recovery only after that proof.

A competing head, incomplete/corrupt read model or reconciliation failure remains HTTP 202 recovery state with the immutable Git authority preserved.

## HTTP, authorization and UI migration

- keep `GET /api/relations`, `GET /api/node/{code}/relations` and `GET /api/relations/count` as stable read URLs;
- retire DB-first `POST /api/relations` and `DELETE /api/relations/{id}` with explicit HTTP 410;
- authorize the Git-authoritative `/api/architecture/relations/**` and `/api/architecture/proposals/**` write paths for global ARCHITECT/ADMIN roles before the fail-closed API fallback; repository/workspace authority remains an additional controller check;
- load a capture-phase browser adapter that intercepts the existing Create/Delete controls;
- resolve both the named relation API client and adapter relative to the loader URL so `/taxonomy/` and other reverse-proxy prefixes remain valid;
- expose one shared API-readiness promise so the relation browser cannot race a slower dynamically loaded client;
- keep raw relation transport in `static/js/api/relations-api.js`; the command adapter itself contains no direct `fetch()` calls;
- use the same API response for productive relation rendering and propagate non-2xx projection states instead of converting them to an empty list;
- render `STALE`, `CORRUPT`, `BRANCH_MISSING` and pending-recovery states as an accessible warning with an explicit retry action;
- use the Git-authoritative identity endpoints under `/api/architecture/relations/{source}/{type}/{target}`;
- require `If-Match` or branch-creation `If-None-Match: *` plus `Idempotency-Key`;
- refresh one authoritative snapshot immediately before each mutation;
- prove before deletion that the visible source/type/target identity still exists in that fresh snapshot;
- never use rebuild-local projection IDs as mutation identity;
- treat HTTP 202 as a successful Git decision with preserved ETag and a separate projection-recovery warning, not as a failed create/delete operation;
- treat a repeated identical PUT as the intended idempotent `UNCHANGED` result: HTTP 200, no second Git commit, unchanged authoritative ETag and still exactly one projected relation;
- surface HTTP 412 branch conflicts without silently retrying DB writes.

## Fork correctness

- preserve `FORK` context in relation and proposal command controllers;
- align proposal bookkeeping with the domain rule that a fork is repository-isolated and may have no workspace ID;
- keep central maintenance authorization unchanged.

## Developer contract

`docs/dev/tasks/add-relation-type.md` now describes the actual architecture: there is no `/api/relations/types` registry endpoint, UI choices remain core template data, reads use complete projections, and writes use the identity-based Git command API with strong preconditions and idempotency.

## Verification

Focused tests cover:

- projected DTO/name mapping and pre-materialization filters;
- direct count without DTO/name loading;
- narrow primary migration fallback and fail-closed workspace/fork/stale cases;
- identical list/node/count authority and HTTP headers;
- omission of the pending-recovery header when the count is zero;
- explicit retirement of DB-first routes;
- Git -> incremental projection -> full rebuild -> readiness -> recovery ordering;
- competing-head and corrupt-projection recovery behavior;
- fork command routing and proposal state-store invariants;
- static UI wiring, reverse-proxy-safe loading, API-layer ownership, ETag/idempotency preconditions, fresh-snapshot mutation proof and visible identity deletion;
- a UI contract preventing unavailable projections from being rendered as an empty relation list;
- a UI contract proving HTTP 202 advances the authoritative ETag and reports recovery separately for create and delete;
- the real primary ARCHITECT browser workflow proving `ADDED` creates one commit and an identical retry is `UNCHANGED`, creates no commit, preserves the ETag and does not duplicate the relation;
- production-volume persistence through a real Git-authoritative relation command and container replacement;
- real Keycloak bearer/session role and CSRF behavior on a Git-authoritative review path;
- matcher-order protection so Git decision paths cannot fall behind `/api/**.denyAll()`.

The exact-head matrix at `50e218ba9077adb2030a42422e37550e75dc4b8d` exposed two independent blockers:

1. the new UI adapter owned three direct `fetch()` calls outside `static/js/api`, violating the main-branch frontend boundary policy;
2. SQL Server reused a persisted workspace for Spring Security's default test user `user`, so three primary-repository fallback assertions correctly failed closed with HTTP 409.

Both causes were fixed at `0b05dead7fe302a453040b161e2516833096d1aa`; its PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security gates were green. Subsequent product review fixed two UI correctness defects: unavailable projections were previously shown as an empty list, and HTTP 202 was previously routed through a generic failure handler despite the successful Git commit.

At `b7b4ba7dadebe595e2a8bf55290955ec61f612e7`, Database Compatibility, JGit consumer, CodeQL and Security were green. Canonical CI/CD reached the primary ARCHITECT browser workflow and exposed one stale acceptance assumption: it waited for the retired DB-first duplicate-error panel after an identical PUT, although the Git command contract correctly returned the semantic no-op `UNCHANGED` without a second commit. Commit `1394b30e925065d4c0f4bd2ab103f09d362127c7` replaces that obsolete expectation with direct response, ETag, commit-created and projected-count evidence.

While that matrix ran, the integration target advanced by 103 commits through a merge from current `main`. Signed merge commit `aa700303a6328ddb193fdd7fc2cdd3c847095f7d` now combines the exact slice with integration head `035771053d779178b6e631cb9e4950b65c9aad72`. The resulting tree is 48 commits ahead, zero behind and retains the exact 25-file slice delta. Only checks on `aa700303a6328ddb193fdd7fc2cdd3c847095f7d` are current; all older results are historical.

All inline review findings are resolved.

## Stack integrity

Base: `035771053d779178b6e631cb9e4950b65c9aad72`.

Head: `aa700303a6328ddb193fdd7fc2cdd3c847095f7d`.

The branch is 48 commits ahead, zero behind and changes exactly 25 files. Merge only into `copilot/architecture-epic-multi-repo` after fresh exact-head CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security Scan checks pass and no unresolved review thread remains.

Advances #698, #610 and #691.