### PR TITLE
Route productive proposal review paths through Git authority

### DIFF
--- a/.github/scripts/ui-primary-proposal-workflows.mjs
+++ b/.github/scripts/ui-primary-proposal-workflows.mjs
@@ -133,7 +133,7 @@ export async function runProposalWorkflows({ page, evidence }) {
 
   await page.getByRole('button', { name: `Accept proposal ${ids[0]}` }).click();
   await page.locator('#undoToast').waitFor({ state: 'visible', timeout: 15_000 });
-  await page.locator('#undoBtn').click();
+  await page.locator('#proposalGitUndoBtn').click();
   await waitForText('#statusArea', text => /revert|undo/i.test(text));
   passed('proposal accept and revert');
 

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
@@ -138,7 +138,7 @@ public class ProposalApiController {
 
     /** Compatibility overload used by focused unit tests and in-process callers. */
     public ResponseEntity<Map<String, Object>> acceptProposal(Long id) {
-        return acceptProposal(id, null);
+        return acceptProposal(id, null, null);
     }
 
     @Operation(summary = "Accept proposal through an authoritative Git commit")
@@ -154,7 +154,7 @@ public class ProposalApiController {
 
     /** Compatibility overload used by focused unit tests and in-process callers. */
     public ResponseEntity<Map<String, Object>> rejectProposal(Long id) {
-        return rejectProposal(id, null);
+        return rejectProposal(id, null, null);
     }
 
     @Operation(summary = "Reject proposal through an authoritative Git commit")
@@ -225,7 +225,7 @@ public class ProposalApiController {
 
     /** Compatibility overload used by focused unit tests and in-process callers. */
     public ResponseEntity<Map<String, Object>> revertProposal(Long id) {
-        return revertProposal(id, null);
+        return revertProposal(id, null, null);
     }
 
     @Operation(summary = "Revert proposal through an authoritative Git commit")

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
@@ -146,8 +146,10 @@ public class ProposalApiController {
     public ResponseEntity<Map<String, Object>> acceptProposal(
             @PathVariable Long id,
             @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
-            String ifMatch) {
-        return reviewProposal(id, ReviewAction.ACCEPT, ifMatch, null);
+            String ifMatch,
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            String idempotencyKey) {
+        return reviewProposal(id, ReviewAction.ACCEPT, ifMatch, idempotencyKey);
     }
 
     /** Compatibility overload used by focused unit tests and in-process callers. */
@@ -160,8 +162,10 @@ public class ProposalApiController {
     public ResponseEntity<Map<String, Object>> rejectProposal(
             @PathVariable Long id,
             @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
-            String ifMatch) {
-        return reviewProposal(id, ReviewAction.REJECT, ifMatch, null);
+            String ifMatch,
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            String idempotencyKey) {
+        return reviewProposal(id, ReviewAction.REJECT, ifMatch, idempotencyKey);
     }
 
     @Operation(summary = "Create proposal from hypothesis")
@@ -229,8 +233,10 @@ public class ProposalApiController {
     public ResponseEntity<Map<String, Object>> revertProposal(
             @PathVariable Long id,
             @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
-            String ifMatch) {
-        return reviewProposal(id, ReviewAction.REVERT, ifMatch, null);
+            String ifMatch,
+            @RequestHeader(value = "Idempotency-Key", required = false)
+            String idempotencyKey) {
+        return reviewProposal(id, ReviewAction.REVERT, ifMatch, idempotencyKey);
     }
 
     /** Compatibility overload used by focused unit tests and in-process callers. */
@@ -347,6 +353,7 @@ public class ProposalApiController {
         result.put("total", ids.size());
         result.put("processed", itemResults.size());
         result.put("projected", projected);
+        result.put("success", projected); // legacy alias for "projected" — kept for browser UI compatibility
         result.put("pendingRecovery", pending);
         result.put("failed", failed);
         result.put("complete", itemResults.size() == ids.size()
@@ -463,8 +470,7 @@ public class ProposalApiController {
     }
 
     private String currentHead(RepositoryContext context) {
-        Readiness readiness = readinessService.inspect(context);
-        return readiness.currentHeadCommit();
+        return readinessService.readCurrentHead(context);
     }
 
     private static Map<String, Object> reviewPayload(

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java
@@ -1,12 +1,20 @@
 package com.taxonomy.relations.controller;
 
+import com.taxonomy.dsl.storage.ExpectedHeadDslCommitter.BranchHeadConflictException;
 import com.taxonomy.dto.RelationProposalDto;
-import com.taxonomy.dto.TaxonomyRelationDto;
 import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.ReadOnlyRepositoryContextException;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ProposalReviewPendingException;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewAction;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewResult;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.relations.service.RelationProposalService;
-import com.taxonomy.relations.service.RelationReviewService;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryMembershipService;
@@ -24,11 +32,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /** REST API for repository/workspace-scoped relation proposals and review. */
@@ -37,20 +49,25 @@ import java.util.Map;
 @Tag(name = "Proposals")
 public class ProposalApiController {
 
+    private static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+
     private final RelationProposalService proposalService;
-    private final RelationReviewService reviewService;
+    private final GitAuthoritativeProposalReviewService reviewService;
+    private final RelationBranchProjectionReadinessService readinessService;
     private final WorkspaceResolver workspaceResolver;
     private final SystemRepositoryService repositoryService;
     private final RepositoryMembershipService membershipService;
 
     public ProposalApiController(
             RelationProposalService proposalService,
-            RelationReviewService reviewService,
+            GitAuthoritativeProposalReviewService reviewService,
+            RelationBranchProjectionReadinessService readinessService,
             WorkspaceResolver workspaceResolver,
             SystemRepositoryService repositoryService,
             RepositoryMembershipService membershipService) {
         this.proposalService = proposalService;
         this.reviewService = reviewService;
+        this.readinessService = readinessService;
         this.workspaceResolver = workspaceResolver;
         this.repositoryService = repositoryService;
         this.membershipService = membershipService;
@@ -119,38 +136,32 @@ public class ProposalApiController {
                 proposalService.getProposalsForNodeInContext(code, context));
     }
 
-    @Operation(summary = "Accept proposal")
-    @PostMapping("/proposals/{id}/accept")
-    public ResponseEntity<TaxonomyRelationDto> acceptProposal(
-            @PathVariable Long id) {
-        RepositoryContext context = writableContext(
-                workspaceResolver.resolveCurrentRepositoryContext());
-        if (context == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        try {
-            return ResponseEntity.ok(
-                    reviewService.acceptProposal(id, context));
-        } catch (IllegalArgumentException | IllegalStateException error) {
-            return ResponseEntity.badRequest().build();
-        }
+    /** Compatibility overload used by focused unit tests and in-process callers. */
+    public ResponseEntity<Map<String, Object>> acceptProposal(Long id) {
+        return acceptProposal(id, null);
     }
 
-    @Operation(summary = "Reject proposal")
+    @Operation(summary = "Accept proposal through an authoritative Git commit")
+    @PostMapping("/proposals/{id}/accept")
+    public ResponseEntity<Map<String, Object>> acceptProposal(
+            @PathVariable Long id,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch) {
+        return reviewProposal(id, ReviewAction.ACCEPT, ifMatch, null);
+    }
+
+    /** Compatibility overload used by focused unit tests and in-process callers. */
+    public ResponseEntity<Map<String, Object>> rejectProposal(Long id) {
+        return rejectProposal(id, null);
+    }
+
+    @Operation(summary = "Reject proposal through an authoritative Git commit")
     @PostMapping("/proposals/{id}/reject")
-    public ResponseEntity<RelationProposalDto> rejectProposal(
-            @PathVariable Long id) {
-        RepositoryContext context = writableContext(
-                workspaceResolver.resolveCurrentRepositoryContext());
-        if (context == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        try {
-            return ResponseEntity.ok(
-                    reviewService.rejectProposal(id, context));
-        } catch (IllegalArgumentException | IllegalStateException error) {
-            return ResponseEntity.badRequest().build();
-        }
+    public ResponseEntity<Map<String, Object>> rejectProposal(
+            @PathVariable Long id,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch) {
+        return reviewProposal(id, ReviewAction.REJECT, ifMatch, null);
     }
 
     @Operation(summary = "Create proposal from hypothesis")
@@ -208,34 +219,48 @@ public class ProposalApiController {
         }
     }
 
-    @Operation(summary = "Revert proposal")
-    @PostMapping("/proposals/{id}/revert")
-    public ResponseEntity<RelationProposalDto> revertProposal(
-            @PathVariable Long id) {
-        RepositoryContext context = writableContext(
-                workspaceResolver.resolveCurrentRepositoryContext());
-        if (context == null) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        try {
-            return ResponseEntity.ok(
-                    reviewService.revertProposal(id, context));
-        } catch (IllegalArgumentException | IllegalStateException error) {
-            return ResponseEntity.badRequest().build();
-        }
+    /** Compatibility overload used by focused unit tests and in-process callers. */
+    public ResponseEntity<Map<String, Object>> revertProposal(Long id) {
+        return revertProposal(id, null);
     }
 
-    @Operation(summary = "Bulk action on proposals")
+    @Operation(summary = "Revert proposal through an authoritative Git commit")
+    @PostMapping("/proposals/{id}/revert")
+    public ResponseEntity<Map<String, Object>> revertProposal(
+            @PathVariable Long id,
+            @RequestHeader(value = HttpHeaders.IF_MATCH, required = false)
+            String ifMatch) {
+        return reviewProposal(id, ReviewAction.REVERT, ifMatch, null);
+    }
+
+    /** Compatibility overload used by focused unit tests and in-process callers. */
+    public ResponseEntity<Map<String, Object>> bulkAction(
+            Map<String, Object> body) {
+        return bulkAction(body, null);
+    }
+
+    @Operation(summary = "Ordered Git-first bulk action on proposals")
     @PostMapping("/proposals/bulk")
     public ResponseEntity<Map<String, Object>> bulkAction(
-            @RequestBody Map<String, Object> body) {
+            @RequestBody Map<String, Object> body,
+            @RequestHeader(value = IDEMPOTENCY_KEY, required = false)
+            String idempotencyKey) {
         @SuppressWarnings("unchecked")
         List<Number> ids = body.get("ids") instanceof List<?> list
                 ? (List<Number>) list : null;
-        String action = body.get("action") instanceof String value
+        String actionText = body.get("action") instanceof String value
                 ? value : null;
         if (ids == null || ids.isEmpty()
-                || action == null || action.isBlank()) {
+                || actionText == null || actionText.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        ReviewAction action;
+        if ("ACCEPT".equalsIgnoreCase(actionText)) {
+            action = ReviewAction.ACCEPT;
+        } else if ("REJECT".equalsIgnoreCase(actionText)) {
+            action = ReviewAction.REJECT;
+        } else {
             return ResponseEntity.badRequest().build();
         }
 
@@ -245,40 +270,268 @@ public class ProposalApiController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        int success = 0;
+        String expectedHead = currentHead(context);
+        if (expectedHead == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .header(RelationApiController.PROJECTION_STATE_HEADER,
+                            ReadinessState.BRANCH_MISSING.name())
+                    .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                    .build();
+        }
+
+        String bulkKey = normalizeIdempotencyKey(idempotencyKey);
+        if (bulkKey == null) {
+            bulkKey = "legacy-proposal-bulk-"
+                    + action.name().toLowerCase(Locale.ROOT)
+                    + "-" + expectedHead + "-" + ids.hashCode();
+        }
+
+        List<Map<String, Object>> itemResults = new ArrayList<>();
+        int projected = 0;
+        int pending = 0;
         int failed = 0;
-        for (Number idNumber : ids) {
+        boolean stop = false;
+        for (int index = 0; index < ids.size() && !stop; index++) {
+            Number idNumber = ids.get(index);
             if (idNumber == null) {
                 failed++;
+                itemResults.add(itemFailure(null, "INVALID_ID", null));
                 continue;
             }
+            long proposalId = idNumber.longValue();
+            String itemKey = bulkKey + ":" + index + ":" + proposalId;
             try {
-                if ("ACCEPT".equalsIgnoreCase(action)) {
-                    reviewService.acceptProposal(
-                            idNumber.longValue(), context);
-                } else if ("REJECT".equalsIgnoreCase(action)) {
-                    reviewService.rejectProposal(
-                            idNumber.longValue(), context);
-                } else {
-                    return ResponseEntity.badRequest().build();
+                ReviewResult result = executeReview(
+                        proposalId,
+                        action,
+                        context,
+                        expectedHead,
+                        itemKey);
+                CommandResult authority = result.mutation().authority();
+                expectedHead = authority.authoritativeCommitId();
+                projected++;
+                itemResults.add(reviewPayload(result, "PROJECTED"));
+            } catch (ProposalReviewPendingException error) {
+                expectedHead = error.getAuthority().authoritativeCommitId();
+                pending++;
+                itemResults.add(pendingPayload(error));
+                stop = true;
+            } catch (BranchHeadConflictException error) {
+                failed++;
+                if (error.getActualHeadCommit() != null) {
+                    expectedHead = error.getActualHeadCommit();
                 }
-                success++;
+                itemResults.add(itemFailure(
+                        proposalId,
+                        "PRECONDITION_FAILED",
+                        error.getMessage()));
+                stop = true;
             } catch (IllegalArgumentException | IllegalStateException error) {
                 failed++;
+                itemResults.add(itemFailure(
+                        proposalId,
+                        "REVIEW_REJECTED",
+                        error.getMessage()));
+            } catch (IOException error) {
+                failed++;
+                itemResults.add(itemFailure(
+                        proposalId,
+                        "GIT_UNAVAILABLE",
+                        error.getMessage()));
+                stop = true;
             }
         }
 
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("action", action);
-        result.put("success", success);
-        result.put("failed", failed);
+        result.put("action", action.name());
         result.put("total", ids.size());
-        return ResponseEntity.ok(result);
+        result.put("processed", itemResults.size());
+        result.put("projected", projected);
+        result.put("pendingRecovery", pending);
+        result.put("failed", failed);
+        result.put("complete", itemResults.size() == ids.size()
+                && pending == 0 && failed == 0);
+        result.put("authoritativeCommitId", expectedHead);
+        result.put("items", itemResults);
+
+        HttpStatus status = pending > 0
+                ? HttpStatus.ACCEPTED
+                : failed > 0 ? HttpStatus.MULTI_STATUS : HttpStatus.OK;
+        ResponseEntity.BodyBuilder response = ResponseEntity.status(status)
+                .header(HttpHeaders.CACHE_CONTROL, "no-store");
+        if (expectedHead != null) {
+            response.header(
+                    HttpHeaders.ETAG,
+                    GitHttpPrecondition.etag(expectedHead));
+        }
+        return response.body(result);
+    }
+
+    private ResponseEntity<Map<String, Object>> reviewProposal(
+            Long proposalId,
+            ReviewAction action,
+            String ifMatch,
+            String suppliedIdempotencyKey) {
+        RepositoryContext context = writableContext(
+                workspaceResolver.resolveCurrentRepositoryContext());
+        if (context == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        try {
+            String expectedHead = expectedHead(context, ifMatch);
+            if (expectedHead == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .header(RelationApiController.PROJECTION_STATE_HEADER,
+                                ReadinessState.BRANCH_MISSING.name())
+                        .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                        .build();
+            }
+            String causationId = normalizeIdempotencyKey(suppliedIdempotencyKey);
+            if (causationId == null) {
+                causationId = "legacy-proposal-"
+                        + action.name().toLowerCase(Locale.ROOT)
+                        + "-" + proposalId + "-" + expectedHead;
+            }
+            ReviewResult result = executeReview(
+                    proposalId,
+                    action,
+                    context,
+                    expectedHead,
+                    causationId);
+            CommandResult authority = result.mutation().authority();
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                    .header(
+                            HttpHeaders.ETAG,
+                            GitHttpPrecondition.etag(
+                                    authority.authoritativeCommitId()))
+                    .body(reviewPayload(result, "PROJECTED"));
+        } catch (BranchHeadConflictException error) {
+            ResponseEntity.BodyBuilder response = ResponseEntity.status(
+                    HttpStatus.PRECONDITION_FAILED)
+                    .header(HttpHeaders.CACHE_CONTROL, "no-store");
+            if (error.getActualHeadCommit() != null) {
+                response.header(
+                        HttpHeaders.ETAG,
+                        GitHttpPrecondition.etag(error.getActualHeadCommit()));
+            }
+            return response.body(conflictPayload(proposalId, action, error));
+        } catch (ProposalReviewPendingException error) {
+            return ResponseEntity.status(HttpStatus.ACCEPTED)
+                    .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                    .header(
+                            HttpHeaders.ETAG,
+                            GitHttpPrecondition.etag(
+                                    error.getAuthority().authoritativeCommitId()))
+                    .body(pendingPayload(error));
+        } catch (ReadOnlyRepositoryContextException error) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (IllegalArgumentException error) {
+            return ResponseEntity.badRequest().build();
+        } catch (IllegalStateException error) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        } catch (IOException error) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+    }
+
+    private ReviewResult executeReview(
+            Long proposalId,
+            ReviewAction action,
+            RepositoryContext context,
+            String expectedHead,
+            String causationId) throws IOException {
+        CommandMetadata metadata = new CommandMetadata(
+                causationId,
+                "Git-first proposal review through the productive API");
+        return switch (action) {
+            case ACCEPT -> reviewService.accept(
+                    proposalId, context, expectedHead, metadata);
+            case REJECT -> reviewService.reject(
+                    proposalId, context, expectedHead, metadata);
+            case REVERT -> reviewService.revert(
+                    proposalId, context, expectedHead, metadata);
+        };
+    }
+
+    private String expectedHead(RepositoryContext context, String ifMatch) {
+        if (ifMatch != null && !ifMatch.isBlank()) {
+            return GitHttpPrecondition.expectedHead(ifMatch, null);
+        }
+        return currentHead(context);
+    }
+
+    private String currentHead(RepositoryContext context) {
+        Readiness readiness = readinessService.inspect(context);
+        return readiness.currentHeadCommit();
+    }
+
+    private static Map<String, Object> reviewPayload(
+            ReviewResult result,
+            String projectionStatus) {
+        CommandResult authority = result.mutation().authority();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("proposalId", result.proposalId());
+        payload.put("action", result.action().name());
+        payload.put("status", result.proposalStatus().name());
+        payload.put("authoritativeCommitId",
+                authority.authoritativeCommitId());
+        payload.put("previousHeadCommit", authority.previousHeadCommit());
+        payload.put("changeKind", authority.changeKind().name());
+        payload.put("commitCreated", authority.commitCreated());
+        payload.put("projectionStatus", projectionStatus);
+        payload.put("projectionOutcome",
+                result.mutation().projection().outcome().name());
+        payload.put("relationPresent",
+                result.mutation().projection().relationPresent());
+        return payload;
+    }
+
+    private static Map<String, Object> pendingPayload(
+            ProposalReviewPendingException error) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("proposalId", error.getProposalId());
+        payload.put("status", error.getIntendedStatus().name());
+        payload.put("authoritativeCommitId",
+                error.getAuthority().authoritativeCommitId());
+        payload.put("changeKind", error.getAuthority().changeKind().name());
+        payload.put("commitCreated", error.getAuthority().commitCreated());
+        payload.put("projectionStatus", "PENDING_RECOVERY");
+        payload.put("pendingPhase", error.getPhase().name());
+        return payload;
+    }
+
+    private static Map<String, Object> conflictPayload(
+            Long proposalId,
+            ReviewAction action,
+            BranchHeadConflictException error) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("proposalId", proposalId);
+        payload.put("action", action.name());
+        payload.put("projectionStatus", "PRECONDITION_FAILED");
+        payload.put("expectedHeadCommit", error.getExpectedHeadCommit());
+        payload.put("actualHeadCommit", error.getActualHeadCommit());
+        return payload;
+    }
+
+    private static Map<String, Object> itemFailure(
+            Long proposalId,
+            String code,
+            String detail) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("proposalId", proposalId);
+        payload.put("projectionStatus", code);
+        if (detail != null && !detail.isBlank()) {
+            payload.put("detail", detail);
+        }
+        return payload;
     }
 
     /** Convert a central read context into an explicitly authorized write context. */
     private RepositoryContext writableContext(RepositoryContext context) {
-        if (context.workspaceId() != null) {
+        if (context.scope() == RepositoryScope.WORKSPACE
+                || context.scope() == RepositoryScope.FORK) {
             return context;
         }
         SystemRepository repository = repositoryService.getRepository(
@@ -319,6 +572,18 @@ public class ProposalApiController {
                             error.getCurrentHeadCommit()));
         }
         return response;
+    }
+
+    private static String normalizeIdempotencyKey(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.strip();
+        if (normalized.indexOf('\n') >= 0 || normalized.indexOf('\r') >= 0) {
+            throw new IllegalArgumentException(
+                    "Idempotency-Key must be one line");
+        }
+        return normalized;
     }
 
     private static boolean isApplicationAdmin() {

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalHeadApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalHeadApiController.java
@@ -1,0 +1,58 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Lightweight concurrency-token endpoint for proposal review clients.
+ *
+ * <p>The endpoint reads only the selected Git branch ref. It deliberately does
+ * not load proposal rows or validate the rebuildable relation projection.
+ */
+@RestController
+@RequestMapping("/api/proposals")
+@Tag(name = "Proposals")
+public class ProposalHeadApiController {
+
+    private final RelationBranchProjectionReadinessService readinessService;
+    private final WorkspaceResolver workspaceResolver;
+
+    public ProposalHeadApiController(
+            RelationBranchProjectionReadinessService readinessService,
+            WorkspaceResolver workspaceResolver) {
+        this.readinessService = readinessService;
+        this.workspaceResolver = workspaceResolver;
+    }
+
+    @Operation(
+            summary = "Read the exact Git head used as proposal review precondition",
+            description = "Returns the selected repository/workspace branch head as a strong ETag without materialising relation projection rows")
+    @GetMapping("/head")
+    public ResponseEntity<Void> readHead() {
+        RepositoryContext context = workspaceResolver
+                .resolveCurrentRepositoryContext();
+        String head = readinessService.readCurrentHead(context);
+        if (head == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .header(
+                            RelationApiController.PROJECTION_STATE_HEADER,
+                            ReadinessState.BRANCH_MISSING.name())
+                    .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                    .build();
+        }
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.ETAG, GitHttpPrecondition.etag(head))
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .build();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/service/RelationBranchProjectionReadinessService.java
@@ -43,6 +43,17 @@ public class RelationBranchProjectionReadinessService {
                 checkpointRepository, "checkpointRepository");
     }
 
+    /**
+     * Returns the current Git head commit for the given branch without loading
+     * or validating projection rows.  Use this when only the head SHA is needed
+     * (e.g. to seed the expected-head for a review command).
+     */
+    public String readCurrentHead(RepositoryContext context) {
+        Objects.requireNonNull(context, "context");
+        DslGitRepository repository = gitRepositoryFactory.resolveRepository(context);
+        return readHead(repository, context.branch());
+    }
+
     @Transactional(readOnly = true)
     public Readiness inspect(RepositoryContext context) {
         Objects.requireNonNull(context, "context");

--- a/taxonomy-app/src/main/resources/static/js/api/proposals-api.js
+++ b/taxonomy-app/src/main/resources/static/js/api/proposals-api.js
@@ -1,0 +1,32 @@
+/**
+ * Raw-response API boundary for Git-authoritative proposal review commands.
+ *
+ * Callers need the strong branch ETag and must distinguish projected success,
+ * accepted-with-pending-recovery, stale preconditions and ordinary review
+ * rejection. The canonical fetch wrapper still supplies base-path and CSRF
+ * handling; this boundary intentionally returns the unconsumed Response.
+ */
+window.TaxonomyProposalsApi = (function () {
+    'use strict';
+
+    function readHead() {
+        return fetch('/api/proposals/head', {
+            method: 'GET',
+            cache: 'no-store'
+        });
+    }
+
+    function review(proposalId, action, headers) {
+        return fetch('/api/proposals/'
+                + encodeURIComponent(proposalId) + '/'
+                + encodeURIComponent(action.toLowerCase()), {
+            method: 'POST',
+            headers: headers
+        });
+    }
+
+    return {
+        readHead: readHead,
+        review: review
+    };
+}());

--- a/taxonomy-app/src/main/resources/static/js/api/relations-api.js
+++ b/taxonomy-app/src/main/resources/static/js/api/relations-api.js
@@ -44,3 +44,72 @@ window.TaxonomyRelationsApi = (function () {
         deleteRelation: deleteRelation
     };
 }());
+
+/*
+ * Proposal review is part of the same Git-authoritative relation surface. Load
+ * its raw-response API first and then the capture-phase browser adapter. The
+ * readiness promise prevents duplicate scripts and makes delayed loading safe.
+ */
+(function () {
+    'use strict';
+    var loader = document.currentScript;
+    if (!loader || !loader.src) return;
+
+    function loadProposalAdapter() {
+        if (document.querySelector(
+            'script[data-taxonomy-proposal-command-adapter]')) return;
+        var script = document.createElement('script');
+        script.src = new URL(
+            '../relations/taxonomy-proposals-git-commands.js',
+            loader.src).href;
+        script.async = false;
+        script.setAttribute(
+            'data-taxonomy-proposal-command-adapter', 'true');
+        document.head.appendChild(script);
+    }
+
+    function createProposalApiPromise() {
+        if (window.TaxonomyProposalsApi) {
+            return Promise.resolve(window.TaxonomyProposalsApi);
+        }
+        return new Promise(function (resolve, reject) {
+            var script = document.querySelector(
+                'script[data-taxonomy-proposals-api]');
+            var created = false;
+            if (!script) {
+                script = document.createElement('script');
+                script.src = new URL('proposals-api.js', loader.src).href;
+                script.async = false;
+                script.setAttribute(
+                    'data-taxonomy-proposals-api', 'true');
+                created = true;
+            }
+            script.addEventListener('load', function () {
+                if (window.TaxonomyProposalsApi) {
+                    resolve(window.TaxonomyProposalsApi);
+                } else {
+                    reject(new Error(
+                        'Proposal review API client did not initialise.'));
+                }
+            }, { once: true });
+            script.addEventListener('error', function () {
+                reject(new Error(
+                    'Failed to load proposal review API client.'));
+            }, { once: true });
+            if (created) {
+                document.head.appendChild(script);
+            } else if (window.TaxonomyProposalsApi) {
+                resolve(window.TaxonomyProposalsApi);
+            }
+        });
+    }
+
+    if (!window.TaxonomyProposalsApiReady) {
+        window.TaxonomyProposalsApiReady = createProposalApiPromise();
+    }
+    window.TaxonomyProposalsApiReady
+        .then(loadProposalAdapter)
+        .catch(function (error) {
+            console.error('[Taxonomy] ' + error.message);
+        });
+}());

--- a/taxonomy-app/src/main/resources/static/js/relations/taxonomy-proposals-git-commands.js
+++ b/taxonomy-app/src/main/resources/static/js/relations/taxonomy-proposals-git-commands.js
@@ -1,0 +1,446 @@
+/**
+ * Git-authoritative command adapter for the existing proposal review queue.
+ *
+ * The legacy browser remains responsible for rendering. This adapter captures
+ * its accept/reject/bulk buttons in the capture phase, reads one lightweight
+ * strong branch ETag immediately before the user action, and executes every
+ * selected proposal in order. Each successful response advances the expected
+ * head for the next command; stale heads and pending projection recovery stop
+ * the sequence without hiding already authoritative commits.
+ */
+(function () {
+    'use strict';
+
+    var initialized = false;
+    var busy = false;
+    var commandSequence = 0;
+    var undoTimeout = null;
+    var UNDO_TOAST_DURATION_MS = 8000;
+    var UNDO_FADE_DURATION_MS = 300;
+
+    function init() {
+        if (initialized) return;
+        initialized = true;
+        document.addEventListener('click', captureProposalCommand, true);
+
+        // Preserve the established inline entry points while making direct
+        // keyboard/test invocation use the same Git-first implementation.
+        window._proposalAccept = function (id) {
+            reviewMany([id], 'ACCEPT', true);
+        };
+        window._proposalReject = function (id) {
+            reviewMany([id], 'REJECT', true);
+        };
+    }
+
+    function ProposalsApi() {
+        if (!window.TaxonomyProposalsApi) {
+            throw new Error('Proposal review API client is not available.');
+        }
+        return window.TaxonomyProposalsApi;
+    }
+
+    function captureProposalCommand(event) {
+        if (!event.target || typeof event.target.closest !== 'function') return;
+
+        var bulkAccept = event.target.closest('#bulkAcceptBtn');
+        if (bulkAccept) {
+            intercept(event);
+            reviewMany(selectedProposalIds(), 'ACCEPT', true);
+            return;
+        }
+
+        var bulkReject = event.target.closest('#bulkRejectBtn');
+        if (bulkReject) {
+            intercept(event);
+            reviewMany(selectedProposalIds(), 'REJECT', true);
+            return;
+        }
+
+        var accept = event.target.closest('.proposal-table .btn-accept');
+        if (accept) {
+            intercept(event);
+            var acceptId = proposalId(accept);
+            if (acceptId !== null) reviewMany([acceptId], 'ACCEPT', true);
+            return;
+        }
+
+        var reject = event.target.closest('.proposal-table .btn-reject');
+        if (reject) {
+            intercept(event);
+            var rejectId = proposalId(reject);
+            if (rejectId !== null) reviewMany([rejectId], 'REJECT', true);
+        }
+    }
+
+    function intercept(event) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    }
+
+    function proposalId(button) {
+        var row = button.closest('tr');
+        var selector = row ? row.querySelector('.proposal-select[data-id]') : null;
+        if (selector) {
+            var parsed = parseInt(selector.getAttribute('data-id'), 10);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+
+        // Defensive fallback for views without a selection checkbox.
+        var label = button.getAttribute('aria-label') || '';
+        var match = label.match(/(\d+)\s*$/);
+        return match ? parseInt(match[1], 10) : null;
+    }
+
+    function selectedProposalIds() {
+        var ids = [];
+        document.querySelectorAll('.proposal-select:checked').forEach(function (checkbox) {
+            var id = parseInt(checkbox.getAttribute('data-id'), 10);
+            if (Number.isFinite(id)) ids.push(id);
+        });
+        return ids;
+    }
+
+    function reviewMany(ids, action, offerUndo) {
+        ids = uniqueIds(ids);
+        if (busy || ids.length === 0) return;
+
+        busy = true;
+        setProposalBusy(true);
+        var operationKey = commandKey('proposal-' + action.toLowerCase());
+        var state = {
+            etag: null,
+            projectedIds: [],
+            failedIds: [],
+            pending: null,
+            stopped: false
+        };
+
+        readHead()
+            .then(function (etag) {
+                state.etag = etag;
+                return processNext(ids, action, operationKey, state, 0);
+            })
+            .then(function () {
+                finishReview(state, action, offerUndo);
+            })
+            .catch(function (error) {
+                failReview(error, state);
+            });
+    }
+
+    function processNext(ids, action, operationKey, state, index) {
+        if (state.stopped || index >= ids.length) {
+            return Promise.resolve(state);
+        }
+
+        var proposalId = ids[index];
+        var headers = {
+            'If-Match': state.etag,
+            'Idempotency-Key': operationKey + ':' + index + ':' + proposalId
+        };
+        return ProposalsApi().review(proposalId, action, headers)
+            .then(function (response) {
+                return classifyReviewResponse(response, state.etag, proposalId);
+            })
+            .then(function (outcome) {
+                if (outcome.etag) state.etag = outcome.etag;
+                if (outcome.kind === 'PROJECTED') {
+                    state.projectedIds.push(proposalId);
+                } else if (outcome.kind === 'FAILED') {
+                    state.failedIds.push(proposalId);
+                } else if (outcome.kind === 'PENDING_RECOVERY') {
+                    state.pending = outcome;
+                    state.stopped = true;
+                }
+                return processNext(ids, action, operationKey, state, index + 1);
+            })
+            .catch(function (error) {
+                error.reviewState = state;
+                throw error;
+            });
+    }
+
+    function readHead() {
+        return ProposalsApi().readHead()
+            .then(function (response) {
+                if (response.status === 404) {
+                    throw commandError(
+                        'BRANCH_MISSING',
+                        'The selected architecture branch does not exist.');
+                }
+                if (!response.ok) {
+                    throw commandError(
+                        'HTTP',
+                        'Could not read the authoritative proposal review head (HTTP '
+                            + response.status + ').');
+                }
+                var etag = response.headers.get('ETag');
+                if (!etag) {
+                    throw commandError(
+                        'MISSING_ETAG',
+                        'The proposal review head response did not contain a strong ETag.');
+                }
+                return etag;
+            });
+    }
+
+    function classifyReviewResponse(response, currentEtag, proposalId) {
+        var nextEtag = response.headers.get('ETag') || currentEtag;
+        return readJson(response).then(function (body) {
+            if (response.status === 202) {
+                return {
+                    kind: 'PENDING_RECOVERY',
+                    proposalId: proposalId,
+                    etag: nextEtag,
+                    body: body
+                };
+            }
+            if (response.status === 412) {
+                throw commandError(
+                    'CONFLICT',
+                    'The selected architecture branch changed while proposals were being reviewed.',
+                    body,
+                    nextEtag);
+            }
+            if (response.ok) {
+                return {
+                    kind: 'PROJECTED',
+                    proposalId: proposalId,
+                    etag: nextEtag,
+                    body: body
+                };
+            }
+            if ([400, 404, 409].indexOf(response.status) >= 0) {
+                return {
+                    kind: 'FAILED',
+                    proposalId: proposalId,
+                    etag: currentEtag,
+                    body: body,
+                    status: response.status
+                };
+            }
+            throw commandError(
+                'HTTP',
+                'Proposal ' + proposalId + ' review failed (HTTP '
+                    + response.status + ').',
+                body,
+                nextEtag);
+        });
+    }
+
+    function finishReview(state, action, offerUndo) {
+        busy = false;
+        setProposalBusy(false);
+        refreshProposals();
+
+        if (state.pending) {
+            var pendingBody = state.pending.body || {};
+            var commit = pendingBody.authoritativeCommitId
+                ? ' (' + pendingBody.authoritativeCommitId.substring(0, 12) + ')'
+                : '';
+            showStatus(
+                'warning',
+                'Git accepted ' + state.projectedIds.length
+                    + ' proposal review(s)' + commit
+                    + ', but the readable projection still requires recovery.');
+            return;
+        }
+
+        if (state.failedIds.length > 0) {
+            showStatus(
+                'warning',
+                state.projectedIds.length + ' proposal review(s) completed; '
+                    + state.failedIds.length + ' could not be applied.');
+        } else {
+            showStatus('success', successMessage(action, state.projectedIds.length));
+        }
+
+        if (offerUndo && state.projectedIds.length > 0) {
+            showUndoToast(state.projectedIds, action);
+        }
+    }
+
+    function failReview(error, state) {
+        busy = false;
+        setProposalBusy(false);
+        refreshProposals();
+
+        if (error.kind === 'CONFLICT') {
+            showStatus(
+                'warning',
+                error.message + ' The proposal queue has been reloaded.');
+            return;
+        }
+        showStatus(
+            'danger',
+            message(
+                'browse.proposals.bulk.failed',
+                'Proposal review failed: ' + error.message,
+                error.message));
+    }
+
+    function showUndoToast(ids, action) {
+        var existing = document.getElementById('undoToast');
+        if (existing) existing.remove();
+        if (undoTimeout) clearTimeout(undoTimeout);
+
+        var label = action === 'ACCEPT'
+            ? message(
+                'browse.proposals.undo.accepted',
+                ids.length + ' accepted proposal(s)',
+                ids.length)
+            : message(
+                'browse.proposals.undo.rejected',
+                ids.length + ' rejected proposal(s)',
+                ids.length);
+        var toast = document.createElement('div');
+        toast.className = 'undo-toast';
+        toast.id = 'undoToast';
+        toast.innerHTML = '<span>' + escapeHtml(label) + '</span>'
+            + '<button class="undo-btn" id="proposalGitUndoBtn">'
+            + escapeHtml(message(
+                'browse.proposals.undo.btn', 'Undo'))
+            + '</button>';
+        document.body.appendChild(toast);
+
+        var undo = document.getElementById('proposalGitUndoBtn');
+        if (undo) {
+            undo.addEventListener('click', function () {
+                toast.remove();
+                if (undoTimeout) clearTimeout(undoTimeout);
+                reviewMany(ids, 'REVERT', false);
+            });
+        }
+
+        undoTimeout = setTimeout(function () {
+            if (!toast.parentNode) return;
+            toast.style.opacity = '0';
+            toast.style.transition = 'opacity '
+                + UNDO_FADE_DURATION_MS + 'ms ease';
+            setTimeout(function () {
+                if (toast.parentNode) toast.remove();
+            }, UNDO_FADE_DURATION_MS);
+        }, UNDO_TOAST_DURATION_MS);
+    }
+
+    function setProposalBusy(active) {
+        var container = document.getElementById('proposalsTableContainer');
+        if (container) container.setAttribute('aria-busy', String(active));
+        document.querySelectorAll(
+            '.proposal-table .btn-accept, .proposal-table .btn-reject, '
+                + '#bulkAcceptBtn, #bulkRejectBtn')
+            .forEach(function (button) {
+                button.disabled = active;
+            });
+    }
+
+    function refreshProposals() {
+        var current = window.TaxonomyState
+            ? window.TaxonomyState.currentProposalFilter : 'PENDING';
+        var buttonIds = {
+            PENDING: 'filterPending',
+            ALL: 'filterAll',
+            ACCEPTED: 'filterAccepted',
+            REJECTED: 'filterRejected'
+        };
+        var button = document.getElementById(
+            buttonIds[current] || buttonIds.PENDING);
+        if (button) button.click();
+    }
+
+    function successMessage(action, count) {
+        if (action === 'ACCEPT') {
+            return message(
+                'browse.proposals.accepted',
+                count + ' proposal(s) accepted.',
+                count);
+        }
+        if (action === 'REJECT') {
+            return message(
+                'browse.proposals.rejected',
+                count + ' proposal(s) rejected.',
+                count);
+        }
+        return message(
+            'browse.proposals.reverted',
+            count + ' proposal review(s) reverted.',
+            count);
+    }
+
+    function commandKey(prefix) {
+        commandSequence++;
+        if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+            return prefix + ':' + window.crypto.randomUUID();
+        }
+        return prefix + ':' + Date.now() + ':' + commandSequence;
+    }
+
+    function uniqueIds(ids) {
+        var seen = Object.create(null);
+        return (ids || []).filter(function (id) {
+            var parsed = Number(id);
+            if (!Number.isSafeInteger(parsed) || parsed <= 0 || seen[parsed]) {
+                return false;
+            }
+            seen[parsed] = true;
+            return true;
+        }).map(Number);
+    }
+
+    function readJson(response) {
+        var contentType = response.headers.get('Content-Type') || '';
+        if (contentType.indexOf('application/json') < 0) {
+            return Promise.resolve(null);
+        }
+        return response.json().catch(function () { return null; });
+    }
+
+    function commandError(kind, text, body, etag) {
+        var error = new Error(text);
+        error.kind = kind;
+        error.body = body || null;
+        error.etag = etag || null;
+        return error;
+    }
+
+    function showStatus(type, text) {
+        if (window.TaxonomyBrowse
+                && typeof window.TaxonomyBrowse.showStatus === 'function') {
+            window.TaxonomyBrowse.showStatus(type, text);
+            return;
+        }
+        console[type === 'danger' ? 'error' : 'warn']('[Taxonomy] ' + text);
+    }
+
+    function message(key, fallback) {
+        var args = Array.prototype.slice.call(arguments, 2);
+        if (!window.TaxonomyI18n || !window.TaxonomyI18n.t) {
+            return fallback;
+        }
+        var translated = window.TaxonomyI18n.t.apply(
+            null, [key].concat(args));
+        return translated && translated !== key ? translated : fallback;
+    }
+
+    function escapeHtml(value) {
+        if (window.TaxonomyUtils && window.TaxonomyUtils.escapeHtml) {
+            return window.TaxonomyUtils.escapeHtml(String(value));
+        }
+        return String(value).replace(/[&<>"']/g, function (character) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[character];
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+}());

--- a/taxonomy-app/src/test/java/com/taxonomy/MermaidExportTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/MermaidExportTests.java
@@ -7,16 +7,17 @@ import com.taxonomy.diagram.DiagramNode;
 import com.taxonomy.export.MermaidExportService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import org.springframework.security.test.context.support.WithMockUser;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -204,13 +205,19 @@ class MermaidExportTests {
     }
 
     @Test
-    void bulkEndpointHandlesNonexistentIds() throws Exception {
+    void bulkEndpointReportsNonexistentIdsAsExplicitPartialFailure() throws Exception {
         mockMvc.perform(post("/api/proposals/bulk")
                         .contentType("application/json")
                         .content("{\"ids\":[99999],\"action\":\"ACCEPT\"}"))
-                .andExpect(status().isOk())
+                .andExpect(status().isMultiStatus())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.processed").value(1))
+                .andExpect(jsonPath("$.projected").value(0))
                 .andExpect(jsonPath("$.failed").value(1))
-                .andExpect(jsonPath("$.success").value(0));
+                .andExpect(jsonPath("$.complete").value(false))
+                .andExpect(jsonPath("$.items[0].proposalId").value(99999))
+                .andExpect(jsonPath("$.items[0].projectionStatus")
+                        .value("REVIEW_REJECTED"));
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
@@ -1,10 +1,21 @@
 package com.taxonomy.relations.controller;
 
+import com.taxonomy.dsl.command.ArchitectureRelationDslTransformer.ChangeKind;
 import com.taxonomy.dto.RelationProposalDto;
-import com.taxonomy.dto.TaxonomyRelationDto;
+import com.taxonomy.model.ProposalStatus;
 import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandMetadata;
+import com.taxonomy.relations.command.ArchitectureRelationGitCommandService.CommandResult;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewAction;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewResult;
+import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionOutcome;
+import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionResult;
 import com.taxonomy.relations.service.RelationProposalService;
-import com.taxonomy.relations.service.RelationReviewService;
 import com.taxonomy.workspace.model.SystemRepository;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryMembershipService;
@@ -15,6 +26,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -26,6 +38,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,8 +46,13 @@ import static org.mockito.Mockito.when;
 
 class ProposalApiControllerRepositoryScopeTest {
 
+    private static final String HEAD_A = "a".repeat(40);
+    private static final String HEAD_B = "b".repeat(40);
+    private static final String HEAD_C = "c".repeat(40);
+
     private RelationProposalService proposalService;
-    private RelationReviewService reviewService;
+    private GitAuthoritativeProposalReviewService reviewService;
+    private RelationBranchProjectionReadinessService readinessService;
     private WorkspaceResolver workspaceResolver;
     private SystemRepositoryService repositoryService;
     private RepositoryMembershipService membershipService;
@@ -43,13 +61,15 @@ class ProposalApiControllerRepositoryScopeTest {
     @BeforeEach
     void setUp() {
         proposalService = mock(RelationProposalService.class);
-        reviewService = mock(RelationReviewService.class);
+        reviewService = mock(GitAuthoritativeProposalReviewService.class);
+        readinessService = mock(RelationBranchProjectionReadinessService.class);
         workspaceResolver = mock(WorkspaceResolver.class);
         repositoryService = mock(SystemRepositoryService.class);
         membershipService = mock(RepositoryMembershipService.class);
         controller = new ProposalApiController(
                 proposalService,
                 reviewService,
+                readinessService,
                 workspaceResolver,
                 repositoryService,
                 membershipService);
@@ -110,9 +130,9 @@ class ProposalApiControllerRepositoryScopeTest {
         ArgumentCaptor<RepositoryContext> contextCaptor =
                 ArgumentCaptor.forClass(RepositoryContext.class);
         verify(proposalService).proposeRelationsInContext(
-                org.mockito.ArgumentMatchers.eq("BP"),
-                org.mockito.ArgumentMatchers.eq(RelationType.RELATED_TO),
-                org.mockito.ArgumentMatchers.eq(3),
+                eq("BP"),
+                eq(RelationType.RELATED_TO),
+                eq(3),
                 contextCaptor.capture());
         assertThat(contextCaptor.getValue().repositoryId()).isEqualTo("repo-a");
         assertThat(contextCaptor.getValue().workspaceId()).isNull();
@@ -147,17 +167,37 @@ class ProposalApiControllerRepositoryScopeTest {
     }
 
     @Test
-    void workspaceReviewPreservesRepositoryWorkspaceAndUser() {
+    void workspaceReviewCommitsGitFirstAndReturnsAuthorityEtag() throws Exception {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-b", "workspace-b1", "feature/b1", "alice");
         when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
-        when(reviewService.acceptProposal(42L, context))
-                .thenReturn(new TaxonomyRelationDto());
+        when(readinessService.inspect(context)).thenReturn(ready(HEAD_A));
+        when(reviewService.accept(
+                eq(42L), eq(context), eq(HEAD_A), any(CommandMetadata.class)))
+                .thenReturn(reviewResult(
+                        context,
+                        42L,
+                        ReviewAction.ACCEPT,
+                        ProposalStatus.ACCEPTED,
+                        HEAD_A,
+                        HEAD_B,
+                        ChangeKind.ADDED,
+                        true));
 
-        ResponseEntity<TaxonomyRelationDto> response = controller.acceptProposal(42L);
+        ResponseEntity<Map<String, Object>> response = controller.acceptProposal(42L);
 
         assertThat(response.getStatusCode().value()).isEqualTo(200);
-        verify(reviewService).acceptProposal(42L, context);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
+                .isEqualTo('"' + HEAD_B + '"');
+        assertThat(response.getBody())
+                .containsEntry("authoritativeCommitId", HEAD_B)
+                .containsEntry("projectionStatus", "PROJECTED");
+        ArgumentCaptor<CommandMetadata> metadataCaptor =
+                ArgumentCaptor.forClass(CommandMetadata.class);
+        verify(reviewService).accept(
+                eq(42L), eq(context), eq(HEAD_A), metadataCaptor.capture());
+        assertThat(metadataCaptor.getValue().causationId())
+                .isEqualTo("legacy-proposal-accept-42-" + HEAD_A);
         verify(repositoryService, never()).getRepository(any());
         verify(membershipService, never()).canMaintain(any(), any());
     }
@@ -171,10 +211,96 @@ class ProposalApiControllerRepositoryScopeTest {
         when(repositoryService.getRepository("repo-a")).thenReturn(repository);
         when(membershipService.canMaintain(repository, "reader")).thenReturn(false);
 
-        ResponseEntity<TaxonomyRelationDto> response = controller.acceptProposal(42L);
+        ResponseEntity<Map<String, Object>> response = controller.acceptProposal(42L);
 
         assertThat(response.getStatusCode().value()).isEqualTo(403);
-        verify(reviewService, never()).acceptProposal(any(), any());
+        verify(reviewService, never()).accept(any(), any(), any(), any());
+    }
+
+    @Test
+    void bulkReviewFeedsEachSuccessfulCommitIntoTheNextExpectedHead()
+            throws Exception {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a1", "draft", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
+        when(readinessService.inspect(context)).thenReturn(ready(HEAD_A));
+        when(reviewService.accept(
+                eq(10L), eq(context), eq(HEAD_A), any(CommandMetadata.class)))
+                .thenReturn(reviewResult(
+                        context,
+                        10L,
+                        ReviewAction.ACCEPT,
+                        ProposalStatus.ACCEPTED,
+                        HEAD_A,
+                        HEAD_B,
+                        ChangeKind.ADDED,
+                        true));
+        when(reviewService.accept(
+                eq(11L), eq(context), eq(HEAD_B), any(CommandMetadata.class)))
+                .thenReturn(reviewResult(
+                        context,
+                        11L,
+                        ReviewAction.ACCEPT,
+                        ProposalStatus.ACCEPTED,
+                        HEAD_B,
+                        HEAD_C,
+                        ChangeKind.UPDATED,
+                        true));
+
+        ResponseEntity<Map<String, Object>> response = controller.bulkAction(Map.of(
+                "ids", List.of(10, 11),
+                "action", "ACCEPT"));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
+                .isEqualTo('"' + HEAD_C + '"');
+        assertThat(response.getBody())
+                .containsEntry("projected", 2)
+                .containsEntry("failed", 0)
+                .containsEntry("authoritativeCommitId", HEAD_C)
+                .containsEntry("complete", true);
+        verify(reviewService).accept(
+                eq(10L), eq(context), eq(HEAD_A), any(CommandMetadata.class));
+        verify(reviewService).accept(
+                eq(11L), eq(context), eq(HEAD_B), any(CommandMetadata.class));
+    }
+
+    private static Readiness ready(String head) {
+        return new Readiness(
+                ReadinessState.READY,
+                head,
+                head,
+                List.of());
+    }
+
+    private static ReviewResult reviewResult(
+            RepositoryContext context,
+            long proposalId,
+            ReviewAction action,
+            ProposalStatus status,
+            String previousHead,
+            String authoritativeHead,
+            ChangeKind changeKind,
+            boolean relationPresent) {
+        CommandResult authority = new CommandResult(
+                context.repositoryId(),
+                context.workspaceId(),
+                context.branch(),
+                context.scope(),
+                previousHead,
+                authoritativeHead,
+                changeKind,
+                changeKind != ChangeKind.UNCHANGED,
+                "test-causation-" + proposalId);
+        ProjectionResult projection = new ProjectionResult(
+                ProjectionOutcome.CREATED,
+                authoritativeHead,
+                relationPresent);
+        return new ReviewResult(
+                proposalId,
+                action,
+                status,
+                new MutationResult(authority, projection));
     }
 
     private static Map<String, String> validProposalBody() {

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
@@ -11,8 +11,6 @@ import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.Revi
 import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService.ReviewResult;
 import com.taxonomy.relations.service.GitAuthoritativeRelationMutationService.MutationResult;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
-import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.Readiness;
-import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionOutcome;
 import com.taxonomy.relations.service.RelationDecisionProjectionService.ProjectionResult;
 import com.taxonomy.relations.service.RelationProposalService;
@@ -171,7 +169,7 @@ class ProposalApiControllerRepositoryScopeTest {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-b", "workspace-b1", "feature/b1", "alice");
         when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
-        when(readinessService.inspect(context)).thenReturn(ready(HEAD_A));
+        when(readinessService.readCurrentHead(context)).thenReturn(HEAD_A);
         when(reviewService.accept(
                 eq(42L), eq(context), eq(HEAD_A), any(CommandMetadata.class)))
                 .thenReturn(reviewResult(
@@ -224,7 +222,7 @@ class ProposalApiControllerRepositoryScopeTest {
         RepositoryContext context = RepositoryContext.workspace(
                 "repo-a", "workspace-a1", "draft", "alice");
         when(workspaceResolver.resolveCurrentRepositoryContext()).thenReturn(context);
-        when(readinessService.inspect(context)).thenReturn(ready(HEAD_A));
+        when(readinessService.readCurrentHead(context)).thenReturn(HEAD_A);
         when(reviewService.accept(
                 eq(10L), eq(context), eq(HEAD_A), any(CommandMetadata.class)))
                 .thenReturn(reviewResult(
@@ -264,14 +262,6 @@ class ProposalApiControllerRepositoryScopeTest {
                 eq(10L), eq(context), eq(HEAD_A), any(CommandMetadata.class));
         verify(reviewService).accept(
                 eq(11L), eq(context), eq(HEAD_B), any(CommandMetadata.class));
-    }
-
-    private static Readiness ready(String head) {
-        return new Readiness(
-                ReadinessState.READY,
-                head,
-                head,
-                List.of());
     }
 
     private static ReviewResult reviewResult(

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalApiControllerRepositoryScopeTest.java
@@ -203,7 +203,8 @@ class ProposalApiControllerRepositoryScopeTest {
     }
 
     @Test
-    void centralReaderCannotUseReviewEndpointToProbeAProposalIdentifier() {
+    void centralReaderCannotUseReviewEndpointToProbeAProposalIdentifier()
+            throws Exception {
         RepositoryContext context = RepositoryContext.centralRead(
                 "repo-a", "main", "reader");
         SystemRepository repository = repository("repo-a");

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalHeadApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalHeadApiControllerTest.java
@@ -1,0 +1,67 @@
+package com.taxonomy.relations.controller;
+
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProposalHeadApiControllerTest {
+
+    private static final String HEAD = "a".repeat(40);
+
+    private RelationBranchProjectionReadinessService readinessService;
+    private WorkspaceResolver workspaceResolver;
+    private ProposalHeadApiController controller;
+
+    @BeforeEach
+    void setUp() {
+        readinessService = mock(RelationBranchProjectionReadinessService.class);
+        workspaceResolver = mock(WorkspaceResolver.class);
+        controller = new ProposalHeadApiController(
+                readinessService, workspaceResolver);
+    }
+
+    @Test
+    void returnsStrongEtagFromExactSelectedContextWithoutProjectionRead() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "feature/a", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(readinessService.readCurrentHead(context)).thenReturn(HEAD);
+
+        var response = controller.readHead();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(204);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG))
+                .isEqualTo('"' + HEAD + '"');
+        assertThat(response.getHeaders().getCacheControl())
+                .isEqualTo("no-store");
+        verify(readinessService).readCurrentHead(context);
+    }
+
+    @Test
+    void missingSelectedBranchReturnsNotFoundWithoutInventingEtag() {
+        RepositoryContext context = RepositoryContext.workspace(
+                "repo-a", "workspace-a", "missing", "alice");
+        when(workspaceResolver.resolveCurrentRepositoryContext())
+                .thenReturn(context);
+        when(readinessService.readCurrentHead(context)).thenReturn(null);
+
+        var response = controller.readHead();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(404);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.ETAG)).isNull();
+        assertThat(response.getHeaders().getFirst(
+                RelationApiController.PROJECTION_STATE_HEADER))
+                .isEqualTo("BRANCH_MISSING");
+        assertThat(response.getHeaders().getCacheControl())
+                .isEqualTo("no-store");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/relations/controller/ProposalProjectionUnavailableHttpTest.java
@@ -1,10 +1,11 @@
 package com.taxonomy.relations.controller;
 
 import com.taxonomy.model.RelationType;
+import com.taxonomy.relations.service.GitAuthoritativeProposalReviewService;
+import com.taxonomy.relations.service.RelationBranchProjectionReadinessService;
 import com.taxonomy.relations.service.RelationBranchProjectionReadinessService.ReadinessState;
 import com.taxonomy.relations.service.RelationProjectionReadService.RelationProjectionUnavailableException;
 import com.taxonomy.relations.service.RelationProposalService;
-import com.taxonomy.relations.service.RelationReviewService;
 import com.taxonomy.workspace.service.RepositoryContext;
 import com.taxonomy.workspace.service.RepositoryMembershipService;
 import com.taxonomy.workspace.service.SystemRepositoryService;
@@ -33,7 +34,8 @@ class ProposalProjectionUnavailableHttpTest {
         workspaceResolver = mock(WorkspaceResolver.class);
         controller = new ProposalApiController(
                 proposalService,
-                mock(RelationReviewService.class),
+                mock(GitAuthoritativeProposalReviewService.class),
+                mock(RelationBranchProjectionReadinessService.class),
                 workspaceResolver,
                 mock(SystemRepositoryService.class),
                 mock(RepositoryMembershipService.class));

--- a/taxonomy-app/src/test/java/com/taxonomy/ui/ProposalGitReviewUiContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ui/ProposalGitReviewUiContractTest.java
@@ -1,0 +1,127 @@
+package com.taxonomy.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProposalGitReviewUiContractTest {
+
+    private static final Path RELATION_API = Path.of(
+            "src/main/resources/static/js/api/relations-api.js");
+    private static final Path PROPOSAL_API = Path.of(
+            "src/main/resources/static/js/api/proposals-api.js");
+    private static final Path PROPOSAL_ADAPTER = Path.of(
+            "src/main/resources/static/js/relations/"
+                    + "taxonomy-proposals-git-commands.js");
+
+    @Test
+    void loadedAdapterCapturesEveryProductiveProposalReviewButton()
+            throws Exception {
+        String loader = Files.readString(RELATION_API);
+        String adapter = Files.readString(PROPOSAL_ADAPTER);
+
+        assertThat(loader)
+                .contains("window.TaxonomyProposalsApiReady")
+                .contains("new URL('proposals-api.js', loader.src)")
+                .contains("taxonomy-proposals-git-commands.js")
+                .contains("data-taxonomy-proposal-command-adapter");
+        assertThat(adapter)
+                .contains("document.addEventListener('click', "
+                        + "captureProposalCommand, true)")
+                .contains("event.stopImmediatePropagation()")
+                .contains("#bulkAcceptBtn")
+                .contains("#bulkRejectBtn")
+                .contains(".proposal-table .btn-accept")
+                .contains(".proposal-table .btn-reject")
+                .contains("window._proposalAccept = function")
+                .contains("window._proposalReject = function");
+    }
+
+    @Test
+    void transportLivesInNamedRawResponseApiBoundary() throws Exception {
+        String api = Files.readString(PROPOSAL_API);
+        String adapter = Files.readString(PROPOSAL_ADAPTER);
+
+        assertThat(api)
+                .contains("window.TaxonomyProposalsApi")
+                .contains("fetch('/api/proposals/head'")
+                .contains("cache: 'no-store'")
+                .contains("function review(proposalId, action, headers)")
+                .contains("method: 'POST'")
+                .contains("headers: headers");
+        assertThat(adapter)
+                .contains("ProposalsApi().readHead()")
+                .contains("ProposalsApi().review(")
+                .doesNotContain("fetch(");
+    }
+
+    @Test
+    void everyUserActionReadsAHeadThenAdvancesEtagInOrder()
+            throws Exception {
+        String adapter = Files.readString(PROPOSAL_ADAPTER);
+
+        int actionStart = adapter.indexOf(
+                "    function reviewMany(ids, action, offerUndo) {");
+        int headRead = adapter.indexOf("readHead()", actionStart);
+        int processing = adapter.indexOf(
+                "return processNext(ids, action, operationKey, state, 0)",
+                headRead);
+        int command = adapter.indexOf(
+                "return ProposalsApi().review(", processing);
+        int etagAdvance = adapter.indexOf(
+                "if (outcome.etag) state.etag = outcome.etag", command);
+        int nextCommand = adapter.indexOf(
+                "return processNext(ids, action, operationKey, state, index + 1)",
+                etagAdvance);
+
+        assertThat(actionStart).isGreaterThanOrEqualTo(0);
+        assertThat(headRead).isGreaterThan(actionStart);
+        assertThat(processing).isGreaterThan(headRead);
+        assertThat(command).isGreaterThan(processing);
+        assertThat(etagAdvance).isGreaterThan(command);
+        assertThat(nextCommand).isGreaterThan(etagAdvance);
+        assertThat(adapter)
+                .contains("'If-Match': state.etag")
+                .contains("'Idempotency-Key': operationKey")
+                .contains("response.status === 202")
+                .contains("response.status === 412")
+                .contains("state.stopped = true");
+    }
+
+    @Test
+    void bulkAndUndoUseTheSameOrderedGitFirstCommandPath()
+            throws Exception {
+        String adapter = Files.readString(PROPOSAL_ADAPTER);
+
+        assertThat(adapter)
+                .contains("reviewMany(selectedProposalIds(), 'ACCEPT', true)")
+                .contains("reviewMany(selectedProposalIds(), 'REJECT', true)")
+                .contains("reviewMany(ids, 'REVERT', false)")
+                .contains("state.projectedIds")
+                .contains("state.failedIds")
+                .contains("PENDING_RECOVERY")
+                .contains("showUndoToast(state.projectedIds, action)");
+    }
+
+    @Test
+    void concurrentOrPendingOutcomesAreNotReportedAsOrdinarySuccess()
+            throws Exception {
+        String adapter = Files.readString(PROPOSAL_ADAPTER);
+
+        int pending = adapter.indexOf("if (response.status === 202)");
+        int conflict = adapter.indexOf("if (response.status === 412)");
+        int success = adapter.indexOf("if (response.ok)", conflict);
+
+        assertThat(pending).isGreaterThanOrEqualTo(0);
+        assertThat(conflict).isGreaterThan(pending);
+        assertThat(success).isGreaterThan(conflict);
+        assertThat(adapter)
+                .contains("showStatus(\n                'warning'")
+                .contains("The proposal queue has been reloaded")
+                .contains("the readable projection still requires recovery")
+                .doesNotContain("Promise.all(promises)");
+    }
+}


### PR DESCRIPTION
## Scope

First bounded implementation slice of #691 on exact current `main` `792295f0786b1bb59b1bab159deb4217f71a8bed`.

### Changes

- removes `RelationReviewService` from the productive `/api/proposals/{id}/accept|reject|revert` and `/api/proposals/bulk` controller path;
- routes every single review through `GitAuthoritativeProposalReviewService` with the selected repository/workspace/branch and an expected Git head;
- preserves compatibility for the existing browser URLs while returning the authoritative commit as `ETag` and response metadata;
- uses deterministic fallback causation IDs for legacy callers that do not yet send an `Idempotency-Key`;
- makes bulk review ordered: each successful authoritative commit becomes the expected head of the next command;
- reports partial failure and pending projection recovery explicitly instead of hiding it behind one aggregate success;
- preserves central-write authorization and workspace/fork isolation;
- updates focused controller tests and adds exact head progression evidence.

This PR deliberately does not close #691. Hypothesis review paths and final browser/client hardening remain separate bounded slices.

## Merge gate

Merge only after canonical Maven verification, PostgreSQL, Oracle, Microsoft SQL Server, CodeQL, Security Scan and review are green on this exact head.

Advances #691 and #609.