### PR TITLE
Scope proposal duplicate validation to one branch projection snapshot

### DIFF
--- a/.github/scripts/ui-primary-proposal-workflows.mjs
+++ b/.github/scripts/ui-primary-proposal-workflows.mjs
@@ -1,21 +1,120 @@
 import { csrfJson, navigateArchitectureSubtab } from './ui-role-fixtures.mjs';
 
+const PROJECTION_ENDPOINT = '/api/architecture/relations/projection';
+
+function responseSummary(response) {
+  return `${response.status} ${response.text || JSON.stringify(response.json) || ''}`.trim();
+}
+
+async function waitForTaxonomyReady(page, assert) {
+  let response = null;
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    response = await csrfJson(page, '/api/taxonomy', { method: 'GET' });
+    if (response.status === 200) return;
+    await page.waitForTimeout(250);
+  }
+  assert(false, `Taxonomy did not become ready: ${responseSummary(response)}`);
+}
+
+async function csrfJsonWithHeaders(page, endpoint, {
+  method = 'POST',
+  headers: additionalHeaders = {},
+  body = undefined
+} = {}) {
+  return page.evaluate(async ({ endpoint, method, additionalHeaders, body }) => {
+    const token = document.querySelector('meta[name="_csrf"]')?.content;
+    const header = document.querySelector('meta[name="_csrf_header"]')?.content
+      || 'X-CSRF-TOKEN';
+    const headers = { 'Content-Type': 'application/json', ...additionalHeaders };
+    if (token) headers[header] = token;
+    const response = await fetch(endpoint, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body)
+    });
+    const text = await response.text();
+    let json = null;
+    try { json = text ? JSON.parse(text) : null; } catch { /* retain text evidence */ }
+    return { status: response.status, text, json };
+  }, { endpoint, method, additionalHeaders, body });
+}
+
+async function waitForReadyProjection(page, assert) {
+  let readiness = null;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    readiness = await csrfJson(page, `${PROJECTION_ENDPOINT}/readiness`, {
+      method: 'GET'
+    });
+    if (readiness.status === 200 && readiness.json?.readinessState === 'READY') {
+      return readiness;
+    }
+    await page.waitForTimeout(250);
+  }
+  assert(false, `Relation projection did not become ready: ${responseSummary(readiness)}`);
+  return readiness;
+}
+
+async function ensureWorkspaceProjection(page, assert) {
+  await waitForTaxonomyReady(page, assert);
+
+  const provision = await csrfJson(page, '/api/workspace/provision');
+  assert(
+    provision.status === 200 && provision.json?.status === 'READY',
+    `Workspace provisioning failed: ${responseSummary(provision)}`);
+
+  const readiness = await csrfJson(page, `${PROJECTION_ENDPOINT}/readiness`, {
+    method: 'GET'
+  });
+  assert(readiness.status === 200,
+    `Unable to inspect relation projection: ${responseSummary(readiness)}`);
+
+  if (readiness.json?.readinessState !== 'READY') {
+    const currentHead = readiness.json?.currentHeadCommit;
+    assert(currentHead,
+      `Provisioned workspace has no authoritative branch head: ${responseSummary(readiness)}`);
+    const rebuild = await csrfJsonWithHeaders(
+      page,
+      `${PROJECTION_ENDPOINT}/rebuild`,
+      { headers: { 'If-Match': `"${currentHead}"` } });
+    assert(rebuild.status === 200,
+      `Relation projection rebuild failed: ${responseSummary(rebuild)}`);
+  }
+
+  await waitForReadyProjection(page, assert);
+
+  // Reload so a provisioning modal opened during login observes READY and cannot
+  // obscure the controls exercised by the remainder of the workflow.
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.locator('#mainContent').waitFor({ state: 'visible', timeout: 60_000 });
+  await page.evaluate(() => window.TaxonomyI18n?.ready?.());
+  await page.waitForFunction(
+    () => Boolean(window.TaxonomyRoleSurface?.ready),
+    null,
+    { timeout: 20_000 });
+  await page.evaluate(() => window.TaxonomyRoleSurface.ready);
+}
+
 async function createPendingProposals(page, assert) {
+  await ensureWorkspaceProjection(page, assert);
+
   const candidates = [
     ['CP', 'BR', 'SUPPORTS'], ['BP', 'UA', 'DEPENDS_ON'],
     ['CI', 'CO', 'COMMUNICATES_WITH'], ['CR', 'IP', 'PRODUCES'],
     ['UA', 'CO', 'USES'], ['BP', 'CI', 'REALIZES']
   ];
   const ids = [];
+  const attempts = [];
   for (const [sourceCode, targetCode, relationType] of candidates) {
     const response = await csrfJson(page, '/api/proposals/from-hypothesis', {
       body: { sourceCode, targetCode, relationType, confidence: 0.73,
         rationale: `Primary workflow ${sourceCode}-${targetCode}-${relationType}` }
     });
+    attempts.push(`${sourceCode}-${targetCode}-${relationType}: ${response.status}`);
     if (response.status === 200 && response.json?.id) ids.push(response.json.id);
     if (ids.length >= 4) break;
   }
-  assert(ids.length >= 4, `Unable to create four independent proposals; created ${ids.length}`);
+  assert(ids.length >= 4,
+    `Unable to create four independent proposals; created ${ids.length}; ${attempts.join(', ')}`);
   return ids;
 }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
@@ -3,6 +3,8 @@ package com.taxonomy.relations.controller;
 import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.relations.service.RelationProposalService;
 import com.taxonomy.relations.service.RelationReviewService;
 import com.taxonomy.workspace.model.SystemRepository;
@@ -13,6 +15,7 @@ import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -40,11 +43,12 @@ public class ProposalApiController {
     private final SystemRepositoryService repositoryService;
     private final RepositoryMembershipService membershipService;
 
-    public ProposalApiController(RelationProposalService proposalService,
-                                 RelationReviewService reviewService,
-                                 WorkspaceResolver workspaceResolver,
-                                 SystemRepositoryService repositoryService,
-                                 RepositoryMembershipService membershipService) {
+    public ProposalApiController(
+            RelationProposalService proposalService,
+            RelationReviewService reviewService,
+            WorkspaceResolver workspaceResolver,
+            SystemRepositoryService repositoryService,
+            RepositoryMembershipService membershipService) {
         this.proposalService = proposalService;
         this.reviewService = reviewService;
         this.workspaceResolver = workspaceResolver;
@@ -80,6 +84,8 @@ public class ProposalApiController {
         try {
             return ResponseEntity.ok(proposalService.proposeRelationsInContext(
                     sourceCode, relationType, limit, context));
+        } catch (RelationProjectionUnavailableException error) {
+            return projectionUnavailable(error).build();
         } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -88,36 +94,43 @@ public class ProposalApiController {
     @Operation(summary = "List all proposals")
     @GetMapping("/proposals")
     public ResponseEntity<List<RelationProposalDto>> getAllProposals() {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
-        return ResponseEntity.ok(proposalService.getAllProposalsInContext(context));
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        return ResponseEntity.ok(
+                proposalService.getAllProposalsInContext(context));
     }
 
     @Operation(summary = "List pending proposals")
     @GetMapping("/proposals/pending")
     public ResponseEntity<List<RelationProposalDto>> getPendingProposals() {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
-        return ResponseEntity.ok(proposalService.getPendingProposalsInContext(context));
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        return ResponseEntity.ok(
+                proposalService.getPendingProposalsInContext(context));
     }
 
     @Operation(summary = "List node proposals")
     @GetMapping("/node/{code}/proposals")
     public ResponseEntity<List<RelationProposalDto>> getProposalsForNode(
             @PathVariable String code) {
-        RepositoryContext context = workspaceResolver.resolveCurrentRepositoryContext();
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
         return ResponseEntity.ok(
                 proposalService.getProposalsForNodeInContext(code, context));
     }
 
     @Operation(summary = "Accept proposal")
     @PostMapping("/proposals/{id}/accept")
-    public ResponseEntity<TaxonomyRelationDto> acceptProposal(@PathVariable Long id) {
+    public ResponseEntity<TaxonomyRelationDto> acceptProposal(
+            @PathVariable Long id) {
         RepositoryContext context = writableContext(
                 workspaceResolver.resolveCurrentRepositoryContext());
         if (context == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         try {
-            return ResponseEntity.ok(reviewService.acceptProposal(id, context));
+            return ResponseEntity.ok(
+                    reviewService.acceptProposal(id, context));
         } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -125,14 +138,16 @@ public class ProposalApiController {
 
     @Operation(summary = "Reject proposal")
     @PostMapping("/proposals/{id}/reject")
-    public ResponseEntity<RelationProposalDto> rejectProposal(@PathVariable Long id) {
+    public ResponseEntity<RelationProposalDto> rejectProposal(
+            @PathVariable Long id) {
         RepositoryContext context = writableContext(
                 workspaceResolver.resolveCurrentRepositoryContext());
         if (context == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         try {
-            return ResponseEntity.ok(reviewService.rejectProposal(id, context));
+            return ResponseEntity.ok(
+                    reviewService.rejectProposal(id, context));
         } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -142,11 +157,16 @@ public class ProposalApiController {
     @PostMapping("/proposals/from-hypothesis")
     public ResponseEntity<RelationProposalDto> createFromHypothesis(
             @RequestBody Map<String, Object> body) {
-        String sourceCode = body.get("sourceCode") instanceof String value ? value : null;
-        String targetCode = body.get("targetCode") instanceof String value ? value : null;
-        String relationTypeText = body.get("relationType") instanceof String value ? value : null;
-        Number confidenceNumber = body.get("confidence") instanceof Number value ? value : null;
-        String rationale = body.get("rationale") instanceof String value ? value : null;
+        String sourceCode = body.get("sourceCode") instanceof String value
+                ? value : null;
+        String targetCode = body.get("targetCode") instanceof String value
+                ? value : null;
+        String relationTypeText = body.get("relationType") instanceof String value
+                ? value : null;
+        Number confidenceNumber = body.get("confidence") instanceof Number value
+                ? value : null;
+        String rationale = body.get("rationale") instanceof String value
+                ? value : null;
         if (sourceCode == null || sourceCode.isBlank()
                 || targetCode == null || targetCode.isBlank()
                 || relationTypeText == null || relationTypeText.isBlank()) {
@@ -155,7 +175,8 @@ public class ProposalApiController {
 
         RelationType relationType;
         try {
-            relationType = RelationType.valueOf(relationTypeText.toUpperCase());
+            relationType = RelationType.valueOf(
+                    relationTypeText.toUpperCase());
         } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -166,18 +187,22 @@ public class ProposalApiController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        double confidence = confidenceNumber != null ? confidenceNumber.doubleValue() : 0.5;
+        double confidence = confidenceNumber != null
+                ? confidenceNumber.doubleValue() : 0.5;
         try {
-            RelationProposalDto proposal = proposalService.createFromHypothesisInContext(
-                    sourceCode,
-                    targetCode,
-                    relationType,
-                    confidence,
-                    rationale,
-                    context);
+            RelationProposalDto proposal =
+                    proposalService.createFromHypothesisInContext(
+                            sourceCode,
+                            targetCode,
+                            relationType,
+                            confidence,
+                            rationale,
+                            context);
             return proposal != null
                     ? ResponseEntity.ok(proposal)
                     : ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (RelationProjectionUnavailableException error) {
+            return projectionUnavailable(error).build();
         } catch (IllegalArgumentException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -185,14 +210,16 @@ public class ProposalApiController {
 
     @Operation(summary = "Revert proposal")
     @PostMapping("/proposals/{id}/revert")
-    public ResponseEntity<RelationProposalDto> revertProposal(@PathVariable Long id) {
+    public ResponseEntity<RelationProposalDto> revertProposal(
+            @PathVariable Long id) {
         RepositoryContext context = writableContext(
                 workspaceResolver.resolveCurrentRepositoryContext());
         if (context == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         try {
-            return ResponseEntity.ok(reviewService.revertProposal(id, context));
+            return ResponseEntity.ok(
+                    reviewService.revertProposal(id, context));
         } catch (IllegalArgumentException | IllegalStateException error) {
             return ResponseEntity.badRequest().build();
         }
@@ -205,8 +232,10 @@ public class ProposalApiController {
         @SuppressWarnings("unchecked")
         List<Number> ids = body.get("ids") instanceof List<?> list
                 ? (List<Number>) list : null;
-        String action = body.get("action") instanceof String value ? value : null;
-        if (ids == null || ids.isEmpty() || action == null || action.isBlank()) {
+        String action = body.get("action") instanceof String value
+                ? value : null;
+        if (ids == null || ids.isEmpty()
+                || action == null || action.isBlank()) {
             return ResponseEntity.badRequest().build();
         }
 
@@ -225,9 +254,11 @@ public class ProposalApiController {
             }
             try {
                 if ("ACCEPT".equalsIgnoreCase(action)) {
-                    reviewService.acceptProposal(idNumber.longValue(), context);
+                    reviewService.acceptProposal(
+                            idNumber.longValue(), context);
                 } else if ("REJECT".equalsIgnoreCase(action)) {
-                    reviewService.rejectProposal(idNumber.longValue(), context);
+                    reviewService.rejectProposal(
+                            idNumber.longValue(), context);
                 } else {
                     return ResponseEntity.badRequest().build();
                 }
@@ -250,9 +281,11 @@ public class ProposalApiController {
         if (context.workspaceId() != null) {
             return context;
         }
-        SystemRepository repository = repositoryService.getRepository(context.repositoryId());
+        SystemRepository repository = repositoryService.getRepository(
+                context.repositoryId());
         if (!isApplicationAdmin()
-                && !membershipService.canMaintain(repository, context.username())) {
+                && !membershipService.canMaintain(
+                        repository, context.username())) {
             return null;
         }
         return new RepositoryContext(
@@ -263,11 +296,38 @@ public class ProposalApiController {
                 RepositoryScope.CENTRAL_WRITE);
     }
 
+    private static ResponseEntity.BodyBuilder projectionUnavailable(
+            RelationProjectionUnavailableException error) {
+        HttpStatus status = error.getReadinessState()
+                == ReadinessState.BRANCH_MISSING
+                ? HttpStatus.NOT_FOUND
+                : HttpStatus.CONFLICT;
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(status)
+                .header(
+                        RelationApiController.PROJECTION_STATE_HEADER,
+                        error.getReadinessState().name())
+                .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        if (error.getPendingRecoveryCount() > 0) {
+            response.header(
+                    RelationApiController.PENDING_RECOVERY_HEADER,
+                    String.valueOf(error.getPendingRecoveryCount()));
+        }
+        if (error.getCurrentHeadCommit() != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(
+                            error.getCurrentHeadCommit()));
+        }
+        return response;
+    }
+
     private static boolean isApplicationAdmin() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
         return authentication != null
                 && authentication.getAuthorities().stream()
-                        .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
+                        .anyMatch(authority -> "ROLE_ADMIN".equals(
+                                authority.getAuthority()));
     }
 
     private static int parseLimit(String value) {

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProjectionReadService.java
@@ -104,45 +104,75 @@ public class RelationProjectionReadService {
     /** Count from the same proven source without allocating relation DTOs. */
     public CountResult count(RepositoryContext context) {
         RepositoryContext selected = Objects.requireNonNull(context, "context");
-        Readiness readiness = readinessService.inspect(selected);
-        if (readiness.state() == ReadinessState.READY) {
-            return new CountResult(
-                    ReadModel.PROJECTION,
-                    readiness.state(),
-                    readiness.currentHeadCommit(),
-                    readiness.rows().size());
-        }
+        ResolvedSource source = resolveSource(selected);
+        long count = source.readModel() == ReadModel.PROJECTION
+                ? source.readiness().rows().size()
+                : legacyRelationService.countRelationsInContext(selected);
+        return new CountResult(
+                source.readModel(),
+                source.readiness().state(),
+                source.readiness().currentHeadCommit(),
+                count);
+    }
 
-        long pendingRecoveries = recoveryService.pendingCount(selected);
-        if (readiness.state() == ReadinessState.NOT_BUILT
-                && pendingRecoveries == 0
-                && mayUseLegacyFallback(selected)) {
-            reportFallback(selected);
-            return new CountResult(
-                    ReadModel.LEGACY_FALLBACK,
-                    readiness.state(),
-                    readiness.currentHeadCommit(),
-                    legacyRelationService.countRelationsInContext(selected));
+    /**
+     * Resolve one immutable relation-identity snapshot for proposal duplicate
+     * validation without loading node names or allocating relation DTOs for a
+     * ready projection.
+     */
+    public IdentitySnapshot readIdentitySnapshot(RepositoryContext context) {
+        RepositoryContext selected = Objects.requireNonNull(context, "context");
+        ResolvedSource source = resolveSource(selected);
+        Set<RelationIdentity> identities = new LinkedHashSet<>();
+        if (source.readModel() == ReadModel.PROJECTION) {
+            source.readiness().rows().forEach(row -> identities.add(
+                    new RelationIdentity(
+                            row.getSourceCode(),
+                            row.getRelationType(),
+                            row.getTargetCode())));
+        } else {
+            legacyRelationService.getAllRelationsInContext(selected)
+                    .forEach(relation -> identities.add(new RelationIdentity(
+                            relation.getSourceCode(),
+                            RelationType.valueOf(relation.getRelationType()),
+                            relation.getTargetCode())));
         }
-
-        throw unavailable(selected, readiness, pendingRecoveries);
+        return new IdentitySnapshot(
+                source.readModel(),
+                source.readiness().state(),
+                source.readiness().currentHeadCommit(),
+                identities);
     }
 
     private ReadResult read(
             RepositoryContext selected,
             Predicate<RelationDecisionProjection> projectionFilter,
             Supplier<List<TaxonomyRelationDto>> legacyRead) {
-        Readiness readiness = readinessService.inspect(selected);
-        if (readiness.state() == ReadinessState.READY) {
-            List<RelationDecisionProjection> selectedRows = readiness.rows()
+        ResolvedSource source = resolveSource(selected);
+        if (source.readModel() == ReadModel.PROJECTION) {
+            List<RelationDecisionProjection> selectedRows = source.readiness()
+                    .rows()
                     .stream()
                     .filter(projectionFilter)
                     .toList();
             return new ReadResult(
-                    ReadModel.PROJECTION,
-                    readiness.state(),
-                    readiness.currentHeadCommit(),
+                    source.readModel(),
+                    source.readiness().state(),
+                    source.readiness().currentHeadCommit(),
                     projectionDtos(selectedRows));
+        }
+        return new ReadResult(
+                source.readModel(),
+                source.readiness().state(),
+                source.readiness().currentHeadCommit(),
+                legacyRead.get());
+    }
+
+    /** One authority/fallback decision shared by list, count and identity reads. */
+    private ResolvedSource resolveSource(RepositoryContext selected) {
+        Readiness readiness = readinessService.inspect(selected);
+        if (readiness.state() == ReadinessState.READY) {
+            return new ResolvedSource(ReadModel.PROJECTION, readiness);
         }
 
         long pendingRecoveries = recoveryService.pendingCount(selected);
@@ -150,11 +180,7 @@ public class RelationProjectionReadService {
                 && pendingRecoveries == 0
                 && mayUseLegacyFallback(selected)) {
             reportFallback(selected);
-            return new ReadResult(
-                    ReadModel.LEGACY_FALLBACK,
-                    readiness.state(),
-                    readiness.currentHeadCommit(),
-                    legacyRead.get());
+            return new ResolvedSource(ReadModel.LEGACY_FALLBACK, readiness);
         }
 
         throw unavailable(selected, readiness, pendingRecoveries);
@@ -278,6 +304,49 @@ public class RelationProjectionReadService {
             if (count < 0) {
                 throw new IllegalArgumentException("count must not be negative");
             }
+        }
+    }
+
+    public record RelationIdentity(
+            String sourceCode,
+            RelationType relationType,
+            String targetCode) {
+        public RelationIdentity {
+            sourceCode = requireText(sourceCode, "sourceCode");
+            relationType = Objects.requireNonNull(
+                    relationType, "relationType");
+            targetCode = requireText(targetCode, "targetCode");
+        }
+    }
+
+    public record IdentitySnapshot(
+            ReadModel readModel,
+            ReadinessState readinessState,
+            String authoritativeCommitId,
+            Set<RelationIdentity> identities) {
+        public IdentitySnapshot {
+            readModel = Objects.requireNonNull(readModel, "readModel");
+            readinessState = Objects.requireNonNull(
+                    readinessState, "readinessState");
+            identities = Set.copyOf(Objects.requireNonNull(
+                    identities, "identities"));
+        }
+
+        public boolean contains(
+                String sourceCode,
+                RelationType relationType,
+                String targetCode) {
+            return identities.contains(new RelationIdentity(
+                    sourceCode, relationType, targetCode));
+        }
+    }
+
+    private record ResolvedSource(
+            ReadModel readModel,
+            Readiness readiness) {
+        private ResolvedSource {
+            readModel = Objects.requireNonNull(readModel, "readModel");
+            readiness = Objects.requireNonNull(readiness, "readiness");
         }
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
@@ -8,6 +8,7 @@ import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.relations.service.RelationProjectionReadService.IdentitySnapshot;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryScope;
 import com.taxonomy.workspace.service.WorkspaceResolver;
@@ -28,6 +29,7 @@ import java.util.List;
  *
  * <p>Pipeline stages:
  * <ol>
+ *   <li>Resolve one complete active-relation identity snapshot</li>
  *   <li>Candidate Search (via {@link RelationCandidateService})</li>
  *   <li>RelationType Compatibility filtering</li>
  *   <li>Validation (via {@link RelationValidationService})</li>
@@ -38,22 +40,27 @@ import java.util.List;
 @Service
 public class RelationProposalService {
 
-    private static final Logger log = LoggerFactory.getLogger(RelationProposalService.class);
+    private static final Logger log = LoggerFactory.getLogger(
+            RelationProposalService.class);
 
     private final TaxonomyNodeRepository nodeRepository;
     private final RelationProposalRepository proposalRepository;
     private final RelationCandidateService candidateService;
+    private final RelationProjectionReadService relationReadService;
     private final RelationValidationService validationService;
     private final WorkspaceResolver workspaceResolver;
 
-    public RelationProposalService(TaxonomyNodeRepository nodeRepository,
-                                   RelationProposalRepository proposalRepository,
-                                   RelationCandidateService candidateService,
-                                   RelationValidationService validationService,
-                                   WorkspaceResolver workspaceResolver) {
+    public RelationProposalService(
+            TaxonomyNodeRepository nodeRepository,
+            RelationProposalRepository proposalRepository,
+            RelationCandidateService candidateService,
+            RelationProjectionReadService relationReadService,
+            RelationValidationService validationService,
+            WorkspaceResolver workspaceResolver) {
         this.nodeRepository = nodeRepository;
         this.proposalRepository = proposalRepository;
         this.candidateService = candidateService;
+        this.relationReadService = relationReadService;
         this.validationService = validationService;
         this.workspaceResolver = workspaceResolver;
     }
@@ -67,9 +74,10 @@ public class RelationProposalService {
      * context-aware method.</p>
      */
     @Transactional
-    public List<RelationProposalDto> proposeRelations(String sourceNodeCode,
-                                                       RelationType relationType,
-                                                       int limit) {
+    public List<RelationProposalDto> proposeRelations(
+            String sourceNodeCode,
+            RelationType relationType,
+            int limit) {
         return proposeRelationsInContext(
                 sourceNodeCode,
                 relationType,
@@ -89,12 +97,16 @@ public class RelationProposalService {
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Source node not found: " + sourceNodeCode));
 
-        log.info("Proposing {} relations for node '{}' (repository={}, workspace={})",
+        log.info("Proposing {} relations for node '{}' "
+                        + "(repository={}, workspace={}, branch={})",
                 relationType,
                 sourceNodeCode,
                 tenant.repositoryId(),
-                tenant.workspaceId());
+                tenant.workspaceId(),
+                tenant.branch());
 
+        IdentitySnapshot existingRelations =
+                relationReadService.readIdentitySnapshot(tenant);
         List<TaxonomyNodeDto> candidates = candidateService.findCandidates(
                 source, relationType, limit);
         List<RelationProposalDto> proposals = new ArrayList<>();
@@ -118,9 +130,28 @@ public class RelationProposalService {
                 continue;
             }
 
+            if (existingRelations.contains(
+                    sourceNodeCode,
+                    relationType,
+                    candidate.getCode())) {
+                log.debug("Active relation already exists: {} → {} [{}] "
+                                + "(repository={}, workspace={}, branch={})",
+                        sourceNodeCode,
+                        candidate.getCode(),
+                        relationType,
+                        tenant.repositoryId(),
+                        tenant.workspaceId(),
+                        tenant.branch());
+                continue;
+            }
+
             RelationValidationService.ValidationResult result =
-                    validationService.validate(source, candidate, relationType,
-                            i, candidates.size());
+                    validationService.validate(
+                            source,
+                            candidate,
+                            relationType,
+                            i,
+                            candidates.size());
 
             if (!result.isValid()) {
                 continue;
@@ -157,12 +188,14 @@ public class RelationProposalService {
         }
 
         log.info("Proposed {} relations for node '{}' [{}] "
-                        + "(repository={}, workspace={})",
+                        + "(repository={}, workspace={}, branch={}, relationCommit={})",
                 proposals.size(),
                 sourceNodeCode,
                 relationType,
                 tenant.repositoryId(),
-                tenant.workspaceId());
+                tenant.workspaceId(),
+                tenant.branch(),
+                existingRelations.authoritativeCommitId());
         return proposals;
     }
 
@@ -229,11 +262,12 @@ public class RelationProposalService {
      * {@link #proposeRelations(String, RelationType, int)}.
      */
     @Transactional
-    public RelationProposalDto createFromHypothesis(String sourceCode,
-                                                     String targetCode,
-                                                     RelationType relationType,
-                                                     double confidence,
-                                                     String rationale) {
+    public RelationProposalDto createFromHypothesis(
+            String sourceCode,
+            String targetCode,
+            RelationType relationType,
+            double confidence,
+            String rationale) {
         return createFromHypothesisInContext(
                 sourceCode,
                 targetCode,
@@ -273,6 +307,20 @@ public class RelationProposalService {
                     relationType,
                     tenant.repositoryId(),
                     tenant.workspaceId());
+            return null;
+        }
+
+        IdentitySnapshot existingRelations =
+                relationReadService.readIdentitySnapshot(tenant);
+        if (existingRelations.contains(sourceCode, relationType, targetCode)) {
+            log.debug("Active relation already exists: {} → {} [{}] "
+                            + "(repository={}, workspace={}, branch={})",
+                    sourceCode,
+                    targetCode,
+                    relationType,
+                    tenant.repositoryId(),
+                    tenant.workspaceId(),
+                    tenant.branch());
             return null;
         }
 
@@ -332,12 +380,14 @@ public class RelationProposalService {
 
     private static RepositoryContext requireContext(RepositoryContext context) {
         if (context == null) {
-            throw new IllegalArgumentException("RepositoryContext must not be null");
+            throw new IllegalArgumentException(
+                    "RepositoryContext must not be null");
         }
         return context;
     }
 
-    private static RepositoryContext requireWritableContext(RepositoryContext context) {
+    private static RepositoryContext requireWritableContext(
+            RepositoryContext context) {
         RepositoryContext tenant = requireContext(context);
         if (tenant.workspaceId() == null) {
             if (tenant.scope() != RepositoryScope.CENTRAL_WRITE) {

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationValidationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationValidationService.java
@@ -1,20 +1,21 @@
 package com.taxonomy.relations.service;
 
+import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.dto.TaxonomyNodeDto;
 import com.taxonomy.model.RelationType;
-import com.taxonomy.catalog.model.TaxonomyNode;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 /**
  * Validates a candidate relation and computes a confidence score.
  *
+ * <p>Repository/workspace/branch duplicate detection is deliberately performed
+ * by {@link RelationProposalService} against one immutable identity snapshot.
+ * This service therefore remains a persistence-free compatibility and scoring
+ * component.</p>
+ *
  * <p>Validation rules:
  * <ol>
  *   <li>Compatibility — source/target roots must be allowed for the relation type.</li>
- *   <li>Duplicate check — relation must not already exist.</li>
  *   <li>Self-relation check — source must differ from target.</li>
  * </ol>
  *
@@ -24,17 +25,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class RelationValidationService {
 
-    private static final Logger log = LoggerFactory.getLogger(RelationValidationService.class);
-
     private final RelationCompatibilityMatrix compatibilityMatrix;
-    private final TaxonomyRelationRepository relationRepository;
     private final RelationQualityService qualityService;
 
-    public RelationValidationService(RelationCompatibilityMatrix compatibilityMatrix,
-                                     TaxonomyRelationRepository relationRepository,
-                                     RelationQualityService qualityService) {
+    public RelationValidationService(
+            RelationCompatibilityMatrix compatibilityMatrix,
+            RelationQualityService qualityService) {
         this.compatibilityMatrix = compatibilityMatrix;
-        this.relationRepository = relationRepository;
         this.qualityService = qualityService;
     }
 
@@ -43,17 +40,16 @@ public class RelationValidationService {
      *
      * @return a {@link ValidationResult} with pass/fail and confidence
      */
-    public ValidationResult validate(TaxonomyNode source,
-                                     TaxonomyNodeDto candidateTarget,
-                                     RelationType relationType,
-                                     int rank,
-                                     int totalCandidates) {
-        // Self-relation
+    public ValidationResult validate(
+            TaxonomyNode source,
+            TaxonomyNodeDto candidateTarget,
+            RelationType relationType,
+            int rank,
+            int totalCandidates) {
         if (source.getCode().equals(candidateTarget.getCode())) {
             return ValidationResult.fail("Self-relation not allowed");
         }
 
-        // Compatibility check
         if (!compatibilityMatrix.isCompatible(
                 source.getTaxonomyRoot(),
                 candidateTarget.getTaxonomyRoot(),
@@ -64,20 +60,8 @@ public class RelationValidationService {
                     + " for " + relationType);
         }
 
-        // Duplicate check (already exists as a persisted relation)
-        boolean exists = !relationRepository
-                .findBySourceNodeCodeAndRelationTypeIn(
-                        source.getCode(),
-                        java.util.List.of(relationType))
-                .stream()
-                .filter(r -> r.getTargetNode().getCode().equals(candidateTarget.getCode()))
-                .toList()
-                .isEmpty();
-        if (exists) {
-            return ValidationResult.fail("Relation already exists");
-        }
-
-        // Confidence: 80% rank-based + 20% acceptance history feedback
+        // Confidence: 80% rank-based + 20% acceptance history feedback.
+        // Repository scoping of that feedback is tracked separately by #728.
         double rankConfidence = computeConfidence(rank, totalCandidates);
         double historyWeight = qualityService.acceptanceHistoryWeight(
                 source.getTaxonomyRoot(),
@@ -100,25 +84,27 @@ public class RelationValidationService {
      */
     public double computeConfidence(int rank, int totalCandidates) {
         if (totalCandidates <= 1) return 0.9;
-        // Linear decay from 0.95 to 0.3
         double ratio = (double) rank / (totalCandidates - 1);
         return 0.95 - (0.65 * ratio);
     }
-
-    // ── Inner result record ───────────────────────────────────────────────────
 
     public static class ValidationResult {
         private final boolean valid;
         private final double confidence;
         private final String rationale;
 
-        private ValidationResult(boolean valid, double confidence, String rationale) {
+        private ValidationResult(
+                boolean valid,
+                double confidence,
+                String rationale) {
             this.valid = valid;
             this.confidence = confidence;
             this.rationale = rationale;
         }
 
-        public static ValidationResult pass(double confidence, String rationale) {
+        public static ValidationResult pass(
+                double confidence,
+                String rationale) {
             return new ValidationResult(true, confidence, rationale);
         }
 
@@ -126,8 +112,16 @@ public class RelationValidationService {
             return new ValidationResult(false, 0.0, reason);
         }
 
-        public boolean isValid() { return valid; }
-        public double getConfidence() { return confidence; }
-        public String getRationale() { return rationale; }
+        public boolean isValid() {
+            return valid;
+        }
+
+        public double getConfidence() {
+            return confidence;
+        }
+
+        public String getRationale() {
+            return rationale;
+        }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/AuthorizationRulesConfigurer.java
@@ -79,6 +79,11 @@ public class AuthorizationRulesConfigurer {
         auth.requestMatchers(HttpMethod.POST, "/api/context/**").hasAnyRole("ARCHITECT", "ADMIN");
 
         auth.requestMatchers(HttpMethod.GET, "/api/workspace/**").authenticated();
+        // Provisioning creates only the authenticated user's isolated working
+        // copy. It must remain available to every product role and is ordered
+        // before the privileged catch-all for workspace administration.
+        auth.requestMatchers(HttpMethod.POST, "/api/workspace/provision")
+                .hasAnyRole("USER", "ARCHITECT", "ADMIN");
         auth.requestMatchers(HttpMethod.POST,
                         "/api/workspace/sync-from-shared",
                         "/api/workspace/publish",

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/service/AppInitializationStateService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/service/AppInitializationStateService.java
@@ -1,8 +1,11 @@
 package com.taxonomy.shared.service;
 
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -17,7 +20,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * single {@link AtomicReference} to guarantee a consistent view across threads.
  */
 @Service
-public class AppInitializationStateService {
+public class AppInitializationStateService
+        implements ApplicationEventPublisherAware {
 
     public enum State {
         STARTING,
@@ -28,10 +32,36 @@ public class AppInitializationStateService {
     }
 
     /** Immutable snapshot of the current initialisation state. */
-    public record StateSnapshot(State state, String message, Instant updatedAt, String error) {}
+    public record StateSnapshot(
+            State state,
+            String message,
+            Instant updatedAt,
+            String error) {
+    }
+
+    /** Emitted synchronously after the application enters the READY state. */
+    public record InitializationReadyEvent(StateSnapshot snapshot) {
+        public InitializationReadyEvent {
+            snapshot = Objects.requireNonNull(snapshot, "snapshot");
+        }
+    }
 
     private final AtomicReference<StateSnapshot> snapshot =
-            new AtomicReference<>(new StateSnapshot(State.STARTING, "Starting application", Instant.now(), null));
+            new AtomicReference<>(new StateSnapshot(
+                    State.STARTING,
+                    "Starting application",
+                    Instant.now(),
+                    null));
+
+    private volatile ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void setApplicationEventPublisher(
+            ApplicationEventPublisher applicationEventPublisher) {
+        this.eventPublisher = Objects.requireNonNull(
+                applicationEventPublisher,
+                "applicationEventPublisher");
+    }
 
     public State getState() {
         return snapshot.get().state();
@@ -54,11 +84,24 @@ public class AppInitializationStateService {
     }
 
     public void update(State newState, String newMessage) {
-        snapshot.set(new StateSnapshot(newState, newMessage, Instant.now(), null));
+        StateSnapshot updated = new StateSnapshot(
+                newState,
+                newMessage,
+                Instant.now(),
+                null);
+        snapshot.set(updated);
+
+        ApplicationEventPublisher publisher = eventPublisher;
+        if (newState == State.READY && publisher != null) {
+            publisher.publishEvent(new InitializationReadyEvent(updated));
+        }
     }
 
     public void fail(String newMessage, Throwable t) {
-        snapshot.set(new StateSnapshot(State.FAILED, newMessage, Instant.now(),
+        snapshot.set(new StateSnapshot(
+                State.FAILED,
+                newMessage,
+                Instant.now(),
                 t == null ? null : t.getMessage()));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
@@ -4,6 +4,7 @@ import com.taxonomy.dsl.export.TaxDslExportService;
 import com.taxonomy.dsl.storage.DslGitRepository;
 import com.taxonomy.dsl.storage.DslGitRepositoryFactory;
 import com.taxonomy.shared.service.AppInitializationStateService;
+import com.taxonomy.shared.service.AppInitializationStateService.InitializationReadyEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,9 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * version history, variants, compare) work correctly from the start.
  *
  * <p>In synchronous init mode (default), the taxonomy is already loaded by the time
- * {@link ApplicationReadyEvent} fires. In asynchronous init mode, this component
- * checks {@link AppInitializationStateService#isReady()} and skips if not ready —
- * the first user-initiated DSL commit will create the branch in that case.
+ * {@link ApplicationReadyEvent} fires. In asynchronous init mode, the application-ready
+ * event can precede catalogue completion; {@link InitializationReadyEvent} retries the
+ * same idempotent bootstrap immediately after the catalogue becomes authoritative.
  *
  * <p>Controlled by the {@code taxonomy.git.bootstrap} property (default: {@code true}).
  * A JVM-wide static guard ensures that only the <em>first</em> Spring context in a
@@ -39,10 +40,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@code ddl-auto=create} recreates tables between contexts.
  */
 @Component
-@ConditionalOnProperty(name = "taxonomy.git.bootstrap", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(
+        name = "taxonomy.git.bootstrap",
+        havingValue = "true",
+        matchIfMissing = true)
 public class GitRepositoryBootstrap {
 
-    private static final Logger log = LoggerFactory.getLogger(GitRepositoryBootstrap.class);
+    private static final Logger log = LoggerFactory.getLogger(
+            GitRepositoryBootstrap.class);
 
     /**
      * JVM-wide guard: ensures bootstrap runs at most once per JVM lifetime.
@@ -57,9 +62,10 @@ public class GitRepositoryBootstrap {
     private final TaxDslExportService exportService;
     private final AppInitializationStateService stateService;
 
-    public GitRepositoryBootstrap(DslGitRepositoryFactory repositoryFactory,
-                                  TaxDslExportService exportService,
-                                  AppInitializationStateService stateService) {
+    public GitRepositoryBootstrap(
+            DslGitRepositoryFactory repositoryFactory,
+            TaxDslExportService exportService,
+            AppInitializationStateService stateService) {
         this.gitRepository = repositoryFactory.getSystemRepository();
         this.exportService = exportService;
         this.stateService = stateService;
@@ -81,8 +87,8 @@ public class GitRepositoryBootstrap {
         }
 
         if (!stateService.isReady()) {
-            log.debug("Taxonomy not yet loaded (async mode) — skipping draft branch bootstrap.");
-            BOOTSTRAPPED.set(false); // allow retry after taxonomy loads
+            log.debug("Taxonomy not yet loaded — deferring draft branch bootstrap.");
+            BOOTSTRAPPED.set(false);
             return;
         }
 
@@ -93,13 +99,26 @@ public class GitRepositoryBootstrap {
             }
 
             String dsl = exportService.exportAll("default");
-            String commitId = gitRepository.commitDsl("draft", dsl, "system",
+            String commitId = gitRepository.commitDsl(
+                    "draft",
+                    dsl,
+                    "system",
                     "Initial taxonomy materialization");
 
-            log.info("Bootstrapped 'draft' branch with initial taxonomy DSL " +
-                    "(commit={}, {} chars)", commitId.substring(0, 7), dsl.length());
-        } catch (IOException e) {
-            log.warn("Failed to bootstrap 'draft' branch: {}", e.getMessage());
+            log.info(
+                    "Bootstrapped 'draft' branch with initial taxonomy DSL "
+                            + "(commit={}, {} chars)",
+                    commitId.substring(0, 7),
+                    dsl.length());
+        } catch (IOException error) {
+            BOOTSTRAPPED.set(false);
+            log.warn("Failed to bootstrap 'draft' branch: {}", error.getMessage());
         }
+    }
+
+    /** Completes the deferred bootstrap after asynchronous taxonomy loading. */
+    @EventListener(InitializationReadyEvent.class)
+    public void initializeAfterTaxonomyReady() {
+        initializeDraftBranch();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
@@ -110,7 +110,7 @@ public class GitRepositoryBootstrap {
                             + "(commit={}, {} chars)",
                     commitId.substring(0, 7),
                     dsl.length());
-        } catch (IOException error) {
+        } catch (IOException | RuntimeException error) {
             BOOTSTRAPPED.set(false);
             log.warn("Failed to bootstrap 'draft' branch: {}", error.getMessage());
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitRepositoryBootstrap.java
@@ -81,14 +81,16 @@ public class GitRepositoryBootstrap {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void initializeDraftBranch() {
-        if (!BOOTSTRAPPED.compareAndSet(false, true)) {
-            log.debug("Draft branch already bootstrapped in this JVM — skipping.");
+        // Check readiness before acquiring the one-shot guard. Otherwise an
+        // ApplicationReady listener can hold the guard while the asynchronous
+        // READY event is dispatched, causing that only retry to be skipped.
+        if (!stateService.isReady()) {
+            log.debug("Taxonomy not yet loaded — deferring draft branch bootstrap.");
             return;
         }
 
-        if (!stateService.isReady()) {
-            log.debug("Taxonomy not yet loaded — deferring draft branch bootstrap.");
-            BOOTSTRAPPED.set(false);
+        if (!BOOTSTRAPPED.compareAndSet(false, true)) {
+            log.debug("Draft branch already bootstrapped in this JVM — skipping.");
             return;
         }
 

--- a/taxonomy-app/src/main/resources/static/js/api/workspace-provisioning-api.js
+++ b/taxonomy-app/src/main/resources/static/js/api/workspace-provisioning-api.js
@@ -1,0 +1,65 @@
+/**
+ * Raw-response API boundary for workspace provisioning and branch projection.
+ *
+ * The canonical fetch wrapper installed by taxonomy-api-client.js supplies
+ * reverse-proxy base-path and CSRF handling. This client owns transport while
+ * the workspace UI owns only modal and lifecycle presentation.
+ */
+window.TaxonomyWorkspaceProvisioningApi = (function () {
+    'use strict';
+
+    function provisioningStatus() {
+        return requestJson('/api/workspace/provisioning-status', {
+            cache: 'no-store'
+        });
+    }
+
+    function provisionWorkspace() {
+        return requestJson('/api/workspace/provision', {
+            method: 'POST'
+        });
+    }
+
+    function projectionReadiness() {
+        return requestJson('/api/architecture/relations/projection/readiness', {
+            cache: 'no-store'
+        });
+    }
+
+    function rebuildProjection(expectedHead) {
+        return requestJson('/api/architecture/relations/projection/rebuild', {
+            method: 'POST',
+            headers: {
+                'If-Match': '"' + expectedHead + '"'
+            }
+        });
+    }
+
+    function requestJson(url, options) {
+        return fetch(url, options || {})
+            .then(function (response) {
+                return response.text().then(function (text) {
+                    var body = {};
+                    if (text) {
+                        try {
+                            body = JSON.parse(text);
+                        } catch (error) {
+                            body = { message: text };
+                        }
+                    }
+                    return {
+                        ok: response.ok,
+                        status: response.status,
+                        body: body
+                    };
+                });
+            });
+    }
+
+    return {
+        provisioningStatus: provisioningStatus,
+        provisionWorkspace: provisionWorkspace,
+        projectionReadiness: projectionReadiness,
+        rebuildProjection: rebuildProjection
+    };
+}());

--- a/taxonomy-app/src/main/resources/static/js/workspace/taxonomy-workspace-provisioning.js
+++ b/taxonomy-app/src/main/resources/static/js/workspace/taxonomy-workspace-provisioning.js
@@ -14,8 +14,11 @@ window.TaxonomyWorkspaceProvisioning = (function () {
 
     var t = TaxonomyI18n.t;
     var POLL_INTERVAL = 2000;
-    var PROJECTION_ENDPOINT = '/api/architecture/relations/projection';
     var pollTimer = null;
+    var loaderScript = document.currentScript;
+    var apiReady = loadApiClient(loaderScript);
+
+    window.TaxonomyWorkspaceProvisioningApiReady = apiReady;
 
     // ── Public API ──────────────────────────────────────────────────
 
@@ -24,13 +27,19 @@ window.TaxonomyWorkspaceProvisioning = (function () {
      * Called on page load after i18n strings are available.
      */
     function check() {
-        fetch('/api/workspace/provisioning-status')
-            .then(parseJsonResponse)
+        apiReady
+            .then(function () {
+                return Api().provisioningStatus();
+            })
             .then(function (response) {
+                if (!response.ok) {
+                    throw new Error(responseError(
+                        'Could not check provisioning status', response));
+                }
                 var status = response.body;
                 switch (status.status) {
                     case 'NOT_PROVISIONED':
-                        showProvisioningDialog(status);
+                        showProvisioningDialog();
                         break;
                     case 'PROVISIONING':
                         showSpinner();
@@ -53,7 +62,7 @@ window.TaxonomyWorkspaceProvisioning = (function () {
 
     // ── Provisioning Dialog ─────────────────────────────────────────
 
-    function showProvisioningDialog(status) {
+    function showProvisioningDialog() {
         removeExistingModal();
         var modal = document.createElement('div');
         modal.id = 'workspaceProvisioningModal';
@@ -192,11 +201,10 @@ window.TaxonomyWorkspaceProvisioning = (function () {
             existingModal.hide();
         }
         showSpinner();
-        fetch('/api/workspace/provision', {
-            method: 'POST',
-            headers: csrfHeaders()
-        })
-            .then(parseJsonResponse)
+        apiReady
+            .then(function () {
+                return Api().provisionWorkspace();
+            })
             .then(function (response) {
                 var result = response.body;
                 if (!response.ok) {
@@ -221,8 +229,10 @@ window.TaxonomyWorkspaceProvisioning = (function () {
     function pollUntilReady() {
         if (pollTimer) clearInterval(pollTimer);
         pollTimer = setInterval(function () {
-            fetch('/api/workspace/provisioning-status')
-                .then(parseJsonResponse)
+            apiReady
+                .then(function () {
+                    return Api().provisioningStatus();
+                })
                 .then(function (response) {
                     var status = response.body;
                     if (status.status === 'READY') {
@@ -251,11 +261,13 @@ window.TaxonomyWorkspaceProvisioning = (function () {
      * the same fail-closed, Git-authoritative projection.
      */
     function ensureRelationProjection() {
-        return fetch(PROJECTION_ENDPOINT + '/readiness')
-            .then(parseJsonResponse)
+        return apiReady
+            .then(function () {
+                return Api().projectionReadiness();
+            })
             .then(function (response) {
                 if (!response.ok) {
-                    throw new Error(projectionError(
+                    throw new Error(responseError(
                         'Could not inspect relation projection', response));
                 }
                 var readiness = response.body;
@@ -263,20 +275,14 @@ window.TaxonomyWorkspaceProvisioning = (function () {
                     return readiness;
                 }
                 if (!readiness.currentHeadCommit) {
-                    throw new Error(projectionError(
+                    throw new Error(responseError(
                         'Workspace has no authoritative branch head', response));
                 }
-                return fetch(PROJECTION_ENDPOINT + '/rebuild', {
-                    method: 'POST',
-                    headers: csrfHeaders({
-                        'If-Match': '"' + readiness.currentHeadCommit + '"'
-                    })
-                })
-                    .then(parseJsonResponse)
+                return Api().rebuildProjection(readiness.currentHeadCommit)
                     .then(function (rebuildResponse) {
                         if (!rebuildResponse.ok ||
                                 rebuildResponse.body.readinessState !== 'READY') {
-                            throw new Error(projectionError(
+                            throw new Error(responseError(
                                 'Could not rebuild relation projection',
                                 rebuildResponse));
                         }
@@ -285,38 +291,45 @@ window.TaxonomyWorkspaceProvisioning = (function () {
             });
     }
 
-    function csrfHeaders(additionalHeaders) {
-        var headers = Object.assign({
-            'Accept': 'application/json'
-        }, additionalHeaders || {});
-        var token = document.querySelector('meta[name="_csrf"]');
-        var header = document.querySelector('meta[name="_csrf_header"]');
-        if (token && token.content) {
-            headers[header && header.content ? header.content : 'X-CSRF-TOKEN'] =
-                token.content;
+    function Api() {
+        if (!window.TaxonomyWorkspaceProvisioningApi) {
+            throw new Error('Workspace provisioning API client is unavailable.');
         }
-        return headers;
+        return window.TaxonomyWorkspaceProvisioningApi;
     }
 
-    function parseJsonResponse(response) {
-        return response.text().then(function (text) {
-            var body = {};
-            if (text) {
-                try {
-                    body = JSON.parse(text);
-                } catch (error) {
-                    body = { message: text };
+    function loadApiClient(currentScript) {
+        if (window.TaxonomyWorkspaceProvisioningApi) {
+            return Promise.resolve(window.TaxonomyWorkspaceProvisioningApi);
+        }
+        if (!currentScript || !currentScript.src) {
+            return Promise.reject(new Error(
+                'Cannot resolve workspace provisioning API client URL.'));
+        }
+
+        return new Promise(function (resolve, reject) {
+            var script = document.createElement('script');
+            script.src = new URL(
+                '../api/workspace-provisioning-api.js',
+                currentScript.src).href;
+            script.async = false;
+            script.setAttribute('data-taxonomy-workspace-provisioning-api', 'true');
+            script.onload = function () {
+                if (window.TaxonomyWorkspaceProvisioningApi) {
+                    resolve(window.TaxonomyWorkspaceProvisioningApi);
+                } else {
+                    reject(new Error(
+                        'Workspace provisioning API client did not initialize.'));
                 }
-            }
-            return {
-                ok: response.ok,
-                status: response.status,
-                body: body
             };
+            script.onerror = function () {
+                reject(new Error('Workspace provisioning API client failed to load.'));
+            };
+            document.head.appendChild(script);
         });
     }
 
-    function projectionError(prefix, response) {
+    function responseError(prefix, response) {
         var body = response.body || {};
         return prefix + ' (' + response.status + '): ' +
             (body.message || body.operationStatus || body.readinessState || 'unknown error');

--- a/taxonomy-app/src/main/resources/static/js/workspace/taxonomy-workspace-provisioning.js
+++ b/taxonomy-app/src/main/resources/static/js/workspace/taxonomy-workspace-provisioning.js
@@ -3,7 +3,7 @@
  *
  * Checks the provisioning status of the user's workspace on page load.
  * If the workspace is not yet provisioned, a modal dialog guides the user
- * through the creation of their personal working copy.
+ * through creation of the personal working copy and its branch projection.
  *
  * Uses i18n keys for all user-visible labels.
  *
@@ -13,7 +13,8 @@ window.TaxonomyWorkspaceProvisioning = (function () {
     'use strict';
 
     var t = TaxonomyI18n.t;
-    var POLL_INTERVAL = 2000; // 2 seconds
+    var POLL_INTERVAL = 2000;
+    var PROJECTION_ENDPOINT = '/api/architecture/relations/projection';
     var pollTimer = null;
 
     // ── Public API ──────────────────────────────────────────────────
@@ -24,8 +25,9 @@ window.TaxonomyWorkspaceProvisioning = (function () {
      */
     function check() {
         fetch('/api/workspace/provisioning-status')
-            .then(function (r) { return r.json(); })
-            .then(function (status) {
+            .then(parseJsonResponse)
+            .then(function (response) {
+                var status = response.body;
                 switch (status.status) {
                     case 'NOT_PROVISIONED':
                         showProvisioningDialog(status);
@@ -38,12 +40,14 @@ window.TaxonomyWorkspaceProvisioning = (function () {
                         showRetryDialog(status.error);
                         break;
                     case 'READY':
-                        // Workspace is ready, nothing to do
+                        ensureRelationProjection().catch(function (error) {
+                            showRetryDialog(error.message || String(error));
+                        });
                         break;
                 }
             })
-            .catch(function (err) {
-                console.warn('Could not check provisioning status:', err);
+            .catch(function (error) {
+                console.warn('Could not check provisioning status:', error);
             });
     }
 
@@ -188,19 +192,29 @@ window.TaxonomyWorkspaceProvisioning = (function () {
             existingModal.hide();
         }
         showSpinner();
-        fetch('/api/workspace/provision', { method: 'POST' })
-            .then(function (r) { return r.json(); })
-            .then(function (result) {
-                if (result.status === 'READY') {
-                    showReadyDialog();
-                } else if (result.error) {
-                    showRetryDialog(result.error || result.message);
-                } else {
-                    pollUntilReady();
+        fetch('/api/workspace/provision', {
+            method: 'POST',
+            headers: csrfHeaders()
+        })
+            .then(parseJsonResponse)
+            .then(function (response) {
+                var result = response.body;
+                if (!response.ok) {
+                    throw new Error(result.message || result.error ||
+                        'Workspace provisioning failed');
                 }
+                if (result.status === 'READY') {
+                    return ensureRelationProjection().then(showReadyDialog);
+                }
+                if (result.error) {
+                    showRetryDialog(result.error || result.message);
+                    return null;
+                }
+                pollUntilReady();
+                return null;
             })
-            .catch(function (err) {
-                showRetryDialog(err.message || String(err));
+            .catch(function (error) {
+                showRetryDialog(error.message || String(error));
             });
     }
 
@@ -208,23 +222,104 @@ window.TaxonomyWorkspaceProvisioning = (function () {
         if (pollTimer) clearInterval(pollTimer);
         pollTimer = setInterval(function () {
             fetch('/api/workspace/provisioning-status')
-                .then(function (r) { return r.json(); })
-                .then(function (status) {
+                .then(parseJsonResponse)
+                .then(function (response) {
+                    var status = response.body;
                     if (status.status === 'READY') {
                         clearInterval(pollTimer);
                         pollTimer = null;
-                        showReadyDialog();
+                        ensureRelationProjection()
+                            .then(showReadyDialog)
+                            .catch(function (error) {
+                                showRetryDialog(error.message || String(error));
+                            });
                     } else if (status.status === 'FAILED') {
                         clearInterval(pollTimer);
                         pollTimer = null;
                         showRetryDialog(status.error);
                     }
-                    // PROVISIONING: keep polling
                 })
                 .catch(function () {
-                    // Network error, keep polling
+                    // Network error, keep polling.
                 });
         }, POLL_INTERVAL);
+    }
+
+    /**
+     * Materialize the exact workspace branch before the UI reports the workspace
+     * as usable. This keeps product reads and proposal duplicate validation on
+     * the same fail-closed, Git-authoritative projection.
+     */
+    function ensureRelationProjection() {
+        return fetch(PROJECTION_ENDPOINT + '/readiness')
+            .then(parseJsonResponse)
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error(projectionError(
+                        'Could not inspect relation projection', response));
+                }
+                var readiness = response.body;
+                if (readiness.readinessState === 'READY') {
+                    return readiness;
+                }
+                if (!readiness.currentHeadCommit) {
+                    throw new Error(projectionError(
+                        'Workspace has no authoritative branch head', response));
+                }
+                return fetch(PROJECTION_ENDPOINT + '/rebuild', {
+                    method: 'POST',
+                    headers: csrfHeaders({
+                        'If-Match': '"' + readiness.currentHeadCommit + '"'
+                    })
+                })
+                    .then(parseJsonResponse)
+                    .then(function (rebuildResponse) {
+                        if (!rebuildResponse.ok ||
+                                rebuildResponse.body.readinessState !== 'READY') {
+                            throw new Error(projectionError(
+                                'Could not rebuild relation projection',
+                                rebuildResponse));
+                        }
+                        return rebuildResponse.body;
+                    });
+            });
+    }
+
+    function csrfHeaders(additionalHeaders) {
+        var headers = Object.assign({
+            'Accept': 'application/json'
+        }, additionalHeaders || {});
+        var token = document.querySelector('meta[name="_csrf"]');
+        var header = document.querySelector('meta[name="_csrf_header"]');
+        if (token && token.content) {
+            headers[header && header.content ? header.content : 'X-CSRF-TOKEN'] =
+                token.content;
+        }
+        return headers;
+    }
+
+    function parseJsonResponse(response) {
+        return response.text().then(function (text) {
+            var body = {};
+            if (text) {
+                try {
+                    body = JSON.parse(text);
+                } catch (error) {
+                    body = { message: text };
+                }
+            }
+            return {
+                ok: response.ok,
+                status: response.status,
+                body: body
+            };
+        });
+    }
+
+    function projectionError(prefix, response) {
+        var body = response.body || {};
+        return prefix + ' (' + response.status + '): ' +
+            (body.message || body.operationStatus || body.readinessState || 'unknown error');
     }
 
     // ── Helpers ─────────────────────────────────────────────────────

--- a/taxonomy-app/src/test/java/com/taxonomy/AppInitializationStateServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/AppInitializationStateServiceTest.java
@@ -1,13 +1,18 @@
 package com.taxonomy;
 
 import com.taxonomy.shared.service.AppInitializationStateService;
+import com.taxonomy.shared.service.AppInitializationStateService.InitializationReadyEvent;
 import com.taxonomy.shared.service.AppInitializationStateService.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Unit tests for {@link AppInitializationStateService}.
@@ -51,6 +56,22 @@ class AppInitializationStateServiceTest {
     }
 
     @Test
+    void readyTransitionPublishesCompletionEvent() {
+        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        service.setApplicationEventPublisher(publisher);
+
+        service.update(State.READY, "Application is ready");
+
+        ArgumentCaptor<Object> event = ArgumentCaptor.forClass(Object.class);
+        verify(publisher).publishEvent(event.capture());
+        assertThat(event.getValue()).isInstanceOf(InitializationReadyEvent.class);
+        InitializationReadyEvent readyEvent =
+                (InitializationReadyEvent) event.getValue();
+        assertThat(readyEvent.snapshot().state()).isEqualTo(State.READY);
+        assertThat(readyEvent.snapshot().message()).isEqualTo("Application is ready");
+    }
+
+    @Test
     void failTransitionsToFailed() {
         service.update(State.LOADING_TAXONOMY, "Loading taxonomy from Excel\u2026");
 
@@ -90,9 +111,9 @@ class AppInitializationStateServiceTest {
 
     @Test
     void isReadyOnlyTrueForReadyState() {
-        for (State s : State.values()) {
-            service.update(s, "test");
-            assertThat(service.isReady()).isEqualTo(s == State.READY);
+        for (State state : State.values()) {
+            service.update(state, "test");
+            assertThat(service.isReady()).isEqualTo(state == State.READY);
         }
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/DiagnosticsOracleContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/DiagnosticsOracleContainerIT.java
@@ -7,6 +7,8 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.oracle.OracleContainer;
 
+import java.time.Duration;
+
 /**
  * Runs the same diagnostics + API tests as {@link DiagnosticsContainerIT}
  * but against an <strong>Oracle Database Free</strong> backend.
@@ -24,7 +26,8 @@ class DiagnosticsOracleContainerIT extends AbstractDatabaseContainerIT {
     static Network network = Network.newNetwork();
 
     @Container
-    static OracleContainer db = ContainerTestUtils.oracleContainer(network);
+    static OracleContainer db = ContainerTestUtils.oracleContainer(network)
+            .withStartupTimeout(Duration.ofMinutes(3));
 
     @Container
     static GenericContainer<?> app = ContainerTestUtils.oracleAppContainer(network)

--- a/taxonomy-app/src/test/java/com/taxonomy/SeleniumOracleContainerIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/SeleniumOracleContainerIT.java
@@ -5,6 +5,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.time.Duration;
+
 /**
  * Selenium UI + REST tests against <strong>Oracle Database Free</strong>.
  * <p>
@@ -20,7 +22,8 @@ class SeleniumOracleContainerIT extends AbstractSeleniumContainerIT {
 
     @Override
     protected GenericContainer<?> createDbContainer(Network net) {
-        return ContainerTestUtils.oracleContainer(net);
+        return ContainerTestUtils.oracleContainer(net)
+                .withStartupTimeout(Duration.ofMinutes(3));
     }
 
     @Override

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
@@ -98,11 +98,11 @@ class ProposalProjectionUnavailableHttpTest {
         assertThat(response.getHeaders().getFirst(
                 RelationApiController.PROJECTION_STATE_HEADER))
                 .isEqualTo("BRANCH_MISSING");
-        assertThat(response.getHeaders().containsKey(HttpHeaders.ETAG))
-                .isFalse();
-        assertThat(response.getHeaders().containsKey(
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
+                .isNull();
+        assertThat(response.getHeaders().getFirst(
                 RelationApiController.PENDING_RECOVERY_HEADER))
-                .isFalse();
+                .isNull();
     }
 
     private static Map<String, String> validProposalBody() {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
@@ -1,6 +1,5 @@
 package com.taxonomy.relations.controller;
 
-import com.taxonomy.dto.RelationProposalDto;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
@@ -61,17 +60,8 @@ class ProposalProjectionUnavailableHttpTest {
 
         var response = controller.proposeRelations(validProposalBody());
 
-        assertThat(response.getStatusCode().value()).isEqualTo(409);
-        assertThat(response.getHeaders().getFirst(
-                RelationApiController.PROJECTION_STATE_HEADER))
-                .isEqualTo("STALE");
-        assertThat(response.getHeaders().getFirst(
-                RelationApiController.PENDING_RECOVERY_HEADER))
-                .isEqualTo("2");
-        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
-                .isEqualTo('"' + currentHead + '"');
-        assertThat(response.getHeaders().getCacheControl())
-                .isEqualTo("no-store");
+        assertStaleResponse(response.getStatusCode().value(),
+                response.getHeaders(), currentHead, "2");
     }
 
     @Test
@@ -94,15 +84,92 @@ class ProposalProjectionUnavailableHttpTest {
 
         var response = controller.proposeRelations(validProposalBody());
 
-        assertThat(response.getStatusCode().value()).isEqualTo(404);
-        assertThat(response.getHeaders().getFirst(
+        assertMissingBranchResponse(
+                response.getStatusCode().value(), response.getHeaders());
+    }
+
+    @Test
+    void staleProjectionBlocksHypothesisConversionWithRecoveryMetadata() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        String currentHead = "c".repeat(40);
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(proposalService.createFromHypothesisInContext(
+                eq("BP"),
+                eq("CP"),
+                eq(RelationType.RELATED_TO),
+                eq(0.82),
+                eq("model evidence"),
+                eq(context)))
+                .thenThrow(new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.STALE,
+                        currentHead,
+                        "d".repeat(40),
+                        3L));
+
+        var response = controller.createFromHypothesis(validHypothesisBody());
+
+        assertStaleResponse(response.getStatusCode().value(),
+                response.getHeaders(), currentHead, "3");
+    }
+
+    @Test
+    void missingBranchBlocksHypothesisConversionWithoutInventingAnEtag() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "missing", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(proposalService.createFromHypothesisInContext(
+                eq("BP"),
+                eq("CP"),
+                eq(RelationType.RELATED_TO),
+                eq(0.82),
+                eq("model evidence"),
+                eq(context)))
+                .thenThrow(new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.BRANCH_MISSING,
+                        null,
+                        null,
+                        0L));
+
+        var response = controller.createFromHypothesis(validHypothesisBody());
+
+        assertMissingBranchResponse(
+                response.getStatusCode().value(), response.getHeaders());
+    }
+
+    private static void assertStaleResponse(
+            int status,
+            HttpHeaders headers,
+            String currentHead,
+            String pendingRecoveryCount) {
+        assertThat(status).isEqualTo(409);
+        assertThat(headers.getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("STALE");
+        assertThat(headers.getFirst(
+                RelationApiController.PENDING_RECOVERY_HEADER))
+                .isEqualTo(pendingRecoveryCount);
+        assertThat(headers.getFirst(HttpHeaders.ETAG))
+                .isEqualTo('"' + currentHead + '"');
+        assertThat(headers.getCacheControl()).isEqualTo("no-store");
+    }
+
+    private static void assertMissingBranchResponse(
+            int status,
+            HttpHeaders headers) {
+        assertThat(status).isEqualTo(404);
+        assertThat(headers.getFirst(
                 RelationApiController.PROJECTION_STATE_HEADER))
                 .isEqualTo("BRANCH_MISSING");
-        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
-                .isNull();
-        assertThat(response.getHeaders().getFirst(
+        assertThat(headers.getFirst(HttpHeaders.ETAG)).isNull();
+        assertThat(headers.getFirst(
                 RelationApiController.PENDING_RECOVERY_HEADER))
                 .isNull();
+        assertThat(headers.getCacheControl()).isEqualTo("no-store");
     }
 
     private static Map<String, String> validProposalBody() {
@@ -110,5 +177,14 @@ class ProposalProjectionUnavailableHttpTest {
                 "sourceCode", "BP",
                 "relationType", "RELATED_TO",
                 "limit", "3");
+    }
+
+    private static Map<String, Object> validHypothesisBody() {
+        return Map.of(
+                "sourceCode", "BP",
+                "targetCode", "CP",
+                "relationType", "RELATED_TO",
+                "confidence", 0.82,
+                "rationale", "model evidence");
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
@@ -1,0 +1,114 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dto.RelationProposalDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
+import com.taxonomy.relations.service.RelationProposalService;
+import com.taxonomy.relations.service.RelationReviewService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProposalProjectionUnavailableHttpTest {
+
+    private RelationProposalService proposalService;
+    private WorkspaceResolver workspaceResolver;
+    private ProposalApiController controller;
+
+    @BeforeEach
+    void setUp() {
+        proposalService = mock(RelationProposalService.class);
+        workspaceResolver = mock(WorkspaceResolver.class);
+        controller = new ProposalApiController(
+                proposalService,
+                mock(RelationReviewService.class),
+                workspaceResolver,
+                mock(SystemRepositoryService.class),
+                mock(RepositoryMembershipService.class));
+    }
+
+    @Test
+    void staleProjectionReturnsConflictAndRecoveryMetadata() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        String currentHead = "a".repeat(40);
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(proposalService.proposeRelationsInContext(
+                eq("BP"),
+                eq(RelationType.RELATED_TO),
+                anyInt(),
+                eq(context)))
+                .thenThrow(new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.STALE,
+                        currentHead,
+                        "b".repeat(40),
+                        2L));
+
+        var response = controller.proposeRelations(validProposalBody());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(409);
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("STALE");
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PENDING_RECOVERY_HEADER))
+                .isEqualTo("2");
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
+                .isEqualTo('"' + currentHead + '"');
+        assertThat(response.getHeaders().getCacheControl())
+                .isEqualTo("no-store");
+    }
+
+    @Test
+    void missingSelectedBranchReturnsNotFoundWithoutInventingAnEtag() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "missing", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(proposalService.proposeRelationsInContext(
+                eq("BP"),
+                eq(RelationType.RELATED_TO),
+                anyInt(),
+                eq(context)))
+                .thenThrow(new RelationProjectionUnavailableException(
+                        context,
+                        ReadinessState.BRANCH_MISSING,
+                        null,
+                        null,
+                        0L));
+
+        var response = controller.proposeRelations(validProposalBody());
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("BRANCH_MISSING");
+        assertThat(response.getHeaders().containsKey(HttpHeaders.ETAG))
+                .isFalse();
+        assertThat(response.getHeaders().containsKey(
+                RelationApiController.PENDING_RECOVERY_HEADER))
+                .isFalse();
+    }
+
+    private static Map<String, String> validProposalBody() {
+        return Map.of(
+                "sourceCode", "BP",
+                "relationType", "RELATED_TO",
+                "limit", "3");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalDuplicateProjectionArchitectureTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/ProposalDuplicateProjectionArchitectureTest.java
@@ -1,0 +1,45 @@
+package com.taxonomy.relations.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProposalDuplicateProjectionArchitectureTest {
+
+    private static final Path PROPOSAL_SERVICE = Path.of(
+            "src/main/java/com/taxonomy/relations/service/"
+                    + "RelationProposalService.java");
+    private static final Path VALIDATION_SERVICE = Path.of(
+            "src/main/java/com/taxonomy/relations/service/"
+                    + "RelationValidationService.java");
+    private static final Path RELATION_READ_SERVICE = Path.of(
+            "src/main/java/com/taxonomy/relations/service/"
+                    + "RelationProjectionReadService.java");
+
+    @Test
+    void proposalDuplicateValidationUsesOneProjectedIdentitySnapshot()
+            throws Exception {
+        String proposal = Files.readString(PROPOSAL_SERVICE);
+        String validation = Files.readString(VALIDATION_SERVICE);
+        String relationRead = Files.readString(RELATION_READ_SERVICE);
+
+        assertThat(proposal)
+                .contains("relationReadService.readIdentitySnapshot(tenant)")
+                .contains("IdentitySnapshot existingRelations")
+                .contains("existingRelations.contains(")
+                .doesNotContain("TaxonomyRelationRepository")
+                .doesNotContain("findBySourceNodeCodeAndRelationTypeIn");
+        assertThat(validation)
+                .doesNotContain("TaxonomyRelationRepository")
+                .doesNotContain("relationRepository")
+                .doesNotContain("findBySourceNodeCodeAndRelationTypeIn");
+        assertThat(relationRead)
+                .contains("public IdentitySnapshot readIdentitySnapshot(")
+                .contains("ResolvedSource source = resolveSource(selected)")
+                .contains("ReadModel.LEGACY_FALLBACK")
+                .contains("throw unavailable(selected, readiness, pendingRecoveries)");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProjectionReadServiceTest.java
@@ -93,14 +93,75 @@ class RelationProjectionReadServiceTest {
     }
 
     @Test
+    void readyIdentitySnapshotAvoidsDtoAndNameMaterialization() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        when(readinessService.inspect(context)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "a".repeat(40),
+                "a".repeat(40),
+                List.of(
+                        projection(
+                                1L, "BP", RelationType.SUPPORTS, "CP",
+                                "manual", "a".repeat(40)),
+                        projection(
+                                2L, "CP", RelationType.REALIZES, "CR",
+                                "manual", "a".repeat(40)))));
+
+        var snapshot = service.readIdentitySnapshot(context);
+
+        assertThat(snapshot.readModel()).isEqualTo(ReadModel.PROJECTION);
+        assertThat(snapshot.readinessState()).isEqualTo(ReadinessState.READY);
+        assertThat(snapshot.authoritativeCommitId()).isEqualTo("a".repeat(40));
+        assertThat(snapshot.contains("BP", RelationType.SUPPORTS, "CP"))
+                .isTrue();
+        assertThat(snapshot.contains("BP", RelationType.SUPPORTS, "CR"))
+                .isFalse();
+        verifyNoInteractions(
+                nodeRepository, legacyRelationService, repositoryService);
+        verify(recoveryService, never()).pendingCount(context);
+    }
+
+    @Test
+    void identitySnapshotsRemainBranchLocal() {
+        RepositoryContext branchA = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RepositoryContext branchB = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/b", "alice");
+        when(readinessService.inspect(branchA)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "a".repeat(40),
+                "a".repeat(40),
+                List.of(projection(
+                        1L, "BP", RelationType.SUPPORTS, "CP",
+                        null, "a".repeat(40)))));
+        when(readinessService.inspect(branchB)).thenReturn(new Readiness(
+                ReadinessState.READY,
+                "b".repeat(40),
+                "b".repeat(40),
+                List.of(projection(
+                        2L, "BP", RelationType.SUPPORTS, "CR",
+                        null, "b".repeat(40)))));
+
+        var snapshotA = service.readIdentitySnapshot(branchA);
+        var snapshotB = service.readIdentitySnapshot(branchB);
+
+        assertThat(snapshotA.contains("BP", RelationType.SUPPORTS, "CP"))
+                .isTrue();
+        assertThat(snapshotA.contains("BP", RelationType.SUPPORTS, "CR"))
+                .isFalse();
+        assertThat(snapshotB.contains("BP", RelationType.SUPPORTS, "CP"))
+                .isFalse();
+        assertThat(snapshotB.contains("BP", RelationType.SUPPORTS, "CR"))
+                .isTrue();
+    }
+
+    @Test
     void primaryDefaultBranchMayUseLegacyOnlyBeforeAnyBuildOrFailure() {
         RepositoryContext context = RepositoryContext.centralRead(
                 "primary", "draft", "alice");
-        TaxonomyRelationDto legacy = new TaxonomyRelationDto();
-        legacy.setId(8L);
-        legacy.setSourceCode("BP");
-        legacy.setTargetCode("CP");
-        legacy.setRelationType("SUPPORTS");
+        TaxonomyRelationDto legacy = relation(
+                8L, "BP", RelationType.SUPPORTS, "CP");
         when(readinessService.inspect(context)).thenReturn(new Readiness(
                 ReadinessState.NOT_BUILT,
                 "b".repeat(40),
@@ -118,6 +179,27 @@ class RelationProjectionReadServiceTest {
         assertThat(result.readinessState()).isEqualTo(ReadinessState.NOT_BUILT);
         assertThat(result.authoritativeCommitId()).isEqualTo("b".repeat(40));
         assertThat(result.relations()).containsExactly(legacy);
+    }
+
+    @Test
+    void identitySnapshotUsesTheSamePrimaryMigrationFallback() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "primary", "draft", "alice");
+        when(readinessService.inspect(context)).thenReturn(notBuilt("b"));
+        when(recoveryService.pendingCount(context)).thenReturn(0L);
+        when(repositoryService.getPrimaryRepository()).thenReturn(
+                primary("primary", "draft"));
+        when(legacyRelationService.getAllRelationsInContext(context))
+                .thenReturn(List.of(relation(
+                        8L, "BP", RelationType.SUPPORTS, "CP")));
+
+        var snapshot = service.readIdentitySnapshot(context);
+
+        assertThat(snapshot.readModel()).isEqualTo(ReadModel.LEGACY_FALLBACK);
+        assertThat(snapshot.readinessState()).isEqualTo(ReadinessState.NOT_BUILT);
+        assertThat(snapshot.contains("BP", RelationType.SUPPORTS, "CP"))
+                .isTrue();
+        verifyNoInteractions(nodeRepository);
     }
 
     @Test
@@ -174,6 +256,11 @@ class RelationProjectionReadServiceTest {
         when(recoveryService.pendingCount(context)).thenReturn(0L);
 
         assertThatThrownBy(() -> service.readAll(context))
+                .isInstanceOfSatisfying(
+                        RelationProjectionUnavailableException.class,
+                        error -> assertThat(error.getReadinessState())
+                                .isEqualTo(ReadinessState.STALE));
+        assertThatThrownBy(() -> service.readIdentitySnapshot(context))
                 .isInstanceOfSatisfying(
                         RelationProjectionUnavailableException.class,
                         error -> assertThat(error.getReadinessState())
@@ -267,6 +354,19 @@ class RelationProjectionReadServiceTest {
         projection.setAuthoritativeCommitId(commit);
         projection.setCausationId("rebuild:" + commit);
         return projection;
+    }
+
+    private static TaxonomyRelationDto relation(
+            Long id,
+            String source,
+            RelationType type,
+            String target) {
+        TaxonomyRelationDto relation = new TaxonomyRelationDto();
+        relation.setId(id);
+        relation.setSourceCode(source);
+        relation.setRelationType(type.name());
+        relation.setTargetCode(target);
+        return relation;
     }
 
     private static TaxonomyNode node(String code, String name) {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalProjectionDuplicateTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalProjectionDuplicateTest.java
@@ -1,0 +1,232 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.dto.TaxonomyNodeDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.IdentitySnapshot;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
+import com.taxonomy.relations.service.RelationProjectionReadService.RelationIdentity;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class RelationProposalProjectionDuplicateTest {
+
+    private TaxonomyNodeRepository nodeRepository;
+    private RelationProposalRepository proposalRepository;
+    private RelationCandidateService candidateService;
+    private RelationProjectionReadService relationReadService;
+    private RelationValidationService validationService;
+    private WorkspaceResolver workspaceResolver;
+    private RelationProposalService service;
+
+    @BeforeEach
+    void setUp() {
+        nodeRepository = mock(TaxonomyNodeRepository.class);
+        proposalRepository = mock(RelationProposalRepository.class);
+        candidateService = mock(RelationCandidateService.class);
+        relationReadService = mock(RelationProjectionReadService.class);
+        validationService = mock(RelationValidationService.class);
+        workspaceResolver = mock(WorkspaceResolver.class);
+        service = new RelationProposalService(
+                nodeRepository,
+                proposalRepository,
+                candidateService,
+                relationReadService,
+                validationService,
+                workspaceResolver);
+    }
+
+    @Test
+    void relationInRepositoryBDoesNotSuppressRepositoryACandidate() {
+        RepositoryContext repositoryA = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        RepositoryContext repositoryB = RepositoryContext.workspace(
+                "repo-b", "workspace-b", "feature/b", "bob");
+        TaxonomyNode source = source("BP", "BP");
+        TaxonomyNodeDto candidate = candidate("CR", "CR");
+        prepareCandidate(source, candidate, RelationType.RELATED_TO);
+        when(relationReadService.readIdentitySnapshot(repositoryA))
+                .thenReturn(snapshot("a", Set.of()));
+        when(relationReadService.readIdentitySnapshot(repositoryB))
+                .thenReturn(snapshot("b", Set.of(new RelationIdentity(
+                        "BP", RelationType.RELATED_TO, "CR"))));
+        when(validationService.validate(
+                source,
+                candidate,
+                RelationType.RELATED_TO,
+                0,
+                1)).thenReturn(
+                        RelationValidationService.ValidationResult.fail(
+                                "stop after duplicate boundary"));
+
+        service.proposeRelationsInContext(
+                "BP", RelationType.RELATED_TO, 1, repositoryA);
+
+        verify(validationService).validate(
+                source, candidate, RelationType.RELATED_TO, 0, 1);
+        clearInvocations(validationService);
+
+        service.proposeRelationsInContext(
+                "BP", RelationType.RELATED_TO, 1, repositoryB);
+
+        verifyNoInteractions(validationService);
+        verify(relationReadService).readIdentitySnapshot(repositoryA);
+        verify(relationReadService).readIdentitySnapshot(repositoryB);
+    }
+
+    @Test
+    void privateWorkspaceRelationDoesNotSuppressSiblingWorkspaceCandidate() {
+        RepositoryContext workspaceA1 = RepositoryContext.workspace(
+                "repo-a", "workspace-a1", "feature/a1", "alice");
+        RepositoryContext workspaceA2 = RepositoryContext.workspace(
+                "repo-a", "workspace-a2", "feature/a2", "bob");
+        TaxonomyNode source = source("BP", "BP");
+        TaxonomyNodeDto candidate = candidate("CR", "CR");
+        prepareCandidate(source, candidate, RelationType.RELATED_TO);
+        when(relationReadService.readIdentitySnapshot(workspaceA1))
+                .thenReturn(snapshot("1", Set.of()));
+        when(relationReadService.readIdentitySnapshot(workspaceA2))
+                .thenReturn(snapshot("2", Set.of(new RelationIdentity(
+                        "BP", RelationType.RELATED_TO, "CR"))));
+        when(validationService.validate(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(RelationValidationService.ValidationResult.fail(
+                        "stop after duplicate boundary"));
+
+        service.proposeRelationsInContext(
+                "BP", RelationType.RELATED_TO, 1, workspaceA1);
+        verify(validationService).validate(
+                source, candidate, RelationType.RELATED_TO, 0, 1);
+        clearInvocations(validationService);
+
+        service.proposeRelationsInContext(
+                "BP", RelationType.RELATED_TO, 1, workspaceA2);
+        verifyNoInteractions(validationService);
+    }
+
+    @Test
+    void proposalRunResolvesOneIdentitySnapshotForAllCandidates() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        TaxonomyNode source = source("BP", "BP");
+        TaxonomyNodeDto first = candidate("CR", "CR");
+        TaxonomyNodeDto second = candidate("CP", "CP");
+        when(nodeRepository.findByCode("BP"))
+                .thenReturn(Optional.of(source));
+        when(candidateService.findCandidates(
+                source, RelationType.RELATED_TO, 2))
+                .thenReturn(List.of(first, second));
+        when(relationReadService.readIdentitySnapshot(context))
+                .thenReturn(snapshot("a", Set.of()));
+        when(proposalRepository.existsInRepositoryWorkspace(
+                eq("repo-a"),
+                eq("BP"),
+                any(),
+                eq(RelationType.RELATED_TO),
+                eq("workspace-a")))
+                .thenReturn(false);
+        when(validationService.validate(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(RelationValidationService.ValidationResult.fail(
+                        "not relevant"));
+
+        service.proposeRelationsInContext(
+                "BP", RelationType.RELATED_TO, 2, context);
+
+        verify(relationReadService, times(1)).readIdentitySnapshot(context);
+        verify(validationService, times(2)).validate(
+                eq(source), any(), eq(RelationType.RELATED_TO), anyInt(), eq(2));
+    }
+
+    @Test
+    void hypothesisProposalIsNotCreatedForAnExistingActiveRelation() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        TaxonomyNode source = source("BP", "BP");
+        TaxonomyNode target = source("CR", "CR");
+        when(nodeRepository.findByCode("BP"))
+                .thenReturn(Optional.of(source));
+        when(nodeRepository.findByCode("CR"))
+                .thenReturn(Optional.of(target));
+        when(proposalRepository.existsInRepositoryWorkspace(
+                "repo-a",
+                "BP",
+                "CR",
+                RelationType.RELATED_TO,
+                "workspace-a"))
+                .thenReturn(false);
+        when(relationReadService.readIdentitySnapshot(context))
+                .thenReturn(snapshot("a", Set.of(new RelationIdentity(
+                        "BP", RelationType.RELATED_TO, "CR"))));
+
+        var result = service.createFromHypothesisInContext(
+                "BP",
+                "CR",
+                RelationType.RELATED_TO,
+                0.8,
+                "candidate",
+                context);
+
+        assertThat(result).isNull();
+        verify(proposalRepository, never()).save(any(RelationProposal.class));
+    }
+
+    private void prepareCandidate(
+            TaxonomyNode source,
+            TaxonomyNodeDto candidate,
+            RelationType type) {
+        when(nodeRepository.findByCode(source.getCode()))
+                .thenReturn(Optional.of(source));
+        when(candidateService.findCandidates(source, type, 1))
+                .thenReturn(List.of(candidate));
+        when(proposalRepository.existsInRepositoryWorkspace(
+                any(), any(), any(), eq(type), any()))
+                .thenReturn(false);
+    }
+
+    private static IdentitySnapshot snapshot(
+            String digit,
+            Set<RelationIdentity> identities) {
+        return new IdentitySnapshot(
+                ReadModel.PROJECTION,
+                ReadinessState.READY,
+                digit.repeat(40),
+                identities);
+    }
+
+    private static TaxonomyNode source(String code, String root) {
+        TaxonomyNode node = new TaxonomyNode();
+        node.setCode(code);
+        node.setTaxonomyRoot(root);
+        node.setNameEn(code);
+        return node;
+    }
+
+    private static TaxonomyNodeDto candidate(String code, String root) {
+        TaxonomyNodeDto candidate = new TaxonomyNodeDto();
+        candidate.setCode(code);
+        candidate.setTaxonomyRoot(root);
+        candidate.setNameEn(code);
+        return candidate;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalRepositoryScopeTest.java
@@ -6,6 +6,9 @@ import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationProjectionReadService.IdentitySnapshot;
+import com.taxonomy.relations.service.RelationProjectionReadService.ReadModel;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryScope;
 import com.taxonomy.workspace.service.WorkspaceResolver;
@@ -15,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -29,6 +33,7 @@ class RelationProposalRepositoryScopeTest {
     private TaxonomyNodeRepository nodeRepository;
     private RelationProposalRepository proposalRepository;
     private RelationCandidateService candidateService;
+    private RelationProjectionReadService relationReadService;
     private RelationValidationService validationService;
     private WorkspaceResolver workspaceResolver;
     private RelationProposalService service;
@@ -38,12 +43,20 @@ class RelationProposalRepositoryScopeTest {
         nodeRepository = mock(TaxonomyNodeRepository.class);
         proposalRepository = mock(RelationProposalRepository.class);
         candidateService = mock(RelationCandidateService.class);
+        relationReadService = mock(RelationProjectionReadService.class);
         validationService = mock(RelationValidationService.class);
         workspaceResolver = mock(WorkspaceResolver.class);
+        when(relationReadService.readIdentitySnapshot(any()))
+                .thenReturn(new IdentitySnapshot(
+                        ReadModel.PROJECTION,
+                        ReadinessState.READY,
+                        "a".repeat(40),
+                        Set.of()));
         service = new RelationProposalService(
                 nodeRepository,
                 proposalRepository,
                 candidateService,
+                relationReadService,
                 validationService,
                 workspaceResolver);
     }
@@ -88,6 +101,7 @@ class RelationProposalRepositoryScopeTest {
 
         verify(nodeRepository, never()).findByCode(any());
         verify(proposalRepository, never()).save(any());
+        verify(relationReadService, never()).readIdentitySnapshot(any());
     }
 
     @Test
@@ -115,6 +129,7 @@ class RelationProposalRepositoryScopeTest {
         ArgumentCaptor<RelationProposal> captor =
                 ArgumentCaptor.forClass(RelationProposal.class);
         verify(proposalRepository).save(captor.capture());
+        verify(relationReadService).readIdentitySnapshot(context);
         RelationProposal saved = captor.getValue();
         assertThat(saved.getRepositoryId()).isEqualTo("repo-a");
         assertThat(saved.getWorkspaceId()).isEqualTo("workspace-a");
@@ -140,6 +155,7 @@ class RelationProposalRepositoryScopeTest {
 
         verify(proposalRepository).existsInRepositoryWorkspace(
                 "repo-a", "BP", "CP", RelationType.SUPPORTS, null);
+        verify(relationReadService).readIdentitySnapshot(context);
         verify(proposalRepository, never()).existsInWorkspace(any(), any(), any(), any());
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/ApiWriteDenyByDefaultSecurityTest.java
@@ -71,6 +71,24 @@ class ApiWriteDenyByDefaultSecurityTest {
     }
 
     @Test
+    @WithMockUser(roles = "ARCHITECT")
+    void architectReachesSelfServiceWorkspaceProvisioning() throws Exception {
+        mockMvc.perform(post("/api/workspace/provision").with(csrf()))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .as("architect workspace provisioning must pass authorization")
+                        .isNotEqualTo(403));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void userReachesSelfServiceWorkspaceProvisioning() throws Exception {
+        mockMvc.perform(post("/api/workspace/provision").with(csrf()))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .as("user workspace provisioning must pass authorization")
+                        .isNotEqualTo(403));
+    }
+
+    @Test
     @WithMockUser(roles = "USER")
     void userCannotTriggerDerivedMetadataWrites() throws Exception {
         mockMvc.perform(post("/api/architecture/metadata/recompute").with(csrf()))


### PR DESCRIPTION
## Scope

Implements #727 as one bounded proposal-pipeline slice on the multi-repository architecture line.

#725 was verified and integrated into `copilot/architecture-epic-multi-repo` as `d4e7c32c5271484468ffb41aa6ac372f0c12d823`. This PR now targets that integration branch directly.

## Authority and isolation change

- add `RelationProjectionReadService#readIdentitySnapshot(...)`;
- resolve the same readiness and migration-fallback decision used by productive relation list/count reads;
- build one immutable source/type/target identity set from the selected repository/workspace/branch projection;
- keep the narrow primary/default-branch legacy fallback only through that shared resolver;
- fail closed for stale, corrupt or missing workspace/fork projections;
- avoid node-name loading and relation DTO allocation for READY identity checks.

## Proposal pipeline

- resolve one identity snapshot before candidate search and reuse it for the complete proposal run;
- prevent active relations in the selected branch from becoming proposals;
- keep another repository, sibling workspace or branch from suppressing valid candidates;
- apply the same active-relation guard to hypothesis-derived proposals;
- remove the unscoped legacy relation query from `RelationValidationService`;
- keep compatibility and confidence validation independent from active-relation persistence.

The separately identified quality-metric and acceptance-history tenancy defect remains isolated in #728/#731.

## HTTP behavior

Proposal generation and hypothesis conversion expose projection unavailability explicitly:

- `BRANCH_MISSING` -> HTTP 404;
- `NOT_BUILT`, `STALE` or `CORRUPT` -> HTTP 409;
- `X-Taxonomy-Relation-Projection-State` identifies the state;
- pending recovery count and authoritative branch `ETag` are included when available;
- responses use `Cache-Control: no-store`.

## Provisioning and asynchronous startup hardening

The exact-head browser workflow exposed that asynchronous catalogue loading could finish after `ApplicationReadyEvent`, leaving the Git bootstrap permanently skipped. The resulting workspace could be marked provisioned without an authoritative branch projection, so proposal generation correctly failed closed.

This PR now also:

- emits an explicit initialization-complete event on the `READY` transition;
- retries the idempotent Git bootstrap after asynchronous catalogue completion;
- checks catalogue readiness before acquiring the one-shot bootstrap guard, preventing a READY event from being lost in a narrow ApplicationReady race;
- makes workspace readiness include an exact-head relation-projection rebuild;
- classifies `/api/workspace/provision` explicitly as authenticated self-service for USER, ARCHITECT and ADMIN before the privileged workspace catch-all;
- proves USER and ARCHITECT provisioning authorization through MockMvc;
- moves provisioning transport into `static/js/api/workspace-provisioning-api.js` and keeps the UI module transport-free;
- preserves reverse-proxy prefixes when dynamically loading that API client;
- makes the primary browser fixture provision and rebuild through the productive HTTP contracts before creating proposals.

## Oracle verification hardening

The prior Oracle failure occurred before application execution: the second Oracle Free container in the same job missed its 60-second ready-message deadline after the Selenium suite had already passed. Oracle database startup now receives the same realistic CI startup budget as the application container; PostgreSQL and SQL Server behavior is unchanged. The subsequent exact-head database matrix passed all three database jobs.

## Verification

Focused evidence covers:

- READY identity snapshots without DTO/name materialization;
- identical primary migration-fallback policy for product and duplicate reads;
- fail-closed stale state and branch-missing state;
- branch-local identity differences;
- repository B cannot suppress repository A;
- private workspace A2 cannot suppress workspace A1;
- one snapshot per multi-candidate proposal run;
- active relations block hypothesis-derived duplicates;
- HTTP 404/409 projection metadata for both proposal-generation entry points;
- asynchronous READY event publication and race-free deferred bootstrap;
- API-layer ownership of provisioning transport;
- self-service provisioning authorization for normal product roles;
- exact workspace projection readiness before primary browser proposal workflows;
- a source contract preventing proposal validation from returning to an unscoped relation query.

All inline review findings are resolved.

Current exact head: `51a899566c2f33605acf106d73ca4c959bba3f1c`.

Merge only after exact-head CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security Scan gates are green.

Closes #727 after integration.