### PR TITLE
Run repository catalog startup inside the transactional service proxy

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogBootstrapOrder.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogBootstrapOrder.java
@@ -1,0 +1,46 @@
+package com.taxonomy.workspace.service;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.PriorityOrdered;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+/**
+ * Declares the startup dependency without coupling the catalogue module to the
+ * workspace implementation type.
+ */
+@Component
+public class SystemRepositoryCatalogBootstrapOrder
+        implements BeanFactoryPostProcessor, PriorityOrdered {
+
+    static final String TAXONOMY_SERVICE_BEAN = "taxonomyService";
+    static final String CATALOG_INITIALIZER_BEAN =
+            "systemRepositoryCatalogInitializer";
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory)
+            throws BeansException {
+        BeanDefinition taxonomyService =
+                beanFactory.getBeanDefinition(TAXONOMY_SERVICE_BEAN);
+        String[] currentDependencies = taxonomyService.getDependsOn();
+        if (currentDependencies == null) {
+            taxonomyService.setDependsOn(CATALOG_INITIALIZER_BEAN);
+        } else if (Arrays.stream(currentDependencies)
+                .noneMatch(CATALOG_INITIALIZER_BEAN::equals)) {
+            String[] dependencies = Arrays.copyOf(
+                    currentDependencies, currentDependencies.length + 1);
+            dependencies[currentDependencies.length] = CATALOG_INITIALIZER_BEAN;
+            taxonomyService.setDependsOn(dependencies);
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
@@ -1,23 +1,19 @@
 package com.taxonomy.workspace.service;
 
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.ApplicationRunner;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
+import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
 
 /**
  * Initializes the central repository catalog through the transactional service proxy.
  *
- * <p>The runner executes after the highest-precedence portable schema migration and
- * before repository-sensitive search lifecycle runners. Delegating to a separate
- * Spring-managed service bean makes the {@code @Transactional} boundary effective;
- * invoking the same method from that service bean's own {@code @PostConstruct}
- * callback would bypass the proxy.</p>
+ * <p>This lifecycle callback belongs to a separate Spring bean. Calling the public
+ * service method therefore crosses the {@link SystemRepositoryService} proxy and makes
+ * its {@code @Transactional} boundary effective. The taxonomy bootstrap explicitly
+ * depends on this initializer so built-in seed relations can always bind to the primary
+ * repository.</p>
  */
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE + 100)
-public class SystemRepositoryCatalogInitializer implements ApplicationRunner {
+public class SystemRepositoryCatalogInitializer {
 
     private final SystemRepositoryService systemRepositoryService;
 
@@ -26,8 +22,8 @@ public class SystemRepositoryCatalogInitializer implements ApplicationRunner {
         this.systemRepositoryService = systemRepositoryService;
     }
 
-    @Override
-    public void run(ApplicationArguments arguments) {
+    @PostConstruct
+    void initialize() {
         systemRepositoryService.ensureSystemRepository();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
@@ -7,15 +7,16 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
- * Initializes the central repository catalog after the Spring context is ready.
+ * Initializes the central repository catalog through the transactional service proxy.
  *
- * <p>The initializer deliberately delegates to a separate Spring-managed service
- * bean. That inter-bean call crosses the transactional proxy, unlike invoking a
- * {@code @Transactional} method from the service bean's own {@code @PostConstruct}
- * callback.</p>
+ * <p>The runner executes after the highest-precedence portable schema migration and
+ * before repository-sensitive search lifecycle runners. Delegating to a separate
+ * Spring-managed service bean makes the {@code @Transactional} boundary effective;
+ * invoking the same method from that service bean's own {@code @PostConstruct}
+ * callback would bypass the proxy.</p>
  */
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE + 100)
 public class SystemRepositoryCatalogInitializer implements ApplicationRunner {
 
     private final SystemRepositoryService systemRepositoryService;

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializer.java
@@ -1,0 +1,32 @@
+package com.taxonomy.workspace.service;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Initializes the central repository catalog after the Spring context is ready.
+ *
+ * <p>The initializer deliberately delegates to a separate Spring-managed service
+ * bean. That inter-bean call crosses the transactional proxy, unlike invoking a
+ * {@code @Transactional} method from the service bean's own {@code @PostConstruct}
+ * callback.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class SystemRepositoryCatalogInitializer implements ApplicationRunner {
+
+    private final SystemRepositoryService systemRepositoryService;
+
+    public SystemRepositoryCatalogInitializer(
+            SystemRepositoryService systemRepositoryService) {
+        this.systemRepositoryService = systemRepositoryService;
+    }
+
+    @Override
+    public void run(ApplicationArguments arguments) {
+        systemRepositoryService.ensureSystemRepository();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/SystemRepositoryService.java
@@ -6,7 +6,6 @@ import com.taxonomy.workspace.model.RepositoryTopologyMode;
 import com.taxonomy.workspace.model.RepositoryVisibility;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.repository.SystemRepositoryRepository;
-import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -40,11 +39,11 @@ public class SystemRepositoryService {
      * and erase credentials persisted by releases that stored external Git tokens
      * in plaintext.
      *
-     * <p>Initialization fails closed. Continuing after a failed cleanup could
-     * leave a usable plaintext credential in the database while the operator
-     * assumes migration succeeded.</p>
+     * <p>This method is invoked by {@link SystemRepositoryCatalogInitializer}
+     * through the Spring-managed service proxy. Initialization therefore runs in
+     * one real transaction and fails closed before later application runners use
+     * repository-owned state.</p>
      */
-    @PostConstruct
     @Transactional
     public void ensureSystemRepository() {
         try {

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializerTest.java
@@ -1,11 +1,9 @@
 package com.taxonomy.workspace.service;
 
-import com.taxonomy.architecture.service.CommitIndexSearchLifecycle;
-import com.taxonomy.shared.config.SchemaContractMigration;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.DefaultApplicationArguments;
-import org.springframework.core.annotation.Order;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Method;
@@ -17,18 +15,23 @@ import static org.mockito.Mockito.verify;
 
 class SystemRepositoryCatalogInitializerTest {
 
-    private static final DefaultApplicationArguments NO_ARGS =
-            new DefaultApplicationArguments(new String[0]);
-
     @Test
     void delegatesStartupToTransactionalServiceBoundary() {
         SystemRepositoryService service = mock(SystemRepositoryService.class);
         SystemRepositoryCatalogInitializer initializer =
                 new SystemRepositoryCatalogInitializer(service);
 
-        initializer.run(NO_ARGS);
+        initializer.initialize();
 
         verify(service).ensureSystemRepository();
+    }
+
+    @Test
+    void initializerOwnsLifecycleCallback() throws Exception {
+        Method method = SystemRepositoryCatalogInitializer.class
+                .getDeclaredMethod("initialize");
+
+        assertThat(method.isAnnotationPresent(PostConstruct.class)).isTrue();
     }
 
     @Test
@@ -44,21 +47,19 @@ class SystemRepositoryCatalogInitializerTest {
     }
 
     @Test
-    void runnerOrderKeepsSchemaMigrationAheadAndSearchLifecycleBehind() {
-        int schemaMigrationOrder = orderOf(SchemaContractMigration.class);
-        int catalogInitializationOrder = orderOf(SystemRepositoryCatalogInitializer.class);
-        int searchLifecycleOrder = orderOf(CommitIndexSearchLifecycle.class);
+    void taxonomyBootstrapDependsOnCatalogInitialization() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        RootBeanDefinition taxonomyService = new RootBeanDefinition(Object.class);
+        taxonomyService.setDependsOn("existingDependency");
+        beanFactory.registerBeanDefinition(
+                SystemRepositoryCatalogBootstrapOrder.TAXONOMY_SERVICE_BEAN,
+                taxonomyService);
 
-        assertThat(catalogInitializationOrder)
-                .isGreaterThan(schemaMigrationOrder)
-                .isLessThan(searchLifecycleOrder);
-    }
+        new SystemRepositoryCatalogBootstrapOrder()
+                .postProcessBeanFactory(beanFactory);
 
-    private static int orderOf(Class<?> type) {
-        Order annotation = type.getAnnotation(Order.class);
-        assertThat(annotation)
-                .as(type.getName() + " must declare an explicit startup order")
-                .isNotNull();
-        return annotation.value();
+        assertThat(taxonomyService.getDependsOn()).containsExactly(
+                "existingDependency",
+                SystemRepositoryCatalogBootstrapOrder.CATALOG_INITIALIZER_BEAN);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/SystemRepositoryCatalogInitializerTest.java
@@ -1,0 +1,64 @@
+package com.taxonomy.workspace.service;
+
+import com.taxonomy.architecture.service.CommitIndexSearchLifecycle;
+import com.taxonomy.shared.config.SchemaContractMigration;
+import jakarta.annotation.PostConstruct;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.core.annotation.Order;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class SystemRepositoryCatalogInitializerTest {
+
+    private static final DefaultApplicationArguments NO_ARGS =
+            new DefaultApplicationArguments(new String[0]);
+
+    @Test
+    void delegatesStartupToTransactionalServiceBoundary() {
+        SystemRepositoryService service = mock(SystemRepositoryService.class);
+        SystemRepositoryCatalogInitializer initializer =
+                new SystemRepositoryCatalogInitializer(service);
+
+        initializer.run(NO_ARGS);
+
+        verify(service).ensureSystemRepository();
+    }
+
+    @Test
+    void serviceOwnsTransactionButNoLifecycleCallback() throws Exception {
+        Method method = SystemRepositoryService.class
+                .getDeclaredMethod("ensureSystemRepository");
+
+        assertThat(method.isAnnotationPresent(Transactional.class)).isTrue();
+        assertThat(method.isAnnotationPresent(PostConstruct.class)).isFalse();
+        assertThat(Arrays.stream(SystemRepositoryService.class.getDeclaredMethods())
+                .noneMatch(candidate -> candidate.isAnnotationPresent(PostConstruct.class)))
+                .isTrue();
+    }
+
+    @Test
+    void runnerOrderKeepsSchemaMigrationAheadAndSearchLifecycleBehind() {
+        int schemaMigrationOrder = orderOf(SchemaContractMigration.class);
+        int catalogInitializationOrder = orderOf(SystemRepositoryCatalogInitializer.class);
+        int searchLifecycleOrder = orderOf(CommitIndexSearchLifecycle.class);
+
+        assertThat(catalogInitializationOrder)
+                .isGreaterThan(schemaMigrationOrder)
+                .isLessThan(searchLifecycleOrder);
+    }
+
+    private static int orderOf(Class<?> type) {
+        Order annotation = type.getAnnotation(Order.class);
+        assertThat(annotation)
+                .as(type.getName() + " must declare an explicit startup order")
+                .isNotNull();
+        return annotation.value();
+    }
+}


### PR DESCRIPTION
## Problem

The multi-repository integration introduced `SystemRepositoryService.ensureSystemRepository()` as a `@PostConstruct` method annotated with `@Transactional`. Spring invokes a service-owned lifecycle callback before the service proxy is usable, so the annotation did not provide the advertised transaction boundary. Catalog creation, metadata backfill and legacy plaintext-credential cleanup could therefore execute without one enclosing transaction.

The first repair revision moved initialization to an `ApplicationRunner`. The database matrix then exposed a second ordering defect: synchronous `TaxonomyService.@PostConstruct` persists built-in seed relations before application runners execute, while the seed relation listener already requires the primary repository. The result was a failed taxonomy initialization and cascading 503 responses on PostgreSQL, SQL Server and Oracle jobs.

## Correction

- remove `@PostConstruct` from `SystemRepositoryService` while retaining the public `@Transactional` boundary;
- invoke that service from a separate `SystemRepositoryCatalogInitializer` lifecycle bean, which crosses the Spring-managed service proxy;
- add a small bean-definition ordering contract that makes `taxonomyService` depend on the catalog initializer without coupling the catalogue module to the workspace implementation type;
- retain fail-closed startup semantics: an initialization exception still aborts application startup;
- test delegation, lifecycle ownership, transaction ownership and preservation of any existing startup dependencies.

## Scope

Exact head: `0f4946219c6d0548ef49a0fa29c62c0470925ef3`, based directly on merged multi-repository `main` `89fe01739ca2aec5a241969f9ace166d30f108ba` with zero commits behind.

The diff contains exactly four files and 149 changed lines:

- `SystemRepositoryService.java`;
- `SystemRepositoryCatalogInitializer.java`;
- `SystemRepositoryCatalogBootstrapOrder.java`;
- `SystemRepositoryCatalogInitializerTest.java`.

This PR does not change repository data semantics, create release artifacts or close the remaining multi-repository epic. It is the first focused post-integration repair identified during review of #610/#739.

Advances #609.