### PR TITLE
Scope relation quality metrics and feedback to repository context

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/QualityApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/QualityApiController.java
@@ -5,24 +5,26 @@ import com.taxonomy.dto.RelationQualityMetrics;
 import com.taxonomy.dto.RelationTypeMetrics;
 import com.taxonomy.dto.TopRejectedProposal;
 import com.taxonomy.relations.service.RelationQualityService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 /**
  * REST API for the Relation Quality Dashboard.
  *
- * <p>Endpoints:
- * <ul>
- *   <li>{@code GET /api/relations/metrics} — full quality dashboard</li>
- *   <li>{@code GET /api/relations/metrics/by-type} — metrics by relation type</li>
- *   <li>{@code GET /api/relations/metrics/by-provenance} — metrics by provenance</li>
- *   <li>{@code GET /api/relations/metrics/top-rejected} — top rejected proposals</li>
- * </ul>
+ * <p>Every request resolves one stable selected repository context. Responses
+ * are not cacheable because the URL is intentionally independent of the
+ * repository/workspace selection stored in the user session.</p>
  */
 @RestController
 @RequestMapping("/api/relations/metrics")
@@ -30,45 +32,64 @@ import java.util.List;
 public class QualityApiController {
 
     private final RelationQualityService qualityService;
+    private final WorkspaceResolver workspaceResolver;
 
-    public QualityApiController(RelationQualityService qualityService) {
+    public QualityApiController(
+            RelationQualityService qualityService,
+            WorkspaceResolver workspaceResolver) {
         this.qualityService = qualityService;
+        this.workspaceResolver = workspaceResolver;
     }
 
-    /**
-     * Returns the full quality dashboard metrics.
-     */
-    @Operation(summary = "Quality dashboard", description = "Returns the full quality dashboard metrics")
+    /** Returns the full quality dashboard metrics. */
+    @Operation(
+            summary = "Quality dashboard",
+            description = "Returns quality metrics for the selected repository context")
     @GetMapping
     public ResponseEntity<RelationQualityMetrics> getMetrics() {
-        return ResponseEntity.ok(qualityService.calculateMetrics());
+        RepositoryContext context = currentContext();
+        return noStore(qualityService.calculateMetrics(context));
     }
 
-    /**
-     * Returns metrics broken down by relation type.
-     */
-    @Operation(summary = "Metrics by relation type", description = "Returns quality metrics broken down by relation type")
+    /** Returns metrics broken down by relation type. */
+    @Operation(
+            summary = "Metrics by relation type",
+            description = "Returns relation-type metrics for the selected repository context")
     @GetMapping("/by-type")
     public ResponseEntity<List<RelationTypeMetrics>> getMetricsByType() {
-        return ResponseEntity.ok(qualityService.metricsByRelationType());
+        RepositoryContext context = currentContext();
+        return noStore(qualityService.metricsByRelationType(context));
     }
 
-    /**
-     * Returns metrics broken down by provenance.
-     */
-    @Operation(summary = "Metrics by provenance", description = "Returns quality metrics broken down by provenance")
+    /** Returns metrics broken down by provenance. */
+    @Operation(
+            summary = "Metrics by provenance",
+            description = "Returns provenance metrics for the selected repository context")
     @GetMapping("/by-provenance")
     public ResponseEntity<List<ProvenanceMetrics>> getMetricsByProvenance() {
-        return ResponseEntity.ok(qualityService.metricsByProvenance());
+        RepositoryContext context = currentContext();
+        return noStore(qualityService.metricsByProvenance(context));
     }
 
-    /**
-     * Returns top rejected proposals ordered by confidence descending.
-     */
-    @Operation(summary = "Top rejected proposals", description = "Returns top rejected proposals ordered by confidence descending")
+    /** Returns the highest-confidence rejected proposals in the visible scope. */
+    @Operation(
+            summary = "Top rejected proposals",
+            description = "Returns rejected proposals from the selected repository context")
     @GetMapping("/top-rejected")
     public ResponseEntity<List<TopRejectedProposal>> getTopRejected(
-            @Parameter(description = "Maximum number of results") @RequestParam(defaultValue = "10") int limit) {
-        return ResponseEntity.ok(qualityService.topRejected(limit));
+            @Parameter(description = "Maximum number of results")
+            @RequestParam(defaultValue = "10") int limit) {
+        RepositoryContext context = currentContext();
+        return noStore(qualityService.topRejected(limit, context));
+    }
+
+    private RepositoryContext currentContext() {
+        return workspaceResolver.resolveCurrentRepositoryContext();
+    }
+
+    private static <T> ResponseEntity<T> noStore(T body) {
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .body(body);
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/repository/RelationProposalRepository.java
@@ -87,6 +87,28 @@ public interface RelationProposalRepository extends JpaRepository<RelationPropos
             @Param("workspaceId") String workspaceId,
             @Param("sourceCode") String sourceCode);
 
+    /**
+     * Counts reviewed history visible in one selected context. A null workspace
+     * intentionally means central rows only; a workspace inherits central rows
+     * plus rows from that exact workspace and never sibling workspaces.
+     */
+    @Query("""
+            SELECT COUNT(p) FROM RelationProposal p
+            WHERE p.repositoryId = :repositoryId
+              AND (p.workspaceId IS NULL OR p.workspaceId = :workspaceId)
+              AND p.sourceNode.taxonomyRoot = :sourceRoot
+              AND p.targetNode.taxonomyRoot = :targetRoot
+              AND p.relationType = :relationType
+              AND p.status = :status
+            """)
+    long countVisibleReviewHistory(
+            @Param("repositoryId") String repositoryId,
+            @Param("workspaceId") String workspaceId,
+            @Param("sourceRoot") String sourceRoot,
+            @Param("targetRoot") String targetRoot,
+            @Param("relationType") RelationType relationType,
+            @Param("status") ProposalStatus status);
+
     /** Looks up a proposal in exactly one mutable repository/workspace scope. */
     @Query("""
             SELECT p FROM RelationProposal p

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationProposalService.java
@@ -151,7 +151,8 @@ public class RelationProposalService {
                             candidate,
                             relationType,
                             i,
-                            candidates.size());
+                            candidates.size(),
+                            tenant);
 
             if (!result.isValid()) {
                 continue;
@@ -368,7 +369,9 @@ public class RelationProposalService {
 
     private String deriveExplanationBasis(RelationProposal proposal) {
         String provenance = proposal.getProvenance();
-        if (provenance == null) return "unknown source";
+        if (provenance == null) {
+            return "unknown source";
+        }
 
         return switch (provenance) {
             case "hybrid-search" -> "Discovered via hybrid search (semantic + keyword) "

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationQualityService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationQualityService.java
@@ -6,16 +6,24 @@ import com.taxonomy.dto.RelationTypeMetrics;
 import com.taxonomy.dto.TopRejectedProposal;
 import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
-import com.taxonomy.relations.model.RelationProposal;
+import java.util.Objects;
 
 /**
- * Service for computing quality metrics over {@link com.taxonomy.relations.model.RelationProposal}
- * entities and providing a feedback signal for confidence scoring.
+ * Computes relation-review quality metrics inside one selected repository
+ * context and provides the same scoped history as a confidence signal.
+ *
+ * <p>A central context sees central reviews in exactly one repository. A
+ * workspace context intentionally inherits those central reviews and adds only
+ * reviews from that exact workspace. Sibling workspaces and other repositories
+ * are never part of the normal product view.</p>
  */
 @Service
 public class RelationQualityService {
@@ -23,111 +31,210 @@ public class RelationQualityService {
     private final RelationProposalRepository proposalRepository;
 
     public RelationQualityService(RelationProposalRepository proposalRepository) {
-        this.proposalRepository = proposalRepository;
+        this.proposalRepository = Objects.requireNonNull(
+                proposalRepository, "proposalRepository");
     }
 
-    /**
-     * Computes the full quality dashboard metrics.
-     */
+    /** Computes the full dashboard from one request-stable visible snapshot. */
     @Transactional(readOnly = true)
-    public RelationQualityMetrics calculateMetrics() {
-        long accepted = proposalRepository.countByStatus(ProposalStatus.ACCEPTED);
-        long rejected = proposalRepository.countByStatus(ProposalStatus.REJECTED);
-        long pending  = proposalRepository.countByStatus(ProposalStatus.PENDING);
-        long total    = accepted + rejected + pending;
-
-        double acceptanceRate = (accepted + rejected) > 0
-                ? (double) accepted / (accepted + rejected) : 0.0;
-
-        Double avgAccepted = proposalRepository.avgConfidenceByStatus(ProposalStatus.ACCEPTED);
-        Double avgRejected = proposalRepository.avgConfidenceByStatus(ProposalStatus.REJECTED);
+    public RelationQualityMetrics calculateMetrics(RepositoryContext context) {
+        List<RelationProposal> proposals = visibleProposals(context);
+        long accepted = countByStatus(proposals, ProposalStatus.ACCEPTED);
+        long rejected = countByStatus(proposals, ProposalStatus.REJECTED);
+        long pending = countByStatus(proposals, ProposalStatus.PENDING);
+        long reviewed = accepted + rejected;
 
         return new RelationQualityMetrics(
-                (int) total,
-                (int) accepted,
-                (int) rejected,
-                (int) pending,
-                acceptanceRate,
-                avgAccepted != null ? avgAccepted : 0.0,
-                avgRejected != null ? avgRejected : 0.0,
-                metricsByRelationType(),
-                metricsByProvenance()
-        );
+                Math.toIntExact(accepted + rejected + pending),
+                Math.toIntExact(accepted),
+                Math.toIntExact(rejected),
+                Math.toIntExact(pending),
+                reviewed > 0 ? (double) accepted / reviewed : 0.0,
+                averageConfidence(proposals, ProposalStatus.ACCEPTED),
+                averageConfidence(proposals, ProposalStatus.REJECTED),
+                metricsByRelationType(proposals),
+                metricsByProvenance(proposals));
+    }
+
+    /** Returns metrics by relation type in the exact selected context. */
+    @Transactional(readOnly = true)
+    public List<RelationTypeMetrics> metricsByRelationType(
+            RepositoryContext context) {
+        return metricsByRelationType(visibleProposals(context));
+    }
+
+    /** Returns metrics by provenance in the exact selected context. */
+    @Transactional(readOnly = true)
+    public List<ProvenanceMetrics> metricsByProvenance(
+            RepositoryContext context) {
+        return metricsByProvenance(visibleProposals(context));
     }
 
     /**
-     * Aggregates metrics broken down by relation type.
+     * Returns rejected proposals visible in the selected context, ordered by
+     * descending confidence (the worst false positives first).
      */
     @Transactional(readOnly = true)
-    public List<RelationTypeMetrics> metricsByRelationType() {
-        return proposalRepository.findDistinctRelationTypes().stream()
-                .map(rt -> {
-                    long accepted = proposalRepository.countByRelationTypeAndStatus(rt, ProposalStatus.ACCEPTED);
-                    long rejected = proposalRepository.countByRelationTypeAndStatus(rt, ProposalStatus.REJECTED);
-                    long pending  = proposalRepository.countByRelationTypeAndStatus(rt, ProposalStatus.PENDING);
-                    long proposed = accepted + rejected + pending;
-                    double rate   = (accepted + rejected) > 0
-                            ? (double) accepted / (accepted + rejected) : 0.0;
-                    return new RelationTypeMetrics(rt.name(), (int) proposed, (int) accepted, (int) rejected, rate);
-                })
-                .toList();
-    }
-
-    /**
-     * Aggregates metrics broken down by provenance string.
-     */
-    @Transactional(readOnly = true)
-    public List<ProvenanceMetrics> metricsByProvenance() {
-        return proposalRepository.findDistinctProvenances().stream()
-                .map(prov -> {
-                    long accepted = proposalRepository.countByProvenanceAndStatus(prov, ProposalStatus.ACCEPTED);
-                    long rejected = proposalRepository.countByProvenanceAndStatus(prov, ProposalStatus.REJECTED);
-                    long pending  = proposalRepository.countByProvenanceAndStatus(prov, ProposalStatus.PENDING);
-                    long proposed = accepted + rejected + pending;
-                    double rate   = (accepted + rejected) > 0
-                            ? (double) accepted / (accepted + rejected) : 0.0;
-                    return new ProvenanceMetrics(prov, (int) proposed, (int) accepted, rate);
-                })
-                .toList();
-    }
-
-    /**
-     * Returns the top rejected proposals ordered by confidence descending (worst false positives first).
-     */
-    @Transactional(readOnly = true)
-    public List<TopRejectedProposal> topRejected(int limit) {
-        return proposalRepository.findByStatusOrderByConfidenceDesc(ProposalStatus.REJECTED)
-                .stream()
-                .limit(limit)
-                .map(p -> new TopRejectedProposal(
-                        p.getSourceNode().getCode(),
-                        p.getSourceNode().getNameEn(),
-                        p.getTargetNode().getCode(),
-                        p.getTargetNode().getNameEn(),
-                        p.getRelationType().name(),
-                        p.getConfidence(),
-                        p.getRationale()
-                ))
-                .toList();
-    }
-
-    /**
-     * Returns a feedback weight [0.0, 1.0] derived from the acceptance history
-     * for the given source root, target root, and relation type.
-     *
-     * <p>Returns 0.5 (neutral) when no history exists.
-     */
-    public double acceptanceHistoryWeight(String sourceRoot, String targetRoot, RelationType relationType) {
-        long accepted = proposalRepository
-                .countBySourceNodeTaxonomyRootAndTargetNodeTaxonomyRootAndRelationTypeAndStatus(
-                        sourceRoot, targetRoot, relationType, ProposalStatus.ACCEPTED);
-        long rejected = proposalRepository
-                .countBySourceNodeTaxonomyRootAndTargetNodeTaxonomyRootAndRelationTypeAndStatus(
-                        sourceRoot, targetRoot, relationType, ProposalStatus.REJECTED);
-
-        if ((accepted + rejected) == 0) {
-            return 0.5;
+    public List<TopRejectedProposal> topRejected(
+            int limit,
+            RepositoryContext context) {
+        if (limit <= 0) {
+            return List.of();
         }
-        return (double) accepted / (accepted + rejected);
+        return visibleProposals(context).stream()
+                .filter(proposal -> proposal.getStatus() == ProposalStatus.REJECTED)
+                .sorted(Comparator
+                        .comparingDouble(RelationProposal::getConfidence)
+                        .reversed()
+                        .thenComparing(
+                                RelationProposal::getId,
+                                Comparator.nullsLast(Long::compareTo)))
+                .limit(limit)
+                .map(proposal -> new TopRejectedProposal(
+                        proposal.getSourceNode().getCode(),
+                        proposal.getSourceNode().getNameEn(),
+                        proposal.getTargetNode().getCode(),
+                        proposal.getTargetNode().getNameEn(),
+                        proposal.getRelationType().name(),
+                        proposal.getConfidence(),
+                        proposal.getRationale()))
+                .toList();
+    }
+
+    /**
+     * Returns a feedback weight in {@code [0.0, 1.0]} from review history
+     * visible in the exact proposal-generation context.
+     *
+     * <p>Returns {@code 0.5} when no reviewed history exists. A workspace
+     * intentionally inherits central review history from the same repository,
+     * but never history from a sibling workspace or another repository.</p>
+     */
+    @Transactional(readOnly = true)
+    public double acceptanceHistoryWeight(
+            String sourceRoot,
+            String targetRoot,
+            RelationType relationType,
+            RepositoryContext context) {
+        RepositoryContext tenant = requireContext(context);
+        long accepted = proposalRepository.countVisibleReviewHistory(
+                tenant.repositoryId(),
+                tenant.workspaceId(),
+                sourceRoot,
+                targetRoot,
+                relationType,
+                ProposalStatus.ACCEPTED);
+        long rejected = proposalRepository.countVisibleReviewHistory(
+                tenant.repositoryId(),
+                tenant.workspaceId(),
+                sourceRoot,
+                targetRoot,
+                relationType,
+                ProposalStatus.REJECTED);
+        long reviewed = accepted + rejected;
+        return reviewed == 0 ? 0.5 : (double) accepted / reviewed;
+    }
+
+    private List<RelationProposal> visibleProposals(
+            RepositoryContext context) {
+        RepositoryContext tenant = requireContext(context);
+        if (tenant.workspaceId() == null) {
+            return proposalRepository.findCentralByRepository(
+                    tenant.repositoryId());
+        }
+        return proposalRepository.findVisibleByRepositoryAndWorkspace(
+                tenant.repositoryId(), tenant.workspaceId());
+    }
+
+    private static List<RelationTypeMetrics> metricsByRelationType(
+            List<RelationProposal> proposals) {
+        return proposals.stream()
+                .map(RelationProposal::getRelationType)
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted()
+                .map(relationType -> {
+                    long accepted = countByTypeAndStatus(
+                            proposals, relationType, ProposalStatus.ACCEPTED);
+                    long rejected = countByTypeAndStatus(
+                            proposals, relationType, ProposalStatus.REJECTED);
+                    long pending = countByTypeAndStatus(
+                            proposals, relationType, ProposalStatus.PENDING);
+                    long reviewed = accepted + rejected;
+                    return new RelationTypeMetrics(
+                            relationType.name(),
+                            Math.toIntExact(reviewed + pending),
+                            Math.toIntExact(accepted),
+                            Math.toIntExact(rejected),
+                            reviewed > 0 ? (double) accepted / reviewed : 0.0);
+                })
+                .toList();
+    }
+
+    private static List<ProvenanceMetrics> metricsByProvenance(
+            List<RelationProposal> proposals) {
+        return proposals.stream()
+                .map(RelationProposal::getProvenance)
+                .distinct()
+                .sorted(Comparator.nullsFirst(String::compareTo))
+                .map(provenance -> {
+                    long accepted = countByProvenanceAndStatus(
+                            proposals, provenance, ProposalStatus.ACCEPTED);
+                    long rejected = countByProvenanceAndStatus(
+                            proposals, provenance, ProposalStatus.REJECTED);
+                    long pending = countByProvenanceAndStatus(
+                            proposals, provenance, ProposalStatus.PENDING);
+                    long reviewed = accepted + rejected;
+                    return new ProvenanceMetrics(
+                            provenance,
+                            Math.toIntExact(reviewed + pending),
+                            Math.toIntExact(accepted),
+                            reviewed > 0 ? (double) accepted / reviewed : 0.0);
+                })
+                .toList();
+    }
+
+    private static long countByStatus(
+            List<RelationProposal> proposals,
+            ProposalStatus status) {
+        return proposals.stream()
+                .filter(proposal -> proposal.getStatus() == status)
+                .count();
+    }
+
+    private static long countByTypeAndStatus(
+            List<RelationProposal> proposals,
+            RelationType relationType,
+            ProposalStatus status) {
+        return proposals.stream()
+                .filter(proposal -> proposal.getRelationType() == relationType)
+                .filter(proposal -> proposal.getStatus() == status)
+                .count();
+    }
+
+    private static long countByProvenanceAndStatus(
+            List<RelationProposal> proposals,
+            String provenance,
+            ProposalStatus status) {
+        return proposals.stream()
+                .filter(proposal -> Objects.equals(
+                        proposal.getProvenance(), provenance))
+                .filter(proposal -> proposal.getStatus() == status)
+                .count();
+    }
+
+    private static double averageConfidence(
+            List<RelationProposal> proposals,
+            ProposalStatus status) {
+        return proposals.stream()
+                .filter(proposal -> proposal.getStatus() == status)
+                .mapToDouble(RelationProposal::getConfidence)
+                .average()
+                .orElse(0.0);
+    }
+
+    private static RepositoryContext requireContext(
+            RepositoryContext context) {
+        return Objects.requireNonNull(
+                context, "RepositoryContext must not be null");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationQualityService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationQualityService.java
@@ -81,8 +81,8 @@ public class RelationQualityService {
         if (limit <= 0) {
             return List.of();
         }
-        return visibleProposals(context).stream()
-                .filter(proposal -> proposal.getStatus() == ProposalStatus.REJECTED)
+        return visibleProposalsByStatus(
+                        context, ProposalStatus.REJECTED).stream()
                 .sorted(Comparator
                         .comparingDouble(RelationProposal::getConfidence)
                         .reversed()
@@ -143,6 +143,18 @@ public class RelationQualityService {
         }
         return proposalRepository.findVisibleByRepositoryAndWorkspace(
                 tenant.repositoryId(), tenant.workspaceId());
+    }
+
+    private List<RelationProposal> visibleProposalsByStatus(
+            RepositoryContext context,
+            ProposalStatus status) {
+        RepositoryContext tenant = requireContext(context);
+        if (tenant.workspaceId() == null) {
+            return proposalRepository.findCentralByRepositoryAndStatus(
+                    tenant.repositoryId(), status);
+        }
+        return proposalRepository.findVisibleByRepositoryAndWorkspaceAndStatus(
+                tenant.repositoryId(), tenant.workspaceId(), status);
     }
 
     private static List<RelationTypeMetrics> metricsByRelationType(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationValidationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationValidationService.java
@@ -3,24 +3,15 @@ package com.taxonomy.relations.service;
 import com.taxonomy.catalog.model.TaxonomyNode;
 import com.taxonomy.dto.TaxonomyNodeDto;
 import com.taxonomy.model.RelationType;
+import com.taxonomy.workspace.service.RepositoryContext;
 import org.springframework.stereotype.Service;
 
 /**
  * Validates a candidate relation and computes a confidence score.
  *
- * <p>Repository/workspace/branch duplicate detection is deliberately performed
- * by {@link RelationProposalService} against one immutable identity snapshot.
- * This service therefore remains a persistence-free compatibility and scoring
- * component.</p>
- *
- * <p>Validation rules:
- * <ol>
- *   <li>Compatibility — source/target roots must be allowed for the relation type.</li>
- *   <li>Self-relation check — source must differ from target.</li>
- * </ol>
- *
- * <p>Confidence is derived from the candidate's search rank position
- * (higher rank → higher confidence).
+ * <p>Repository/workspace/branch duplicate detection is performed by
+ * {@link RelationProposalService} against one immutable identity snapshot.
+ * Review-history feedback is delegated with the same explicit context.</p>
  */
 @Service
 public class RelationValidationService {
@@ -35,17 +26,14 @@ public class RelationValidationService {
         this.qualityService = qualityService;
     }
 
-    /**
-     * Validates a candidate relation.
-     *
-     * @return a {@link ValidationResult} with pass/fail and confidence
-     */
+    /** Validates and scores a candidate in the proposal-generation context. */
     public ValidationResult validate(
             TaxonomyNode source,
             TaxonomyNodeDto candidateTarget,
             RelationType relationType,
             int rank,
-            int totalCandidates) {
+            int totalCandidates,
+            RepositoryContext context) {
         if (source.getCode().equals(candidateTarget.getCode())) {
             return ValidationResult.fail("Self-relation not allowed");
         }
@@ -56,21 +44,20 @@ public class RelationValidationService {
                 relationType)) {
             return ValidationResult.fail(
                     "Incompatible roots: " + source.getTaxonomyRoot()
-                    + " → " + candidateTarget.getTaxonomyRoot()
+                    + " to " + candidateTarget.getTaxonomyRoot()
                     + " for " + relationType);
         }
 
-        // Confidence: 80% rank-based + 20% acceptance history feedback.
-        // Repository scoping of that feedback is tracked separately by #728.
         double rankConfidence = computeConfidence(rank, totalCandidates);
         double historyWeight = qualityService.acceptanceHistoryWeight(
                 source.getTaxonomyRoot(),
                 candidateTarget.getTaxonomyRoot(),
-                relationType);
+                relationType,
+                context);
         double confidence = 0.80 * rankConfidence + 0.20 * historyWeight;
 
         String rationale = String.format(
-                "%s [%s] → %s [%s] (%s), rank %d/%d",
+                "%s [%s] to %s [%s] (%s), rank %d/%d",
                 source.getCode(), source.getTaxonomyRoot(),
                 candidateTarget.getCode(), candidateTarget.getTaxonomyRoot(),
                 relationType, rank + 1, totalCandidates);
@@ -80,10 +67,12 @@ public class RelationValidationService {
 
     /**
      * Computes confidence from the rank position.
-     * Rank 0 → highest confidence (0.95), higher ranks → lower confidence (min 0.3).
+     * Rank 0 has the highest confidence, later ranks decline to 0.3.
      */
     public double computeConfidence(int rank, int totalCandidates) {
-        if (totalCandidates <= 1) return 0.9;
+        if (totalCandidates <= 1) {
+            return 0.9;
+        }
         double ratio = (double) rank / (totalCandidates - 1);
         return 0.95 - (0.65 * ratio);
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/RelationProposalTests.java
@@ -89,7 +89,12 @@ class RelationProposalTests {
         candidate.setTaxonomyRoot("BP");
 
         var result = validationService.validate(
-                source, candidate, RelationType.RELATED_TO, 0, 1);
+                source,
+                candidate,
+                RelationType.RELATED_TO,
+                0,
+                1,
+                centralWriteContext());
 
         assertThat(result.isValid()).isFalse();
         assertThat(result.getRationale()).contains("Self-relation");

--- a/taxonomy-app/src/test/java/com/taxonomy/RelationQualityTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/RelationQualityTests.java
@@ -1,22 +1,25 @@
 package com.taxonomy;
 
+import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.repository.RelationProposalRepository;
-import com.taxonomy.catalog.repository.TaxonomyRelationRepository;
 import com.taxonomy.relations.service.RelationQualityService;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.SystemRepositoryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import org.springframework.security.test.context.support.WithMockUser;
-import com.taxonomy.relations.controller.QualityApiController;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for the Relation Quality Dashboard:
@@ -31,6 +34,7 @@ class RelationQualityTests {
     @Autowired private RelationQualityService qualityService;
     @Autowired private RelationProposalRepository proposalRepository;
     @Autowired private TaxonomyRelationRepository relationRepository;
+    @Autowired private SystemRepositoryService systemRepositoryService;
 
     @BeforeEach
     void clean() {
@@ -94,7 +98,14 @@ class RelationQualityTests {
 
     @Test
     void feedbackLoopServiceReturnsNeutralWithNoHistory() {
-        double weight = qualityService.acceptanceHistoryWeight("BP", "CP", RelationType.RELATED_TO);
+        double weight = qualityService.acceptanceHistoryWeight(
+                "BP", "CP", RelationType.RELATED_TO, centralReadContext());
         assertThat(weight).isEqualTo(0.5);
+    }
+
+    private RepositoryContext centralReadContext() {
+        SystemRepository primary = systemRepositoryService.getPrimaryRepository();
+        return RepositoryContext.centralRead(
+                primary.getRepositoryId(), primary.getDefaultBranch(), "user");
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/QualityApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/QualityApiControllerRepositoryScopeTest.java
@@ -1,0 +1,73 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.dto.RelationQualityMetrics;
+import com.taxonomy.dto.TopRejectedProposal;
+import com.taxonomy.relations.service.RelationQualityService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class QualityApiControllerRepositoryScopeTest {
+
+    private RelationQualityService qualityService;
+    private WorkspaceResolver workspaceResolver;
+    private QualityApiController controller;
+
+    @BeforeEach
+    void setUp() {
+        qualityService = mock(RelationQualityService.class);
+        workspaceResolver = mock(WorkspaceResolver.class);
+        controller = new QualityApiController(qualityService, workspaceResolver);
+    }
+
+    @Test
+    void dashboardUsesOneExactResolvedContextAndDisablesCaching() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-b", "workspace-b1", "feature/b1", "alice");
+        RelationQualityMetrics metrics = new RelationQualityMetrics(
+                2, 1, 1, 0, 0.5, 0.8, 0.6, List.of(), List.of());
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(qualityService.calculateMetrics(context)).thenReturn(metrics);
+
+        var response = controller.getMetrics();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isSameAs(metrics);
+        assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-store");
+        verify(workspaceResolver).resolveCurrentRepositoryContext();
+        verify(qualityService).calculateMetrics(context);
+        verifyNoMoreInteractions(workspaceResolver, qualityService);
+    }
+
+    @Test
+    void topRejectedRoutesLimitAndContextTogether() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-a", "main", "bob");
+        TopRejectedProposal proposal = new TopRejectedProposal(
+                "A", "Node A", "B", "Node B",
+                "RELATED_TO", 0.9, "evidence");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(qualityService.topRejected(4, context))
+                .thenReturn(List.of(proposal));
+
+        var response = controller.getTopRejected(4);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).containsExactly(proposal);
+        assertThat(response.getHeaders().getCacheControl()).isEqualTo("no-store");
+        verify(workspaceResolver).resolveCurrentRepositoryContext();
+        verify(qualityService).topRejected(4, context);
+        verifyNoMoreInteractions(workspaceResolver, qualityService);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalProjectionDuplicateTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationProposalProjectionDuplicateTest.java
@@ -77,7 +77,8 @@ class RelationProposalProjectionDuplicateTest {
                 candidate,
                 RelationType.RELATED_TO,
                 0,
-                1)).thenReturn(
+                1,
+                repositoryA)).thenReturn(
                         RelationValidationService.ValidationResult.fail(
                                 "stop after duplicate boundary"));
 
@@ -85,7 +86,12 @@ class RelationProposalProjectionDuplicateTest {
                 "BP", RelationType.RELATED_TO, 1, repositoryA);
 
         verify(validationService).validate(
-                source, candidate, RelationType.RELATED_TO, 0, 1);
+                source,
+                candidate,
+                RelationType.RELATED_TO,
+                0,
+                1,
+                repositoryA);
         clearInvocations(validationService);
 
         service.proposeRelationsInContext(
@@ -110,14 +116,25 @@ class RelationProposalProjectionDuplicateTest {
         when(relationReadService.readIdentitySnapshot(workspaceA2))
                 .thenReturn(snapshot("2", Set.of(new RelationIdentity(
                         "BP", RelationType.RELATED_TO, "CR"))));
-        when(validationService.validate(any(), any(), any(), anyInt(), anyInt()))
+        when(validationService.validate(
+                any(TaxonomyNode.class),
+                any(TaxonomyNodeDto.class),
+                any(RelationType.class),
+                anyInt(),
+                anyInt(),
+                any(RepositoryContext.class)))
                 .thenReturn(RelationValidationService.ValidationResult.fail(
                         "stop after duplicate boundary"));
 
         service.proposeRelationsInContext(
                 "BP", RelationType.RELATED_TO, 1, workspaceA1);
         verify(validationService).validate(
-                source, candidate, RelationType.RELATED_TO, 0, 1);
+                source,
+                candidate,
+                RelationType.RELATED_TO,
+                0,
+                1,
+                workspaceA1);
         clearInvocations(validationService);
 
         service.proposeRelationsInContext(
@@ -146,7 +163,13 @@ class RelationProposalProjectionDuplicateTest {
                 eq(RelationType.RELATED_TO),
                 eq("workspace-a")))
                 .thenReturn(false);
-        when(validationService.validate(any(), any(), any(), anyInt(), anyInt()))
+        when(validationService.validate(
+                any(TaxonomyNode.class),
+                any(TaxonomyNodeDto.class),
+                any(RelationType.class),
+                anyInt(),
+                anyInt(),
+                any(RepositoryContext.class)))
                 .thenReturn(RelationValidationService.ValidationResult.fail(
                         "not relevant"));
 
@@ -155,7 +178,12 @@ class RelationProposalProjectionDuplicateTest {
 
         verify(relationReadService, times(1)).readIdentitySnapshot(context);
         verify(validationService, times(2)).validate(
-                eq(source), any(), eq(RelationType.RELATED_TO), anyInt(), eq(2));
+                eq(source),
+                any(TaxonomyNodeDto.class),
+                eq(RelationType.RELATED_TO),
+                anyInt(),
+                eq(2),
+                eq(context));
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityContextArchitectureTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityContextArchitectureTest.java
@@ -1,0 +1,61 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.relations.controller.QualityApiController;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelationQualityContextArchitectureTest {
+
+    private static final Set<String> QUALITY_OPERATIONS = Set.of(
+            "calculateMetrics",
+            "metricsByRelationType",
+            "metricsByProvenance",
+            "topRejected",
+            "acceptanceHistoryWeight");
+
+    @Test
+    void everyPublicQualityOperationRequiresRepositoryContext() {
+        Arrays.stream(RelationQualityService.class.getDeclaredMethods())
+                .filter(method -> Modifier.isPublic(method.getModifiers()))
+                .filter(method -> QUALITY_OPERATIONS.contains(method.getName()))
+                .forEach(method -> assertThat(method.getParameterTypes())
+                        .as(method.toGenericString())
+                        .contains(RepositoryContext.class));
+
+        assertThat(Arrays.stream(RelationQualityService.class.getDeclaredMethods())
+                .filter(method -> Modifier.isPublic(method.getModifiers()))
+                .map(Method::getName)
+                .filter(QUALITY_OPERATIONS::contains)
+                .toList())
+                .containsExactlyInAnyOrderElementsOf(QUALITY_OPERATIONS);
+    }
+
+    @Test
+    void validationCannotComputeFeedbackWithoutRepositoryContext() {
+        Method[] validationMethods = Arrays.stream(
+                        RelationValidationService.class.getDeclaredMethods())
+                .filter(method -> method.getName().equals("validate"))
+                .toArray(Method[]::new);
+
+        assertThat(validationMethods).hasSize(1);
+        assertThat(validationMethods[0].getParameterTypes())
+                .contains(RepositoryContext.class);
+    }
+
+    @Test
+    void qualityHttpBoundaryMustReceiveAWorkspaceResolver() {
+        assertThat(QualityApiController.class.getConstructors())
+                .singleElement()
+                .satisfies(constructor -> assertThat(
+                        constructor.getParameterTypes())
+                        .contains(WorkspaceResolver.class));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityRepositoryIsolationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityRepositoryIsolationTests.java
@@ -6,13 +6,18 @@ import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
 import com.taxonomy.relations.model.RelationProposal;
 import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.model.RepositoryTopologyMode;
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.repository.SystemRepositoryRepository;
 import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +40,15 @@ class RelationQualityRepositoryIsolationTests {
 
     @Autowired private TaxonomyNodeRepository nodeRepository;
     @Autowired private RelationProposalRepository proposalRepository;
+    @Autowired private SystemRepositoryRepository systemRepositoryRepository;
     @Autowired private RelationQualityService qualityService;
+
+    @BeforeEach
+    void persistReferencedRepositoryCatalogRows() {
+        persistRepository(REPOSITORY_A);
+        persistRepository(REPOSITORY_B);
+        systemRepositoryRepository.flush();
+    }
 
     @Test
     void metricsAndTopRejectedExcludeForeignRepositoriesAndSiblingWorkspaces() {
@@ -132,6 +145,27 @@ class RelationQualityRepositoryIsolationTests {
     private double historyWeight(RepositoryContext context) {
         return qualityService.acceptanceHistoryWeight(
                 "BP", "CP", RelationType.RELATED_TO, context);
+    }
+
+    private void persistRepository(String repositoryId) {
+        if (systemRepositoryRepository.findByRepositoryId(repositoryId).isPresent()) {
+            return;
+        }
+        Instant now = Instant.now();
+        SystemRepository repository = new SystemRepository();
+        repository.setRepositoryId(repositoryId);
+        repository.setStorageRepositoryName(repositoryId);
+        repository.setSlug(repositoryId);
+        repository.setDisplayName("Quality isolation " + repositoryId);
+        repository.setDescription("Database-profile tenant isolation fixture");
+        repository.setTopologyMode(RepositoryTopologyMode.INTERNAL_SHARED);
+        repository.setDefaultBranch("main");
+        repository.setOwnerId("quality-admin");
+        repository.setCreatedBy("quality-admin");
+        repository.setCreatedAt(now);
+        repository.setUpdatedAt(now);
+        repository.setPrimaryRepo(false);
+        systemRepositoryRepository.save(repository);
     }
 
     private TaxonomyNode node(String code, String taxonomyRoot) {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityRepositoryIsolationTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityRepositoryIsolationTests.java
@@ -1,0 +1,167 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.catalog.repository.TaxonomyNodeRepository;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Database-backed regression evidence for repository/workspace quality isolation.
+ *
+ * <p>Unlike the focused mock tests, these tests execute the actual JPQL queries
+ * and lifecycle normalization used by every supported database profile.</p>
+ */
+@SpringBootTest
+@Transactional
+@WithMockUser(username = "quality-admin", roles = {"USER", "ARCHITECT", "ADMIN"})
+class RelationQualityRepositoryIsolationTests {
+
+    private static final String REPOSITORY_A = "qa-quality-repository-a";
+    private static final String REPOSITORY_B = "qa-quality-repository-b";
+    private static final String WORKSPACE_A1 = "qa-quality-workspace-a1";
+    private static final String WORKSPACE_A2 = "qa-quality-workspace-a2";
+
+    @Autowired private TaxonomyNodeRepository nodeRepository;
+    @Autowired private RelationProposalRepository proposalRepository;
+    @Autowired private RelationQualityService qualityService;
+
+    @Test
+    void metricsAndTopRejectedExcludeForeignRepositoriesAndSiblingWorkspaces() {
+        TaxonomyNode source = node("qa-quality-metrics-source", "BP");
+        TaxonomyNode centralTarget = node("qa-quality-central-target", "CP");
+        TaxonomyNode workspaceA1Target = node("qa-quality-a1-target", "CP");
+        TaxonomyNode workspaceA2Target = node("qa-quality-a2-target", "CP");
+        TaxonomyNode repositoryBTarget = node("qa-quality-b-target", "CP");
+        nodeRepository.saveAllAndFlush(List.of(
+                source,
+                centralTarget,
+                workspaceA1Target,
+                workspaceA2Target,
+                repositoryBTarget));
+
+        proposalRepository.saveAllAndFlush(List.of(
+                proposal(REPOSITORY_A, null, source, centralTarget,
+                        ProposalStatus.ACCEPTED, 0.80),
+                proposal(REPOSITORY_A, WORKSPACE_A1, source, workspaceA1Target,
+                        ProposalStatus.REJECTED, 0.90),
+                proposal(REPOSITORY_A, WORKSPACE_A2, source, workspaceA2Target,
+                        ProposalStatus.REJECTED, 0.95),
+                proposal(REPOSITORY_B, null, source, repositoryBTarget,
+                        ProposalStatus.REJECTED, 0.99)));
+
+        RepositoryContext centralA = RepositoryContext.centralRead(
+                REPOSITORY_A, "main", "quality-admin");
+        RepositoryContext workspaceA1 = RepositoryContext.workspace(
+                REPOSITORY_A, WORKSPACE_A1, "feature/a1", "quality-admin");
+        RepositoryContext workspaceA2 = RepositoryContext.workspace(
+                REPOSITORY_A, WORKSPACE_A2, "feature/a2", "quality-admin");
+        RepositoryContext centralB = RepositoryContext.centralRead(
+                REPOSITORY_B, "main", "quality-admin");
+
+        var centralMetrics = qualityService.calculateMetrics(centralA);
+        assertThat(centralMetrics.totalProposals()).isEqualTo(1);
+        assertThat(centralMetrics.accepted()).isEqualTo(1);
+        assertThat(centralMetrics.rejected()).isZero();
+
+        var workspaceA1Metrics = qualityService.calculateMetrics(workspaceA1);
+        assertThat(workspaceA1Metrics.totalProposals()).isEqualTo(2);
+        assertThat(workspaceA1Metrics.accepted()).isEqualTo(1);
+        assertThat(workspaceA1Metrics.rejected()).isEqualTo(1);
+        assertThat(qualityService.topRejected(10, workspaceA1))
+                .extracting(proposal -> proposal.targetCode())
+                .containsExactly(workspaceA1Target.getCode());
+
+        var workspaceA2Metrics = qualityService.calculateMetrics(workspaceA2);
+        assertThat(workspaceA2Metrics.totalProposals()).isEqualTo(2);
+        assertThat(qualityService.topRejected(10, workspaceA2))
+                .extracting(proposal -> proposal.targetCode())
+                .containsExactly(workspaceA2Target.getCode());
+
+        var repositoryBMetrics = qualityService.calculateMetrics(centralB);
+        assertThat(repositoryBMetrics.totalProposals()).isEqualTo(1);
+        assertThat(repositoryBMetrics.accepted()).isZero();
+        assertThat(repositoryBMetrics.rejected()).isEqualTo(1);
+
+        // Switching back must not reuse data from the preceding workspace/repository.
+        assertThat(qualityService.calculateMetrics(centralA).totalProposals())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void acceptanceHistoryIsIndependentPerRepositoryAndExactWorkspace() {
+        TaxonomyNode source = node("qa-quality-history-source", "BP");
+        TaxonomyNode target = node("qa-quality-history-target", "CP");
+        nodeRepository.saveAllAndFlush(List.of(source, target));
+
+        proposalRepository.saveAllAndFlush(List.of(
+                proposal(REPOSITORY_A, null, source, target,
+                        ProposalStatus.ACCEPTED, 0.80),
+                proposal(REPOSITORY_A, WORKSPACE_A1, source, target,
+                        ProposalStatus.REJECTED, 0.70),
+                proposal(REPOSITORY_A, WORKSPACE_A2, source, target,
+                        ProposalStatus.ACCEPTED, 0.90),
+                proposal(REPOSITORY_B, null, source, target,
+                        ProposalStatus.REJECTED, 0.95)));
+
+        assertThat(historyWeight(RepositoryContext.centralRead(
+                REPOSITORY_A, "main", "quality-admin")))
+                .isEqualTo(1.0);
+        assertThat(historyWeight(RepositoryContext.workspace(
+                REPOSITORY_A, WORKSPACE_A1, "feature/a1", "quality-admin")))
+                .isEqualTo(0.5);
+        assertThat(historyWeight(RepositoryContext.workspace(
+                REPOSITORY_A, WORKSPACE_A2, "feature/a2", "quality-admin")))
+                .isEqualTo(1.0);
+        assertThat(historyWeight(RepositoryContext.centralRead(
+                REPOSITORY_B, "main", "quality-admin")))
+                .isEqualTo(0.0);
+    }
+
+    private double historyWeight(RepositoryContext context) {
+        return qualityService.acceptanceHistoryWeight(
+                "BP", "CP", RelationType.RELATED_TO, context);
+    }
+
+    private TaxonomyNode node(String code, String taxonomyRoot) {
+        TaxonomyNode node = new TaxonomyNode();
+        node.setCode(code);
+        node.setNameEn("Quality isolation " + code);
+        node.setTaxonomyRoot(taxonomyRoot);
+        node.setLevel(1);
+        return node;
+    }
+
+    private RelationProposal proposal(
+            String repositoryId,
+            String workspaceId,
+            TaxonomyNode source,
+            TaxonomyNode target,
+            ProposalStatus status,
+            double confidence) {
+        RelationProposal proposal = new RelationProposal();
+        proposal.setRepositoryId(repositoryId);
+        proposal.setWorkspaceId(workspaceId);
+        proposal.setOwnerUsername(
+                workspaceId == null ? "central-quality-admin" : workspaceId);
+        proposal.setSourceNode(source);
+        proposal.setTargetNode(target);
+        proposal.setRelationType(RelationType.RELATED_TO);
+        proposal.setStatus(status);
+        proposal.setConfidence(confidence);
+        proposal.setRationale("quality tenant isolation evidence");
+        proposal.setProvenance("qa-quality-isolation");
+        return proposal;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityServiceRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityServiceRepositoryScopeTest.java
@@ -112,28 +112,49 @@ class RelationQualityServiceRepositoryScopeTest {
     }
 
     @Test
-    void topRejectedNeverReadsAnotherRepositoryOrSiblingWorkspace() {
+    void topRejectedQueriesOnlyRejectedRowsFromTheExactWorkspaceView() {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a1", "feature/a1", "alice");
-        when(repository.findVisibleByRepositoryAndWorkspace(
-                "repo-a", "workspace-a1"))
+        when(repository.findVisibleByRepositoryAndWorkspaceAndStatus(
+                "repo-a", "workspace-a1", ProposalStatus.REJECTED))
                 .thenReturn(List.of(
                         proposal(1L, ProposalStatus.REJECTED, 0.4,
                                 RelationType.RELATED_TO, "manual", "A", "B"),
                         proposal(2L, ProposalStatus.REJECTED, 0.9,
-                                RelationType.DEPENDS_ON, "manual", "A", "C"),
-                        proposal(3L, ProposalStatus.ACCEPTED, 0.99,
-                                RelationType.RELATED_TO, "manual", "A", "D")));
+                                RelationType.DEPENDS_ON, "manual", "A", "C")));
 
         var rejected = service.topRejected(1, context);
 
         assertThat(rejected).hasSize(1);
         assertThat(rejected.getFirst().targetCode()).isEqualTo("C");
         assertThat(rejected.getFirst().confidence()).isEqualTo(0.9);
-        verify(repository).findVisibleByRepositoryAndWorkspace(
-                "repo-a", "workspace-a1");
+        verify(repository).findVisibleByRepositoryAndWorkspaceAndStatus(
+                "repo-a", "workspace-a1", ProposalStatus.REJECTED);
+        verify(repository, never()).findVisibleByRepositoryAndWorkspace(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
         verify(repository, never()).findByStatusOrderByConfidenceDesc(
                 ProposalStatus.REJECTED);
+    }
+
+    @Test
+    void topRejectedQueriesOnlyRejectedRowsFromTheSelectedCentralRepository() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-b", "main", "bob");
+        when(repository.findCentralByRepositoryAndStatus(
+                "repo-b", ProposalStatus.REJECTED))
+                .thenReturn(List.of(
+                        proposal(4L, ProposalStatus.REJECTED, 0.7,
+                                RelationType.RELATED_TO, "manual", "B", "C")));
+
+        var rejected = service.topRejected(5, context);
+
+        assertThat(rejected).singleElement()
+                .satisfies(item -> assertThat(item.confidence()).isEqualTo(0.7));
+        verify(repository).findCentralByRepositoryAndStatus(
+                "repo-b", ProposalStatus.REJECTED);
+        verify(repository, never()).findCentralByRepository(
+                org.mockito.ArgumentMatchers.anyString());
     }
 
     private static RelationProposal proposal(

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityServiceRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationQualityServiceRepositoryScopeTest.java
@@ -1,0 +1,167 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.model.ProposalStatus;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.model.RelationProposal;
+import com.taxonomy.relations.repository.RelationProposalRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationQualityServiceRepositoryScopeTest {
+
+    private RelationProposalRepository repository;
+    private RelationQualityService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(RelationProposalRepository.class);
+        service = new RelationQualityService(repository);
+    }
+
+    @Test
+    void centralMetricsReadOnlyCentralRowsFromTheSelectedRepository() {
+        RepositoryContext context = RepositoryContext.centralRead(
+                "repo-a", "main", "alice");
+        when(repository.findCentralByRepository("repo-a"))
+                .thenReturn(List.of(
+                        proposal(1L, ProposalStatus.ACCEPTED, 0.8,
+                                RelationType.RELATED_TO, "manual", "A", "B"),
+                        proposal(2L, ProposalStatus.REJECTED, 0.6,
+                                RelationType.RELATED_TO, "manual", "A", "C"),
+                        proposal(3L, ProposalStatus.PENDING, 0.7,
+                                RelationType.DEPENDS_ON, "hybrid-search", "A", "D")));
+
+        var metrics = service.calculateMetrics(context);
+
+        assertThat(metrics.totalProposals()).isEqualTo(3);
+        assertThat(metrics.accepted()).isEqualTo(1);
+        assertThat(metrics.rejected()).isEqualTo(1);
+        assertThat(metrics.pending()).isEqualTo(1);
+        assertThat(metrics.acceptanceRate()).isEqualTo(0.5);
+        assertThat(metrics.avgConfidenceAccepted()).isEqualTo(0.8);
+        assertThat(metrics.avgConfidenceRejected()).isEqualTo(0.6);
+        assertThat(metrics.byRelationType()).hasSize(2);
+        assertThat(metrics.byProvenance()).hasSize(2);
+        verify(repository).findCentralByRepository("repo-a");
+        verify(repository, never()).findVisibleByRepositoryAndWorkspace(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString());
+        verify(repository, never()).findAll();
+    }
+
+    @Test
+    void workspaceMetricsUseCentralPlusThatExactWorkspaceSnapshot() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a1", "feature/a1", "alice");
+        when(repository.findVisibleByRepositoryAndWorkspace(
+                "repo-a", "workspace-a1"))
+                .thenReturn(List.of(
+                        proposal(1L, ProposalStatus.ACCEPTED, 0.9,
+                                RelationType.RELATED_TO, "central", "A", "B"),
+                        proposal(2L, ProposalStatus.REJECTED, 0.7,
+                                RelationType.RELATED_TO, "workspace-a1", "A", "C")));
+
+        var metrics = service.calculateMetrics(context);
+
+        assertThat(metrics.totalProposals()).isEqualTo(2);
+        assertThat(metrics.acceptanceRate()).isEqualTo(0.5);
+        verify(repository).findVisibleByRepositoryAndWorkspace(
+                "repo-a", "workspace-a1");
+        verify(repository, never()).findCentralByRepository("repo-a");
+    }
+
+    @Test
+    void feedbackHistoryUsesRepositoryAndExactWorkspaceForBothStatuses() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-b", "workspace-b1", "feature/b1", "bob");
+        when(repository.countVisibleReviewHistory(
+                "repo-b", "workspace-b1", "BP", "CP",
+                RelationType.RELATED_TO, ProposalStatus.ACCEPTED))
+                .thenReturn(3L);
+        when(repository.countVisibleReviewHistory(
+                "repo-b", "workspace-b1", "BP", "CP",
+                RelationType.RELATED_TO, ProposalStatus.REJECTED))
+                .thenReturn(1L);
+
+        double weight = service.acceptanceHistoryWeight(
+                "BP", "CP", RelationType.RELATED_TO, context);
+
+        assertThat(weight).isEqualTo(0.75);
+        verify(repository).countVisibleReviewHistory(
+                "repo-b", "workspace-b1", "BP", "CP",
+                RelationType.RELATED_TO, ProposalStatus.ACCEPTED);
+        verify(repository).countVisibleReviewHistory(
+                "repo-b", "workspace-b1", "BP", "CP",
+                RelationType.RELATED_TO, ProposalStatus.REJECTED);
+        verify(repository, never())
+                .countBySourceNodeTaxonomyRootAndTargetNodeTaxonomyRootAndRelationTypeAndStatus(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void topRejectedNeverReadsAnotherRepositoryOrSiblingWorkspace() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a1", "feature/a1", "alice");
+        when(repository.findVisibleByRepositoryAndWorkspace(
+                "repo-a", "workspace-a1"))
+                .thenReturn(List.of(
+                        proposal(1L, ProposalStatus.REJECTED, 0.4,
+                                RelationType.RELATED_TO, "manual", "A", "B"),
+                        proposal(2L, ProposalStatus.REJECTED, 0.9,
+                                RelationType.DEPENDS_ON, "manual", "A", "C"),
+                        proposal(3L, ProposalStatus.ACCEPTED, 0.99,
+                                RelationType.RELATED_TO, "manual", "A", "D")));
+
+        var rejected = service.topRejected(1, context);
+
+        assertThat(rejected).hasSize(1);
+        assertThat(rejected.getFirst().targetCode()).isEqualTo("C");
+        assertThat(rejected.getFirst().confidence()).isEqualTo(0.9);
+        verify(repository).findVisibleByRepositoryAndWorkspace(
+                "repo-a", "workspace-a1");
+        verify(repository, never()).findByStatusOrderByConfidenceDesc(
+                ProposalStatus.REJECTED);
+    }
+
+    private static RelationProposal proposal(
+            long id,
+            ProposalStatus status,
+            double confidence,
+            RelationType relationType,
+            String provenance,
+            String sourceCode,
+            String targetCode) {
+        RelationProposal proposal = new RelationProposal();
+        proposal.setId(id);
+        proposal.setRepositoryId("repo-a");
+        proposal.setSourceNode(node(sourceCode));
+        proposal.setTargetNode(node(targetCode));
+        proposal.setRelationType(relationType);
+        proposal.setStatus(status);
+        proposal.setConfidence(confidence);
+        proposal.setProvenance(provenance);
+        proposal.setRationale("evidence");
+        return proposal;
+    }
+
+    private static TaxonomyNode node(String code) {
+        TaxonomyNode node = new TaxonomyNode();
+        node.setCode(code);
+        node.setNameEn("Node " + code);
+        node.setTaxonomyRoot(code);
+        return node;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationValidationServiceRepositoryContextTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationValidationServiceRepositoryContextTest.java
@@ -1,0 +1,93 @@
+package com.taxonomy.relations.service;
+
+import com.taxonomy.catalog.model.TaxonomyNode;
+import com.taxonomy.dto.TaxonomyNodeDto;
+import com.taxonomy.model.RelationType;
+import com.taxonomy.workspace.service.RepositoryContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RelationValidationServiceRepositoryContextTest {
+
+    private RelationCompatibilityMatrix compatibilityMatrix;
+    private RelationQualityService qualityService;
+    private RelationValidationService validationService;
+
+    @BeforeEach
+    void setUp() {
+        compatibilityMatrix = mock(RelationCompatibilityMatrix.class);
+        qualityService = mock(RelationQualityService.class);
+        validationService = new RelationValidationService(
+                compatibilityMatrix, qualityService);
+    }
+
+    @Test
+    void confidenceFeedbackReceivesTheExactProposalGenerationContext() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-b", "workspace-b1", "feature/b1", "alice");
+        TaxonomyNode source = node("BP-1000", "BP");
+        TaxonomyNodeDto target = target("CP-1000", "CP");
+        when(compatibilityMatrix.isCompatible(
+                "BP", "CP", RelationType.RELATED_TO)).thenReturn(true);
+        when(qualityService.acceptanceHistoryWeight(
+                "BP", "CP", RelationType.RELATED_TO, context)).thenReturn(0.25);
+
+        var result = validationService.validate(
+                source,
+                target,
+                RelationType.RELATED_TO,
+                0,
+                2,
+                context);
+
+        assertThat(result.isValid()).isTrue();
+        assertThat(result.getConfidence()).isEqualTo(0.81);
+        verify(qualityService).acceptanceHistoryWeight(
+                "BP", "CP", RelationType.RELATED_TO, context);
+    }
+
+    @Test
+    void invalidCompatibilityDoesNotReadAnyReviewHistory() {
+        RepositoryContext context = RepositoryContext.centralWrite(
+                "repo-a", "main", "architect");
+        TaxonomyNode source = node("BP-1000", "BP");
+        TaxonomyNodeDto target = target("IP-1000", "IP");
+        when(compatibilityMatrix.isCompatible(
+                "BP", "IP", RelationType.RELATED_TO)).thenReturn(false);
+
+        var result = validationService.validate(
+                source,
+                target,
+                RelationType.RELATED_TO,
+                0,
+                1,
+                context);
+
+        assertThat(result.isValid()).isFalse();
+        verify(qualityService, never()).acceptanceHistoryWeight(
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    private static TaxonomyNode node(String code, String root) {
+        TaxonomyNode node = new TaxonomyNode();
+        node.setCode(code);
+        node.setTaxonomyRoot(root);
+        return node;
+    }
+
+    private static TaxonomyNodeDto target(String code, String root) {
+        TaxonomyNodeDto target = new TaxonomyNodeDto();
+        target.setCode(code);
+        target.setTaxonomyRoot(root);
+        return target;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationValidationServiceRepositoryContextTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/service/RelationValidationServiceRepositoryContextTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -47,7 +48,7 @@ class RelationValidationServiceRepositoryContextTest {
                 context);
 
         assertThat(result.isValid()).isTrue();
-        assertThat(result.getConfidence()).isEqualTo(0.81);
+        assertThat(result.getConfidence()).isCloseTo(0.81, within(1.0e-12));
         verify(qualityService).acceptanceHistoryWeight(
                 "BP", "CP", RelationType.RELATED_TO, context);
     }


### PR DESCRIPTION
## Scope

Implements #728 as the quality/feedback tenant-isolation slice on the multi-repository architecture line.

## Explicit visibility rule

- a central context sees only central proposal reviews from the selected repository;
- a workspace context sees central reviews from that repository plus reviews from that exact workspace;
- another repository and a sibling workspace are never visible and never influence confidence;
- a fork remains isolated by its own repository identity;
- cross-repository analytics, if introduced later, require a separate explicitly authorized API and DTO.

## Product behavior

- every quality HTTP endpoint resolves one request-stable `RepositoryContext` and passes it unchanged to the service;
- dashboard totals, acceptance rate, confidence averages, relation-type metrics, provenance metrics and top-rejected details use only the selected visibility scope;
- responses use `Cache-Control: no-store` because repository/workspace selection is session context rather than part of the URL;
- the 20% acceptance-history component receives the exact proposal-generation context;
- central feedback inheritance inside a workspace is intentional and documented rather than an implicit global fallback;
- context-free quality-service entry points are removed from application paths.

## Persistence boundary

- add repository/workspace-scoped review-history queries;
- central reads use `findCentralByRepository(...)`;
- workspace reads use `findVisibleByRepositoryAndWorkspace(...)`;
- `topRejected(...)` loads only `REJECTED` rows through `findCentralByRepositoryAndStatus(...)` or `findVisibleByRepositoryAndWorkspaceAndStatus(...)`, rather than loading all visible proposals and filtering in memory;
- no dashboard, top-rejected or confidence-feedback path calls the primary-repository compatibility aggregates;
- no cache is introduced, so there is no cross-context cache-key risk.

## Executable evidence

Focused mock and architecture contracts prove:

- one exact resolver result per HTTP request;
- `no-store` response policy;
- context and limit routing for top-rejected rows;
- central and workspace service selection;
- rejected-only repository queries for top-rejected details in both central and workspace contexts;
- exact repository/workspace arguments for accepted and rejected history;
- absence of context-free quality-service methods and legacy aggregate calls.

A database-backed Spring/JPA regression test persists identical review identities across two repository catalog entries and two sibling workspace scopes and proves through the real JPQL/lifecycle path that:

- repository A excludes repository B;
- central A excludes both private workspaces;
- workspace A1 inherits central A but excludes A2;
- workspace A2 excludes A1;
- `topRejected` never returns foreign details;
- switching contexts does not reuse prior metrics;
- acceptance-history weights remain independent for central A, A1, A2 and central B.

The main-targeted checkpoint exposed and resolved two kinds of test-fixture drift rather than masking them:

1. three older tests still called the now intentionally context-required validation/feedback APIs without `RepositoryContext`; they now supply and verify the exact central or workspace context;
2. the database-backed isolation fixture inserted `RelationProposal.repository_id` values without first persisting the referenced `system_repository` rows; the fixture now creates both non-primary repository catalog entries before proposal rows, preserving the production foreign-key contract on every database profile.

## Stack and verification

- #725 was integrated as `d4e7c32c5271484468ffb41aa6ac372f0c12d823`;
- #729 was integrated as `c7a933e0d51150e21d6af6a4d0c88a82ec95b539` after exact-head full-matrix verification;
- this PR targets `copilot/architecture-epic-multi-repo` directly and is mergeable without conflicts;
- current exact head: `f1208c0259d72de32af44d647f5b1a0a97ad654b`;
- all review threads are resolved;
- temporary main-targeted verification checkpoint #732 runs this exact head through CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security gates and must be closed unmerged after this PR is integrated.

Merge only after that exact-head gate matrix is green.

Closes #728 after integration.