### PR TITLE
Preserve reviewed release notes through publication

### DIFF
--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -143,7 +143,6 @@ def main() -> int:
         "EXPECTED_MAIN_SHA: ${{ steps.final_main.outputs.sha }}",
         'run: bash "$RUNNER_TEMP/verify-exact-release-gates.sh"',
         'docker buildx imagetools inspect "$image"',
-        'gh release edit "$tag" --draft=false --latest',
         "Draft release is missing required Helm asset",
         "Render deployment triggered after complete release publication.",
     ):
@@ -295,6 +294,16 @@ def main() -> int:
                 )
 
         publish_block = workflow[publish:]
+        for needle in (
+            'gh release edit "$tag"',
+            "--notes-file release_notes.md",
+            "--draft=false",
+            "--latest",
+        ):
+            if needle not in publish_block:
+                failures.append(
+                    f"Final publication step is missing {needle!r}"
+                )
         if "RENDER_DEPLOY_HOOK_URL" not in publish_block:
             failures.append("Only the final publication step may trigger deployment")
     except ValueError as error:

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 : "${METADATA_HELPER:?METADATA_HELPER is required}"
 : "${VERSION_STATE_HELPER:?VERSION_STATE_HELPER is required}"
 : "${VEX_HELPER:?VEX_HELPER is required}"
+: "${RELEASE_NOTES_VALIDATOR:?RELEASE_NOTES_VALIDATOR is required}"
 
 NEXT_VERSION_INPUT=${NEXT_VERSION_INPUT:-}
 SKIP_TESTS=${SKIP_TESTS:-false}
@@ -85,26 +86,30 @@ if next_version <= release:
     )
 PY
 
-generate_release_notes() {
-  echo "Generating release notes..."
-  local previous_tag=""
-  previous_tag=$(git tag --merged HEAD --sort=-creatordate \
-    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-    | grep -vx "$TAG_NAME" \
-    | head -n 1 || true)
+materialize_release_notes() {
+  RELEASE_VERSION="$RELEASE_VERSION" \
+    RELEASE_NOTES_COMMIT="$RELEASE_COMMIT" \
+    RELEASE_NOTES_FILE=release_notes.md \
+    "$RELEASE_NOTES_VALIDATOR"
+}
 
-  if [[ -n "$previous_tag" ]]; then
-    local previous_date
-    previous_date=$(git log -1 --format=%aI "$previous_tag")
-    gh issue list --state closed --search "closed:>$previous_date" \
-      --json number,title --jq '.[] | "- #\(.number): \(.title)"' > release_notes.md || true
-    if [[ ! -s release_notes.md ]]; then
-      echo "No closed issues found since $previous_tag" > release_notes.md
-    fi
-  else
-    echo "Initial release" > release_notes.md
+restore_release_notes_checkout() {
+  # The reviewed notes may deliberately differ from the already-advanced main
+  # checkout. Restore the current HEAD after GitHub has consumed the immutable
+  # file so the workflow can subsequently checkout the release tag safely.
+  git restore --source=HEAD --worktree -- release_notes.md
+}
+
+validate_release_notes() {
+  local notes_file=release_notes.md
+  if [[ "$(git rev-parse HEAD)" != "$RELEASE_COMMIT" ]]; then
+    fail "Reviewed release notes must be validated at release commit $RELEASE_COMMIT"
   fi
-  cat release_notes.md
+  git ls-files --error-unmatch "$notes_file" >/dev/null \
+    || fail "$notes_file must be tracked by the exact release commit"
+  git diff --quiet HEAD -- "$notes_file" \
+    || fail "$notes_file differs from the exact release commit"
+  materialize_release_notes
 }
 
 collect_release_artifacts() {
@@ -286,6 +291,8 @@ else
     --expected-version "$RELEASE_VERSION" --tag "$TAG_NAME"
 fi
 
+validate_release_notes
+
 if [[ "$SKIP_TESTS" == "true" ]]; then
   run_maven_release_check release release-check clean package -DskipTests
 else
@@ -293,7 +300,6 @@ else
 fi
 python3 "$VEX_HELPER"
 collect_release_artifacts
-generate_release_notes
 
 PUBLISHED_THIS_RUN=false
 if [[ "$DRY_RUN" != "true" && "$STATE" == "new" ]]; then
@@ -332,12 +338,13 @@ else
 fi
 
 if [[ "$DRY_RUN" != "true" && "$STATE" == "tagged" ]]; then
+  materialize_release_notes
   gh release create "$TAG_NAME" \
     --verify-tag \
     --draft \
     --title "Release $RELEASE_VERSION" \
-    --notes-file release_notes.md \
-    --generate-notes
+    --notes-file release_notes.md
+  restore_release_notes_checkout
   STATE=draft
 fi
 
@@ -351,7 +358,12 @@ if [[ "$DRY_RUN" != "true" && "$STATE" == "draft" ]]; then
   if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then
     echo "Release $TAG_NAME remains a draft until downstream artifacts and final CI succeed."
   else
-    gh release edit "$TAG_NAME" --draft=false --latest
+    materialize_release_notes
+    gh release edit "$TAG_NAME" \
+      --notes-file release_notes.md \
+      --draft=false \
+      --latest
+    restore_release_notes_checkout
     STATE=published
     PUBLISHED_THIS_RUN=true
   fi

--- a/.github/scripts/validate-reviewed-release-notes.sh
+++ b/.github/scripts/validate-reviewed-release-notes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Materialize and validate the exact reviewed release notes committed with the release source.
+set -euo pipefail
+
+RELEASE_VERSION=${RELEASE_VERSION:-}
+RELEASE_NOTES_COMMIT=${RELEASE_NOTES_COMMIT:-}
+RELEASE_NOTES_FILE=${RELEASE_NOTES_FILE:-release_notes.md}
+readonly RELEASE_NOTES_PATH=release_notes.md
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+if ! [[ "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "RELEASE_VERSION must use canonical X.Y.Z syntax, got '$RELEASE_VERSION'"
+fi
+
+source_commit=""
+notes_blob=""
+if [[ -n "$RELEASE_NOTES_COMMIT" ]]; then
+  if ! source_commit=$(git rev-parse "${RELEASE_NOTES_COMMIT}^{commit}" 2>/dev/null); then
+    fail "Unable to resolve release-notes source commit: $RELEASE_NOTES_COMMIT"
+  fi
+  if ! notes_blob=$(git rev-parse "${source_commit}:${RELEASE_NOTES_PATH}" 2>/dev/null); then
+    fail "Release commit $source_commit does not contain $RELEASE_NOTES_PATH"
+  fi
+
+  mkdir -p "$(dirname "$RELEASE_NOTES_FILE")"
+  temporary_file="${RELEASE_NOTES_FILE}.tmp.$$"
+  trap 'rm -f "$temporary_file"' EXIT
+  git cat-file blob "$notes_blob" > "$temporary_file"
+
+  materialized_blob=$(git hash-object "$temporary_file")
+  if [[ "$materialized_blob" != "$notes_blob" ]]; then
+    fail "Materialized release notes do not match committed blob $notes_blob"
+  fi
+  mv "$temporary_file" "$RELEASE_NOTES_FILE"
+  trap - EXIT
+fi
+
+if [[ ! -f "$RELEASE_NOTES_FILE" ]]; then
+  fail "Reviewed release notes file is missing: $RELEASE_NOTES_FILE"
+fi
+if [[ ! -s "$RELEASE_NOTES_FILE" ]]; then
+  fail "Reviewed release notes file is empty: $RELEASE_NOTES_FILE"
+fi
+
+expected_heading="# Taxonomy ${RELEASE_VERSION}"
+first_content_line=$(awk 'NF { print; exit }' "$RELEASE_NOTES_FILE")
+if [[ "$first_content_line" != "$expected_heading" ]]; then
+  fail "Reviewed release notes must begin with '$expected_heading', got '$first_content_line'"
+fi
+if [[ $(grep -Fxc "$expected_heading" "$RELEASE_NOTES_FILE") -ne 1 ]]; then
+  fail "Reviewed release notes must contain the exact version heading once"
+fi
+if ! grep -Eq '^##[[:space:]]+[^[:space:]]' "$RELEASE_NOTES_FILE"; then
+  fail "Reviewed release notes must contain at least one substantive section"
+fi
+
+byte_count=$(wc -c < "$RELEASE_NOTES_FILE")
+if (( byte_count < 200 )); then
+  fail "Reviewed release notes are implausibly short (${byte_count} bytes)"
+fi
+
+for placeholder in \
+  'No closed issues found since' \
+  'Initial release'; do
+  if grep -Fq "$placeholder" "$RELEASE_NOTES_FILE"; then
+    fail "Reviewed release notes still contain generated placeholder text: $placeholder"
+  fi
+done
+
+if [[ -n "$source_commit" ]]; then
+  printf 'Reviewed release notes materialized from %s:%s (blob %s).\n' \
+    "$source_commit" "$RELEASE_NOTES_PATH" "$notes_blob"
+fi
+printf 'Reviewed release notes are valid for Taxonomy %s: %s (%s bytes).\n' \
+  "$RELEASE_VERSION" "$RELEASE_NOTES_FILE" "$byte_count"

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -100,11 +100,14 @@ jobs:
           cp .github/scripts/generate-vex.py "$RUNNER_TEMP/generate-vex.py"
           cp .github/scripts/verify-exact-release-gates.sh \
             "$RUNNER_TEMP/verify-exact-release-gates.sh"
+          cp .github/scripts/validate-reviewed-release-notes.sh \
+            "$RUNNER_TEMP/validate-reviewed-release-notes.sh"
           chmod +x "$RUNNER_TEMP/release.sh" \
             "$RUNNER_TEMP/update-release-metadata.py" \
             "$RUNNER_TEMP/check-version-state.py" \
             "$RUNNER_TEMP/generate-vex.py" \
-            "$RUNNER_TEMP/verify-exact-release-gates.sh"
+            "$RUNNER_TEMP/verify-exact-release-gates.sh" \
+            "$RUNNER_TEMP/validate-reviewed-release-notes.sh"
 
       - name: Test release guards
         shell: bash
@@ -113,6 +116,7 @@ jobs:
           python3 .github/scripts/test-resolve-release-parameters.py
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/verify-exact-release-gates.sh
+          bash -n .github/scripts/validate-reviewed-release-notes.sh
           bash -n .github/scripts/install-helm.sh
           bash -n deploy/helm/taxonomy/verify.sh
           python3 .github/scripts/check-release-delivery-contract.py
@@ -131,6 +135,7 @@ jobs:
           METADATA_HELPER: ${{ runner.temp }}/update-release-metadata.py
           VERSION_STATE_HELPER: ${{ runner.temp }}/check-version-state.py
           VEX_HELPER: ${{ runner.temp }}/generate-vex.py
+          RELEASE_NOTES_VALIDATOR: ${{ runner.temp }}/validate-reviewed-release-notes.sh
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
           TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: 'false'
         run: "$RUNNER_TEMP/release.sh"
@@ -141,6 +146,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
           NEXT_VERSION_INPUT: ${{ steps.release_parameters.outputs.next_development_version }}
+          RELEASE_NOTES_VALIDATOR: ${{ runner.temp }}/validate-reviewed-release-notes.sh
         shell: bash
         run: |
           set -euo pipefail
@@ -157,6 +163,9 @@ jobs:
           git checkout --detach "$tag"
           python3 "$RUNNER_TEMP/check-version-state.py" \
             --mode release --expected-version "$RELEASE_VERSION" --tag "$tag"
+          RELEASE_NOTES_COMMIT="$tag" \
+            RELEASE_NOTES_FILE=release_notes.md \
+            "$RELEASE_NOTES_VALIDATOR"
 
           release_tag=$(gh release view "$tag" --json tagName --jq '.tagName')
           is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft')
@@ -405,6 +414,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.release_parameters.outputs.release_version }}
           IMAGE_DIGEST: ${{ steps.release_image.outputs.digest }}
+          RELEASE_NOTES_VALIDATOR: ${{ runner.temp }}/validate-reviewed-release-notes.sh
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         shell: bash
         run: |
@@ -412,6 +422,10 @@ jobs:
           tag="v${RELEASE_VERSION}"
           repository="ghcr.io/${GITHUB_REPOSITORY_OWNER}/taxonomy"
           image="${repository}@${IMAGE_DIGEST}"
+
+          RELEASE_NOTES_COMMIT="$tag" \
+            RELEASE_NOTES_FILE=release_notes.md \
+            "$RELEASE_NOTES_VALIDATOR"
 
           assets=$(gh release view "$tag" --json assets --jq '.assets[].name')
           for expected in \
@@ -450,7 +464,10 @@ jobs:
 
           is_draft=$(gh release view "$tag" --json isDraft --jq '.isDraft')
           if [[ "$is_draft" == "true" ]]; then
-            gh release edit "$tag" --draft=false --latest
+            gh release edit "$tag" \
+              --notes-file release_notes.md \
+              --draft=false \
+              --latest
           elif [[ "$is_draft" != "false" ]]; then
             echo "::error::Unexpected draft state for $tag: $is_draft"
             exit 1

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseNotesCheckoutCleanlinessContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReleaseNotesCheckoutCleanlinessContractTest.java
@@ -1,0 +1,190 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Prevent reviewed notes from leaving the advanced-main checkout dirty. */
+class ReleaseNotesCheckoutCleanlinessContractTest {
+
+    @Test
+    void releaseScriptRestoresTheCheckoutAfterGitHubConsumesReviewedNotes()
+            throws Exception {
+        String script = Files.readString(findRepositoryRoot().resolve(
+                ".github/scripts/release.sh"), StandardCharsets.UTF_8);
+
+        assertThat(script)
+                .contains("restore_release_notes_checkout()")
+                .contains("git restore --source=HEAD --worktree -- release_notes.md");
+
+        String draftCreationBlock = between(
+                script,
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"tagged\" ]]; then",
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"draft\" ]]; then");
+        assertOrdered(
+                draftCreationBlock,
+                "materialize_release_notes",
+                "gh release create \"$TAG_NAME\"",
+                "restore_release_notes_checkout",
+                "STATE=draft");
+
+        String directPublicationBlock = between(
+                script,
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"draft\" ]]; then",
+                "if [[ \"$DRY_RUN\" != \"true\" ]]; then");
+        assertOrdered(
+                directPublicationBlock,
+                "materialize_release_notes",
+                "gh release edit \"$TAG_NAME\"",
+                "restore_release_notes_checkout",
+                "STATE=published");
+    }
+
+    @Test
+    void restoreMakesTheSubsequentTagCheckoutPossibleWhenNotesDiverge(
+            @TempDir Path root) throws Exception {
+        initializeRepository(root);
+        String releaseNotes = validNotes("1.4.0", "release");
+        write(root.resolve("release_notes.md"), releaseNotes);
+        git(root, "add", "release_notes.md");
+        git(root, "commit", "-m", "Review release notes");
+        String releaseCommit = git(root, "rev-parse", "HEAD").output().trim();
+
+        write(root.resolve("release_notes.md"), validNotes("1.4.1", "next"));
+        git(root, "commit", "-am", "Prepare next development notes");
+        String nextCommit = git(root, "rev-parse", "HEAD").output().trim();
+
+        Result materialized = runValidator(root, releaseCommit);
+        assertThat(materialized.exitCode()).as(materialized.output()).isZero();
+        assertThat(git(root, "rev-parse", "HEAD").output().trim())
+                .isEqualTo(nextCommit);
+        assertThat(git(root, "status", "--porcelain").output())
+                .contains(" M release_notes.md");
+
+        git(root, "restore", "--source=HEAD", "--worktree", "--", "release_notes.md");
+        assertThat(git(root, "status", "--porcelain").output()).isEmpty();
+
+        git(root, "checkout", "--detach", releaseCommit);
+        assertThat(Files.readString(
+                root.resolve("release_notes.md"), StandardCharsets.UTF_8))
+                .isEqualTo(releaseNotes);
+    }
+
+    private static Result runValidator(Path workingDirectory, String releaseCommit)
+            throws Exception {
+        Path validator = findRepositoryRoot().resolve(
+                ".github/scripts/validate-reviewed-release-notes.sh");
+        ProcessBuilder builder = new ProcessBuilder("bash", validator.toString())
+                .directory(workingDirectory.toFile())
+                .redirectErrorStream(true);
+        Map<String, String> environment = builder.environment();
+        environment.put("RELEASE_VERSION", "1.4.0");
+        environment.put("RELEASE_NOTES_COMMIT", releaseCommit);
+        environment.put("RELEASE_NOTES_FILE", "release_notes.md");
+        return run(builder, "Release-notes validator");
+    }
+
+    private static void assertOrdered(String text, String... needles) {
+        int previous = -1;
+        for (String needle : needles) {
+            int current = text.indexOf(needle);
+            assertThat(current)
+                    .as("position of %s in release block", needle)
+                    .isGreaterThan(previous);
+            previous = current;
+        }
+    }
+
+    private static String between(String text, String start, String end) {
+        int startIndex = text.indexOf(start);
+        int endIndex = text.indexOf(end, startIndex);
+        if (startIndex < 0 || endIndex < 0) {
+            throw new AssertionError(
+                    "Unable to locate source block between " + start + " and " + end);
+        }
+        return text.substring(startIndex, endIndex);
+    }
+
+    private static void initializeRepository(Path root) throws Exception {
+        git(root, "init");
+        git(root, "config", "user.name", "Taxonomy release contract");
+        git(root, "config", "user.email", "release-contract@example.invalid");
+    }
+
+    private static Result git(Path root, String... arguments) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(Arrays.asList(arguments));
+        Result result = run(
+                new ProcessBuilder(command)
+                        .directory(root.toFile())
+                        .redirectErrorStream(true),
+                "Git fixture command " + command);
+        if (result.exitCode() != 0) {
+            throw new AssertionError(
+                    "Git fixture command failed: " + command + "\n" + result.output());
+        }
+        return result;
+    }
+
+    private static Result run(ProcessBuilder builder, String description)
+            throws Exception {
+        Process process = builder.start();
+        boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new AssertionError(description + " exceeded 10 seconds");
+        }
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        return new Result(process.exitValue(), output);
+    }
+
+    private static String validNotes(String version, String marker) {
+        return """
+                # Taxonomy %s
+
+                ## Product highlights
+
+                This substantive reviewed %s fixture documents deterministic exports,
+                repository-owned evidence, deployment profiles and traceable workflows.
+
+                ## Verification boundary
+
+                Publication remains bound to source, tag, artifacts, image digest,
+                vulnerability evidence and Helm manifests for this fixture.
+                """.formatted(version, marker);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                    ".github/scripts/release.sh"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private record Result(int exitCode, String output) {
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReviewedReleaseNotesContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReviewedReleaseNotesContractTest.java
@@ -1,0 +1,320 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** JUnit-owned contract for version-bound, reviewed GitHub release notes. */
+class ReviewedReleaseNotesContractTest {
+
+    @Test
+    void acceptsSubstantiveReviewedNotesForTheExactVersion(@TempDir Path root)
+            throws Exception {
+        Path notes = root.resolve("release_notes.md");
+        write(notes, validNotes("1.4.0"));
+
+        Result result = runValidator(root, notes, "1.4.0", null);
+
+        assertThat(result.exitCode()).as(result.output()).isZero();
+        assertThat(result.output())
+                .contains("Reviewed release notes are valid for Taxonomy 1.4.0")
+                .doesNotContain("::error::");
+    }
+
+    @Test
+    void materializesTheExactCommittedBlobInsteadOfDirtyWorkingTreeContent(
+            @TempDir Path root) throws Exception {
+        initializeRepository(root);
+        String committedNotes = validNotes("1.4.0");
+        write(root.resolve("release_notes.md"), committedNotes);
+        git(root, "add", "release_notes.md");
+        git(root, "commit", "-m", "Review release notes");
+        String commit = git(root, "rev-parse", "HEAD").output().trim();
+
+        write(root.resolve("release_notes.md"), validNotes("9.9.9"));
+        Path output = root.resolve("materialized/release-notes.md");
+
+        Result result = runValidator(root, output, "1.4.0", commit);
+
+        assertThat(result.exitCode()).as(result.output()).isZero();
+        assertThat(Files.readString(output, StandardCharsets.UTF_8))
+                .isEqualTo(committedNotes);
+        assertThat(result.output())
+                .contains("materialized from " + commit + ":release_notes.md")
+                .contains("blob");
+    }
+
+    @Test
+    void rejectsACommitWithoutReviewedReleaseNotes(@TempDir Path root)
+            throws Exception {
+        initializeRepository(root);
+        write(root.resolve("README.md"), "fixture\n");
+        git(root, "add", "README.md");
+        git(root, "commit", "-m", "Commit without release notes");
+        String commit = git(root, "rev-parse", "HEAD").output().trim();
+
+        Result result = runValidator(
+                root,
+                root.resolve("materialized/release-notes.md"),
+                "1.4.0",
+                commit);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("does not contain release_notes.md")
+                .contains(commit);
+    }
+
+    @Test
+    void rejectsNotesWhoseHeadingNamesAnotherVersion(@TempDir Path root)
+            throws Exception {
+        Path notes = root.resolve("release_notes.md");
+        write(notes, validNotes("1.3.1"));
+
+        Result result = runValidator(root, notes, "1.4.0", null);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("must begin with '# Taxonomy 1.4.0'")
+                .contains("# Taxonomy 1.3.1");
+    }
+
+    @Test
+    void rejectsDynamicallyGeneratedPlaceholderNotes(@TempDir Path root)
+            throws Exception {
+        Path notes = root.resolve("release_notes.md");
+        write(notes, """
+                # Taxonomy 1.4.0
+
+                ## Changes
+
+                No closed issues found since v1.3.0
+
+                This text is padded so the fixture is long enough to prove that
+                placeholder detection is independent from the minimum-size gate.
+                The reviewed release must never publish this generated fallback.
+                """);
+
+        Result result = runValidator(root, notes, "1.4.0", null);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output())
+                .contains("generated placeholder text")
+                .contains("No closed issues found since");
+    }
+
+    @Test
+    void rejectsImplausiblyShortNotes(@TempDir Path root) throws Exception {
+        Path notes = root.resolve("release_notes.md");
+        write(notes, "# Taxonomy 1.4.0\n\n## Changes\n\nSmall.\n");
+
+        Result result = runValidator(root, notes, "1.4.0", null);
+
+        assertThat(result.exitCode()).isNotZero();
+        assertThat(result.output()).contains("implausibly short");
+    }
+
+    @Test
+    void releaseTransactionUsesTheCommittedReviewedFileWithoutRegeneration()
+            throws Exception {
+        Path repositoryRoot = findRepositoryRoot();
+        String releaseScript = Files.readString(repositoryRoot.resolve(
+                ".github/scripts/release.sh"), StandardCharsets.UTF_8);
+        String workflow = Files.readString(repositoryRoot.resolve(
+                ".github/workflows/deploy-release.yml"), StandardCharsets.UTF_8);
+
+        assertThat(releaseScript)
+                .contains(": \"${RELEASE_NOTES_VALIDATOR:?RELEASE_NOTES_VALIDATOR is required}\"")
+                .contains("materialize_release_notes()")
+                .contains("validate_release_notes()")
+                .contains("$(git rev-parse HEAD)")
+                .contains("git ls-files --error-unmatch \"$notes_file\"")
+                .contains("git diff --quiet HEAD -- \"$notes_file\"")
+                .contains("RELEASE_NOTES_COMMIT=\"$RELEASE_COMMIT\"")
+                .contains("RELEASE_NOTES_FILE=release_notes.md")
+                .contains("\"$RELEASE_NOTES_VALIDATOR\"")
+                .doesNotContain("generate_release_notes()")
+                .doesNotContain("gh issue list")
+                .doesNotContain("--generate-notes")
+                .doesNotContain("No closed issues found since");
+
+        assertThat(countOccurrences(releaseScript, "--notes-file release_notes.md"))
+                .isEqualTo(2);
+
+        String draftCreationBlock = between(
+                releaseScript,
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"tagged\" ]]; then",
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"draft\" ]]; then");
+        assertThat(draftCreationBlock)
+                .contains("materialize_release_notes\n"
+                        + "  gh release create \"$TAG_NAME\"")
+                .contains("--notes-file release_notes.md");
+
+        String directPublishBlock = between(
+                releaseScript,
+                "if [[ \"$DRY_RUN\" != \"true\" && \"$STATE\" == \"draft\" ]]; then",
+                "if [[ \"$DRY_RUN\" != \"true\" ]]; then");
+        assertThat(directPublishBlock)
+                .contains("materialize_release_notes\n"
+                        + "    gh release edit \"$TAG_NAME\"")
+                .contains("--notes-file release_notes.md")
+                .contains("--draft=false")
+                .contains("--latest");
+
+        assertThat(workflow)
+                .contains("cp .github/scripts/validate-reviewed-release-notes.sh")
+                .contains("$RUNNER_TEMP/validate-reviewed-release-notes.sh")
+                .contains("bash -n .github/scripts/validate-reviewed-release-notes.sh")
+                .contains("RELEASE_NOTES_VALIDATOR: ${{ runner.temp }}/validate-reviewed-release-notes.sh");
+
+        String resumeBlock = between(
+                workflow,
+                "- name: Validate staged release for resume",
+                "- name: Record exact final main snapshot");
+        assertThat(resumeBlock)
+                .contains("RELEASE_NOTES_COMMIT=\"$tag\"")
+                .contains("RELEASE_NOTES_FILE=release_notes.md")
+                .contains("\"$RELEASE_NOTES_VALIDATOR\"");
+
+        String publishBlock = workflow.substring(workflow.indexOf(
+                "- name: Publish complete release and trigger deployment"));
+        assertThat(publishBlock)
+                .contains("RELEASE_NOTES_COMMIT=\"$tag\"")
+                .contains("RELEASE_NOTES_FILE=release_notes.md")
+                .contains("gh release edit \"$tag\"")
+                .contains("--notes-file release_notes.md")
+                .contains("--draft=false")
+                .contains("--latest");
+    }
+
+    private static Result runValidator(
+            Path workingDirectory,
+            Path notes,
+            String version,
+            String commit) throws Exception {
+        Path repositoryRoot = findRepositoryRoot();
+        Path validator = repositoryRoot.resolve(
+                ".github/scripts/validate-reviewed-release-notes.sh");
+        ProcessBuilder builder = new ProcessBuilder("bash", validator.toString())
+                .directory(workingDirectory.toFile())
+                .redirectErrorStream(true);
+        Map<String, String> environment = builder.environment();
+        environment.put("RELEASE_VERSION", version);
+        environment.put("RELEASE_NOTES_FILE", notes.toString());
+        if (commit == null) {
+            environment.remove("RELEASE_NOTES_COMMIT");
+        } else {
+            environment.put("RELEASE_NOTES_COMMIT", commit);
+        }
+        return run(builder, "Release-notes validator");
+    }
+
+    private static void initializeRepository(Path root) throws Exception {
+        git(root, "init");
+        git(root, "config", "user.name", "Taxonomy release contract");
+        git(root, "config", "user.email", "release-contract@example.invalid");
+    }
+
+    private static Result git(Path root, String... arguments) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(Arrays.asList(arguments));
+        Result result = run(
+                new ProcessBuilder(command)
+                        .directory(root.toFile())
+                        .redirectErrorStream(true),
+                "Git fixture command " + command);
+        if (result.exitCode() != 0) {
+            throw new AssertionError(
+                    "Git fixture command failed: " + command + "\n" + result.output());
+        }
+        return result;
+    }
+
+    private static Result run(ProcessBuilder builder, String description)
+            throws Exception {
+        Process process = builder.start();
+        boolean finished = process.waitFor(10, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+            throw new AssertionError(description + " exceeded 10 seconds");
+        }
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        return new Result(process.exitValue(), output);
+    }
+
+    private static String between(String text, String start, String end) {
+        int startIndex = text.indexOf(start);
+        int endIndex = text.indexOf(end, startIndex);
+        if (startIndex < 0 || endIndex < 0) {
+            throw new AssertionError(
+                    "Unable to locate source block between " + start + " and " + end);
+        }
+        return text.substring(startIndex, endIndex);
+    }
+
+    private static int countOccurrences(String text, String needle) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(needle, index)) >= 0) {
+            count++;
+            index += needle.length();
+        }
+        return count;
+    }
+
+    private static String validNotes(String version) {
+        return """
+                # Taxonomy %s
+
+                ## Product highlights
+
+                This reviewed release contains deterministic architecture exports,
+                repository-owned verification evidence, documented deployment
+                profiles, and a complete traceable project portfolio workflow.
+
+                ## Upgrade notes
+
+                Back up persistent state, deploy only the immutable release image,
+                and verify the readiness endpoint before routing production traffic.
+
+                ## Verification boundary
+
+                Publication is allowed only after source, tag, artifacts, image
+                digest, vulnerability evidence and Helm manifests agree.
+                """.formatted(version);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                    ".github/scripts/release.sh"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+
+    private record Result(int exitCode, String output) {
+    }
+}


### PR DESCRIPTION
## Purpose

Keep the reviewed, version-bound `release_notes.md` from the immutable release source authoritative for draft creation, staged-release resume and final publication.

## Root cause and correction

`release.sh` previously regenerated the file from recently closed issues and also passed `--generate-notes`. This PR removes both paths. The release now validates the tracked notes at the exact release commit, supplies them explicitly when creating or publishing the GitHub Release, and re-materializes them from the immutable tag during resume and final publication.

The validator resolves the exact commit and Git blob, materializes that blob, verifies its hash, and rejects missing, empty, wrong-version, duplicate-heading, sectionless, implausibly short or generated-placeholder notes.

## Checkout cleanliness

By the time the draft is created, the workflow may already be checked out at the new development `main`. Materializing the immutable release notes over that checkout can intentionally make `release_notes.md` differ from `HEAD`; a later checkout of the release tag would then fail because Git refuses to overwrite the dirty file.

The correction:

- restores only `release_notes.md` from the current `HEAD` immediately after `gh release create` has consumed the immutable file;
- applies the same cleanup after direct `gh release edit` publication;
- retains re-materialization immediately before every GitHub publication operation;
- adds `ReleaseNotesCheckoutCleanlinessContractTest`, including a real temporary Git repository whose release and next-development notes deliberately diverge;
- proves that the bounded restore makes the checkout clean and permits the subsequent detached release-tag checkout with the exact reviewed content.

## Verification authority

The behavioral release-notes contract is owned by Maven/JUnit:

- `ReviewedReleaseNotesContractTest` exercises positive and negative validator behavior and statically proves exact `--notes-file` use in draft, direct-publication and resume paths;
- it forbids dynamic `gh issue list` regeneration, `--generate-notes` and placeholder notes;
- `ReleaseNotesCheckoutCleanlinessContractTest` proves the real Git checkout transition and bounded restore behavior.

The existing supplemental Python delivery guard is also corrected: it now verifies `gh release edit`, `--notes-file release_notes.md`, `--draft=false` and `--latest` independently inside the final publication step instead of requiring one fragile single-line shell spelling. Multi-line formatting therefore no longer creates a false CI failure, while omission or relocation of any required publication flag still fails closed.

## Focused post-integration reconstruction

Exact base: `4f3f31f5426fc9459db56fb4478b6bbb04108ea2`

Exact head: `266ae5ccd5428ae4773e65bbf4718c83af69ec6d`

The branch is two focused commits ahead and zero commits behind. Its diff contains exactly six files, 653 additions and 26 deletions:

- `.github/scripts/check-release-delivery-contract.py`;
- `.github/scripts/release.sh`;
- `.github/scripts/validate-reviewed-release-notes.sh`;
- `.github/workflows/deploy-release.yml`;
- `taxonomy-build/src/test/java/com/taxonomy/build/ReleaseNotesCheckoutCleanlinessContractTest.java`;
- `taxonomy-build/src/test/java/com/taxonomy/build/ReviewedReleaseNotesContractTest.java`.

## Merge gate

Require fresh exact-head CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL and Security Scan results for `266ae5ccd5428ae4773e65bbf4718c83af69ec6d`, plus no unresolved review thread.

This PR does not modify `.github/release-request.json` and creates no tag, GitHub Release, OCI image, Helm publication or deployment.

Advances #711 and #673.