### PR TITLE
Correct terminal hypothesis review messages after #751

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitAuthoritativeHypothesisReviewService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/versioning/service/GitAuthoritativeHypothesisReviewService.java
@@ -206,7 +206,7 @@ public class GitAuthoritativeHypothesisReviewService {
                     && current != HypothesisStatus.PROPOSED) {
                 throw new IllegalStateException(
                         "Hypothesis " + hypothesisId
-                                + " cannot be " + name().toLowerCase()
+                                + " cannot be " + dslStatus
                                 + " from " + current);
             }
         }

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/GitAuthoritativeHypothesisReviewServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/GitAuthoritativeHypothesisReviewServiceTest.java
@@ -220,7 +220,7 @@ class GitAuthoritativeHypothesisReviewServiceTest {
         assertThatThrownBy(() -> service.reject(
                 42L, context, HEAD_A, metadata))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("cannot be reject");
+                .hasMessageContaining("cannot be rejected");
         verify(mutationService, never()).upsert(any(), any(), any(), any());
         verify(mutationService, never()).remove(any(), any(), any(), any());
     }


### PR DESCRIPTION
## Purpose

Follow up the merged Git-authoritative hypothesis review path from #751 with the remaining user-facing wording correction identified during review.

## Changes

- use the already canonical DSL status (`accepted` / `rejected`) when reporting an invalid terminal-state review;
- replace the ungrammatical `cannot be reject` response with `cannot be rejected`;
- update the focused service test so it protects the intended HTTP-visible text rather than preserving the defect.

## Scope and safety

- exact base: `6b60b538d563454497ba04afad98bcd0efc331f7`;
- two files only;
- no Git authority, projection, tenancy, HTTP status, idempotency or recovery behavior changes;
- closes the remaining substantive wording findings from the #751 review.

Merge only after the exact-head verification required by branch protection succeeds.