### PR TITLE
Add dependency-free Java version-state tooling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     </issueManagement>
 
     <modules>
+        <!-- Dependency-free build tooling is built first. -->
+        <module>taxonomy-tooling</module>
         <module>taxonomy-domain</module>
         <module>taxonomy-dsl</module>
         <module>taxonomy-export</module>

--- a/taxonomy-tooling/pom.xml
+++ b/taxonomy-tooling/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.taxonomy</groupId>
+        <artifactId>taxonomy</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>taxonomy-tooling</artifactId>
+    <packaging>jar</packaging>
+    <name>Taxonomy Build and Release Tooling</name>
+    <description>Dependency-free Java command line tooling for release, version and repository policy operations.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.taxonomy.tooling.TaxonomyTooling</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
@@ -1,0 +1,221 @@
+package com.taxonomy.tooling;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Strict dependency-free JSON reader for release and archive metadata. */
+final class FlatJson {
+
+    private final String source;
+    private int index;
+
+    private FlatJson(String source) {
+        this.source = source;
+    }
+
+    static Map<String, Object> parseObject(String source) {
+        FlatJson parser = new FlatJson(source);
+        Map<String, Object> result = parser.object();
+        parser.whitespace();
+        if (!parser.end()) {
+            throw parser.error("Unexpected content after JSON object");
+        }
+        return result;
+    }
+
+    private Map<String, Object> object() {
+        whitespace();
+        expect('{');
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+        whitespace();
+        if (consume('}')) {
+            return result;
+        }
+        while (true) {
+            whitespace();
+            String key = string();
+            if (result.containsKey(key)) {
+                throw error("Duplicate JSON key '" + key + "'");
+            }
+            whitespace();
+            expect(':');
+            whitespace();
+            result.put(key, value());
+            whitespace();
+            if (consume('}')) {
+                return result;
+            }
+            expect(',');
+        }
+    }
+
+    private List<Object> array() {
+        expect('[');
+        List<Object> result = new ArrayList<>();
+        whitespace();
+        if (consume(']')) {
+            return result;
+        }
+        while (true) {
+            whitespace();
+            result.add(value());
+            whitespace();
+            if (consume(']')) {
+                return result;
+            }
+            expect(',');
+        }
+    }
+
+    private Object value() {
+        whitespace();
+        if (end()) {
+            throw error("Missing JSON value");
+        }
+        return switch (source.charAt(index)) {
+            case '"' -> string();
+            case '{' -> object();
+            case '[' -> array();
+            case 't' -> literal("true", Boolean.TRUE);
+            case 'f' -> literal("false", Boolean.FALSE);
+            case 'n' -> literal("null", null);
+            default -> number();
+        };
+    }
+
+    private Object literal(String literal, Object value) {
+        if (!source.startsWith(literal, index)) {
+            throw error("Invalid JSON literal");
+        }
+        index += literal.length();
+        return value;
+    }
+
+    private Number number() {
+        int start = index;
+        consume('-');
+        if (consume('0')) {
+            if (!end() && Character.isDigit(source.charAt(index))) {
+                throw error("JSON numbers may not contain leading zeroes");
+            }
+        } else {
+            int digits = consumeDigits();
+            if (digits == 0) {
+                throw error("Unsupported JSON value");
+            }
+        }
+
+        boolean decimal = false;
+        if (consume('.')) {
+            decimal = true;
+            if (consumeDigits() == 0) {
+                throw error("JSON fraction requires digits");
+            }
+        }
+        if (!end() && (source.charAt(index) == 'e'
+                || source.charAt(index) == 'E')) {
+            decimal = true;
+            index++;
+            if (!end() && (source.charAt(index) == '+'
+                    || source.charAt(index) == '-')) {
+                index++;
+            }
+            if (consumeDigits() == 0) {
+                throw error("JSON exponent requires digits");
+            }
+        }
+
+        String token = source.substring(start, index);
+        try {
+            return decimal ? new BigDecimal(token) : Long.valueOf(token);
+        } catch (NumberFormatException error) {
+            throw error("JSON number is out of range");
+        }
+    }
+
+    private int consumeDigits() {
+        int start = index;
+        while (!end() && Character.isDigit(source.charAt(index))) {
+            index++;
+        }
+        return index - start;
+    }
+
+    private String string() {
+        expect('"');
+        StringBuilder value = new StringBuilder();
+        while (!end()) {
+            char current = source.charAt(index++);
+            if (current == '"') {
+                return value.toString();
+            }
+            if (current == '\\') {
+                if (end()) {
+                    throw error("Incomplete JSON escape");
+                }
+                char escaped = source.charAt(index++);
+                switch (escaped) {
+                    case '"', '\\', '/' -> value.append(escaped);
+                    case 'b' -> value.append('\b');
+                    case 'f' -> value.append('\f');
+                    case 'n' -> value.append('\n');
+                    case 'r' -> value.append('\r');
+                    case 't' -> value.append('\t');
+                    case 'u' -> value.append(unicode());
+                    default -> throw error("Invalid JSON escape \\" + escaped);
+                }
+            } else {
+                if (current < 0x20) {
+                    throw error("Control character in JSON string");
+                }
+                value.append(current);
+            }
+        }
+        throw error("Unterminated JSON string");
+    }
+
+    private char unicode() {
+        if (index + 4 > source.length()) {
+            throw error("Incomplete JSON unicode escape");
+        }
+        String digits = source.substring(index, index + 4);
+        index += 4;
+        try {
+            return (char) Integer.parseInt(digits, 16);
+        } catch (NumberFormatException error) {
+            throw error("Invalid JSON unicode escape");
+        }
+    }
+
+    private void whitespace() {
+        while (!end() && Character.isWhitespace(source.charAt(index))) {
+            index++;
+        }
+    }
+
+    private boolean consume(char expected) {
+        if (!end() && source.charAt(index) == expected) {
+            index++;
+            return true;
+        }
+        return false;
+    }
+
+    private void expect(char expected) {
+        if (!consume(expected)) {
+            throw error("Expected '" + expected + "'");
+        }
+    }
+
+    private boolean end() {
+        return index >= source.length();
+    }
+
+    private IllegalArgumentException error(String message) {
+        return new IllegalArgumentException(
+                message + " at JSON character " + (index + 1));
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -1,0 +1,164 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Entry point for dependency-free version-state tooling. */
+public final class TaxonomyTooling {
+
+    private TaxonomyTooling() {
+    }
+
+    public static void main(String[] arguments) {
+        int exitCode = run(arguments, Path.of("."), System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(
+            String[] arguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        if (arguments.length == 0) {
+            error.println("Usage: taxonomy-tooling <command> [options]");
+            return 2;
+        }
+        String command = arguments[0];
+        String[] commandArguments = java.util.Arrays.copyOfRange(
+                arguments, 1, arguments.length);
+        return switch (command) {
+            case "check-version-state" -> checkVersionState(
+                    commandArguments, workingDirectory, output, error);
+            case "read-pom-version" -> readPomVersion(
+                    commandArguments, workingDirectory, output, error);
+            default -> {
+                error.println("Unknown taxonomy-tooling command: " + command);
+                yield 2;
+            }
+        };
+    }
+
+    private static int checkVersionState(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            VersionStateVerifier.Verification verification =
+                    VersionStateVerifier.verify(
+                            root,
+                            arguments.required("mode"),
+                            arguments.optional("expected-version"),
+                            arguments.optional("tag"));
+            if (!verification.successful()) {
+                error.println("Inconsistent repository version state:");
+                for (String failure : verification.failures()) {
+                    error.println("- " + failure);
+                }
+                return 1;
+            }
+            output.println("Repository version state is consistent: "
+                    + verification.version() + " (" + verification.mode() + ").");
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int readPomVersion(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            String version;
+            if (arguments.flag("stdin")) {
+                Element project = XmlSupport.parse(System.in).getDocumentElement();
+                version = XmlSupport.childText(project, "version");
+                if (version.isBlank()) {
+                    throw new IllegalArgumentException(
+                            "pom.xml has no project version");
+                }
+            } else {
+                version = XmlSupport.rootProjectVersion(
+                        arguments.path("file", workingDirectory));
+            }
+            output.println(version);
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("::error::" + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static final class Arguments {
+        private final Map<String, String> values;
+        private final Map<String, Boolean> flags;
+
+        private Arguments(
+                Map<String, String> values,
+                Map<String, Boolean> flags) {
+            this.values = values;
+            this.flags = flags;
+        }
+
+        static Arguments parse(String[] raw) {
+            LinkedHashMap<String, String> values = new LinkedHashMap<>();
+            LinkedHashMap<String, Boolean> flags = new LinkedHashMap<>();
+            for (int index = 0; index < raw.length; index++) {
+                String token = raw[index];
+                if (!token.startsWith("--") || token.length() == 2) {
+                    throw new IllegalArgumentException(
+                            "Expected --option, got " + token);
+                }
+                String name = token.substring(2);
+                if ("stdin".equals(name)) {
+                    flags.put(name, Boolean.TRUE);
+                    continue;
+                }
+                if (index + 1 >= raw.length || raw[index + 1].startsWith("--")) {
+                    throw new IllegalArgumentException(
+                            "Missing value for --" + name);
+                }
+                if (values.putIfAbsent(name, raw[++index]) != null) {
+                    throw new IllegalArgumentException(
+                            "Duplicate option --" + name);
+                }
+            }
+            return new Arguments(values, flags);
+        }
+
+        String required(String name) {
+            String value = values.get(name);
+            if (value == null) {
+                throw new IllegalArgumentException("--" + name + " is required");
+            }
+            return value;
+        }
+
+        String optional(String name) {
+            return values.get(name);
+        }
+
+        Path path(String name, Path fallback) {
+            String value = values.get(name);
+            return value == null ? fallback : Path.of(value);
+        }
+
+        boolean flag(String name) {
+            return flags.getOrDefault(name, Boolean.FALSE);
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -93,7 +93,9 @@ public final class TaxonomyTooling {
                 }
             } else {
                 version = XmlSupport.rootProjectVersion(
-                        arguments.path("file", workingDirectory));
+                        arguments.path(
+                                "file",
+                                workingDirectory.resolve("pom.xml")));
             }
             output.println(version);
             return 0;

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionNumbers.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionNumbers.java
@@ -1,0 +1,100 @@
+package com.taxonomy.tooling;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+final class VersionNumbers {
+
+    static final Pattern RELEASE = Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+$");
+    static final Pattern DEVELOPMENT = Pattern.compile(
+            "^[0-9]+\\.[0-9]+\\.[0-9]+-SNAPSHOT$");
+
+    private VersionNumbers() {
+    }
+
+    static String normalizeRelease(Object value, String field) {
+        return normalize(value, field, false, RELEASE, "X.Y.Z");
+    }
+
+    static String normalizeDevelopment(
+            Object value,
+            String field,
+            boolean optional) {
+        return normalize(value, field, optional, DEVELOPMENT, "X.Y.Z-SNAPSHOT");
+    }
+
+    private static String normalize(
+            Object value,
+            String field,
+            boolean optional,
+            Pattern pattern,
+            String expected) {
+        if (value == null && optional) {
+            return "";
+        }
+        if (!(value instanceof String text)) {
+            throw new IllegalArgumentException(field + " must be a string");
+        }
+        String normalized = text.strip();
+        if (optional && normalized.isEmpty()) {
+            return "";
+        }
+        if (normalized.startsWith("${")) {
+            throw new IllegalArgumentException(
+                    field + " was not supplied. Pass -D" + field
+                            + " with an explicit version.");
+        }
+        if (!pattern.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    field + " must use " + expected + ", got '" + normalized + "'");
+        }
+        return normalized;
+    }
+
+    static SemanticVersion semantic(String version) {
+        Objects.requireNonNull(version, "version");
+        String normalized = version.endsWith("-SNAPSHOT")
+                ? version.substring(0, version.length() - "-SNAPSHOT".length())
+                : version;
+        String[] components = normalized.split("\\.", -1);
+        if (components.length != 3) {
+            throw new IllegalArgumentException("Invalid semantic version: " + version);
+        }
+        try {
+            return new SemanticVersion(
+                    Integer.parseInt(components[0]),
+                    Integer.parseInt(components[1]),
+                    Integer.parseInt(components[2]));
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(
+                    "Invalid semantic version: " + version, error);
+        }
+    }
+
+    static void requireNewer(String releaseVersion, String nextVersion) {
+        if (nextVersion == null || nextVersion.isBlank()) {
+            return;
+        }
+        if (semantic(nextVersion).compareTo(semantic(releaseVersion)) <= 0) {
+            throw new IllegalArgumentException(
+                    "next development version " + nextVersion
+                            + " must be newer than release " + releaseVersion);
+        }
+    }
+
+    record SemanticVersion(int major, int minor, int patch)
+            implements Comparable<SemanticVersion> {
+        @Override
+        public int compareTo(SemanticVersion other) {
+            int majorOrder = Integer.compare(major, other.major);
+            if (majorOrder != 0) {
+                return majorOrder;
+            }
+            int minorOrder = Integer.compare(minor, other.minor);
+            if (minorOrder != 0) {
+                return minorOrder;
+            }
+            return Integer.compare(patch, other.patch);
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
@@ -1,0 +1,225 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/** Verifies Maven, citation, archive and Helm metadata as one version state. */
+public final class VersionStateVerifier {
+
+    private static final Pattern CFF_VERSION = Pattern.compile(
+            "(?m)^version: \\\"([^\\\"]+)\\\"$");
+    private static final Pattern CFF_DATE = Pattern.compile(
+            "(?m)^date-released: ");
+    private static final Pattern CITATION_PREFERRED = Pattern.compile(
+            "Taxonomy Architecture Analyzer\\*\\*\\. Version ([0-9A-Za-z.-]+)\\.");
+    private static final Pattern CITATION_BIBTEX = Pattern.compile(
+            "(?m)^\\s*version\\s+= \\{([^}]+)},$");
+    private static final Pattern CITATION_DATE = Pattern.compile(
+            "(?m)^\\s*date\\s+= \\{[^}]+},$");
+    private static final Pattern CHART_VERSION = Pattern.compile(
+            "(?m)^appVersion:\\s*[\\\"']?([^\\\"'\\s]+)[\\\"']?\\s*$");
+
+    private VersionStateVerifier() {
+    }
+
+    public static Verification verify(
+            Path root,
+            String mode,
+            String expectedVersion,
+            String tag) throws IOException {
+        Path repository = root.toAbsolutePath().normalize();
+        String actual = XmlSupport.rootProjectVersion(repository.resolve("pom.xml"));
+        String expected = expectedVersion == null || expectedVersion.isBlank()
+                ? actual
+                : expectedVersion.strip();
+        List<String> failures = new ArrayList<>();
+
+        if (!actual.equals(expected)) {
+            failures.add("Root Maven version '" + actual
+                    + "' != expected '" + expected + "'");
+        }
+        boolean releaseMode;
+        if ("release".equals(mode)) {
+            releaseMode = true;
+            if (!VersionNumbers.RELEASE.matcher(actual).matches()) {
+                failures.add("Version '" + actual
+                        + "' is not a valid release version");
+            }
+        } else if ("development".equals(mode)) {
+            releaseMode = false;
+            if (!VersionNumbers.DEVELOPMENT.matcher(actual).matches()) {
+                failures.add("Version '" + actual
+                        + "' is not a valid development version");
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "mode must be development or release");
+        }
+
+        if (tag != null && !tag.isBlank()) {
+            String expectedTag = "v" + actual;
+            if (!releaseMode) {
+                failures.add("A release tag is only valid in release mode");
+            } else if (!tag.equals(expectedTag)) {
+                failures.add("Tag '" + tag + "' != expected '" + expectedTag + "'");
+            }
+        }
+
+        failures.addAll(pomFailures(repository, actual));
+        failures.addAll(metadataFailures(repository, actual, releaseMode));
+        return new Verification(actual, mode, List.copyOf(failures));
+    }
+
+    private static List<String> pomFailures(Path root, String expected)
+            throws IOException {
+        List<String> failures = new ArrayList<>();
+        List<Path> poms;
+        try (Stream<Path> paths = Files.walk(root)) {
+            poms = paths.filter(Files::isRegularFile)
+                    .filter(path -> "pom.xml".equals(path.getFileName().toString()))
+                    .filter(path -> !contains(path, "target"))
+                    .filter(path -> !contains(path, ".git"))
+                    .sorted(Comparator.comparing(Path::toString))
+                    .toList();
+        }
+        for (Path pom : poms) {
+            Element project = XmlSupport.parse(pom).getDocumentElement();
+            Element parent = XmlSupport.child(project, "parent");
+            String parentGroup = XmlSupport.childText(parent, "groupId");
+            String parentArtifact = XmlSupport.childText(parent, "artifactId");
+            String parentVersion = XmlSupport.childText(parent, "version");
+            if ("com.taxonomy".equals(parentGroup)
+                    && "taxonomy".equals(parentArtifact)
+                    && !expected.equals(parentVersion)) {
+                failures.add(relative(root, pom) + " parent version '"
+                        + emptyToNull(parentVersion) + "' != '" + expected + "'");
+            }
+            String group = XmlSupport.childText(project, "groupId");
+            if (group.isBlank()) {
+                group = parentGroup;
+            }
+            String projectVersion = XmlSupport.childText(project, "version");
+            if ("com.taxonomy".equals(group)
+                    && !projectVersion.isBlank()
+                    && !expected.equals(projectVersion)) {
+                failures.add(relative(root, pom) + " project version '"
+                        + projectVersion + "' != '" + expected + "'");
+            }
+        }
+        return failures;
+    }
+
+    private static List<String> metadataFailures(
+            Path root,
+            String expected,
+            boolean releaseMode) throws IOException {
+        List<String> failures = new ArrayList<>();
+
+        String citation = read(root.resolve("CITATION.cff"));
+        Matcher cffVersion = CFF_VERSION.matcher(citation);
+        if (!cffVersion.find() || !expected.equals(cffVersion.group(1))) {
+            failures.add("CITATION.cff version does not match the Maven version");
+        }
+        if (CFF_DATE.matcher(citation).find() != releaseMode) {
+            failures.add(
+                    "CITATION.cff release-date state does not match the requested mode");
+        }
+
+        String citationMarkdown = read(root.resolve("CITATION.md"));
+        Matcher preferred = CITATION_PREFERRED.matcher(citationMarkdown);
+        Matcher bibtex = CITATION_BIBTEX.matcher(citationMarkdown);
+        if (!preferred.find() || !expected.equals(preferred.group(1))) {
+            failures.add("CITATION.md preferred citation version does not match");
+        }
+        if (!bibtex.find() || !expected.equals(bibtex.group(1))) {
+            failures.add("CITATION.md BibTeX version does not match");
+        }
+        if (CITATION_DATE.matcher(citationMarkdown).find() != releaseMode) {
+            failures.add(
+                    "CITATION.md release-date state does not match the requested mode");
+        }
+
+        checkJsonMetadata(
+                root.resolve(".zenodo.json"),
+                "version",
+                "publication_date",
+                expected,
+                releaseMode,
+                failures);
+        checkJsonMetadata(
+                root.resolve("codemeta.json"),
+                "version",
+                "datePublished",
+                expected,
+                releaseMode,
+                failures);
+
+        Path chart = root.resolve("deploy/helm/taxonomy/Chart.yaml");
+        if (Files.isRegularFile(chart)) {
+            Matcher chartVersion = CHART_VERSION.matcher(read(chart));
+            if (!chartVersion.find() || !expected.equals(chartVersion.group(1))) {
+                failures.add(
+                        "Helm Chart.yaml appVersion does not match the Maven version");
+            }
+        }
+        return failures;
+    }
+
+    private static void checkJsonMetadata(
+            Path path,
+            String versionKey,
+            String dateKey,
+            String expected,
+            boolean releaseMode,
+            List<String> failures) throws IOException {
+        Map<String, Object> data = FlatJson.parseObject(read(path));
+        if (!expected.equals(data.get(versionKey))) {
+            failures.add(path.getFileName() + " version does not match");
+        }
+        if (data.containsKey(dateKey) != releaseMode) {
+            failures.add(path.getFileName()
+                    + " release-date state does not match the requested mode");
+        }
+    }
+
+    private static boolean contains(Path path, String name) {
+        for (Path component : path) {
+            if (name.equals(component.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static String relative(Path root, Path path) {
+        return root.relativize(path).toString().replace('\\', '/');
+    }
+
+    private static String emptyToNull(String value) {
+        return value.isBlank() ? "null" : value;
+    }
+
+    public record Verification(
+            String version,
+            String mode,
+            List<String> failures) {
+        public boolean successful() {
+            return failures.isEmpty();
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
@@ -4,15 +4,17 @@ import org.w3c.dom.Element;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /** Verifies Maven, citation, archive and Helm metadata as one version state. */
 public final class VersionStateVerifier {
@@ -84,15 +86,31 @@ public final class VersionStateVerifier {
     private static List<String> pomFailures(Path root, String expected)
             throws IOException {
         List<String> failures = new ArrayList<>();
-        List<Path> poms;
-        try (Stream<Path> paths = Files.walk(root)) {
-            poms = paths.filter(Files::isRegularFile)
-                    .filter(path -> "pom.xml".equals(path.getFileName().toString()))
-                    .filter(path -> !contains(path, "target"))
-                    .filter(path -> !contains(path, ".git"))
-                    .sorted(Comparator.comparing(Path::toString))
-                    .toList();
-        }
+        List<Path> poms = new ArrayList<>();
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(
+                    Path directory,
+                    BasicFileAttributes attributes) {
+                if (!directory.equals(root) && ignoredDirectory(directory)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(
+                    Path file,
+                    BasicFileAttributes attributes) {
+                if (attributes.isRegularFile()
+                        && "pom.xml".equals(file.getFileName().toString())) {
+                    poms.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        poms.sort(Comparator.comparing(Path::toString));
+
         for (Path pom : poms) {
             Element project = XmlSupport.parse(pom).getDocumentElement();
             Element parent = XmlSupport.child(project, "parent");
@@ -193,13 +211,13 @@ public final class VersionStateVerifier {
         }
     }
 
-    private static boolean contains(Path path, String name) {
-        for (Path component : path) {
-            if (name.equals(component.toString())) {
-                return true;
-            }
+    private static boolean ignoredDirectory(Path directory) {
+        Path fileName = directory.getFileName();
+        if (fileName == null) {
+            return false;
         }
-        return false;
+        String name = fileName.toString();
+        return ".git".equals(name) || "target".equals(name);
     }
 
     private static String read(Path path) throws IOException {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/XmlSupport.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/XmlSupport.java
@@ -1,0 +1,127 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+final class XmlSupport {
+
+    static final String MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0";
+
+    private XmlSupport() {
+    }
+
+    static Document parse(Path path) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return parse(input);
+        }
+    }
+
+    static Document parse(InputStream input) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            return factory.newDocumentBuilder().parse(input);
+        } catch (ParserConfigurationException | SAXException error) {
+            throw new IOException("Cannot parse XML: " + error.getMessage(), error);
+        }
+    }
+
+    static String childText(Element parent, String localName) {
+        if (parent == null) {
+            return "";
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                return text(element);
+            }
+        }
+        return "";
+    }
+
+    static Element child(Element parent, String localName) {
+        if (parent == null) {
+            return null;
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    static List<Element> children(Element parent, String localName) {
+        List<Element> result = new ArrayList<>();
+        if (parent == null) {
+            return result;
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                result.add(element);
+            }
+        }
+        return result;
+    }
+
+    static List<Element> descendants(Element parent, String localName) {
+        List<Element> result = new ArrayList<>();
+        collect(parent, localName, result);
+        return result;
+    }
+
+    private static void collect(
+            Element parent,
+            String localName,
+            List<Element> result) {
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element) {
+                if (localName.equals(element.getLocalName())) {
+                    result.add(element);
+                }
+                collect(element, localName, result);
+            }
+        }
+    }
+
+    static String text(Element element) {
+        return element == null ? "" : element.getTextContent().strip();
+    }
+
+    static String rootProjectVersion(Path pom) throws IOException {
+        Element project = parse(pom).getDocumentElement();
+        String version = childText(project, "version");
+        if (version.isBlank()) {
+            throw new IllegalArgumentException("root pom.xml has no project version");
+        }
+        return version;
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TaxonomyToolingTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TaxonomyToolingTest.java
@@ -1,0 +1,64 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaxonomyToolingTest {
+
+    @Test
+    void readPomVersionDefaultsToTheWorkingDirectoryPom(@TempDir Path root)
+            throws Exception {
+        Files.writeString(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>fixture</artifactId>
+                  <version>2.3.4-SNAPSHOT</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"read-pom-version"},
+                root,
+                new PrintStream(output, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(exitCode).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("2.3.4-SNAPSHOT\n");
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+
+    @Test
+    void readPomVersionStillAcceptsAnExplicitFile(@TempDir Path root)
+            throws Exception {
+        Path nested = root.resolve("nested.xml");
+        Files.writeString(nested, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <version>9.8.7</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"read-pom-version", "--file", nested.toString()},
+                root,
+                new PrintStream(output, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(exitCode).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("9.8.7\n");
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateTraversalTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateTraversalTest.java
@@ -1,0 +1,51 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionStateTraversalTest {
+
+    @Test
+    void prunesGitAndGeneratedTreesBeforeParsingPomFiles(@TempDir Path root)
+            throws Exception {
+        String version = "1.2.9-SNAPSHOT";
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version));
+        write(root.resolve("CITATION.cff"),
+                "version: \"" + version + "\"\n");
+        write(root.resolve("CITATION.md"),
+                "Carsten Hammer. **Taxonomy Architecture Analyzer**. Version "
+                        + version + ". 2026.\n"
+                        + "  version      = {" + version + "},\n");
+        write(root.resolve(".zenodo.json"),
+                "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("codemeta.json"),
+                "{\"version\":\"" + version + "\"}\n");
+
+        write(root.resolve("target/pom.xml"), "<deliberately-invalid");
+        write(root.resolve(".git/pom.xml"), "<deliberately-invalid");
+
+        VersionStateVerifier.Verification verification =
+                VersionStateVerifier.verify(
+                        root, "development", version, null);
+
+        assertThat(verification.failures()).isEmpty();
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateVerifierTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateVerifierTest.java
@@ -1,0 +1,154 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionStateVerifierTest {
+
+    @Test
+    void acceptsConsistentDevelopmentAndReleaseStates(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        var development = VersionStateVerifier.verify(
+                root, "development", null, null);
+        assertThat(development.successful()).isTrue();
+
+        writeRepository(root, "1.2.9", true);
+        var release = VersionStateVerifier.verify(
+                root, "release", "1.2.9", "v1.2.9");
+        assertThat(release.successful()).isTrue();
+    }
+
+    @Test
+    void rejectsSnapshotReleaseAndReleaseTagInDevelopmentMode(
+            @TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+
+        var release = VersionStateVerifier.verify(root, "release", null, null);
+        var taggedDevelopment = VersionStateVerifier.verify(
+                root, "development", null, "v1.2.9-SNAPSHOT");
+
+        assertThat(release.failures())
+                .anyMatch(message -> message.contains("not a valid release version"));
+        assertThat(taggedDevelopment.failures())
+                .contains("A release tag is only valid in release mode");
+    }
+
+    @Test
+    void rejectsUnexpectedTagAndExplicitExpectedVersion(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9", true);
+        assertThat(VersionStateVerifier.verify(
+                root, "release", null, "v1.2.8").failures())
+                .contains("Tag 'v1.2.8' != expected 'v1.2.9'");
+
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        assertThat(VersionStateVerifier.verify(
+                root,
+                "development",
+                "1.2.10-SNAPSHOT",
+                null).failures())
+                .contains("Root Maven version '1.2.9-SNAPSHOT' != expected '1.2.10-SNAPSHOT'");
+    }
+
+    @Test
+    void rejectsPomHelmCitationAndArchiveDrift(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        write(root.resolve("module/pom.xml"), modulePom("1.2.8-SNAPSHOT"));
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "1.2.8-SNAPSHOT"
+                """);
+        write(root.resolve("CITATION.cff"), """
+                version: "1.2.8-SNAPSHOT"
+                date-released: "2026-08-10"
+                """);
+        write(root.resolve(".zenodo.json"), """
+                {"version":"1.2.8-SNAPSHOT","publication_date":"2026-08-10"}
+                """);
+        write(root.resolve("codemeta.json"), """
+                {"version":"1.2.8-SNAPSHOT","datePublished":"2026-08-10"}
+                """);
+
+        var verification = VersionStateVerifier.verify(
+                root, "development", null, null);
+
+        assertThat(verification.failures())
+                .anyMatch(message -> message.contains("module/pom.xml parent version"))
+                .contains(
+                        "Helm Chart.yaml appVersion does not match the Maven version",
+                        "CITATION.cff version does not match the Maven version",
+                        "CITATION.cff release-date state does not match the requested mode",
+                        ".zenodo.json version does not match",
+                        ".zenodo.json release-date state does not match the requested mode",
+                        "codemeta.json version does not match",
+                        "codemeta.json release-date state does not match the requested mode");
+    }
+
+    private static void writeRepository(
+            Path root,
+            String version,
+            boolean release) throws Exception {
+        write(root.resolve("pom.xml"), rootPom(version));
+        write(root.resolve("module/pom.xml"), modulePom(version));
+        write(root.resolve("CITATION.cff"),
+                "version: \"" + version + "\"\n"
+                        + (release ? "date-released: \"2026-08-10\"\n" : ""));
+        write(root.resolve("CITATION.md"),
+                "Carsten Hammer. **Taxonomy Architecture Analyzer**. Version "
+                        + version + ". 2026.\n"
+                        + "  version      = {" + version + "},\n"
+                        + (release ? "  date         = {2026-08-10},\n" : ""));
+        write(root.resolve(".zenodo.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"publication_date\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("codemeta.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"datePublished\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "%s"
+                """.formatted(version));
+    }
+
+    private static String rootPom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version);
+    }
+
+    private static String modulePom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>%s</version>
+                  </parent>
+                  <artifactId>module</artifactId>
+                </project>
+                """.formatted(version);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Purpose

First bounded #673 slice. Introduce a normal Maven reactor module that verifies Taxonomy's Maven, citation, CodeMeta, Zenodo and Helm version state without Python or runtime dependencies.

## Scope

- add `taxonomy-tooling` as the first reactor module;
- add strict JDK-only JSON and hardened XML readers;
- add `VersionStateVerifier` for development/release metadata agreement;
- expose `check-version-state` and `read-pom-version` through an executable JAR;
- add positive and negative JUnit fixtures for snapshot/release modes, tags, metadata drift and default/explicit POM reads;
- share semantic version primitives needed by later stacked slices;
- prune `.git` and generated `target` trees before scanning POMs, with invalid-POM regression fixtures proving those subtrees are never parsed.

This PR deliberately does not switch workflows, disable the still-productive Python `release-check`, or delete adapters. It is the independently green foundation for the stacked release-parameter, release-plan, workflow and cleanup slices.

Base: current `main` after #753. The separate truthful 1.4.0 release-note correction remains outstanding and is not claimed by this PR.

Advances #673. Publication remains blocked by #711 and the remaining Python inventory.