### PR TITLE
Move Maven release-plan validation to Java tooling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     </issueManagement>
 
     <modules>
+        <!-- Dependency-free build tooling is built first. -->
+        <module>taxonomy-tooling</module>
         <module>taxonomy-domain</module>
         <module>taxonomy-dsl</module>
         <module>taxonomy-export</module>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
     </issueManagement>
 
     <modules>
+        <!-- Dependency-free release and repository tooling is built first. -->
+        <module>taxonomy-tooling</module>
         <module>taxonomy-domain</module>
         <module>taxonomy-dsl</module>
         <module>taxonomy-export</module>
@@ -316,42 +318,10 @@
         </profile>
         <profile>
             <id>release-check</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>${exec-maven-plugin.version}</version>
-                        <inherited>false</inherited>
-                        <executions>
-                            <execution>
-                                <id>validate-release-plan</id>
-                                <phase>validate</phase>
-                                <goals><goal>exec</goal></goals>
-                                <configuration>
-                                    <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-                                    <executable>python3</executable>
-                                    <arguments>
-                                        <argument>.github/scripts/check-release-plan.py</argument>
-                                        <argument>--root</argument>
-                                        <argument>${maven.multiModuleProjectDirectory}</argument>
-                                        <argument>--current-version</argument>
-                                        <argument>${project.version}</argument>
-                                        <argument>--release-version</argument>
-                                        <argument>${releaseVersion}</argument>
-                                        <argument>--next-development-version</argument>
-                                        <argument>${nextDevelopmentVersion}</argument>
-                                        <argument>--state</argument>
-                                        <argument>${releaseCheckCurrentState}</argument>
-                                        <argument>--require-clean</argument>
-                                        <argument>${releaseCheckRequireClean}</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- The dependency-free Java tooling performs the release-plan check. -->
+                <taxonomy.release.check>true</taxonomy.release.check>
+            </properties>
         </profile>
         <profile>
             <id>quality</id>

--- a/taxonomy-tooling/pom.xml
+++ b/taxonomy-tooling/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.taxonomy</groupId>
+        <artifactId>taxonomy</artifactId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>taxonomy-tooling</artifactId>
+    <packaging>jar</packaging>
+    <name>Taxonomy Build and Release Tooling</name>
+    <description>Dependency-free Java command line tooling for release, version and repository policy operations.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.taxonomy.tooling.TaxonomyTooling</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
@@ -1,0 +1,221 @@
+package com.taxonomy.tooling;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Strict dependency-free JSON reader for release and archive metadata. */
+final class FlatJson {
+
+    private final String source;
+    private int index;
+
+    private FlatJson(String source) {
+        this.source = source;
+    }
+
+    static Map<String, Object> parseObject(String source) {
+        FlatJson parser = new FlatJson(source);
+        Map<String, Object> result = parser.object();
+        parser.whitespace();
+        if (!parser.end()) {
+            throw parser.error("Unexpected content after JSON object");
+        }
+        return result;
+    }
+
+    private Map<String, Object> object() {
+        whitespace();
+        expect('{');
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+        whitespace();
+        if (consume('}')) {
+            return result;
+        }
+        while (true) {
+            whitespace();
+            String key = string();
+            if (result.containsKey(key)) {
+                throw error("Duplicate JSON key '" + key + "'");
+            }
+            whitespace();
+            expect(':');
+            whitespace();
+            result.put(key, value());
+            whitespace();
+            if (consume('}')) {
+                return result;
+            }
+            expect(',');
+        }
+    }
+
+    private List<Object> array() {
+        expect('[');
+        List<Object> result = new ArrayList<>();
+        whitespace();
+        if (consume(']')) {
+            return result;
+        }
+        while (true) {
+            whitespace();
+            result.add(value());
+            whitespace();
+            if (consume(']')) {
+                return result;
+            }
+            expect(',');
+        }
+    }
+
+    private Object value() {
+        whitespace();
+        if (end()) {
+            throw error("Missing JSON value");
+        }
+        return switch (source.charAt(index)) {
+            case '"' -> string();
+            case '{' -> object();
+            case '[' -> array();
+            case 't' -> literal("true", Boolean.TRUE);
+            case 'f' -> literal("false", Boolean.FALSE);
+            case 'n' -> literal("null", null);
+            default -> number();
+        };
+    }
+
+    private Object literal(String literal, Object value) {
+        if (!source.startsWith(literal, index)) {
+            throw error("Invalid JSON literal");
+        }
+        index += literal.length();
+        return value;
+    }
+
+    private Number number() {
+        int start = index;
+        consume('-');
+        if (consume('0')) {
+            if (!end() && Character.isDigit(source.charAt(index))) {
+                throw error("JSON numbers may not contain leading zeroes");
+            }
+        } else {
+            int digits = consumeDigits();
+            if (digits == 0) {
+                throw error("Unsupported JSON value");
+            }
+        }
+
+        boolean decimal = false;
+        if (consume('.')) {
+            decimal = true;
+            if (consumeDigits() == 0) {
+                throw error("JSON fraction requires digits");
+            }
+        }
+        if (!end() && (source.charAt(index) == 'e'
+                || source.charAt(index) == 'E')) {
+            decimal = true;
+            index++;
+            if (!end() && (source.charAt(index) == '+'
+                    || source.charAt(index) == '-')) {
+                index++;
+            }
+            if (consumeDigits() == 0) {
+                throw error("JSON exponent requires digits");
+            }
+        }
+
+        String token = source.substring(start, index);
+        try {
+            return decimal ? new BigDecimal(token) : Long.valueOf(token);
+        } catch (NumberFormatException error) {
+            throw error("JSON number is out of range");
+        }
+    }
+
+    private int consumeDigits() {
+        int start = index;
+        while (!end() && Character.isDigit(source.charAt(index))) {
+            index++;
+        }
+        return index - start;
+    }
+
+    private String string() {
+        expect('"');
+        StringBuilder value = new StringBuilder();
+        while (!end()) {
+            char current = source.charAt(index++);
+            if (current == '"') {
+                return value.toString();
+            }
+            if (current == '\\') {
+                if (end()) {
+                    throw error("Incomplete JSON escape");
+                }
+                char escaped = source.charAt(index++);
+                switch (escaped) {
+                    case '"', '\\', '/' -> value.append(escaped);
+                    case 'b' -> value.append('\b');
+                    case 'f' -> value.append('\f');
+                    case 'n' -> value.append('\n');
+                    case 'r' -> value.append('\r');
+                    case 't' -> value.append('\t');
+                    case 'u' -> value.append(unicode());
+                    default -> throw error("Invalid JSON escape \\" + escaped);
+                }
+            } else {
+                if (current < 0x20) {
+                    throw error("Control character in JSON string");
+                }
+                value.append(current);
+            }
+        }
+        throw error("Unterminated JSON string");
+    }
+
+    private char unicode() {
+        if (index + 4 > source.length()) {
+            throw error("Incomplete JSON unicode escape");
+        }
+        String digits = source.substring(index, index + 4);
+        index += 4;
+        try {
+            return (char) Integer.parseInt(digits, 16);
+        } catch (NumberFormatException error) {
+            throw error("Invalid JSON unicode escape");
+        }
+    }
+
+    private void whitespace() {
+        while (!end() && Character.isWhitespace(source.charAt(index))) {
+            index++;
+        }
+    }
+
+    private boolean consume(char expected) {
+        if (!end() && source.charAt(index) == expected) {
+            index++;
+            return true;
+        }
+        return false;
+    }
+
+    private void expect(char expected) {
+        if (!consume(expected)) {
+            throw error("Expected '" + expected + "'");
+        }
+    }
+
+    private boolean end() {
+        return index >= source.length();
+    }
+
+    private IllegalArgumentException error(String message) {
+        return new IllegalArgumentException(
+                message + " at JSON character " + (index + 1));
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/GitSupport.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/GitSupport.java
@@ -6,6 +6,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 final class GitSupport {
 
@@ -34,17 +38,27 @@ final class GitSupport {
             Process process = new ProcessBuilder(command)
                     .directory(root.toFile())
                     .start();
-            String stdout = new String(
-                    process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-            String stderr = new String(
-                    process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
-            return new Result(process.waitFor(), stdout, stderr);
+            try (ExecutorService readers =
+                    Executors.newVirtualThreadPerTaskExecutor()) {
+                Future<String> stdout = readers.submit(() -> new String(
+                        process.getInputStream().readAllBytes(),
+                        StandardCharsets.UTF_8));
+                Future<String> stderr = readers.submit(() -> new String(
+                        process.getErrorStream().readAllBytes(),
+                        StandardCharsets.UTF_8));
+                int exitCode = process.waitFor();
+                return new Result(exitCode, stdout.get(), stderr.get());
+            }
         } catch (IOException error) {
             throw new IllegalArgumentException(
                     "Cannot execute Git: " + error.getMessage(), error);
         } catch (InterruptedException error) {
             Thread.currentThread().interrupt();
             throw new IllegalArgumentException("Git command was interrupted", error);
+        } catch (ExecutionException error) {
+            Throwable cause = error.getCause() == null ? error : error.getCause();
+            throw new IllegalArgumentException(
+                    "Cannot read Git process output: " + cause.getMessage(), cause);
         }
     }
 

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/GitSupport.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/GitSupport.java
@@ -1,0 +1,53 @@
+package com.taxonomy.tooling;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+final class GitSupport {
+
+    private GitSupport() {
+    }
+
+    static String require(Path root, String... arguments) {
+        Result result = run(root, arguments);
+        if (result.exitCode() != 0) {
+            String detail = !result.stderr().isBlank()
+                    ? result.stderr().strip()
+                    : !result.stdout().isBlank()
+                            ? result.stdout().strip()
+                            : "unknown Git error";
+            throw new IllegalArgumentException(
+                    "git " + String.join(" ", arguments) + " failed: " + detail);
+        }
+        return result.stdout();
+    }
+
+    static Result run(Path root, String... arguments) {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(Arrays.asList(arguments));
+        try {
+            Process process = new ProcessBuilder(command)
+                    .directory(root.toFile())
+                    .start();
+            String stdout = new String(
+                    process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            String stderr = new String(
+                    process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+            return new Result(process.waitFor(), stdout, stderr);
+        } catch (IOException error) {
+            throw new IllegalArgumentException(
+                    "Cannot execute Git: " + error.getMessage(), error);
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Git command was interrupted", error);
+        }
+    }
+
+    record Result(int exitCode, String stdout, String stderr) {
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseParametersResolver.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseParametersResolver.java
@@ -1,0 +1,422 @@
+package com.taxonomy.tooling;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Resolves and validates the exact parameters consumed by the release workflow. */
+public final class ReleaseParametersResolver {
+
+    private static final Pattern COMMIT_ID = Pattern.compile("^[0-9a-f]{40}$");
+    private static final Set<String> INCREMENTS = Set.of("patch", "minor", "major");
+    private static final List<String> OUTPUT_KEYS = List.of(
+            "release_version",
+            "next_development_version",
+            "skip_tests",
+            "dry_run",
+            "resume_staged_release");
+
+    private ReleaseParametersResolver() {
+    }
+
+    public static Parameters resolve(
+            String eventName,
+            Map<String, String> environment,
+            Map<String, Object> request,
+            String currentVersion) {
+        String releaseVersion;
+        String nextVersion;
+        Object skipValue;
+        Object dryRunValue;
+        Object resumeValue;
+
+        if ("push".equals(eventName)) {
+            if (request == null) {
+                throw new IllegalArgumentException(
+                        "release request is required for a push event");
+            }
+            releaseVersion = VersionNumbers.normalizeRelease(
+                    request.get("release_version"), "release_version");
+            nextVersion = VersionNumbers.normalizeDevelopment(
+                    request.getOrDefault("next_development_version", ""),
+                    "next_development_version",
+                    true);
+            skipValue = request.getOrDefault("skip_tests", Boolean.FALSE);
+            dryRunValue = request.getOrDefault("dry_run", Boolean.FALSE);
+            resumeValue = request.getOrDefault(
+                    "resume_staged_release", Boolean.FALSE);
+        } else if ("workflow_dispatch".equals(eventName)) {
+            if (currentVersion == null) {
+                throw new IllegalArgumentException(
+                        "current project version is required for workflow_dispatch");
+            }
+            DerivedVersions derived = deriveReleaseVersions(
+                    currentVersion,
+                    environment.getOrDefault(
+                            "INPUT_NEXT_VERSION_INCREMENT", "patch"),
+                    environment.getOrDefault(
+                            "INPUT_NEXT_DEVELOPMENT_VERSION", ""));
+            releaseVersion = derived.releaseVersion();
+            nextVersion = derived.nextDevelopmentVersion();
+            skipValue = defaultBoolean(environment.get("INPUT_SKIP_TESTS"));
+            dryRunValue = defaultBoolean(environment.get("INPUT_DRY_RUN"));
+            resumeValue = Boolean.FALSE;
+        } else {
+            throw new IllegalArgumentException(
+                    "unsupported release event: " + eventName);
+        }
+
+        Parameters parameters = new Parameters(
+                releaseVersion,
+                nextVersion,
+                normalizeBoolean(skipValue, "skip_tests"),
+                normalizeBoolean(dryRunValue, "dry_run"),
+                normalizeBoolean(resumeValue, "resume_staged_release"));
+        requireNewerNextVersion(releaseVersion, nextVersion, null);
+
+        if (parameters.resumeStagedRelease()) {
+            if (parameters.dryRun()) {
+                throw new IllegalArgumentException(
+                        "resume_staged_release cannot be combined with dry_run");
+            }
+            if (parameters.nextDevelopmentVersion().isBlank()) {
+                throw new IllegalArgumentException(
+                        "next_development_version is required when "
+                                + "resume_staged_release is true");
+            }
+        }
+        return parameters;
+    }
+
+    public static Parameters resolveFromEnvironment(
+            Path root,
+            Map<String, String> environment) throws IOException {
+        String eventName = requireEnvironment(environment, "EVENT_NAME");
+        String currentVersion = XmlSupport.rootProjectVersion(root.resolve("pom.xml"));
+        Map<String, Object> request = null;
+        if ("push".equals(eventName)) {
+            Path configured = Path.of(environment.getOrDefault(
+                    "RELEASE_REQUEST_PATH", ".github/release-request.json"));
+            Path requestPath = configured.isAbsolute()
+                    ? configured
+                    : root.resolve(configured);
+            request = FlatJson.parseObject(Files.readString(
+                    requestPath, StandardCharsets.UTF_8));
+            validateReleaseRequestAnchor(root, requestPath, request);
+        }
+
+        Parameters parameters = resolve(
+                eventName, environment, request, currentVersion);
+        validateStagedReleaseAncestry(root, parameters, currentVersion);
+        appendOutputs(
+                Path.of(requireEnvironment(environment, "GITHUB_OUTPUT")),
+                parameters);
+        return parameters;
+    }
+
+    public static DerivedVersions deriveReleaseVersions(
+            String currentVersion,
+            String increment,
+            Object exactNextVersion) {
+        if (!VersionNumbers.DEVELOPMENT.matcher(currentVersion).matches()) {
+            throw new IllegalArgumentException(
+                    "current project version '" + currentVersion
+                            + "' must use X.Y.Z-SNAPSHOT");
+        }
+        String releaseVersion = currentVersion.substring(
+                0, currentVersion.length() - "-SNAPSHOT".length());
+        String nextVersion = VersionNumbers.normalizeDevelopment(
+                exactNextVersion,
+                "next_development_version",
+                true);
+        if (nextVersion.isBlank()) {
+            nextVersion = defaultNextVersion(releaseVersion, increment);
+        }
+        requireNewerNextVersion(releaseVersion, nextVersion, currentVersion);
+        return new DerivedVersions(releaseVersion, nextVersion);
+    }
+
+    public static String defaultNextVersion(
+            String releaseVersion,
+            String increment) {
+        String normalized = increment == null || increment.isBlank()
+                ? "patch"
+                : increment.strip().toLowerCase(Locale.ROOT);
+        if (!INCREMENTS.contains(normalized)) {
+            throw new IllegalArgumentException(
+                    "next_version_increment must be patch, minor or major");
+        }
+        VersionNumbers.SemanticVersion current = VersionNumbers.semantic(
+                releaseVersion);
+        int major = current.major();
+        int minor = current.minor();
+        int patch = current.patch();
+        switch (normalized) {
+            case "patch" -> patch++;
+            case "minor" -> {
+                minor++;
+                patch = 0;
+            }
+            case "major" -> {
+                major++;
+                minor = 0;
+                patch = 0;
+            }
+            default -> throw new IllegalStateException(normalized);
+        }
+        return major + "." + minor + "." + patch + "-SNAPSHOT";
+    }
+
+    public static void requireNewerNextVersion(
+            String releaseVersion,
+            String nextVersion,
+            String currentVersion) {
+        if (nextVersion == null || nextVersion.isBlank()
+                || VersionNumbers.semantic(nextVersion).compareTo(
+                        VersionNumbers.semantic(releaseVersion)) > 0) {
+            return;
+        }
+        String context;
+        String guidance;
+        if (currentVersion != null) {
+            context = "current project version " + currentVersion
+                    + " means this run releases " + releaseVersion;
+            guidance = "Leave next_development_version empty to use the selected "
+                    + "patch, minor or major increment, or enter a higher "
+                    + "X.Y.Z-SNAPSHOT version.";
+        } else {
+            context = "release request publishes " + releaseVersion;
+            guidance = "Set next_development_version to a higher "
+                    + "X.Y.Z-SNAPSHOT version, or leave it empty when no "
+                    + "post-release version advance is required.";
+        }
+        throw new IllegalArgumentException(
+                context + "; next development version " + nextVersion
+                        + " must be newer. " + guidance);
+    }
+
+    public static void validateReleaseRequestAnchor(
+            Path root,
+            Path requestPath,
+            Map<String, Object> request) {
+        Path repository = root.toAbsolutePath().normalize();
+        Path absoluteRequest = requestPath.isAbsolute()
+                ? requestPath.toAbsolutePath().normalize()
+                : repository.resolve(requestPath).normalize();
+        if (!absoluteRequest.startsWith(repository)) {
+            throw new IllegalArgumentException(
+                    "release request path must stay inside the repository");
+        }
+        String relativeRequest = repository.relativize(absoluteRequest)
+                .toString().replace('\\', '/');
+
+        Object anchorValue = request.get("requested_after_commit");
+        if (!(anchorValue instanceof String anchor)
+                || !COMMIT_ID.matcher(anchor.strip()).matches()) {
+            throw new IllegalArgumentException(
+                    "requested_after_commit must be a full Git commit ID");
+        }
+        anchor = anchor.strip();
+        long requestRevision = normalizeRequestRevision(
+                request.get("request_revision"));
+
+        String parent = GitSupport.require(
+                repository, "rev-parse", "HEAD^1").strip();
+        if (!parent.equals(anchor)) {
+            throw new IllegalArgumentException(
+                    "requested_after_commit must equal the release-request "
+                            + "commit's first parent " + parent + ", got " + anchor);
+        }
+
+        List<String> changedPaths = GitSupport.require(
+                repository,
+                "diff",
+                "--name-only",
+                "--diff-filter=ACDMRTUXB",
+                anchor,
+                "HEAD",
+                "--").lines().filter(line -> !line.isBlank()).toList();
+        if (!changedPaths.equals(List.of(relativeRequest))) {
+            String changed = changedPaths.isEmpty()
+                    ? "<none>"
+                    : String.join(", ", changedPaths);
+            throw new IllegalArgumentException(
+                    "release request commit must change only " + relativeRequest
+                            + "; changed paths: " + changed);
+        }
+
+        GitSupport.Result previousExists = GitSupport.run(
+                repository, "cat-file", "-e", anchor + ":" + relativeRequest);
+        long previousRevision;
+        if (previousExists.exitCode() == 0) {
+            Map<String, Object> previous = FlatJson.parseObject(
+                    GitSupport.require(repository, "show",
+                            anchor + ":" + relativeRequest));
+            previousRevision = normalizeRequestRevision(
+                    previous.get("request_revision"));
+        } else if (previousExists.exitCode() == 1
+                || previousExists.exitCode() == 128) {
+            previousRevision = 0;
+        } else {
+            String detail = previousExists.stderr().isBlank()
+                    ? "unknown Git error"
+                    : previousExists.stderr().strip();
+            throw new IllegalArgumentException(
+                    "cannot inspect previous release request: " + detail);
+        }
+
+        long expected = previousRevision + 1;
+        if (requestRevision != expected) {
+            throw new IllegalArgumentException(
+                    "request_revision must advance from " + previousRevision
+                            + " to " + expected + ", got " + requestRevision);
+        }
+    }
+
+    public static void validateStagedReleaseAncestry(
+            Path root,
+            Parameters parameters,
+            String currentVersion) {
+        if (parameters.nextDevelopmentVersion().isBlank()
+                || !currentVersion.equals(parameters.nextDevelopmentVersion())) {
+            return;
+        }
+        Path repository = root.toAbsolutePath().normalize();
+        if (GitSupport.run(repository, "rev-parse", "--git-dir").exitCode() != 0) {
+            return;
+        }
+        String tag = "v" + parameters.releaseVersion();
+        GitSupport.Result tagCommit = GitSupport.run(
+                repository,
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                tag + "^{commit}");
+        if (tagCommit.exitCode() != 0) {
+            return;
+        }
+        GitSupport.Result ancestry = GitSupport.run(
+                repository,
+                "merge-base",
+                "--is-ancestor",
+                tagCommit.stdout().strip(),
+                "HEAD");
+        if (ancestry.exitCode() == 0) {
+            return;
+        }
+        if (ancestry.exitCode() == 1) {
+            throw new IllegalArgumentException(
+                    "staged release tag " + tag
+                            + " is not an ancestor of the current "
+                            + currentVersion
+                            + " checkout; repair release ancestry before publication");
+        }
+        String detail = ancestry.stderr().isBlank()
+                ? "unknown git merge-base error"
+                : ancestry.stderr().strip();
+        throw new IllegalArgumentException(
+                "cannot verify staged release ancestry for " + tag + ": " + detail);
+    }
+
+    public static void appendOutputs(Path output, Parameters parameters)
+            throws IOException {
+        Map<String, String> values = parameters.outputs();
+        StringBuilder text = new StringBuilder();
+        for (String key : OUTPUT_KEYS) {
+            text.append(key).append('=').append(values.get(key)).append('\n');
+        }
+        Path parent = output.toAbsolutePath().normalize().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        Files.writeString(
+                output,
+                text,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND);
+    }
+
+    static Map<String, Object> readRequest(Path path) throws IOException {
+        return FlatJson.parseObject(Files.readString(path, StandardCharsets.UTF_8));
+    }
+
+    private static String normalizeBoolean(Object value, String field) {
+        if (value instanceof Boolean bool) {
+            return Boolean.toString(bool);
+        }
+        if (value instanceof String text) {
+            String normalized = text.strip().toLowerCase(Locale.ROOT);
+            if ("true".equals(normalized) || "false".equals(normalized)) {
+                return normalized;
+            }
+        }
+        throw new IllegalArgumentException(field + " must be true or false");
+    }
+
+    private static Object defaultBoolean(String value) {
+        return value == null || value.isBlank() ? "false" : value;
+    }
+
+    private static long normalizeRequestRevision(Object value) {
+        if (!(value instanceof Long revision) || revision < 1) {
+            throw new IllegalArgumentException(
+                    "request_revision must be a positive integer");
+        }
+        return revision;
+    }
+
+    private static String requireEnvironment(
+            Map<String, String> environment,
+            String name) {
+        String value = environment.get(name);
+        if (value == null) {
+            throw new IllegalArgumentException(
+                    name + " environment variable is required");
+        }
+        return value;
+    }
+
+    public record DerivedVersions(
+            String releaseVersion,
+            String nextDevelopmentVersion) {
+    }
+
+    public record Parameters(
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String skipTestsValue,
+            String dryRunValue,
+            String resumeStagedReleaseValue) {
+
+        public boolean skipTests() {
+            return Boolean.parseBoolean(skipTestsValue);
+        }
+
+        public boolean dryRun() {
+            return Boolean.parseBoolean(dryRunValue);
+        }
+
+        public boolean resumeStagedRelease() {
+            return Boolean.parseBoolean(resumeStagedReleaseValue);
+        }
+
+        public Map<String, String> outputs() {
+            LinkedHashMap<String, String> result = new LinkedHashMap<>();
+            result.put("release_version", releaseVersion);
+            result.put("next_development_version", nextDevelopmentVersion);
+            result.put("skip_tests", skipTestsValue);
+            result.put("dry_run", dryRunValue);
+            result.put("resume_staged_release", resumeStagedReleaseValue);
+            return result;
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseParametersResolver.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseParametersResolver.java
@@ -99,23 +99,24 @@ public final class ReleaseParametersResolver {
     public static Parameters resolveFromEnvironment(
             Path root,
             Map<String, String> environment) throws IOException {
+        Path repository = root.toRealPath();
         String eventName = requireEnvironment(environment, "EVENT_NAME");
-        String currentVersion = XmlSupport.rootProjectVersion(root.resolve("pom.xml"));
+        String currentVersion = XmlSupport.rootProjectVersion(
+                repository.resolve("pom.xml"));
         Map<String, Object> request = null;
         if ("push".equals(eventName)) {
             Path configured = Path.of(environment.getOrDefault(
                     "RELEASE_REQUEST_PATH", ".github/release-request.json"));
-            Path requestPath = configured.isAbsolute()
-                    ? configured
-                    : root.resolve(configured);
+            Path requestPath = resolveRequestPath(repository, configured);
             request = FlatJson.parseObject(Files.readString(
                     requestPath, StandardCharsets.UTF_8));
-            validateReleaseRequestAnchor(root, requestPath, request);
+            validateReleaseRequestAnchor(repository, requestPath, request);
         }
 
         Parameters parameters = resolve(
                 eventName, environment, request, currentVersion);
-        validateStagedReleaseAncestry(root, parameters, currentVersion);
+        validateStagedReleaseAncestry(
+                repository, parameters, currentVersion);
         appendOutputs(
                 Path.of(requireEnvironment(environment, "GITHUB_OUTPUT")),
                 parameters);
@@ -347,6 +348,27 @@ public final class ReleaseParametersResolver {
 
     static Map<String, Object> readRequest(Path path) throws IOException {
         return FlatJson.parseObject(Files.readString(path, StandardCharsets.UTF_8));
+    }
+
+    private static Path resolveRequestPath(
+            Path repository,
+            Path configured) throws IOException {
+        Path candidate = (configured.isAbsolute()
+                ? configured
+                : repository.resolve(configured))
+                .toAbsolutePath()
+                .normalize();
+        if (!candidate.startsWith(repository)) {
+            throw new IllegalArgumentException(
+                    "release request path must stay inside the repository");
+        }
+        Path realPath = candidate.toRealPath();
+        if (!realPath.startsWith(repository) || !realPath.equals(candidate)) {
+            throw new IllegalArgumentException(
+                    "release request path must stay inside the repository "
+                            + "and must not traverse symbolic links");
+        }
+        return realPath;
     }
 
     private static String normalizeBoolean(Object value, String field) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -1,0 +1,462 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/** Validates the declared Maven reactor and release transition without SCM writes. */
+public final class ReleasePlanValidator {
+
+    private static final Pattern PROPERTY = Pattern.compile("\\$\\{([^}]+)}");
+    private static final Set<String> STATES = Set.of(
+            "development", "release", "advanced");
+
+    private ReleasePlanValidator() {
+    }
+
+    public static Result validate(
+            Path root,
+            String currentVersion,
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state,
+            boolean requireClean) throws IOException {
+        Path repository = root.toAbsolutePath().normalize();
+        String release = VersionNumbers.normalizeRelease(
+                releaseVersion, "releaseVersion");
+        String next = VersionNumbers.normalizeDevelopment(
+                nextDevelopmentVersion,
+                "nextDevelopmentVersion",
+                false);
+        String current = Objects.requireNonNull(
+                currentVersion, "currentVersion").strip();
+        if (!STATES.contains(state)) {
+            throw new IllegalArgumentException(
+                    "releaseCheckCurrentState must be one of " + STATES.stream().sorted().toList());
+        }
+        VersionNumbers.requireNewer(release, next);
+
+        String expected = expectedCurrentVersion(release, next, state);
+        if (!current.equals(expected)) {
+            throw new IllegalArgumentException(
+                    "release state " + state + " expects project version "
+                            + expected + ", but Maven resolved " + current);
+        }
+
+        List<Path> paths = reactorPomPaths(repository);
+        List<PomModel> models = new ArrayList<>();
+        for (Path path : paths) {
+            models.add(modelFor(path));
+        }
+        if (!models.getFirst().path().equals(repository.resolve("pom.xml"))) {
+            throw new IllegalArgumentException(
+                    "reactor discovery did not start at the root pom.xml");
+        }
+
+        Map<Coordinate, PomModel> byCoordinate = modelsByCoordinate(models);
+        Set<Coordinate> internalCoordinates = byCoordinate.keySet();
+        Map<Path, Map<String, String>> propertyCache = new HashMap<>();
+        List<String> failures = new ArrayList<>();
+
+        for (PomModel model : models) {
+            String relative = relative(repository, model.path());
+            Map<String, String> properties = effectiveProperties(
+                    model, byCoordinate, propertyCache, new HashSet<>());
+            String resolvedModelVersion = resolveProperties(
+                    model.version(), properties);
+            if (PROPERTY.matcher(resolvedModelVersion).find()) {
+                failures.add(relative + ": reactor version '" + model.version()
+                        + "' contains an unresolved version property (resolved as '"
+                        + resolvedModelVersion + "')");
+            } else if (!resolvedModelVersion.equals(current)) {
+                failures.add(relative + ": reactor version '" + resolvedModelVersion
+                        + "' differs from " + current);
+            }
+
+            for (VersionedElement versioned : versionedElements(model)) {
+                if ("forbidden-plugin".equals(versioned.kind())) {
+                    failures.add(relative
+                            + ": maven-release-plugin would create a second SCM release authority");
+                    continue;
+                }
+                String resolved = resolveProperties(
+                        versioned.rawVersion(), properties);
+                String coordinateText = versioned.coordinate() == null
+                        ? ""
+                        : " " + versioned.coordinate().groupId() + ":"
+                                + versioned.coordinate().artifactId();
+                if (PROPERTY.matcher(resolved).find()) {
+                    failures.add(relative + ": " + versioned.kind()
+                            + coordinateText + " uses unresolved version property '"
+                            + versioned.rawVersion() + "' (resolved as '"
+                            + resolved + "')");
+                    continue;
+                }
+                if (!resolved.toUpperCase().contains("SNAPSHOT")) {
+                    continue;
+                }
+                boolean internalSnapshot = ("dependency".equals(versioned.kind())
+                        || "parent".equals(versioned.kind()))
+                        && internalCoordinates.contains(versioned.coordinate())
+                        && resolved.equals(current)
+                        && ("development".equals(state) || "advanced".equals(state));
+                if (!internalSnapshot) {
+                    failures.add(relative + ": external " + versioned.kind()
+                            + coordinateText + " uses snapshot version '"
+                            + versioned.rawVersion() + "' (resolved as '"
+                            + resolved + "')");
+                }
+            }
+        }
+
+        if (Files.exists(repository.resolve("release.properties"))) {
+            failures.add(
+                    "release.properties: stale Maven Release Plugin state is present");
+        }
+        try (Stream<Path> files = Files.walk(repository)) {
+            files.filter(Files::isRegularFile)
+                    .filter(path -> "pom.xml.releaseBackup".equals(
+                            path.getFileName().toString()))
+                    .filter(path -> !contains(path, "target"))
+                    .forEach(path -> failures.add(relative(repository, path)
+                            + ": stale Maven Release Plugin backup is present"));
+        }
+
+        if (!failures.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "release plan validation failed:\n- "
+                            + String.join("\n- ", failures));
+        }
+        if (requireClean) {
+            checkGitClean(repository);
+        }
+        return new Result(current, release, next, state, models.size());
+    }
+
+    public static String expectedCurrentVersion(
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state) {
+        return switch (state) {
+            case "development" -> releaseVersion + "-SNAPSHOT";
+            case "release" -> releaseVersion;
+            case "advanced" -> nextDevelopmentVersion;
+            default -> throw new IllegalArgumentException(
+                    "releaseCheckCurrentState must be one of "
+                            + STATES.stream().sorted().toList());
+        };
+    }
+
+    static List<Path> reactorPomPaths(Path root) throws IOException {
+        Path repository = root.toAbsolutePath().normalize();
+        Path rootPom = repository.resolve("pom.xml");
+        if (!Files.isRegularFile(rootPom)) {
+            throw new IllegalArgumentException(
+                    "root pom.xml does not exist below " + repository);
+        }
+        Deque<Path> pending = new ArrayDeque<>();
+        pending.add(rootPom);
+        List<Path> discovered = new ArrayList<>();
+        Set<Path> seen = new LinkedHashSet<>();
+        while (!pending.isEmpty()) {
+            Path pom = pending.removeFirst().toAbsolutePath().normalize();
+            if (!seen.add(pom)) {
+                continue;
+            }
+            if (!Files.isRegularFile(pom)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module POM does not exist: " + pom);
+            }
+            if (!pom.startsWith(repository)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module escapes repository root: " + pom);
+            }
+            Element project = XmlSupport.parse(pom).getDocumentElement();
+            discovered.add(pom);
+            Element modules = XmlSupport.child(project, "modules");
+            for (Element moduleElement : XmlSupport.children(modules, "module")) {
+                String module = XmlSupport.text(moduleElement);
+                if (module.isBlank()) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " contains an empty Maven module declaration");
+                }
+                Path modulePath = pom.getParent().resolve(module)
+                        .toAbsolutePath().normalize();
+                Path modulePom = "pom.xml".equals(
+                        modulePath.getFileName().toString())
+                                ? modulePath
+                                : modulePath.resolve("pom.xml");
+                if (!modulePom.startsWith(repository)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' outside the repository");
+                }
+                if (!Files.isRegularFile(modulePom)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module + "', but "
+                            + relative(repository, modulePom) + " does not exist");
+                }
+                pending.add(modulePom);
+            }
+        }
+        return discovered;
+    }
+
+    private static PomModel modelFor(Path path) throws IOException {
+        Element project = XmlSupport.parse(path).getDocumentElement();
+        Element parent = XmlSupport.child(project, "parent");
+        Coordinate parentCoordinate = null;
+        String groupId = XmlSupport.childText(project, "groupId");
+        String version = XmlSupport.childText(project, "version");
+        if (parent != null) {
+            parentCoordinate = new Coordinate(
+                    XmlSupport.childText(parent, "groupId"),
+                    XmlSupport.childText(parent, "artifactId"));
+            if (groupId.isBlank()) {
+                groupId = parentCoordinate.groupId();
+            }
+            if (version.isBlank()) {
+                version = XmlSupport.childText(parent, "version");
+            }
+        }
+        String artifactId = XmlSupport.childText(project, "artifactId");
+        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
+            throw new IllegalArgumentException(path
+                    + ": Maven coordinates must provide effective groupId, "
+                    + "artifactId and version");
+        }
+
+        LinkedHashMap<String, String> properties = new LinkedHashMap<>();
+        Element propertyRoot = XmlSupport.child(project, "properties");
+        if (propertyRoot != null) {
+            for (Element property : XmlSupport.children(propertyRoot, propertyRoot.getLocalName())) {
+                // Unreachable for normal Maven properties; retained for defensive clarity.
+                properties.put(property.getLocalName(), XmlSupport.text(property));
+            }
+            for (int index = 0;
+                    index < propertyRoot.getChildNodes().getLength();
+                    index++) {
+                if (propertyRoot.getChildNodes().item(index) instanceof Element property) {
+                    properties.put(property.getLocalName(), XmlSupport.text(property));
+                }
+            }
+        }
+        properties.put("project.groupId", groupId);
+        properties.put("pom.groupId", groupId);
+        properties.put("project.artifactId", artifactId);
+        properties.put("pom.artifactId", artifactId);
+        properties.put("project.version", version);
+        properties.put("pom.version", version);
+        if (parent != null) {
+            properties.put("project.parent.groupId", parentCoordinate.groupId());
+            properties.put("project.parent.artifactId", parentCoordinate.artifactId());
+            properties.put("project.parent.version",
+                    XmlSupport.childText(parent, "version"));
+        }
+        return new PomModel(
+                path, project, groupId, artifactId, version,
+                Map.copyOf(properties), parentCoordinate);
+    }
+
+    private static Map<Coordinate, PomModel> modelsByCoordinate(
+            List<PomModel> models) {
+        LinkedHashMap<Coordinate, PomModel> result = new LinkedHashMap<>();
+        for (PomModel model : models) {
+            Coordinate coordinate = new Coordinate(
+                    model.groupId(), model.artifactId());
+            PomModel previous = result.putIfAbsent(coordinate, model);
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "duplicate Maven reactor coordinate "
+                                + coordinate.groupId() + ":" + coordinate.artifactId()
+                                + ": " + previous.path() + " and " + model.path());
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, String> effectiveProperties(
+            PomModel model,
+            Map<Coordinate, PomModel> models,
+            Map<Path, Map<String, String>> cache,
+            Set<Path> visiting) {
+        Map<String, String> cached = cache.get(model.path());
+        if (cached != null) {
+            return cached;
+        }
+        if (!visiting.add(model.path())) {
+            throw new IllegalArgumentException(
+                    "cyclic Maven parent relationship involving " + model.path());
+        }
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        if (model.parentCoordinate() != null) {
+            PomModel parent = models.get(model.parentCoordinate());
+            if (parent != null) {
+                result.putAll(effectiveProperties(
+                        parent, models, cache, visiting));
+            }
+        }
+        result.putAll(model.properties());
+        visiting.remove(model.path());
+        Map<String, String> immutable = Map.copyOf(result);
+        cache.put(model.path(), immutable);
+        return immutable;
+    }
+
+    private static String resolveProperties(
+            String value,
+            Map<String, String> properties) {
+        String result = value.strip();
+        for (int round = 0; round < 12; round++) {
+            Matcher matcher = PROPERTY.matcher(result);
+            StringBuffer buffer = new StringBuffer();
+            boolean changed = false;
+            while (matcher.find()) {
+                String replacement = properties.get(matcher.group(1));
+                if (replacement == null) {
+                    matcher.appendReplacement(buffer,
+                            Matcher.quoteReplacement(matcher.group()));
+                } else {
+                    matcher.appendReplacement(buffer,
+                            Matcher.quoteReplacement(replacement));
+                    changed = true;
+                }
+            }
+            matcher.appendTail(buffer);
+            result = buffer.toString();
+            if (!changed) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    private static List<VersionedElement> versionedElements(PomModel model) {
+        List<VersionedElement> result = new ArrayList<>();
+        Element parent = XmlSupport.child(model.project(), "parent");
+        if (parent != null) {
+            String version = XmlSupport.childText(parent, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "parent", model.parentCoordinate(), version));
+            }
+        }
+        for (Element dependency : XmlSupport.descendants(
+                model.project(), "dependency")) {
+            String version = XmlSupport.childText(dependency, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "dependency",
+                        new Coordinate(
+                                XmlSupport.childText(dependency, "groupId"),
+                                XmlSupport.childText(dependency, "artifactId")),
+                        version));
+            }
+        }
+        for (Element plugin : XmlSupport.descendants(model.project(), "plugin")) {
+            String artifactId = XmlSupport.childText(plugin, "artifactId");
+            String version = XmlSupport.childText(plugin, "version");
+            if ("maven-release-plugin".equals(artifactId)) {
+                result.add(new VersionedElement(
+                        "forbidden-plugin", null,
+                        version.isBlank() ? "<managed>" : version));
+            } else if (!version.isBlank()) {
+                String groupId = XmlSupport.childText(plugin, "groupId");
+                result.add(new VersionedElement(
+                        "plugin",
+                        new Coordinate(
+                                groupId.isBlank()
+                                        ? "org.apache.maven.plugins"
+                                        : groupId,
+                                artifactId),
+                        version));
+            }
+        }
+        for (Element extension : XmlSupport.descendants(
+                model.project(), "extension")) {
+            String version = XmlSupport.childText(extension, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "build extension",
+                        new Coordinate(
+                                XmlSupport.childText(extension, "groupId"),
+                                XmlSupport.childText(extension, "artifactId")),
+                        version));
+            }
+        }
+        return result;
+    }
+
+    private static void checkGitClean(Path root) {
+        if (!Files.exists(root.resolve(".git"))) {
+            return;
+        }
+        GitSupport.Result result = GitSupport.run(root, "status", "--porcelain");
+        if (result.exitCode() != 0) {
+            throw new IllegalArgumentException(
+                    "git status failed: " + result.stderr().strip());
+        }
+        if (!result.stdout().strip().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "release verification requires a clean checkout; "
+                            + "commit or stash local changes");
+        }
+    }
+
+    private static boolean contains(Path path, String component) {
+        for (Path part : path) {
+            if (component.equals(part.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String relative(Path root, Path path) {
+        return root.relativize(path.toAbsolutePath().normalize())
+                .toString().replace('\\', '/');
+    }
+
+    public record Result(
+            String currentVersion,
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state,
+            int pomCount) {
+    }
+
+    private record Coordinate(String groupId, String artifactId) {
+    }
+
+    private record PomModel(
+            Path path,
+            Element project,
+            String groupId,
+            String artifactId,
+            String version,
+            Map<String, String> properties,
+            Coordinate parentCoordinate) {
+    }
+
+    private record VersionedElement(
+            String kind,
+            Coordinate coordinate,
+            String rawVersion) {
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -46,17 +46,22 @@ public final class ReleasePlanValidator {
                 false);
         String current = Objects.requireNonNull(
                 currentVersion, "currentVersion").strip();
-        if (!STATES.contains(state)) {
+        String normalizedState = Objects.requireNonNull(
+                state, "state").strip();
+        if (!STATES.contains(normalizedState)) {
             throw new IllegalArgumentException(
-                    "releaseCheckCurrentState must be one of " + STATES.stream().sorted().toList());
+                    "releaseCheckCurrentState must be one of "
+                            + STATES.stream().sorted().toList());
         }
         VersionNumbers.requireNewer(release, next);
 
-        String expected = expectedCurrentVersion(release, next, state);
+        String expected = expectedCurrentVersion(
+                release, next, normalizedState);
         if (!current.equals(expected)) {
             throw new IllegalArgumentException(
-                    "release state " + state + " expects project version "
-                            + expected + ", but Maven resolved " + current);
+                    "release state " + normalizedState
+                            + " expects project version " + expected
+                            + ", but Maven resolved " + current);
         }
 
         List<Path> paths = reactorPomPaths(repository);
@@ -115,7 +120,8 @@ public final class ReleasePlanValidator {
                         || "parent".equals(versioned.kind()))
                         && internalCoordinates.contains(versioned.coordinate())
                         && resolved.equals(current)
-                        && ("development".equals(state) || "advanced".equals(state));
+                        && ("development".equals(normalizedState)
+                                || "advanced".equals(normalizedState));
                 if (!internalSnapshot) {
                     failures.add(relative + ": external " + versioned.kind()
                             + coordinateText + " uses snapshot version '"
@@ -146,14 +152,17 @@ public final class ReleasePlanValidator {
         if (requireClean) {
             checkGitClean(repository);
         }
-        return new Result(current, release, next, state, models.size());
+        return new Result(
+                current, release, next, normalizedState, models.size());
     }
 
     public static String expectedCurrentVersion(
             String releaseVersion,
             String nextDevelopmentVersion,
             String state) {
-        return switch (state) {
+        String normalizedState = Objects.requireNonNull(
+                state, "state").strip();
+        return switch (normalizedState) {
             case "development" -> releaseVersion + "-SNAPSHOT";
             case "release" -> releaseVersion;
             case "advanced" -> nextDevelopmentVersion;
@@ -245,15 +254,13 @@ public final class ReleasePlanValidator {
         LinkedHashMap<String, String> properties = new LinkedHashMap<>();
         Element propertyRoot = XmlSupport.child(project, "properties");
         if (propertyRoot != null) {
-            for (Element property : XmlSupport.children(propertyRoot, propertyRoot.getLocalName())) {
-                // Unreachable for normal Maven properties; retained for defensive clarity.
-                properties.put(property.getLocalName(), XmlSupport.text(property));
-            }
             for (int index = 0;
                     index < propertyRoot.getChildNodes().getLength();
                     index++) {
-                if (propertyRoot.getChildNodes().item(index) instanceof Element property) {
-                    properties.put(property.getLocalName(), XmlSupport.text(property));
+                if (propertyRoot.getChildNodes().item(index)
+                        instanceof Element property) {
+                    properties.put(
+                            property.getLocalName(), XmlSupport.text(property));
                 }
             }
         }

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -218,8 +218,14 @@ public final class ReleasePlanValidator {
                 }
                 Path modulePath = pom.getParent().resolve(module)
                         .toAbsolutePath().normalize();
-                Path modulePom = "pom.xml".equals(
-                        modulePath.getFileName().toString())
+                if (!modulePath.startsWith(repository)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' outside the repository");
+                }
+                Path moduleFileName = modulePath.getFileName();
+                Path modulePom = moduleFileName != null
+                        && "pom.xml".equals(moduleFileName.toString())
                                 ? modulePath
                                 : modulePath.resolve("pom.xml")
                                         .toAbsolutePath().normalize();

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -3,8 +3,11 @@ package com.taxonomy.tooling;
 import org.w3c.dom.Element;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -18,7 +21,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /** Validates the declared Maven reactor and release transition without SCM writes. */
 public final class ReleasePlanValidator {
@@ -37,7 +39,7 @@ public final class ReleasePlanValidator {
             String nextDevelopmentVersion,
             String state,
             boolean requireClean) throws IOException {
-        Path repository = root.toAbsolutePath().normalize();
+        Path repository = root.toRealPath();
         String release = VersionNumbers.normalizeRelease(
                 releaseVersion, "releaseVersion");
         String next = VersionNumbers.normalizeDevelopment(
@@ -135,14 +137,7 @@ public final class ReleasePlanValidator {
             failures.add(
                     "release.properties: stale Maven Release Plugin state is present");
         }
-        try (Stream<Path> files = Files.walk(repository)) {
-            files.filter(Files::isRegularFile)
-                    .filter(path -> "pom.xml.releaseBackup".equals(
-                            path.getFileName().toString()))
-                    .filter(path -> !contains(path, "target"))
-                    .forEach(path -> failures.add(relative(repository, path)
-                            + ": stale Maven Release Plugin backup is present"));
-        }
+        collectReleaseBackups(repository, failures);
 
         if (!failures.isEmpty()) {
             throw new IllegalArgumentException(
@@ -173,29 +168,45 @@ public final class ReleasePlanValidator {
     }
 
     static List<Path> reactorPomPaths(Path root) throws IOException {
-        Path repository = root.toAbsolutePath().normalize();
-        Path rootPom = repository.resolve("pom.xml");
+        Path repository = root.toRealPath();
+        Path rootPom = repository.resolve("pom.xml").toAbsolutePath().normalize();
         if (!Files.isRegularFile(rootPom)) {
             throw new IllegalArgumentException(
                     "root pom.xml does not exist below " + repository);
         }
+        Path realRootPom = rootPom.toRealPath();
+        if (!realRootPom.equals(rootPom) || !realRootPom.startsWith(repository)) {
+            throw new IllegalArgumentException(
+                    "root pom.xml must be a real file inside " + repository);
+        }
+
         Deque<Path> pending = new ArrayDeque<>();
-        pending.add(rootPom);
+        pending.add(realRootPom);
         List<Path> discovered = new ArrayList<>();
         Set<Path> seen = new LinkedHashSet<>();
         while (!pending.isEmpty()) {
-            Path pom = pending.removeFirst().toAbsolutePath().normalize();
+            Path declaredPom = pending.removeFirst()
+                    .toAbsolutePath().normalize();
+            if (!declaredPom.startsWith(repository)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module escapes repository root: "
+                                + declaredPom);
+            }
+            if (!Files.isRegularFile(declaredPom)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module POM does not exist: "
+                                + declaredPom);
+            }
+            Path pom = declaredPom.toRealPath();
+            if (!pom.startsWith(repository) || !pom.equals(declaredPom)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module must not traverse a symbolic link "
+                                + "or escape the repository: " + declaredPom);
+            }
             if (!seen.add(pom)) {
                 continue;
             }
-            if (!Files.isRegularFile(pom)) {
-                throw new IllegalArgumentException(
-                        "declared Maven module POM does not exist: " + pom);
-            }
-            if (!pom.startsWith(repository)) {
-                throw new IllegalArgumentException(
-                        "declared Maven module escapes repository root: " + pom);
-            }
+
             Element project = XmlSupport.parse(pom).getDocumentElement();
             discovered.add(pom);
             Element modules = XmlSupport.child(project, "modules");
@@ -210,7 +221,8 @@ public final class ReleasePlanValidator {
                 Path modulePom = "pom.xml".equals(
                         modulePath.getFileName().toString())
                                 ? modulePath
-                                : modulePath.resolve("pom.xml");
+                                : modulePath.resolve("pom.xml")
+                                        .toAbsolutePath().normalize();
                 if (!modulePom.startsWith(repository)) {
                     throw new IllegalArgumentException(relative(repository, pom)
                             + " declares module '" + module
@@ -221,7 +233,14 @@ public final class ReleasePlanValidator {
                             + " declares module '" + module + "', but "
                             + relative(repository, modulePom) + " does not exist");
                 }
-                pending.add(modulePom);
+                Path realModulePom = modulePom.toRealPath();
+                if (!realModulePom.startsWith(repository)
+                        || !realModulePom.equals(modulePom)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' through a symbolic link or outside the repository");
+                }
+                pending.add(realModulePom);
             }
         }
         return discovered;
@@ -410,6 +429,45 @@ public final class ReleasePlanValidator {
         return result;
     }
 
+    private static void collectReleaseBackups(
+            Path repository,
+            List<String> failures) throws IOException {
+        Files.walkFileTree(repository, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(
+                    Path directory,
+                    BasicFileAttributes attributes) {
+                if (!directory.equals(repository)
+                        && ignoredDirectory(directory)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(
+                    Path file,
+                    BasicFileAttributes attributes) {
+                if (attributes.isRegularFile()
+                        && "pom.xml.releaseBackup".equals(
+                                file.getFileName().toString())) {
+                    failures.add(relative(repository, file)
+                            + ": stale Maven Release Plugin backup is present");
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static boolean ignoredDirectory(Path directory) {
+        Path fileName = directory.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String name = fileName.toString();
+        return ".git".equals(name) || "target".equals(name);
+    }
+
     private static void checkGitClean(Path root) {
         if (!Files.exists(root.resolve(".git"))) {
             return;
@@ -424,15 +482,6 @@ public final class ReleasePlanValidator {
                     "release verification requires a clean checkout; "
                             + "commit or stash local changes");
         }
-    }
-
-    private static boolean contains(Path path, String component) {
-        for (Path part : path) {
-            if (component.equals(part.toString())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private static String relative(Path root, Path path) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -102,12 +102,23 @@ public final class ReleasePlanValidator {
                             + ": maven-release-plugin would create a second SCM release authority");
                     continue;
                 }
+                Coordinate coordinate = resolveCoordinate(
+                        versioned.coordinate(), properties);
+                String coordinateText = coordinate == null
+                        ? ""
+                        : " " + coordinate.groupId() + ":"
+                                + coordinate.artifactId();
+                if (coordinate != null
+                        && (PROPERTY.matcher(coordinate.groupId()).find()
+                                || PROPERTY.matcher(coordinate.artifactId()).find())) {
+                    failures.add(relative + ": " + versioned.kind()
+                            + coordinateText
+                            + " uses unresolved coordinate property");
+                    continue;
+                }
+
                 String resolved = resolveProperties(
                         versioned.rawVersion(), properties);
-                String coordinateText = versioned.coordinate() == null
-                        ? ""
-                        : " " + versioned.coordinate().groupId() + ":"
-                                + versioned.coordinate().artifactId();
                 if (PROPERTY.matcher(resolved).find()) {
                     failures.add(relative + ": " + versioned.kind()
                             + coordinateText + " uses unresolved version property '"
@@ -120,7 +131,7 @@ public final class ReleasePlanValidator {
                 }
                 boolean internalSnapshot = ("dependency".equals(versioned.kind())
                         || "parent".equals(versioned.kind()))
-                        && internalCoordinates.contains(versioned.coordinate())
+                        && internalCoordinates.contains(coordinate)
                         && resolved.equals(current)
                         && ("development".equals(normalizedState)
                                 || "advanced".equals(normalizedState));
@@ -377,6 +388,17 @@ public final class ReleasePlanValidator {
             }
         }
         return result;
+    }
+
+    private static Coordinate resolveCoordinate(
+            Coordinate coordinate,
+            Map<String, String> properties) {
+        if (coordinate == null) {
+            return null;
+        }
+        return new Coordinate(
+                resolveProperties(coordinate.groupId(), properties),
+                resolveProperties(coordinate.artifactId(), properties));
     }
 
     private static List<VersionedElement> versionedElements(PomModel model) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -1,0 +1,164 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Entry point for dependency-free version-state tooling. */
+public final class TaxonomyTooling {
+
+    private TaxonomyTooling() {
+    }
+
+    public static void main(String[] arguments) {
+        int exitCode = run(arguments, Path.of("."), System.out, System.err);
+        if (exitCode != 0) {
+            System.exit(exitCode);
+        }
+    }
+
+    static int run(
+            String[] arguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        if (arguments.length == 0) {
+            error.println("Usage: taxonomy-tooling <command> [options]");
+            return 2;
+        }
+        String command = arguments[0];
+        String[] commandArguments = java.util.Arrays.copyOfRange(
+                arguments, 1, arguments.length);
+        return switch (command) {
+            case "check-version-state" -> checkVersionState(
+                    commandArguments, workingDirectory, output, error);
+            case "read-pom-version" -> readPomVersion(
+                    commandArguments, workingDirectory, output, error);
+            default -> {
+                error.println("Unknown taxonomy-tooling command: " + command);
+                yield 2;
+            }
+        };
+    }
+
+    private static int checkVersionState(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            VersionStateVerifier.Verification verification =
+                    VersionStateVerifier.verify(
+                            root,
+                            arguments.required("mode"),
+                            arguments.optional("expected-version"),
+                            arguments.optional("tag"));
+            if (!verification.successful()) {
+                error.println("Inconsistent repository version state:");
+                for (String failure : verification.failures()) {
+                    error.println("- " + failure);
+                }
+                return 1;
+            }
+            output.println("Repository version state is consistent: "
+                    + verification.version() + " (" + verification.mode() + ").");
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int readPomVersion(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            String version;
+            if (arguments.flag("stdin")) {
+                Element project = XmlSupport.parse(System.in).getDocumentElement();
+                version = XmlSupport.childText(project, "version");
+                if (version.isBlank()) {
+                    throw new IllegalArgumentException(
+                            "pom.xml has no project version");
+                }
+            } else {
+                version = XmlSupport.rootProjectVersion(
+                        arguments.path("file", workingDirectory));
+            }
+            output.println(version);
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("::error::" + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static final class Arguments {
+        private final Map<String, String> values;
+        private final Map<String, Boolean> flags;
+
+        private Arguments(
+                Map<String, String> values,
+                Map<String, Boolean> flags) {
+            this.values = values;
+            this.flags = flags;
+        }
+
+        static Arguments parse(String[] raw) {
+            LinkedHashMap<String, String> values = new LinkedHashMap<>();
+            LinkedHashMap<String, Boolean> flags = new LinkedHashMap<>();
+            for (int index = 0; index < raw.length; index++) {
+                String token = raw[index];
+                if (!token.startsWith("--") || token.length() == 2) {
+                    throw new IllegalArgumentException(
+                            "Expected --option, got " + token);
+                }
+                String name = token.substring(2);
+                if ("stdin".equals(name)) {
+                    flags.put(name, Boolean.TRUE);
+                    continue;
+                }
+                if (index + 1 >= raw.length || raw[index + 1].startsWith("--")) {
+                    throw new IllegalArgumentException(
+                            "Missing value for --" + name);
+                }
+                if (values.putIfAbsent(name, raw[++index]) != null) {
+                    throw new IllegalArgumentException(
+                            "Duplicate option --" + name);
+                }
+            }
+            return new Arguments(values, flags);
+        }
+
+        String required(String name) {
+            String value = values.get(name);
+            if (value == null) {
+                throw new IllegalArgumentException("--" + name + " is required");
+            }
+            return value;
+        }
+
+        String optional(String name) {
+            return values.get(name);
+        }
+
+        Path path(String name, Path fallback) {
+            String value = values.get(name);
+            return value == null ? fallback : Path.of(value);
+        }
+
+        boolean flag(String name) {
+            return flags.getOrDefault(name, Boolean.FALSE);
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -26,6 +26,14 @@ public final class TaxonomyTooling {
         }
     }
 
+    static int run(
+            String[] arguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        return run(arguments, Map.of(), workingDirectory, output, error);
+    }
+
     public static int run(
             String[] arguments,
             Map<String, String> environment,
@@ -138,7 +146,9 @@ public final class TaxonomyTooling {
                 }
             } else {
                 version = XmlSupport.rootProjectVersion(
-                        arguments.path("file", workingDirectory));
+                        arguments.path(
+                                "file",
+                                workingDirectory.resolve("pom.xml")));
             }
             output.println(version);
             return 0;

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Entry point for dependency-free release parameter and version tooling. */
+/** Entry point for dependency-free release and repository tooling. */
 public final class TaxonomyTooling {
 
     private TaxonomyTooling() {
@@ -51,6 +51,8 @@ public final class TaxonomyTooling {
             case "resolve-release-parameters" -> resolveReleaseParameters(
                     commandArguments, environment, workingDirectory, error);
             case "check-version-state" -> checkVersionState(
+                    commandArguments, workingDirectory, output, error);
+            case "check-release-plan" -> checkReleasePlan(
                     commandArguments, workingDirectory, output, error);
             case "compare-versions" -> compareVersions(commandArguments, error);
             case "read-pom-version" -> readPomVersion(
@@ -106,6 +108,34 @@ public final class TaxonomyTooling {
             return 0;
         } catch (IOException | IllegalArgumentException failure) {
             error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int checkReleasePlan(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            ReleasePlanValidator.Result result = ReleasePlanValidator.validate(
+                    root,
+                    arguments.required("current-version"),
+                    arguments.required("release-version"),
+                    arguments.required("next-development-version"),
+                    arguments.optionalOrDefault("state", "development"),
+                    arguments.booleanValue("require-clean", true));
+            output.println("Maven release check passed: "
+                    + result.currentVersion() + " -> " + result.releaseVersion()
+                    + " -> " + result.nextDevelopmentVersion() + " ("
+                    + result.state() + ", " + result.pomCount()
+                    + " reactor POMs).");
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("Release check failed: " + failure.getMessage());
             return 1;
         }
     }
@@ -198,7 +228,8 @@ public final class TaxonomyTooling {
         String required(String name) {
             String value = values.get(name);
             if (value == null) {
-                throw new IllegalArgumentException("--" + name + " is required");
+                throw new IllegalArgumentException(
+                        "--" + name + " is required");
             }
             return value;
         }
@@ -207,9 +238,29 @@ public final class TaxonomyTooling {
             return values.get(name);
         }
 
+        String optionalOrDefault(String name, String fallback) {
+            String value = values.get(name);
+            return value == null ? fallback : value;
+        }
+
         Path path(String name, Path fallback) {
             String value = values.get(name);
             return value == null ? fallback : Path.of(value);
+        }
+
+        boolean booleanValue(String name, boolean fallback) {
+            String value = values.get(name);
+            if (value == null) {
+                return fallback;
+            }
+            if ("true".equalsIgnoreCase(value)) {
+                return true;
+            }
+            if ("false".equalsIgnoreCase(value)) {
+                return false;
+            }
+            throw new IllegalArgumentException(
+                    "--" + name + " must be true or false");
         }
 
         boolean flag(String name) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Entry point for dependency-free release parameter and version tooling. */
+/** Entry point for dependency-free release and repository tooling. */
 public final class TaxonomyTooling {
 
     private TaxonomyTooling() {
@@ -43,6 +43,8 @@ public final class TaxonomyTooling {
             case "resolve-release-parameters" -> resolveReleaseParameters(
                     commandArguments, environment, workingDirectory, error);
             case "check-version-state" -> checkVersionState(
+                    commandArguments, workingDirectory, output, error);
+            case "check-release-plan" -> checkReleasePlan(
                     commandArguments, workingDirectory, output, error);
             case "compare-versions" -> compareVersions(commandArguments, error);
             case "read-pom-version" -> readPomVersion(
@@ -80,10 +82,11 @@ public final class TaxonomyTooling {
             Arguments arguments = Arguments.parse(rawArguments);
             Path root = arguments.path("root", workingDirectory)
                     .toAbsolutePath().normalize();
+            String mode = arguments.required("mode");
             VersionStateVerifier.Verification verification =
                     VersionStateVerifier.verify(
                             root,
-                            arguments.required("mode"),
+                            mode,
                             arguments.optional("expected-version"),
                             arguments.optional("tag"));
             if (!verification.successful()) {
@@ -98,6 +101,34 @@ public final class TaxonomyTooling {
             return 0;
         } catch (IOException | IllegalArgumentException failure) {
             error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int checkReleasePlan(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            ReleasePlanValidator.Result result = ReleasePlanValidator.validate(
+                    root,
+                    arguments.required("current-version"),
+                    arguments.required("release-version"),
+                    arguments.required("next-development-version"),
+                    arguments.optionalOrDefault("state", "development"),
+                    arguments.booleanValue("require-clean", true));
+            output.println("Maven release check passed: "
+                    + result.currentVersion() + " -> " + result.releaseVersion()
+                    + " -> " + result.nextDevelopmentVersion() + " ("
+                    + result.state() + ", " + result.pomCount()
+                    + " reactor POMs).");
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("Release check failed: " + failure.getMessage());
             return 1;
         }
     }
@@ -137,8 +168,8 @@ public final class TaxonomyTooling {
                             "pom.xml has no project version");
                 }
             } else {
-                version = XmlSupport.rootProjectVersion(
-                        arguments.path("file", workingDirectory));
+                Path file = arguments.path("file", workingDirectory);
+                version = XmlSupport.rootProjectVersion(file);
             }
             output.println(version);
             return 0;
@@ -188,7 +219,8 @@ public final class TaxonomyTooling {
         String required(String name) {
             String value = values.get(name);
             if (value == null) {
-                throw new IllegalArgumentException("--" + name + " is required");
+                throw new IllegalArgumentException(
+                        "--" + name + " is required");
             }
             return value;
         }
@@ -197,9 +229,29 @@ public final class TaxonomyTooling {
             return values.get(name);
         }
 
+        String optionalOrDefault(String name, String fallback) {
+            String value = values.get(name);
+            return value == null ? fallback : value;
+        }
+
         Path path(String name, Path fallback) {
             String value = values.get(name);
             return value == null ? fallback : Path.of(value);
+        }
+
+        boolean booleanValue(String name, boolean fallback) {
+            String value = values.get(name);
+            if (value == null) {
+                return fallback;
+            }
+            if ("true".equalsIgnoreCase(value)) {
+                return true;
+            }
+            if ("false".equalsIgnoreCase(value)) {
+                return false;
+            }
+            throw new IllegalArgumentException(
+                    "--" + name + " must be true or false");
         }
 
         boolean flag(String name) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -8,21 +8,27 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Entry point for dependency-free version-state tooling. */
+/** Entry point for dependency-free release parameter and version tooling. */
 public final class TaxonomyTooling {
 
     private TaxonomyTooling() {
     }
 
     public static void main(String[] arguments) {
-        int exitCode = run(arguments, Path.of("."), System.out, System.err);
+        int exitCode = run(
+                arguments,
+                System.getenv(),
+                Path.of("."),
+                System.out,
+                System.err);
         if (exitCode != 0) {
             System.exit(exitCode);
         }
     }
 
-    static int run(
+    public static int run(
             String[] arguments,
+            Map<String, String> environment,
             Path workingDirectory,
             PrintStream output,
             PrintStream error) {
@@ -34,8 +40,11 @@ public final class TaxonomyTooling {
         String[] commandArguments = java.util.Arrays.copyOfRange(
                 arguments, 1, arguments.length);
         return switch (command) {
+            case "resolve-release-parameters" -> resolveReleaseParameters(
+                    commandArguments, environment, workingDirectory, error);
             case "check-version-state" -> checkVersionState(
                     commandArguments, workingDirectory, output, error);
+            case "compare-versions" -> compareVersions(commandArguments, error);
             case "read-pom-version" -> readPomVersion(
                     commandArguments, workingDirectory, output, error);
             default -> {
@@ -43,6 +52,23 @@ public final class TaxonomyTooling {
                 yield 2;
             }
         };
+    }
+
+    private static int resolveReleaseParameters(
+            String[] rawArguments,
+            Map<String, String> environment,
+            Path workingDirectory,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            ReleaseParametersResolver.resolveFromEnvironment(root, environment);
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("::error::" + failure.getMessage());
+            return 1;
+        }
     }
 
     private static int checkVersionState(
@@ -72,6 +98,25 @@ public final class TaxonomyTooling {
             return 0;
         } catch (IOException | IllegalArgumentException failure) {
             error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int compareVersions(
+            String[] rawArguments,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            String release = VersionNumbers.normalizeRelease(
+                    arguments.required("release-version"), "release_version");
+            String next = VersionNumbers.normalizeDevelopment(
+                    arguments.required("next-development-version"),
+                    "next_development_version",
+                    false);
+            VersionNumbers.requireNewer(release, next);
+            return 0;
+        } catch (IllegalArgumentException failure) {
+            error.println("::error::" + failure.getMessage());
             return 1;
         }
     }

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -93,7 +93,9 @@ public final class TaxonomyTooling {
                 }
             } else {
                 version = XmlSupport.rootProjectVersion(
-                        arguments.path("file", workingDirectory));
+                        arguments.path(
+                                "file",
+                                workingDirectory.resolve("pom.xml")));
             }
             output.println(version);
             return 0;

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionNumbers.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionNumbers.java
@@ -1,0 +1,100 @@
+package com.taxonomy.tooling;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+final class VersionNumbers {
+
+    static final Pattern RELEASE = Pattern.compile("^[0-9]+\\.[0-9]+\\.[0-9]+$");
+    static final Pattern DEVELOPMENT = Pattern.compile(
+            "^[0-9]+\\.[0-9]+\\.[0-9]+-SNAPSHOT$");
+
+    private VersionNumbers() {
+    }
+
+    static String normalizeRelease(Object value, String field) {
+        return normalize(value, field, false, RELEASE, "X.Y.Z");
+    }
+
+    static String normalizeDevelopment(
+            Object value,
+            String field,
+            boolean optional) {
+        return normalize(value, field, optional, DEVELOPMENT, "X.Y.Z-SNAPSHOT");
+    }
+
+    private static String normalize(
+            Object value,
+            String field,
+            boolean optional,
+            Pattern pattern,
+            String expected) {
+        if (value == null && optional) {
+            return "";
+        }
+        if (!(value instanceof String text)) {
+            throw new IllegalArgumentException(field + " must be a string");
+        }
+        String normalized = text.strip();
+        if (optional && normalized.isEmpty()) {
+            return "";
+        }
+        if (normalized.startsWith("${")) {
+            throw new IllegalArgumentException(
+                    field + " was not supplied. Pass -D" + field
+                            + " with an explicit version.");
+        }
+        if (!pattern.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    field + " must use " + expected + ", got '" + normalized + "'");
+        }
+        return normalized;
+    }
+
+    static SemanticVersion semantic(String version) {
+        Objects.requireNonNull(version, "version");
+        String normalized = version.endsWith("-SNAPSHOT")
+                ? version.substring(0, version.length() - "-SNAPSHOT".length())
+                : version;
+        String[] components = normalized.split("\\.", -1);
+        if (components.length != 3) {
+            throw new IllegalArgumentException("Invalid semantic version: " + version);
+        }
+        try {
+            return new SemanticVersion(
+                    Integer.parseInt(components[0]),
+                    Integer.parseInt(components[1]),
+                    Integer.parseInt(components[2]));
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(
+                    "Invalid semantic version: " + version, error);
+        }
+    }
+
+    static void requireNewer(String releaseVersion, String nextVersion) {
+        if (nextVersion == null || nextVersion.isBlank()) {
+            return;
+        }
+        if (semantic(nextVersion).compareTo(semantic(releaseVersion)) <= 0) {
+            throw new IllegalArgumentException(
+                    "next development version " + nextVersion
+                            + " must be newer than release " + releaseVersion);
+        }
+    }
+
+    record SemanticVersion(int major, int minor, int patch)
+            implements Comparable<SemanticVersion> {
+        @Override
+        public int compareTo(SemanticVersion other) {
+            int majorOrder = Integer.compare(major, other.major);
+            if (majorOrder != 0) {
+                return majorOrder;
+            }
+            int minorOrder = Integer.compare(minor, other.minor);
+            if (minorOrder != 0) {
+                return minorOrder;
+            }
+            return Integer.compare(patch, other.patch);
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
@@ -1,0 +1,225 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/** Verifies Maven, citation, archive and Helm metadata as one version state. */
+public final class VersionStateVerifier {
+
+    private static final Pattern CFF_VERSION = Pattern.compile(
+            "(?m)^version: \\\"([^\\\"]+)\\\"$");
+    private static final Pattern CFF_DATE = Pattern.compile(
+            "(?m)^date-released: ");
+    private static final Pattern CITATION_PREFERRED = Pattern.compile(
+            "Taxonomy Architecture Analyzer\\*\\*\\. Version ([0-9A-Za-z.-]+)\\.");
+    private static final Pattern CITATION_BIBTEX = Pattern.compile(
+            "(?m)^\\s*version\\s+= \\{([^}]+)},$");
+    private static final Pattern CITATION_DATE = Pattern.compile(
+            "(?m)^\\s*date\\s+= \\{[^}]+},$");
+    private static final Pattern CHART_VERSION = Pattern.compile(
+            "(?m)^appVersion:\\s*[\\\"']?([^\\\"'\\s]+)[\\\"']?\\s*$");
+
+    private VersionStateVerifier() {
+    }
+
+    public static Verification verify(
+            Path root,
+            String mode,
+            String expectedVersion,
+            String tag) throws IOException {
+        Path repository = root.toAbsolutePath().normalize();
+        String actual = XmlSupport.rootProjectVersion(repository.resolve("pom.xml"));
+        String expected = expectedVersion == null || expectedVersion.isBlank()
+                ? actual
+                : expectedVersion.strip();
+        List<String> failures = new ArrayList<>();
+
+        if (!actual.equals(expected)) {
+            failures.add("Root Maven version '" + actual
+                    + "' != expected '" + expected + "'");
+        }
+        boolean releaseMode;
+        if ("release".equals(mode)) {
+            releaseMode = true;
+            if (!VersionNumbers.RELEASE.matcher(actual).matches()) {
+                failures.add("Version '" + actual
+                        + "' is not a valid release version");
+            }
+        } else if ("development".equals(mode)) {
+            releaseMode = false;
+            if (!VersionNumbers.DEVELOPMENT.matcher(actual).matches()) {
+                failures.add("Version '" + actual
+                        + "' is not a valid development version");
+            }
+        } else {
+            throw new IllegalArgumentException(
+                    "mode must be development or release");
+        }
+
+        if (tag != null && !tag.isBlank()) {
+            String expectedTag = "v" + actual;
+            if (!releaseMode) {
+                failures.add("A release tag is only valid in release mode");
+            } else if (!tag.equals(expectedTag)) {
+                failures.add("Tag '" + tag + "' != expected '" + expectedTag + "'");
+            }
+        }
+
+        failures.addAll(pomFailures(repository, actual));
+        failures.addAll(metadataFailures(repository, actual, releaseMode));
+        return new Verification(actual, mode, List.copyOf(failures));
+    }
+
+    private static List<String> pomFailures(Path root, String expected)
+            throws IOException {
+        List<String> failures = new ArrayList<>();
+        List<Path> poms;
+        try (Stream<Path> paths = Files.walk(root)) {
+            poms = paths.filter(Files::isRegularFile)
+                    .filter(path -> "pom.xml".equals(path.getFileName().toString()))
+                    .filter(path -> !contains(path, "target"))
+                    .filter(path -> !contains(path, ".git"))
+                    .sorted(Comparator.comparing(Path::toString))
+                    .toList();
+        }
+        for (Path pom : poms) {
+            Element project = XmlSupport.parse(pom).getDocumentElement();
+            Element parent = XmlSupport.child(project, "parent");
+            String parentGroup = XmlSupport.childText(parent, "groupId");
+            String parentArtifact = XmlSupport.childText(parent, "artifactId");
+            String parentVersion = XmlSupport.childText(parent, "version");
+            if ("com.taxonomy".equals(parentGroup)
+                    && "taxonomy".equals(parentArtifact)
+                    && !expected.equals(parentVersion)) {
+                failures.add(relative(root, pom) + " parent version '"
+                        + emptyToNull(parentVersion) + "' != '" + expected + "'");
+            }
+            String group = XmlSupport.childText(project, "groupId");
+            if (group.isBlank()) {
+                group = parentGroup;
+            }
+            String projectVersion = XmlSupport.childText(project, "version");
+            if ("com.taxonomy".equals(group)
+                    && !projectVersion.isBlank()
+                    && !expected.equals(projectVersion)) {
+                failures.add(relative(root, pom) + " project version '"
+                        + projectVersion + "' != '" + expected + "'");
+            }
+        }
+        return failures;
+    }
+
+    private static List<String> metadataFailures(
+            Path root,
+            String expected,
+            boolean releaseMode) throws IOException {
+        List<String> failures = new ArrayList<>();
+
+        String citation = read(root.resolve("CITATION.cff"));
+        Matcher cffVersion = CFF_VERSION.matcher(citation);
+        if (!cffVersion.find() || !expected.equals(cffVersion.group(1))) {
+            failures.add("CITATION.cff version does not match the Maven version");
+        }
+        if (CFF_DATE.matcher(citation).find() != releaseMode) {
+            failures.add(
+                    "CITATION.cff release-date state does not match the requested mode");
+        }
+
+        String citationMarkdown = read(root.resolve("CITATION.md"));
+        Matcher preferred = CITATION_PREFERRED.matcher(citationMarkdown);
+        Matcher bibtex = CITATION_BIBTEX.matcher(citationMarkdown);
+        if (!preferred.find() || !expected.equals(preferred.group(1))) {
+            failures.add("CITATION.md preferred citation version does not match");
+        }
+        if (!bibtex.find() || !expected.equals(bibtex.group(1))) {
+            failures.add("CITATION.md BibTeX version does not match");
+        }
+        if (CITATION_DATE.matcher(citationMarkdown).find() != releaseMode) {
+            failures.add(
+                    "CITATION.md release-date state does not match the requested mode");
+        }
+
+        checkJsonMetadata(
+                root.resolve(".zenodo.json"),
+                "version",
+                "publication_date",
+                expected,
+                releaseMode,
+                failures);
+        checkJsonMetadata(
+                root.resolve("codemeta.json"),
+                "version",
+                "datePublished",
+                expected,
+                releaseMode,
+                failures);
+
+        Path chart = root.resolve("deploy/helm/taxonomy/Chart.yaml");
+        if (Files.isRegularFile(chart)) {
+            Matcher chartVersion = CHART_VERSION.matcher(read(chart));
+            if (!chartVersion.find() || !expected.equals(chartVersion.group(1))) {
+                failures.add(
+                        "Helm Chart.yaml appVersion does not match the Maven version");
+            }
+        }
+        return failures;
+    }
+
+    private static void checkJsonMetadata(
+            Path path,
+            String versionKey,
+            String dateKey,
+            String expected,
+            boolean releaseMode,
+            List<String> failures) throws IOException {
+        Map<String, Object> data = FlatJson.parseObject(read(path));
+        if (!expected.equals(data.get(versionKey))) {
+            failures.add(path.getFileName() + " version does not match");
+        }
+        if (data.containsKey(dateKey) != releaseMode) {
+            failures.add(path.getFileName()
+                    + " release-date state does not match the requested mode");
+        }
+    }
+
+    private static boolean contains(Path path, String name) {
+        for (Path component : path) {
+            if (name.equals(component.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static String relative(Path root, Path path) {
+        return root.relativize(path).toString().replace('\\', '/');
+    }
+
+    private static String emptyToNull(String value) {
+        return value.isBlank() ? "null" : value;
+    }
+
+    public record Verification(
+            String version,
+            String mode,
+            List<String> failures) {
+        public boolean successful() {
+            return failures.isEmpty();
+        }
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/VersionStateVerifier.java
@@ -4,15 +4,17 @@ import org.w3c.dom.Element;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /** Verifies Maven, citation, archive and Helm metadata as one version state. */
 public final class VersionStateVerifier {
@@ -84,15 +86,31 @@ public final class VersionStateVerifier {
     private static List<String> pomFailures(Path root, String expected)
             throws IOException {
         List<String> failures = new ArrayList<>();
-        List<Path> poms;
-        try (Stream<Path> paths = Files.walk(root)) {
-            poms = paths.filter(Files::isRegularFile)
-                    .filter(path -> "pom.xml".equals(path.getFileName().toString()))
-                    .filter(path -> !contains(path, "target"))
-                    .filter(path -> !contains(path, ".git"))
-                    .sorted(Comparator.comparing(Path::toString))
-                    .toList();
-        }
+        List<Path> poms = new ArrayList<>();
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(
+                    Path directory,
+                    BasicFileAttributes attributes) {
+                if (!directory.equals(root) && ignoredDirectory(directory)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(
+                    Path file,
+                    BasicFileAttributes attributes) {
+                if (attributes.isRegularFile()
+                        && "pom.xml".equals(file.getFileName().toString())) {
+                    poms.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        poms.sort(Comparator.comparing(Path::toString));
+
         for (Path pom : poms) {
             Element project = XmlSupport.parse(pom).getDocumentElement();
             Element parent = XmlSupport.child(project, "parent");
@@ -193,13 +211,13 @@ public final class VersionStateVerifier {
         }
     }
 
-    private static boolean contains(Path path, String name) {
-        for (Path component : path) {
-            if (name.equals(component.toString())) {
-                return true;
-            }
+    private static boolean ignoredDirectory(Path directory) {
+        Path fileName = directory.getFileName();
+        if (fileName == null) {
+            return false;
         }
-        return false;
+        String name = fileName.toString();
+        return ".git".equals(name) || "target".equals(name);
     }
 
     private static String read(Path path) throws IOException {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/XmlSupport.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/XmlSupport.java
@@ -1,0 +1,127 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+final class XmlSupport {
+
+    static final String MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0";
+
+    private XmlSupport() {
+    }
+
+    static Document parse(Path path) throws IOException {
+        try (InputStream input = Files.newInputStream(path)) {
+            return parse(input);
+        }
+    }
+
+    static Document parse(InputStream input) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            return factory.newDocumentBuilder().parse(input);
+        } catch (ParserConfigurationException | SAXException error) {
+            throw new IOException("Cannot parse XML: " + error.getMessage(), error);
+        }
+    }
+
+    static String childText(Element parent, String localName) {
+        if (parent == null) {
+            return "";
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                return text(element);
+            }
+        }
+        return "";
+    }
+
+    static Element child(Element parent, String localName) {
+        if (parent == null) {
+            return null;
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    static List<Element> children(Element parent, String localName) {
+        List<Element> result = new ArrayList<>();
+        if (parent == null) {
+            return result;
+        }
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element
+                    && localName.equals(element.getLocalName())) {
+                result.add(element);
+            }
+        }
+        return result;
+    }
+
+    static List<Element> descendants(Element parent, String localName) {
+        List<Element> result = new ArrayList<>();
+        collect(parent, localName, result);
+        return result;
+    }
+
+    private static void collect(
+            Element parent,
+            String localName,
+            List<Element> result) {
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element) {
+                if (localName.equals(element.getLocalName())) {
+                    result.add(element);
+                }
+                collect(element, localName, result);
+            }
+        }
+    }
+
+    static String text(Element element) {
+        return element == null ? "" : element.getTextContent().strip();
+    }
+
+    static String rootProjectVersion(Path pom) throws IOException {
+        Element project = parse(pom).getDocumentElement();
+        String version = childText(project, "version");
+        if (version.isBlank()) {
+            throw new IllegalArgumentException("root pom.xml has no project version");
+        }
+        return version;
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/GitSupportTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/GitSupportTest.java
@@ -1,0 +1,32 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+class GitSupportTest {
+
+    @Test
+    void drainsLargeStandardOutputAndErrorStreamsConcurrently(
+            @TempDir Path root) throws Exception {
+        TestGit.run(root, "init", "-q");
+        String noisyAlias = "alias.noisy=!f() { i=0; "
+                + "while [ \"$i\" -lt 20000 ]; do "
+                + "printf \"stdout-%s\\n\" \"$i\"; "
+                + "printf \"stderr-%s\\n\" \"$i\" >&2; "
+                + "i=$((i+1)); done; }; f";
+
+        GitSupport.Result result = assertTimeoutPreemptively(
+                Duration.ofSeconds(15),
+                () -> GitSupport.run(root, "-c", noisyAlias, "noisy"));
+
+        assertThat(result.exitCode()).isZero();
+        assertThat(result.stdout()).contains("stdout-19999");
+        assertThat(result.stderr()).contains("stderr-19999");
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParameterAncestryContractTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParameterAncestryContractTest.java
@@ -1,0 +1,87 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseParameterAncestryContractTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void rejectsAnAlreadyAdvancedDevelopmentTreeWhoseReleaseTagDiverged()
+            throws Exception {
+        Path repository = createReleaseRepository(false);
+        var parameters = new ReleaseParametersResolver.Parameters(
+                "1.3.1", "1.3.2-SNAPSHOT", "false", "false", "false");
+
+        assertThatThrownBy(() -> ReleaseParametersResolver
+                .validateStagedReleaseAncestry(
+                        repository, parameters, "1.3.2-SNAPSHOT"))
+                .hasMessageContaining("staged release tag v1.3.1 is not an ancestor")
+                .hasMessageContaining("repair release ancestry before publication");
+    }
+
+    @Test
+    void acceptsTheSameDevelopmentTreeAfterAHistoryOnlyAncestryMerge()
+            throws Exception {
+        Path repository = createReleaseRepository(true);
+        var parameters = new ReleaseParametersResolver.Parameters(
+                "1.3.1", "1.3.2-SNAPSHOT", "false", "false", "false");
+
+        ReleaseParametersResolver.validateStagedReleaseAncestry(
+                repository, parameters, "1.3.2-SNAPSHOT");
+    }
+
+    private Path createReleaseRepository(boolean repairAncestry)
+            throws Exception {
+        Path repository = temporaryDirectory.resolve("repository");
+        Files.createDirectories(repository);
+        TestGit.run(repository, "init");
+        TestGit.run(repository, "symbolic-ref", "HEAD", "refs/heads/main");
+        TestGit.run(repository, "config", "user.name", "Release Contract");
+        TestGit.run(repository, "config", "user.email",
+                "release-contract@taxonomy.local");
+
+        writePom(repository, "1.3.1-SNAPSHOT");
+        commitPom(repository, "Development base");
+        TestGit.run(repository, "checkout", "-b", "release/1.3.1");
+        writePom(repository, "1.3.1");
+        commitPom(repository, "Release version 1.3.1");
+        TestGit.run(repository, "tag", "v1.3.1");
+
+        TestGit.run(repository, "checkout", "main");
+        writePom(repository, "1.3.2-SNAPSHOT");
+        commitPom(repository, "Prepare next development version 1.3.2-SNAPSHOT");
+        if (repairAncestry) {
+            TestGit.run(repository, "merge", "-s", "ours", "--no-ff",
+                    "release/1.3.1", "-m", "Repair v1.3.1 ancestry");
+        }
+        return repository;
+    }
+
+    private static void writePom(Path repository, String version)
+            throws Exception {
+        Files.writeString(repository.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>release-contract</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version), StandardCharsets.UTF_8);
+    }
+
+    private static void commitPom(Path repository, String message)
+            throws Exception {
+        TestGit.run(repository, "add", "pom.xml");
+        TestGit.run(repository, "commit", "-m", message);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParametersResolverTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParametersResolverTest.java
@@ -181,6 +181,37 @@ class ReleaseParametersResolverTest {
     }
 
     @Test
+    void cliRejectsEscapingRequestPathBeforeReadingOutsideContent(
+            @TempDir Path temporaryDirectory) throws Exception {
+        Path root = temporaryDirectory.resolve("repository");
+        Files.createDirectories(root);
+        writePom(root, "1.2.9-SNAPSHOT");
+        Path outside = temporaryDirectory.resolve("outside.json");
+        Files.writeString(
+                outside,
+                "deliberately not JSON",
+                StandardCharsets.UTF_8);
+        Path output = root.resolve("github-output");
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"resolve-release-parameters"},
+                Map.of(
+                        "EVENT_NAME", "push",
+                        "RELEASE_REQUEST_PATH", "../outside.json",
+                        "GITHUB_OUTPUT", output.toString()),
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(errors));
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errors.toString(StandardCharsets.UTF_8))
+                .contains("release request path must stay inside the repository")
+                .doesNotContain("JSON character");
+        assertThat(output).doesNotExist();
+    }
+
+    @Test
     void cliReportsMissingRequiredEnvironment(@TempDir Path root) {
         ByteArrayOutputStream errors = new ByteArrayOutputStream();
         int exitCode = TaxonomyTooling.run(

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParametersResolverTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseParametersResolverTest.java
@@ -1,0 +1,219 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseParametersResolverTest {
+
+    @Test
+    void dispatchPreservesAnExactMajorTransition() {
+        var parameters = ReleaseParametersResolver.resolve(
+                "workflow_dispatch",
+                Map.of(
+                        "INPUT_NEXT_VERSION_INCREMENT", "patch",
+                        "INPUT_NEXT_DEVELOPMENT_VERSION", " 2.0.0-SNAPSHOT ",
+                        "INPUT_SKIP_TESTS", "false",
+                        "INPUT_DRY_RUN", "false"),
+                null,
+                "1.2.9-SNAPSHOT");
+
+        assertThat(parameters.outputs()).containsExactly(
+                Map.entry("release_version", "1.2.9"),
+                Map.entry("next_development_version", "2.0.0-SNAPSHOT"),
+                Map.entry("skip_tests", "false"),
+                Map.entry("dry_run", "false"),
+                Map.entry("resume_staged_release", "false"));
+    }
+
+    @Test
+    void dispatchDerivesPatchMinorAndMajorVersions() {
+        assertThat(dispatch("patch").nextDevelopmentVersion())
+                .isEqualTo("1.2.10-SNAPSHOT");
+        assertThat(dispatch("minor").nextDevelopmentVersion())
+                .isEqualTo("1.3.0-SNAPSHOT");
+        assertThat(dispatch("major").nextDevelopmentVersion())
+                .isEqualTo("2.0.0-SNAPSHOT");
+    }
+
+    @Test
+    void exactNextVersionMakesTheIncrementIrrelevant() {
+        var parameters = ReleaseParametersResolver.resolve(
+                "workflow_dispatch",
+                Map.of(
+                        "INPUT_NEXT_VERSION_INCREMENT", "not-used",
+                        "INPUT_NEXT_DEVELOPMENT_VERSION", "3.7.4-SNAPSHOT"),
+                null,
+                "1.2.9-SNAPSHOT");
+
+        assertThat(parameters.nextDevelopmentVersion())
+                .isEqualTo("3.7.4-SNAPSHOT");
+    }
+
+    @Test
+    void pushPreservesReviewedResumeParameters() {
+        var parameters = ReleaseParametersResolver.resolve(
+                "push",
+                Map.of(),
+                Map.of(
+                        "release_version", "1.2.9 ",
+                        "next_development_version", " 1.3.0-SNAPSHOT",
+                        "skip_tests", false,
+                        "dry_run", false,
+                        "resume_staged_release", true),
+                null);
+
+        assertThat(parameters.releaseVersion()).isEqualTo("1.2.9");
+        assertThat(parameters.nextDevelopmentVersion())
+                .isEqualTo("1.3.0-SNAPSHOT");
+        assertThat(parameters.resumeStagedRelease()).isTrue();
+    }
+
+    @Test
+    void normalPushMayLeaveTheNextVersionEmpty() {
+        var parameters = ReleaseParametersResolver.resolve(
+                "push",
+                Map.of(),
+                Map.of(
+                        "release_version", "1.3.0",
+                        "skip_tests", false,
+                        "dry_run", false),
+                null);
+
+        assertThat(parameters.nextDevelopmentVersion()).isEmpty();
+    }
+
+    @Test
+    void resumeRequiresANextVersionAndCannotBeADryRun() {
+        assertThatThrownBy(() -> ReleaseParametersResolver.resolve(
+                "push",
+                Map.of(),
+                Map.of(
+                        "release_version", "1.2.9",
+                        "next_development_version", "",
+                        "resume_staged_release", true),
+                null))
+                .hasMessageContaining("next_development_version is required");
+
+        assertThatThrownBy(() -> ReleaseParametersResolver.resolve(
+                "push",
+                Map.of(),
+                Map.of(
+                        "release_version", "1.2.9",
+                        "next_development_version", "1.3.0-SNAPSHOT",
+                        "dry_run", true,
+                        "resume_staged_release", true),
+                null))
+                .hasMessageContaining("cannot be combined with dry_run");
+    }
+
+    @Test
+    void invalidIncrementAndRepositoryVersionFailClosed() {
+        assertThatThrownBy(() -> dispatch("custom"))
+                .hasMessageContaining("patch, minor or major");
+        assertThatThrownBy(() -> ReleaseParametersResolver.resolve(
+                "workflow_dispatch",
+                Map.of("INPUT_NEXT_VERSION_INCREMENT", "patch"),
+                null,
+                "1.2.9"))
+                .hasMessageContaining("must use X.Y.Z-SNAPSHOT");
+    }
+
+    @Test
+    void nonAdvancingVersionsGiveTriggerSpecificGuidance() {
+        assertThatThrownBy(() -> ReleaseParametersResolver.resolve(
+                "workflow_dispatch",
+                Map.of("INPUT_NEXT_DEVELOPMENT_VERSION", "1.3.0-SNAPSHOT"),
+                null,
+                "1.3.0-SNAPSHOT"))
+                .hasMessageContaining(
+                        "current project version 1.3.0-SNAPSHOT means this run releases 1.3.0")
+                .hasMessageContaining("patch, minor or major");
+
+        assertThatThrownBy(() -> ReleaseParametersResolver.resolve(
+                "push",
+                Map.of(),
+                Map.of(
+                        "release_version", "1.2.9",
+                        "next_development_version", "1.2.9-SNAPSHOT"),
+                null))
+                .hasMessageContaining("release request publishes 1.2.9")
+                .hasMessageContaining("must be newer");
+    }
+
+    @Test
+    void cliWritesStableGitHubOutputOrder(@TempDir Path root) throws Exception {
+        writePom(root, "1.2.9-SNAPSHOT");
+        Path output = root.resolve("github-output");
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"resolve-release-parameters"},
+                Map.of(
+                        "EVENT_NAME", "workflow_dispatch",
+                        "INPUT_NEXT_VERSION_INCREMENT", "patch",
+                        "INPUT_NEXT_DEVELOPMENT_VERSION", "2.0.0-SNAPSHOT",
+                        "INPUT_SKIP_TESTS", "false",
+                        "INPUT_DRY_RUN", "false",
+                        "GITHUB_OUTPUT", output.toString()),
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(errors));
+
+        assertThat(exitCode).as(errors.toString(StandardCharsets.UTF_8)).isZero();
+        assertThat(Files.readAllLines(output, StandardCharsets.UTF_8))
+                .containsExactly(
+                        "release_version=1.2.9",
+                        "next_development_version=2.0.0-SNAPSHOT",
+                        "skip_tests=false",
+                        "dry_run=false",
+                        "resume_staged_release=false");
+    }
+
+    @Test
+    void cliReportsMissingRequiredEnvironment(@TempDir Path root) {
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"resolve-release-parameters"},
+                Map.of("GITHUB_OUTPUT", root.resolve("output").toString()),
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(errors));
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errors.toString(StandardCharsets.UTF_8))
+                .contains("::error::EVENT_NAME environment variable is required");
+    }
+
+    private static ReleaseParametersResolver.Parameters dispatch(String increment) {
+        return ReleaseParametersResolver.resolve(
+                "workflow_dispatch",
+                Map.of(
+                        "INPUT_NEXT_VERSION_INCREMENT", increment,
+                        "INPUT_NEXT_DEVELOPMENT_VERSION", ""),
+                null,
+                "1.2.9-SNAPSHOT");
+    }
+
+    private static void writePom(Path root, String version) throws Exception {
+        Files.writeString(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version), StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanCoordinatePropertyTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanCoordinatePropertyTest.java
@@ -1,0 +1,99 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanCoordinatePropertyTest {
+
+    @Test
+    void resolvesInternalDependencyCoordinatesFromMavenProperties(
+            @TempDir Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <internal.module>module-a</internal.module>
+                  </properties>
+                  <modules><module>module-a</module></modules>
+                  <dependencies>
+                    <dependency>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>${internal.module}</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """);
+        write(root.resolve("module-a/pom.xml"), modulePom());
+
+        ReleasePlanValidator.Result result = validate(root);
+
+        assertThat(result.pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void reportsUnresolvedCoordinatePropertiesBeforeSnapshotClassification(
+            @TempDir Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>${missing.group}</groupId>
+                      <artifactId>external</artifactId>
+                      <version>9.0.0-SNAPSHOT</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """);
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unresolved coordinate property")
+                .hasMessageContaining("${missing.group}:external");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static String modulePom() {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>1.3.0-SNAPSHOT</version>
+                  </parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
@@ -33,5 +33,10 @@ class ReleasePlanStateNormalizationTest {
 
         assertThat(result.state()).isEqualTo("development");
         assertThat(result.pomCount()).isEqualTo(1);
+        assertThat(ReleasePlanValidator.expectedCurrentVersion(
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "\t release "))
+                .isEqualTo("1.3.0");
     }
 }

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
@@ -1,0 +1,37 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReleasePlanStateNormalizationTest {
+
+    @Test
+    void trimsLifecycleStateBeforeValidation(@TempDir Path root)
+            throws Exception {
+        Files.writeString(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>fixture</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+
+        ReleasePlanValidator.Result result = ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "  development\n",
+                false);
+
+        assertThat(result.state()).isEqualTo("development");
+        assertThat(result.pomCount()).isEqualTo(1);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
@@ -24,13 +24,27 @@ class ReleasePlanTraversalSecurityTest {
         try {
             Files.createSymbolicLink(root.resolve("linked-module"), outside);
         } catch (UnsupportedOperationException | IOException failure) {
-            Assumptions.abort("Symbolic links are unavailable: " + failure);
+            Assumptions.assumeTrue(
+                    false,
+                    () -> "Symbolic links are unavailable: " + failure);
+            return;
         }
 
         assertThatThrownBy(() -> validate(root))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("symbolic link")
                 .hasMessageContaining("linked-module");
+    }
+
+    @Test
+    void rejectsAbsoluteModulePathWithAnActionableDiagnostic(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, root.getRoot().toString());
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outside the repository")
+                .doesNotHaveCauseInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
@@ -1,0 +1,100 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanTraversalSecurityTest {
+
+    @Test
+    void rejectsDeclaredModuleThatEscapesThroughASymbolicLink(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, "linked-module");
+        Path outside = root.resolveSibling(
+                root.getFileName() + "-outside-module");
+        writeModulePom(outside);
+        try {
+            Files.createSymbolicLink(root.resolve("linked-module"), outside);
+        } catch (UnsupportedOperationException | IOException failure) {
+            Assumptions.abort("Symbolic links are unavailable: " + failure);
+        }
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symbolic link")
+                .hasMessageContaining("linked-module");
+    }
+
+    @Test
+    void prunesGitAndGeneratedTreesWhenLookingForReleaseBackups(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, null);
+        write(root.resolve(".git/objects/pom.xml.releaseBackup"), "ignored");
+        write(root.resolve("target/generated/pom.xml.releaseBackup"), "ignored");
+
+        assertThat(validate(root).pomCount()).isEqualTo(1);
+
+        write(root.resolve("src/pom.xml.releaseBackup"), "stale");
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("src/pom.xml.releaseBackup")
+                .hasMessageContaining("stale Maven Release Plugin backup");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static void writeRootPom(Path root, String module)
+            throws Exception {
+        String modules = module == null
+                ? ""
+                : "<modules><module>" + module + "</module></modules>";
+        write(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  %s
+                </project>
+                """.formatted(modules));
+    }
+
+    private static void writeModulePom(Path module) throws Exception {
+        write(module.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>1.3.0-SNAPSHOT</version>
+                  </parent>
+                  <artifactId>linked-module</artifactId>
+                </project>
+                """);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
@@ -1,0 +1,384 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanValidatorTest {
+
+    @Test
+    void developmentPlanAllowsTheInternalSnapshotReactor(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+
+        var result = validate(root);
+
+        assertThat(result.pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void discoversNestedDeclaredModulesAndInheritedProperties(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Path aggregator = root.resolve("module-a/pom.xml");
+        Files.writeString(aggregator,
+                Files.readString(aggregator).replace(
+                        "</project>",
+                        "<properties><nested.external.version>9.0.0"
+                                + "</nested.external.version></properties>"
+                                + "<modules><module>nested</module></modules></project>"),
+                StandardCharsets.UTF_8);
+        writeModule(
+                root,
+                "module-a/nested",
+                "com.taxonomy",
+                "module-a",
+                "1.3.0-SNAPSHOT",
+                "nested",
+                "",
+                "",
+                """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>nested-stable</artifactId>
+                          <version>${nested.external.version}</version>
+                        </dependency>
+                        """,
+                "");
+
+        assertThat(validate(root).pomCount()).isEqualTo(3);
+    }
+
+    @Test
+    void rejectsNestedExternalSnapshotAndUnresolvedProperty(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Path aggregator = root.resolve("module-a/pom.xml");
+        Files.writeString(aggregator,
+                Files.readString(aggregator).replace(
+                        "</project>",
+                        "<properties><nested.external.version>9.0.0-SNAPSHOT"
+                                + "</nested.external.version></properties>"
+                                + "<modules><module>nested</module></modules></project>"),
+                StandardCharsets.UTF_8);
+        writeModule(
+                root,
+                "module-a/nested",
+                "com.taxonomy",
+                "module-a",
+                "1.3.0-SNAPSHOT",
+                "nested",
+                "",
+                "",
+                """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>nested-unstable</artifactId>
+                          <version>${nested.external.version}</version>
+                        </dependency>
+                        """,
+                "");
+
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external dependency example:nested-unstable");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"),
+                "", """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>unknown</artifactId>
+                          <version>${missing.version}</version>
+                        </dependency>
+                        """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("unresolved version property");
+    }
+
+    @Test
+    void rejectsDuplicateCoordinatesAndMissingOrEscapingModules(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("module-a", "module-b"), "", "");
+        writeModule(root, "module-b", "com.taxonomy", "taxonomy",
+                "1.3.0-SNAPSHOT", "module-a", "", "", "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("duplicate Maven reactor coordinate");
+
+        Path missing = root.resolve("missing-case");
+        Files.createDirectories(missing);
+        writeProject(missing, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("missing"), "", "");
+        Files.delete(missing.resolve("missing/pom.xml"));
+        assertThatThrownBy(() -> validate(missing))
+                .hasMessageContaining("does not exist");
+
+        Path escaped = root.resolve("escaped-case");
+        Files.createDirectories(escaped);
+        writeProject(escaped, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("../outside"), "", "");
+        Files.createDirectories(root.resolve("outside"));
+        Files.writeString(root.resolve("outside/pom.xml"), "<project/>");
+        assertThatThrownBy(() -> validate(escaped))
+                .hasMessageContaining("outside the repository");
+    }
+
+    @Test
+    void ignoresUnrelatedPomOutsideTheDeclaredReactor(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Files.createDirectories(root.resolve("examples"));
+        Files.writeString(root.resolve("examples/pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>unrelated</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </project>
+                """);
+
+        assertThat(validate(root).pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void supportsMajorAdvanceAndReleaseAndAdvancedStates(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "2.0.0-SNAPSHOT",
+                "development",
+                false).nextDevelopmentVersion()).isEqualTo("2.0.0-SNAPSHOT");
+
+        writeProject(root, "1.3.0", "1.0.0", List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.0", "1.3.0", "1.3.1-SNAPSHOT",
+                "release", false).state()).isEqualTo("release");
+
+        writeProject(root, "1.3.1-SNAPSHOT", "1.0.0",
+                List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.1-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "advanced", false).state()).isEqualTo("advanced");
+    }
+
+    @Test
+    void rejectsNonAdvancingVersionAndReactorVersionMismatch(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.0-SNAPSHOT",
+                "development", false))
+                .hasMessageContaining("must be newer");
+
+        writeModule(root, "module-a", "com.taxonomy", "taxonomy",
+                "1.3.0-SNAPSHOT", "module-a", "org.other",
+                "1.2.9-SNAPSHOT", "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("reactor version");
+    }
+
+    @Test
+    void rejectsExternalSnapshotParentDependencyPluginAndExtension(
+            @TempDir Path root) throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "9.0.0-SNAPSHOT",
+                List.of("module-a"), "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external parent org.example:external-parent");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"),
+                "<external.version>9.0.0-SNAPSHOT</external.version>",
+                """
+                        <dependency><groupId>example</groupId>
+                          <artifactId>unstable</artifactId>
+                          <version>${external.version}</version></dependency>
+                        """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external dependency example:unstable");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><plugins><plugin><groupId>example</groupId>
+                  <artifactId>unstable-plugin</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </plugin></plugins></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external plugin example:unstable-plugin");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><extensions><extension><groupId>example</groupId>
+                  <artifactId>unstable-extension</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </extension></extensions></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining(
+                        "external build extension example:unstable-extension");
+    }
+
+    @Test
+    void rejectsMavenReleasePluginAndStaleState(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><plugins><plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-release-plugin</artifactId>
+                  <version>3.1.1</version>
+                </plugin></plugins></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("second SCM release authority");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Files.writeString(root.resolve("release.properties"), "stale");
+        Files.writeString(root.resolve("module-a/pom.xml.releaseBackup"), "stale");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("stale Maven Release Plugin");
+    }
+
+    @Test
+    void enforcesCleanOrdinaryAndLinkedWorktreeCheckouts(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        commitProject(root);
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true).pomCount()).isEqualTo(2);
+
+        Files.writeString(root.resolve("untracked.txt"), "dirty");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true))
+                .hasMessageContaining("clean checkout");
+
+        Files.delete(root.resolve("untracked.txt"));
+        Path worktree = root.getParent().resolve("linked-worktree");
+        TestGit.run(root, "worktree", "add", "-q", "-b", "qa-worktree",
+                worktree.toString());
+        Files.writeString(worktree.resolve("untracked.txt"), "dirty");
+        assertThat(Files.isRegularFile(worktree.resolve(".git"))).isTrue();
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                worktree, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true))
+                .hasMessageContaining("clean checkout");
+    }
+
+    @Test
+    void unresolvedReleaseArgumentIsReportedClearly(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "${releaseVersion}",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false))
+                .hasMessageContaining("was not supplied");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static void writeProject(
+            Path root,
+            String version,
+            String externalParentVersion,
+            List<String> modules,
+            String properties,
+            String dependency) throws Exception {
+        Files.createDirectories(root);
+        String moduleText = modules.stream()
+                .map(module -> "<module>" + module + "</module>")
+                .reduce("", String::concat);
+        Files.writeString(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.example</groupId>
+                    <artifactId>external-parent</artifactId>
+                    <version>%s</version><relativePath/></parent>
+                  <groupId>com.taxonomy</groupId><artifactId>taxonomy</artifactId>
+                  <version>%s</version><packaging>pom</packaging>
+                  <properties>%s</properties>
+                  <modules>%s</modules>
+                </project>
+                """.formatted(externalParentVersion, version, properties, moduleText),
+                StandardCharsets.UTF_8);
+        for (String module : modules) {
+            writeModule(root, module, "com.taxonomy", "taxonomy", version,
+                    Path.of(module).getFileName().toString(), "", "",
+                    dependency, "");
+        }
+    }
+
+    private static void writeModule(
+            Path root,
+            String path,
+            String parentGroup,
+            String parentArtifact,
+            String parentVersion,
+            String artifact,
+            String ownGroup,
+            String ownVersion,
+            String dependency,
+            String extra) throws Exception {
+        Path directory = root.resolve(path);
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>%s</groupId><artifactId>%s</artifactId>
+                    <version>%s</version></parent>
+                  %s<artifactId>%s</artifactId>%s
+                  <dependencies>
+                    <dependency><groupId>com.taxonomy</groupId>
+                      <artifactId>taxonomy</artifactId>
+                      <version>${project.version}</version></dependency>
+                    %s
+                  </dependencies>%s
+                </project>
+                """.formatted(
+                        parentGroup,
+                        parentArtifact,
+                        parentVersion,
+                        ownGroup.isBlank() ? "" : "<groupId>" + ownGroup + "</groupId>",
+                        artifact,
+                        ownVersion.isBlank() ? "" : "<version>" + ownVersion + "</version>",
+                        dependency,
+                        extra), StandardCharsets.UTF_8);
+    }
+
+    private static void appendRoot(Path root, String content) throws Exception {
+        Path pom = root.resolve("pom.xml");
+        Files.writeString(pom, Files.readString(pom).replace(
+                "</project>", content + "</project>"), StandardCharsets.UTF_8);
+    }
+
+    private static void commitProject(Path root) throws Exception {
+        TestGit.run(root, "init", "-q");
+        TestGit.run(root, "add", ".");
+        TestGit.run(root, "-c", "user.name=Release QA",
+                "-c", "user.email=qa@example.invalid",
+                "commit", "-qm", "initial");
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseRequestAnchorContractTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseRequestAnchorContractTest.java
@@ -1,0 +1,133 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseRequestAnchorContractTest {
+
+    @Test
+    void acceptsOneRevisionChangingOnlyTheRequestAfterItsExactParent(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 8, false);
+        Map<String, Object> request = ReleaseParametersResolver.readRequest(
+                root.resolve(".github/release-request.json"));
+
+        ReleaseParametersResolver.validateReleaseRequestAnchor(
+                root, root.resolve(".github/release-request.json"), request);
+    }
+
+    @Test
+    void rejectsARequestNotAnchoredToItsImmediateFirstParent(
+            @TempDir Path root) throws Exception {
+        initializeRepository(root);
+        commitRequest(root, "0".repeat(40), 8, false);
+        Map<String, Object> request = ReleaseParametersResolver.readRequest(
+                root.resolve(".github/release-request.json"));
+
+        assertThatThrownBy(() -> ReleaseParametersResolver
+                .validateReleaseRequestAnchor(
+                        root,
+                        root.resolve(".github/release-request.json"),
+                        request))
+                .hasMessageContaining("requested_after_commit must equal")
+                .hasMessageContaining("first parent");
+    }
+
+    @Test
+    void rejectsAReleaseCommitContainingAnyOtherPath(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 8, true);
+        Map<String, Object> request = ReleaseParametersResolver.readRequest(
+                root.resolve(".github/release-request.json"));
+
+        assertThatThrownBy(() -> ReleaseParametersResolver
+                .validateReleaseRequestAnchor(
+                        root,
+                        root.resolve(".github/release-request.json"),
+                        request))
+                .hasMessageContaining("release request commit must change only")
+                .hasMessageContaining("README.md");
+    }
+
+    @Test
+    void rejectsARequestRevisionThatDoesNotAdvanceExactlyOnce(
+            @TempDir Path root) throws Exception {
+        String parent = initializeRepository(root);
+        commitRequest(root, parent, 9, false);
+        Map<String, Object> request = ReleaseParametersResolver.readRequest(
+                root.resolve(".github/release-request.json"));
+
+        assertThatThrownBy(() -> ReleaseParametersResolver
+                .validateReleaseRequestAnchor(
+                        root,
+                        root.resolve(".github/release-request.json"),
+                        request))
+                .hasMessageContaining("request_revision must advance from 7 to 8")
+                .hasMessageContaining("got 9");
+    }
+
+    private static String initializeRepository(Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.4.0-SNAPSHOT</version>
+                </project>
+                """);
+        write(root.resolve(".github/release-request.json"), request(
+                "f".repeat(40), 7));
+        TestGit.run(root, "init");
+        TestGit.run(root, "branch", "-M", "main");
+        TestGit.run(root, "config", "user.name", "Release Contract Test");
+        TestGit.run(root, "config", "user.email",
+                "release-contract@example.invalid");
+        TestGit.run(root, "add", ".");
+        TestGit.run(root, "commit", "-m", "Verified release base");
+        return TestGit.run(root, "rev-parse", "HEAD").strip();
+    }
+
+    private static void commitRequest(
+            Path root,
+            String requestedAfter,
+            int revision,
+            boolean includeOtherPath) throws Exception {
+        write(root.resolve(".github/release-request.json"), request(
+                requestedAfter, revision));
+        if (includeOtherPath) {
+            write(root.resolve("README.md"), "unreviewed release content\n");
+        }
+        TestGit.run(root, "add", ".");
+        TestGit.run(root, "commit", "-m", "Request release dry run");
+    }
+
+    private static String request(String requestedAfter, int revision) {
+        return """
+                {
+                  "release_version": "1.4.0",
+                  "next_development_version": "1.4.1-SNAPSHOT",
+                  "skip_tests": false,
+                  "dry_run": true,
+                  "resume_staged_release": false,
+                  "request_revision": %d,
+                  "requested_after_commit": "%s"
+                }
+                """.formatted(revision, requestedAfter);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TaxonomyToolingTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TaxonomyToolingTest.java
@@ -1,0 +1,64 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaxonomyToolingTest {
+
+    @Test
+    void readPomVersionDefaultsToTheWorkingDirectoryPom(@TempDir Path root)
+            throws Exception {
+        Files.writeString(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>fixture</artifactId>
+                  <version>2.3.4-SNAPSHOT</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"read-pom-version"},
+                root,
+                new PrintStream(output, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(exitCode).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("2.3.4-SNAPSHOT\n");
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+
+    @Test
+    void readPomVersionStillAcceptsAnExplicitFile(@TempDir Path root)
+            throws Exception {
+        Path nested = root.resolve("nested.xml");
+        Files.writeString(nested, """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <version>9.8.7</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{"read-pom-version", "--file", nested.toString()},
+                root,
+                new PrintStream(output, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(exitCode).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8)).isEqualTo("9.8.7\n");
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TestGit.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/TestGit.java
@@ -1,0 +1,29 @@
+package com.taxonomy.tooling;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestGit {
+
+    private TestGit() {
+    }
+
+    static String run(Path root, String... arguments) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(arguments));
+        Process process = new ProcessBuilder(command)
+                .directory(root.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        assertThat(exitCode).as("%s%n%s", command, output).isZero();
+        return output;
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateTraversalTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateTraversalTest.java
@@ -1,0 +1,51 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionStateTraversalTest {
+
+    @Test
+    void prunesGitAndGeneratedTreesBeforeParsingPomFiles(@TempDir Path root)
+            throws Exception {
+        String version = "1.2.9-SNAPSHOT";
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version));
+        write(root.resolve("CITATION.cff"),
+                "version: \"" + version + "\"\n");
+        write(root.resolve("CITATION.md"),
+                "Carsten Hammer. **Taxonomy Architecture Analyzer**. Version "
+                        + version + ". 2026.\n"
+                        + "  version      = {" + version + "},\n");
+        write(root.resolve(".zenodo.json"),
+                "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("codemeta.json"),
+                "{\"version\":\"" + version + "\"}\n");
+
+        write(root.resolve("target/pom.xml"), "<deliberately-invalid");
+        write(root.resolve(".git/pom.xml"), "<deliberately-invalid");
+
+        VersionStateVerifier.Verification verification =
+                VersionStateVerifier.verify(
+                        root, "development", version, null);
+
+        assertThat(verification.failures()).isEmpty();
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateVerifierTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/VersionStateVerifierTest.java
@@ -1,0 +1,154 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionStateVerifierTest {
+
+    @Test
+    void acceptsConsistentDevelopmentAndReleaseStates(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        var development = VersionStateVerifier.verify(
+                root, "development", null, null);
+        assertThat(development.successful()).isTrue();
+
+        writeRepository(root, "1.2.9", true);
+        var release = VersionStateVerifier.verify(
+                root, "release", "1.2.9", "v1.2.9");
+        assertThat(release.successful()).isTrue();
+    }
+
+    @Test
+    void rejectsSnapshotReleaseAndReleaseTagInDevelopmentMode(
+            @TempDir Path root) throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+
+        var release = VersionStateVerifier.verify(root, "release", null, null);
+        var taggedDevelopment = VersionStateVerifier.verify(
+                root, "development", null, "v1.2.9-SNAPSHOT");
+
+        assertThat(release.failures())
+                .anyMatch(message -> message.contains("not a valid release version"));
+        assertThat(taggedDevelopment.failures())
+                .contains("A release tag is only valid in release mode");
+    }
+
+    @Test
+    void rejectsUnexpectedTagAndExplicitExpectedVersion(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9", true);
+        assertThat(VersionStateVerifier.verify(
+                root, "release", null, "v1.2.8").failures())
+                .contains("Tag 'v1.2.8' != expected 'v1.2.9'");
+
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        assertThat(VersionStateVerifier.verify(
+                root,
+                "development",
+                "1.2.10-SNAPSHOT",
+                null).failures())
+                .contains("Root Maven version '1.2.9-SNAPSHOT' != expected '1.2.10-SNAPSHOT'");
+    }
+
+    @Test
+    void rejectsPomHelmCitationAndArchiveDrift(@TempDir Path root)
+            throws Exception {
+        writeRepository(root, "1.2.9-SNAPSHOT", false);
+        write(root.resolve("module/pom.xml"), modulePom("1.2.8-SNAPSHOT"));
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "1.2.8-SNAPSHOT"
+                """);
+        write(root.resolve("CITATION.cff"), """
+                version: "1.2.8-SNAPSHOT"
+                date-released: "2026-08-10"
+                """);
+        write(root.resolve(".zenodo.json"), """
+                {"version":"1.2.8-SNAPSHOT","publication_date":"2026-08-10"}
+                """);
+        write(root.resolve("codemeta.json"), """
+                {"version":"1.2.8-SNAPSHOT","datePublished":"2026-08-10"}
+                """);
+
+        var verification = VersionStateVerifier.verify(
+                root, "development", null, null);
+
+        assertThat(verification.failures())
+                .anyMatch(message -> message.contains("module/pom.xml parent version"))
+                .contains(
+                        "Helm Chart.yaml appVersion does not match the Maven version",
+                        "CITATION.cff version does not match the Maven version",
+                        "CITATION.cff release-date state does not match the requested mode",
+                        ".zenodo.json version does not match",
+                        ".zenodo.json release-date state does not match the requested mode",
+                        "codemeta.json version does not match",
+                        "codemeta.json release-date state does not match the requested mode");
+    }
+
+    private static void writeRepository(
+            Path root,
+            String version,
+            boolean release) throws Exception {
+        write(root.resolve("pom.xml"), rootPom(version));
+        write(root.resolve("module/pom.xml"), modulePom(version));
+        write(root.resolve("CITATION.cff"),
+                "version: \"" + version + "\"\n"
+                        + (release ? "date-released: \"2026-08-10\"\n" : ""));
+        write(root.resolve("CITATION.md"),
+                "Carsten Hammer. **Taxonomy Architecture Analyzer**. Version "
+                        + version + ". 2026.\n"
+                        + "  version      = {" + version + "},\n"
+                        + (release ? "  date         = {2026-08-10},\n" : ""));
+        write(root.resolve(".zenodo.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"publication_date\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("codemeta.json"), release
+                ? "{\"version\":\"" + version
+                        + "\",\"datePublished\":\"2026-08-10\"}\n"
+                : "{\"version\":\"" + version + "\"}\n");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                appVersion: "%s"
+                """.formatted(version));
+    }
+
+    private static String rootPom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(version);
+    }
+
+    private static String modulePom(String version) {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>%s</version>
+                  </parent>
+                  <artifactId>module</artifactId>
+                </project>
+                """.formatted(version);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Purpose

Third bounded #673 slice, stacked on #757. Move the complete declared-reactor and release-transition policy from Python into Maven/JUnit-owned Java tooling.

## Scope

- traverse only declared Maven modules, including nested aggregators;
- resolve inherited Maven properties in versions and internal dependency coordinates;
- reject missing or escaping modules, duplicate coordinates and unresolved versions;
- reject module declarations that leave the repository lexically or through symbolic links;
- distinguish legal internal development snapshots from external parent, dependency, plugin and extension snapshots;
- reject Maven Release Plugin dual authority and stale release state;
- prune `.git` and generated `target` subtrees while checking stale release backups;
- enforce clean ordinary and linked-worktree checkouts;
- support development, release and advanced lifecycle states plus major-version advances;
- normalize lifecycle state before validation so Maven/environment whitespace cannot create false failures;
- expose `check-release-plan` without regressing inherited version-state and POM-reading commands.

## JUnit evidence

- complete positive/negative reactor and release-state fixtures;
- normalized lifecycle-state coverage;
- module symlink escape and absolute-path rejection;
- `.git`/`target` traversal pruning with source-tree backup detection;
- Maven-property-based internal coordinates and actionable unresolved-coordinate diagnostics.

No workflow switch or Python-file deletion occurs here. #759 connects the proven commands to every productive release/version workflow.

Base: `refactor/673-release-parameters-java` / #757. Retarget to `main` only after #757 merges, then update to that exact base and run a fresh complete matrix.

Advances #673 and #711.