### PR TITLE
Route release workflows through the Java tooling boundary

### DIFF
--- a/.github/scripts/check-release-delivery-contract.py
+++ b/.github/scripts/check-release-delivery-contract.py
@@ -9,7 +9,23 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[2]
 ROOT_POM = ROOT / "pom.xml"
-RELEASE_PLAN_CHECK = ROOT / ".github" / "scripts" / "check-release-plan.py"
+TOOLING_POM = ROOT / "taxonomy-tooling" / "pom.xml"
+RELEASE_PLAN_CHECK = (
+    ROOT
+    / "taxonomy-tooling"
+    / "src"
+    / "main"
+    / "java"
+    / "com"
+    / "taxonomy"
+    / "tooling"
+    / "ReleasePlanValidator.java"
+)
+RELEASE_PARAMETER_RESOLVER = RELEASE_PLAN_CHECK.with_name(
+    "ReleaseParametersResolver.java"
+)
+VERSION_STATE_CHECK = RELEASE_PLAN_CHECK.with_name("VersionStateVerifier.java")
+TOOLING_CLI = RELEASE_PLAN_CHECK.with_name("TaxonomyTooling.java")
 RELEASE_SCRIPT = ROOT / ".github" / "scripts" / "release.sh"
 RELEASE_IMAGE_GATE = ROOT / ".github" / "scripts" / "check-release-image-gate.py"
 RELEASE_GATE_HELPER = ROOT / ".github" / "scripts" / "verify-exact-release-gates.sh"
@@ -22,9 +38,18 @@ def require(text: str, needle: str, source: Path, failures: list[str]) -> None:
         failures.append(f"{source.relative_to(ROOT)} is missing {needle!r}")
 
 
+def forbid(text: str, needle: str, source: Path, failures: list[str]) -> None:
+    if needle in text:
+        failures.append(f"{source.relative_to(ROOT)} still contains {needle!r}")
+
+
 def main() -> int:
     pom = ROOT_POM.read_text(encoding="utf-8")
+    tooling_pom = TOOLING_POM.read_text(encoding="utf-8")
     plan_check = RELEASE_PLAN_CHECK.read_text(encoding="utf-8")
+    parameter_resolver = RELEASE_PARAMETER_RESOLVER.read_text(encoding="utf-8")
+    version_state = VERSION_STATE_CHECK.read_text(encoding="utf-8")
+    tooling_cli = TOOLING_CLI.read_text(encoding="utf-8")
     script = RELEASE_SCRIPT.read_text(encoding="utf-8")
     gate_helper = RELEASE_GATE_HELPER.read_text(encoding="utf-8")
     workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -44,18 +69,27 @@ def main() -> int:
         if image_gate.stderr:
             print(image_gate.stderr, end="", file=sys.stderr)
         failures.append(
-            "Immutable OCI image verification contract failed; see check-release-image-gate.py output"
+            "Immutable OCI image verification contract failed; see "
+            "check-release-image-gate.py output"
         )
 
     for needle in (
+        "<module>taxonomy-tooling</module>",
         "<id>release-check</id>",
-        ".github/scripts/check-release-plan.py",
-        "<argument>${releaseVersion}</argument>",
-        "<argument>${nextDevelopmentVersion}</argument>",
-        "<argument>${releaseCheckCurrentState}</argument>",
-        "<argument>${releaseCheckRequireClean}</argument>",
+        "<taxonomy.release.check>true</taxonomy.release.check>",
     ):
         require(pom, needle, ROOT_POM, failures)
+    for needle in (
+        ".github/scripts/check-release-plan.py",
+        "<executable>python3</executable>",
+    ):
+        forbid(pom, needle, ROOT_POM, failures)
+
+    for needle in (
+        "<artifactId>taxonomy-tooling</artifactId>",
+        "<mainClass>com.taxonomy.tooling.TaxonomyTooling</mainClass>",
+    ):
+        require(tooling_pom, needle, TOOLING_POM, failures)
 
     if "<artifactId>maven-release-plugin</artifactId>" in pom:
         failures.append(
@@ -65,32 +99,73 @@ def main() -> int:
     for needle in (
         "release verification requires a clean checkout",
         "maven-release-plugin would create a second SCM release authority",
-        "external {kind}",
-        'state in {"development", "advanced"}',
-        'if state == "release"',
-        "def reactor_pom_paths",
-        "def reactor_models_by_coordinate",
-        "def effective_properties",
+        "reactorPomPaths",
+        "modelsByCoordinate",
+        "effectiveProperties",
         "unresolved version property",
-        'kind in {"dependency", "parent"}',
         "declares module",
+        "external ",
+        "requireNewer",
     ):
         require(plan_check, needle, RELEASE_PLAN_CHECK, failures)
 
     for needle in (
+        "validateReleaseRequestAnchor",
+        "request_revision must advance from",
+        "release request commit must change only",
+        "validateStagedReleaseAncestry",
+        "next_version_increment must be patch, minor or major",
+        "appendOutputs",
+    ):
+        require(parameter_resolver, needle, RELEASE_PARAMETER_RESOLVER, failures)
+
+    for needle in (
+        "CITATION.cff",
+        "codemeta.json",
+        "deploy/helm/taxonomy/Chart.yaml",
+        "rootProjectVersion",
+    ):
+        require(version_state, needle, VERSION_STATE_CHECK, failures)
+
+    for needle in (
+        'case "resolve-release-parameters"',
+        'case "check-version-state"',
+        'case "check-release-plan"',
+        'case "compare-versions"',
+        'case "read-pom-version"',
+    ):
+        require(tooling_cli, needle, TOOLING_CLI, failures)
+
+    for needle in (
         "DEFER_RELEASE_PUBLICATION=${DEFER_RELEASE_PUBLICATION:-false}",
+        '"${TOOLING_JAR:?TOOLING_JAR is required}"',
         "run_maven_release_check()",
+        "run_release_plan_check()",
+        "check_version_state()",
         "stage_version_metadata()",
         "git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'",
-        'run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate',
-        "run_maven_release_check release release-check validate",
-        "-DreleaseCheckRequireClean=false",
+        'java -jar "$TOOLING_JAR" compare-versions',
+        'java -jar "$TOOLING_JAR" check-release-plan',
+        'java -jar "$TOOLING_JAR" check-version-state',
+        'java -jar "$TOOLING_JAR" read-pom-version --stdin',
+        'run_release_plan_check "$RELEASE_CHECK_STATE" true',
+        "run_release_plan_check release false",
         "run_maven_release_check release release-check,ci clean verify",
+        "! -name 'taxonomy-tooling-*.jar'",
         'if [[ "$DEFER_RELEASE_PUBLICATION" == "true" ]]; then',
         "remains a draft until downstream artifacts and final CI succeed",
         'test "$RELEASE_IS_DRAFT" = true',
     ):
         require(script, needle, RELEASE_SCRIPT, failures)
+
+    for forbidden in (
+        "VERSION_STATE_HELPER",
+        "resolve-release-parameters.py",
+        "check-version-state.py",
+        "check-release-plan.py",
+        "python3 - <<'PY'\nimport os\nrelease =",
+    ):
+        forbid(script, forbidden, RELEASE_SCRIPT, failures)
 
     if script.count("\n  stage_version_metadata\n") != 2:
         failures.append(
@@ -117,8 +192,11 @@ def main() -> int:
         "type: choice",
         "INPUT_NEXT_DEVELOPMENT_VERSION:",
         "INPUT_NEXT_VERSION_INCREMENT:",
-        "run: python3 .github/scripts/resolve-release-parameters.py",
-        "python3 .github/scripts/test-resolve-release-parameters.py",
+        "- name: Build Java release tooling",
+        "./mvnw -B -pl taxonomy-tooling -am package -DskipTests",
+        'run: java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" resolve-release-parameters --root .',
+        "./mvnw -B -pl taxonomy-tooling test",
+        "TOOLING_JAR: ${{ runner.temp }}/taxonomy-tooling.jar",
         "group: release-main",
         "ref: ${{ github.event_name == 'push' && github.sha || 'main' }}",
         "SOURCE_BRANCH: ${{ github.ref_name }}",
@@ -127,6 +205,7 @@ def main() -> int:
         "if: steps.release_parameters.outputs.resume_staged_release == 'true'",
         'git merge-base --is-ancestor "$tag" origin/main',
         "Release $tag must still be a draft before publication resumes",
+        'java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state',
         "DEFER_RELEASE_PUBLICATION: 'true'",
         "cp .github/scripts/verify-exact-release-gates.sh",
         "bash -n .github/scripts/verify-exact-release-gates.sh",
@@ -147,6 +226,14 @@ def main() -> int:
         "Render deployment triggered after complete release publication.",
     ):
         require(workflow, needle, RELEASE_WORKFLOW, failures)
+
+    for forbidden in (
+        "run: python3 .github/scripts/resolve-release-parameters.py",
+        "python3 .github/scripts/test-resolve-release-parameters.py",
+        "check-version-state.py",
+        "VERSION_STATE_HELPER:",
+    ):
+        forbid(workflow, forbidden, RELEASE_WORKFLOW, failures)
 
     for needle in (
         "EXPECTED_MAIN_SHA=${EXPECTED_MAIN_SHA:-}",
@@ -190,13 +277,18 @@ def main() -> int:
             )
 
     for needle in (
+        "./mvnw -B -pl taxonomy-tooling package -DskipTests",
+        'java -jar "$tooling_jar" check-release-plan',
+        '--state development',
+        '--require-clean true',
+    ):
+        require(ci_workflow, needle, CI_WORKFLOW, failures)
+    for forbidden in (
         "python3 .github/scripts/test-resolve-release-parameters.py",
         "python3 .github/scripts/test-check-release-plan.py",
         "./mvnw -B -Prelease-check validate",
-        '-DreleaseVersion="$release_version"',
-        '-DnextDevelopmentVersion="$next_version"',
     ):
-        require(ci_workflow, needle, CI_WORKFLOW, failures)
+        forbid(ci_workflow, forbidden, CI_WORKFLOW, failures)
 
     if "main_sha=$(git rev-parse origin/main)" in workflow:
         failures.append(
@@ -206,6 +298,8 @@ def main() -> int:
 
     try:
         checkout = workflow.index("- name: Checkout authoritative release source")
+        setup_java = workflow.index("- name: Set up JDK 21")
+        build_tooling = workflow.index("- name: Build Java release tooling")
         resolve = workflow.index("- name: Resolve release parameters")
         stage = workflow.index(
             "- name: Build and stage release, then prepare next development version"
@@ -226,15 +320,32 @@ def main() -> int:
         publish = workflow.index(
             "- name: Publish complete release and trigger deployment"
         )
-        if not checkout < resolve < stage < resume < record_main < final_gates < checkout_tag < package < image < scan < bind < archive < publish:
+        if not (
+            checkout
+            < setup_java
+            < build_tooling
+            < resolve
+            < stage
+            < resume
+            < record_main
+            < final_gates
+            < checkout_tag
+            < package
+            < image
+            < scan
+            < bind
+            < archive
+            < publish
+        ):
             failures.append(
                 "deploy-release.yml must bind checkout to the triggering source, "
-                "then either stage or validate a resumable draft, record the exact "
-                "main commit, verify its full gate matrix, then fetch and build the "
-                "immutable tag, scan and bind the pushed image digest, and publish last"
+                "build immutable Java tooling, then either stage or validate a "
+                "resumable draft, record the exact main commit, verify its full "
+                "gate matrix, then fetch and build the immutable tag, scan and "
+                "bind the pushed image digest, and publish last"
             )
 
-        checkout_block = workflow[checkout:resolve]
+        checkout_block = workflow[checkout:setup_java]
         exact_push_source = "ref: ${{ github.event_name == 'push' && github.sha || 'main' }}"
         if exact_push_source not in checkout_block:
             failures.append(
@@ -259,8 +370,10 @@ def main() -> int:
             'git fetch origin "refs/heads/main:refs/remotes/origin/main" --force',
             'git fetch origin "refs/tags/${tag}:refs/tags/${tag}"',
             'git merge-base --is-ancestor "$tag" origin/main',
-            '--mode release --expected-version "$RELEASE_VERSION" --tag "$tag"',
-            '--mode development --expected-version "$NEXT_VERSION_INPUT"',
+            '--mode release',
+            '--expected-version "$RELEASE_VERSION" --tag "$tag"',
+            '--mode development',
+            '--expected-version "$NEXT_VERSION_INPUT"',
             'if [[ "$is_draft" != "true" ]]; then',
         ):
             if needle not in resume_block:
@@ -289,9 +402,7 @@ def main() -> int:
             'run: bash "$RUNNER_TEMP/verify-exact-release-gates.sh"',
         ):
             if needle not in final_gate_block:
-                failures.append(
-                    f"Exact final gate step is missing {needle!r}"
-                )
+                failures.append(f"Exact final gate step is missing {needle!r}")
 
         publish_block = workflow[publish:]
         for needle in (
@@ -301,9 +412,7 @@ def main() -> int:
             "--latest",
         ):
             if needle not in publish_block:
-                failures.append(
-                    f"Final publication step is missing {needle!r}"
-                )
+                failures.append(f"Final publication step is missing {needle!r}")
         if "RENDER_DEPLOY_HOOK_URL" not in publish_block:
             failures.append("Only the final publication step may trigger deployment")
     except ValueError as error:
@@ -316,10 +425,12 @@ def main() -> int:
         return 1
 
     print(
-        "Release delivery contract is Maven-verifiable, atomic, freely versionable, "
-        "resumable and digest-bound: the local profile validates the release plan "
-        "without SCM mutation, immutable sources and images are verified explicitly, "
-        "the exact main snapshot passes CI, database, CodeQL and security gates before immutable artifact work, and publication remains the final operation."
+        "Release delivery contract is Maven/JUnit-verifiable, atomic, freely "
+        "versionable, resumable and digest-bound: dependency-free Java tooling "
+        "validates the release plan and version state without SCM mutation, "
+        "immutable sources and images are verified explicitly, the exact main "
+        "snapshot passes CI, database, CodeQL and security gates before immutable "
+        "artifact work, and publication remains the final operation."
     )
     return 0
 

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${RELEASE_VERSION:?RELEASE_VERSION is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${METADATA_HELPER:?METADATA_HELPER is required}"
-: "${VERSION_STATE_HELPER:?VERSION_STATE_HELPER is required}"
+: "${TOOLING_JAR:?TOOLING_JAR is required}"
 : "${VEX_HELPER:?VEX_HELPER is required}"
 : "${RELEASE_NOTES_VALIDATOR:?RELEASE_NOTES_VALIDATOR is required}"
 
@@ -34,6 +34,25 @@ run_maven_release_check() {
     -DreleaseVersion="$RELEASE_VERSION" \
     -DnextDevelopmentVersion="$NEXT_VERSION" \
     -DreleaseCheckCurrentState="$state"
+}
+
+run_release_plan_check() {
+  local state=$1
+  local require_clean=${2:-true}
+  local current_version
+  current_version=$(./mvnw -q -DforceStdout help:evaluate \
+    -Dexpression=project.version)
+  java -jar "$TOOLING_JAR" check-release-plan \
+    --root . \
+    --current-version "$current_version" \
+    --release-version "$RELEASE_VERSION" \
+    --next-development-version "$NEXT_VERSION" \
+    --state "$state" \
+    --require-clean "$require_clean"
+}
+
+check_version_state() {
+  java -jar "$TOOLING_JAR" check-version-state --root . "$@"
 }
 
 stage_version_metadata() {
@@ -75,16 +94,9 @@ fi
 if ! [[ "$NEXT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ ]]; then
   fail "next_development_version must use X.Y.Z-SNAPSHOT"
 fi
-RELEASE_VERSION="$RELEASE_VERSION" NEXT_VERSION="$NEXT_VERSION" python3 - <<'PY'
-import os
-release = tuple(map(int, os.environ['RELEASE_VERSION'].split('.')))
-next_version = tuple(map(int, os.environ['NEXT_VERSION'].removesuffix('-SNAPSHOT').split('.')))
-if next_version <= release:
-    raise SystemExit(
-        f"next development version {os.environ['NEXT_VERSION']} must be newer than "
-        f"release {os.environ['RELEASE_VERSION']}"
-    )
-PY
+java -jar "$TOOLING_JAR" compare-versions \
+  --release-version "$RELEASE_VERSION" \
+  --next-development-version "$NEXT_VERSION"
 
 materialize_release_notes() {
   RELEASE_VERSION="$RELEASE_VERSION" \
@@ -120,6 +132,7 @@ collect_release_artifacts() {
     ! -name '*-sources.jar' \
     ! -name '*-javadoc.jar' \
     ! -name 'original-*' \
+    ! -name 'taxonomy-tooling-*.jar' \
     -exec cp {} target/release-artifacts/ \;
 
   for file in target/taxonomy-sbom.json target/taxonomy-sbom.xml target/taxonomy-vex.json; do
@@ -167,15 +180,8 @@ create_maintenance_branch_if_missing() {
 }
 
 remote_main_version() {
-  git show origin/main:pom.xml | python3 -c '
-import sys, xml.etree.ElementTree as ET
-root = ET.fromstring(sys.stdin.read())
-ns = {"m": "http://maven.apache.org/POM/4.0.0"}
-value = root.findtext("m:version", namespaces=ns)
-if not value:
-    raise SystemExit("origin/main pom.xml has no project version")
-print(value.strip())
-'
+  git show origin/main:pom.xml \
+    | java -jar "$TOOLING_JAR" read-pom-version --stdin
 }
 
 advance_main_via_protected_pr() {
@@ -254,9 +260,9 @@ RELEASE_CHECK_STATE=development
 if [[ "$CURRENT_VERSION" == "$NEXT_VERSION" && "$TAG_EXISTS" == "true" ]]; then
   MAIN_ALREADY_ADVANCED=true
   RELEASE_CHECK_STATE=advanced
-  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+  check_version_state --mode development --expected-version "$NEXT_VERSION"
 elif [[ "$CURRENT_VERSION" == "${RELEASE_VERSION}-SNAPSHOT" ]]; then
-  python3 "$VERSION_STATE_HELPER" --mode development \
+  check_version_state --mode development \
     --expected-version "${RELEASE_VERSION}-SNAPSHOT"
 else
   fail "Current version $CURRENT_VERSION is neither ${RELEASE_VERSION}-SNAPSHOT nor finalized $NEXT_VERSION"
@@ -270,24 +276,23 @@ echo "Main already advanced: $MAIN_ALREADY_ADVANCED"
 echo "Defer release publication: $DEFER_RELEASE_PUBLICATION"
 echo "Dry run: $DRY_RUN"
 
-run_maven_release_check "$RELEASE_CHECK_STATE" release-check validate
+run_release_plan_check "$RELEASE_CHECK_STATE" true
 
 if [[ "$STATE" == "new" ]]; then
   ./mvnw -B versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
   python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
-  python3 "$VERSION_STATE_HELPER" --mode release --expected-version "$RELEASE_VERSION"
+  check_version_state --mode release --expected-version "$RELEASE_VERSION"
   # Validate the actual release-state reactor before committing it. The clean-check
   # is disabled only for this deliberate, uncommitted transition; the subsequent
   # canonical release verification runs from the clean immutable commit.
-  run_maven_release_check release release-check validate \
-    -DreleaseCheckRequireClean=false
+  run_release_plan_check release false
   stage_version_metadata
   git commit -m "Release version $RELEASE_VERSION"
   RELEASE_COMMIT=$(git rev-parse HEAD)
 else
   RELEASE_COMMIT=$(git rev-parse "${TAG_NAME}^{commit}")
   git checkout --detach "$RELEASE_COMMIT"
-  python3 "$VERSION_STATE_HELPER" --mode release \
+  check_version_state --mode release \
     --expected-version "$RELEASE_VERSION" --tag "$TAG_NAME"
 fi
 
@@ -314,12 +319,12 @@ fi
 # the canonical Maven verification. The immutable release commit remains tagged.
 if [[ "$MAIN_ALREADY_ADVANCED" == "true" ]]; then
   git checkout --detach "$ORIGINAL_MAIN"
-  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+  check_version_state --mode development --expected-version "$NEXT_VERSION"
 else
   git checkout --detach "$RELEASE_COMMIT"
   ./mvnw -B versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
   python3 "$METADATA_HELPER" "$NEXT_VERSION"
-  python3 "$VERSION_STATE_HELPER" --mode development --expected-version "$NEXT_VERSION"
+  check_version_state --mode development --expected-version "$NEXT_VERSION"
   stage_version_metadata
   git commit -m "Prepare next development version $NEXT_VERSION"
   NEXT_COMMIT=$(git rev-parse HEAD)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,8 +42,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 .github/scripts/test-resolve-release-parameters.py
-          python3 .github/scripts/test-check-release-plan.py
+          ./mvnw -B -pl taxonomy-tooling package -DskipTests
+          tooling_jar=$(find taxonomy-tooling/target -maxdepth 1 -type f \
+            -name 'taxonomy-tooling-*.jar' \
+            ! -name '*-sources.jar' \
+            ! -name '*-javadoc.jar' \
+            | head -n 1)
+          test -n "$tooling_jar"
+
           python3 .github/scripts/test-generate-quality-site.py
           python3 .github/scripts/test-verify-quality-publication.py
           python3 .github/scripts/test-verify-deployment.py
@@ -62,9 +68,13 @@ jobs:
             release_version=${current_version%-SNAPSHOT}
             IFS='.' read -r major minor patch <<< "$release_version"
             next_version="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-            ./mvnw -B -Prelease-check validate \
-              -DreleaseVersion="$release_version" \
-              -DnextDevelopmentVersion="$next_version"
+            java -jar "$tooling_jar" check-release-plan \
+              --root . \
+              --current-version "$current_version" \
+              --release-version "$release_version" \
+              --next-development-version "$next_version" \
+              --state development \
+              --require-clean true
           fi
 
       - name: Install verified Helm 3.21.0

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,13 +42,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./mvnw -B -pl taxonomy-tooling package -DskipTests
+          ./mvnw -B -pl taxonomy-tooling -am package -DskipTests
           tooling_jar=$(find taxonomy-tooling/target -maxdepth 1 -type f \
             -name 'taxonomy-tooling-*.jar' \
             ! -name '*-sources.jar' \
             ! -name '*-javadoc.jar' \
             | head -n 1)
-          test -n "$tooling_jar"
+          if [[ -z "$tooling_jar" || ! -f "$tooling_jar" ]]; then
+            echo "::error::Java release tooling jar was not produced"
+            exit 1
+          fi
 
           python3 .github/scripts/test-generate-quality-site.py
           python3 .github/scripts/test-verify-quality-publication.py

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -56,6 +56,37 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Set up JDK 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Build Java release tooling
+        id: release_tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mvnw -B -pl taxonomy-tooling -am package -DskipTests
+          tooling_jar=$(find taxonomy-tooling/target -maxdepth 1 -type f \
+            -name 'taxonomy-tooling-*.jar' \
+            ! -name '*-sources.jar' \
+            ! -name '*-javadoc.jar' \
+            | head -n 1)
+          if [[ -z "$tooling_jar" || ! -f "$tooling_jar" ]]; then
+            echo "::error::Java release tooling jar was not produced"
+            exit 1
+          fi
+          cp "$tooling_jar" "$RUNNER_TEMP/taxonomy-tooling.jar"
+          echo "jar=$RUNNER_TEMP/taxonomy-tooling.jar" >> "$GITHUB_OUTPUT"
+
       - name: Resolve release parameters
         id: release_parameters
         env:
@@ -64,26 +95,13 @@ jobs:
           INPUT_NEXT_VERSION_INCREMENT: ${{ inputs.next_version_increment }}
           INPUT_SKIP_TESTS: ${{ inputs.skip_tests }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
-        run: python3 .github/scripts/resolve-release-parameters.py
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
+        run: java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" resolve-release-parameters --root .
 
       - name: Install verified Helm 3.21.0
         env:
           HELM_VERSION: v3.21.0
         shell: bash
         run: bash .github/scripts/install-helm.sh
-
-      - name: Cache Maven dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
 
       - name: Verify release Helm chart before publication
         if: hashFiles('deploy/helm/taxonomy/Chart.yaml') != ''
@@ -95,8 +113,6 @@ jobs:
           cp .github/scripts/release.sh "$RUNNER_TEMP/release.sh"
           cp .github/scripts/update-release-metadata.py \
             "$RUNNER_TEMP/update-release-metadata.py"
-          cp .github/scripts/check-version-state.py \
-            "$RUNNER_TEMP/check-version-state.py"
           cp .github/scripts/generate-vex.py "$RUNNER_TEMP/generate-vex.py"
           cp .github/scripts/verify-exact-release-gates.sh \
             "$RUNNER_TEMP/verify-exact-release-gates.sh"
@@ -104,7 +120,6 @@ jobs:
             "$RUNNER_TEMP/validate-reviewed-release-notes.sh"
           chmod +x "$RUNNER_TEMP/release.sh" \
             "$RUNNER_TEMP/update-release-metadata.py" \
-            "$RUNNER_TEMP/check-version-state.py" \
             "$RUNNER_TEMP/generate-vex.py" \
             "$RUNNER_TEMP/verify-exact-release-gates.sh" \
             "$RUNNER_TEMP/validate-reviewed-release-notes.sh"
@@ -113,7 +128,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 .github/scripts/test-resolve-release-parameters.py
+          ./mvnw -B -pl taxonomy-tooling test
           bash -n .github/scripts/release.sh
           bash -n .github/scripts/verify-exact-release-gates.sh
           bash -n .github/scripts/validate-reviewed-release-notes.sh
@@ -133,7 +148,7 @@ jobs:
           DEFER_RELEASE_PUBLICATION: 'true'
           SOURCE_BRANCH: ${{ github.ref_name }}
           METADATA_HELPER: ${{ runner.temp }}/update-release-metadata.py
-          VERSION_STATE_HELPER: ${{ runner.temp }}/check-version-state.py
+          TOOLING_JAR: ${{ runner.temp }}/taxonomy-tooling.jar
           VEX_HELPER: ${{ runner.temp }}/generate-vex.py
           RELEASE_NOTES_VALIDATOR: ${{ runner.temp }}/validate-reviewed-release-notes.sh
           TAXONOMY_EMBEDDING_MODEL_DIR: ${{ github.workspace }}/models/bge-small-en-v1.5
@@ -161,8 +176,9 @@ jobs:
           fi
 
           git checkout --detach "$tag"
-          python3 "$RUNNER_TEMP/check-version-state.py" \
-            --mode release --expected-version "$RELEASE_VERSION" --tag "$tag"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode release \
+            --expected-version "$RELEASE_VERSION" --tag "$tag"
           RELEASE_NOTES_COMMIT="$tag" \
             RELEASE_NOTES_FILE=release_notes.md \
             "$RELEASE_NOTES_VALIDATOR"
@@ -179,8 +195,9 @@ jobs:
           fi
 
           git checkout --detach origin/main
-          python3 "$RUNNER_TEMP/check-version-state.py" \
-            --mode development --expected-version "$NEXT_VERSION_INPUT"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode development \
+            --expected-version "$NEXT_VERSION_INPUT"
 
       - name: Record exact final main snapshot
         id: final_main
@@ -226,8 +243,9 @@ jobs:
           artifact_dir="$RUNNER_TEMP/helm-release"
           mkdir -p "$artifact_dir"
 
-          python3 .github/scripts/check-version-state.py \
-            --mode release --expected-version "$RELEASE_VERSION" --tag "$tag"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode release \
+            --expected-version "$RELEASE_VERSION" --tag "$tag"
           helm lint deploy/helm/taxonomy \
             --set "image.tag=${tag}" \
             --set existingSecret=taxonomy-secrets

--- a/.github/workflows/prepare-development-version.yml
+++ b/.github/workflows/prepare-development-version.yml
@@ -36,6 +36,20 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: maven
+
+      - name: Preserve Java version tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mvnw -B -pl taxonomy-tooling -am package -DskipTests
+          tooling_jar=$(find taxonomy-tooling/target -maxdepth 1 -type f \
+            -name 'taxonomy-tooling-*.jar' \
+            ! -name '*-sources.jar' \
+            ! -name '*-javadoc.jar' \
+            | head -n 1)
+          test -n "$tooling_jar"
+          cp "$tooling_jar" "$RUNNER_TEMP/taxonomy-tooling.jar"
 
       - name: Validate and prepare exact development version
         id: version
@@ -64,21 +78,9 @@ jobs:
             echo "::error::Current project version is not a canonical development version: $current_version"
             exit 1
           fi
-
-          CURRENT_VERSION="$current_version" NEXT_VERSION="$next_version" python3 - <<'PY'
-          import os
-
-          def version_tuple(value: str) -> tuple[int, int, int]:
-              return tuple(map(int, value.removesuffix("-SNAPSHOT").split(".")))
-
-          current = version_tuple(os.environ["CURRENT_VERSION"])
-          target = version_tuple(os.environ["NEXT_VERSION"])
-          if target <= current:
-              raise SystemExit(
-                  f"next development version {os.environ['NEXT_VERSION']} must be newer than "
-                  f"current {os.environ['CURRENT_VERSION']}"
-              )
-          PY
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" compare-versions \
+            --release-version "${current_version%-SNAPSHOT}" \
+            --next-development-version "$next_version"
 
           branch="prepare-development-${next_version%-SNAPSHOT}"
           branch=${branch//./-}
@@ -108,14 +110,15 @@ jobs:
             -DnewVersion="$NEXT_VERSION" \
             -DgenerateBackupPoms=false
           python3 .github/scripts/update-release-metadata.py "$NEXT_VERSION"
-          python3 .github/scripts/check-version-state.py \
-            --mode development \
-            --expected-version "$NEXT_VERSION"
-          ./mvnw -B -Prelease-check validate \
-            -DreleaseVersion="$CURRENT_RELEASE" \
-            -DnextDevelopmentVersion="$NEXT_VERSION" \
-            -DreleaseCheckCurrentState=advanced \
-            -DreleaseCheckRequireClean=false
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode development --expected-version "$NEXT_VERSION"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-release-plan \
+            --root . \
+            --current-version "$NEXT_VERSION" \
+            --release-version "$CURRENT_RELEASE" \
+            --next-development-version "$NEXT_VERSION" \
+            --state advanced \
+            --require-clean false
 
           mapfile -d '' tracked_poms < <(
             git ls-files -z -- 'pom.xml' ':(glob)**/pom.xml'

--- a/.github/workflows/prepare-development-version.yml
+++ b/.github/workflows/prepare-development-version.yml
@@ -48,7 +48,10 @@ jobs:
             ! -name '*-sources.jar' \
             ! -name '*-javadoc.jar' \
             | head -n 1)
-          test -n "$tooling_jar"
+          if [[ -z "$tooling_jar" || ! -f "$tooling_jar" ]]; then
+            echo "::error::Java version tooling jar was not produced"
+            exit 1
+          fi
           cp "$tooling_jar" "$RUNNER_TEMP/taxonomy-tooling.jar"
 
       - name: Validate and prepare exact development version

--- a/.github/workflows/protected-release-main-advance.yml
+++ b/.github/workflows/protected-release-main-advance.yml
@@ -65,7 +65,10 @@ jobs:
             ! -name '*-sources.jar' \
             ! -name '*-javadoc.jar' \
             | head -n 1)
-          test -n "$tooling_jar"
+          if [[ -z "$tooling_jar" || ! -f "$tooling_jar" ]]; then
+            echo "::error::Java release tooling jar was not produced"
+            exit 1
+          fi
           cp "$tooling_jar" "$RUNNER_TEMP/taxonomy-tooling.jar"
 
       - name: Validate immutable handoff

--- a/.github/workflows/protected-release-main-advance.yml
+++ b/.github/workflows/protected-release-main-advance.yml
@@ -139,7 +139,7 @@ jobs:
               --base main \
               --head "$TEMP_BRANCH" \
               --title "Prepare next development version $NEXT_VERSION" \
-              --body "Release automation prepared this exact next-development snapshot. The branch is merged only after the canonical Maven verification succeeds on $EXPECTED_SHA."
+              --body "Release automation prepared this exact next-development snapshot. The branch is merged only after the complete required pull-request gate matrix succeeds on $EXPECTED_SHA."
             pr_number=$(gh pr list \
               --state open --base main --head "$TEMP_BRANCH" \
               --json number,headRefOid \
@@ -187,6 +187,28 @@ jobs:
           gh run watch "$run_id" --exit-status
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for complete protected-main pull-request gates
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          head_before=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+          test "$head_before" = "$EXPECTED_SHA" || {
+            echo "::error::PR #$PR_NUMBER moved to $head_before before gate verification, expected $EXPECTED_SHA"
+            exit 1
+          }
+
+          gh pr checks "$PR_NUMBER" --required --watch --fail-fast
+
+          head_after=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+          test "$head_after" = "$EXPECTED_SHA" || {
+            echo "::error::PR #$PR_NUMBER moved to $head_after while its gates were running, expected $EXPECTED_SHA"
+            exit 1
+          }
+
       - name: Merge through protected main
         env:
           GH_TOKEN: ${{ github.token }}
@@ -210,7 +232,7 @@ jobs:
             exit 1
           }
 
-          gh pr merge "$PR_NUMBER" --merge
+          gh pr merge "$PR_NUMBER" --merge --match-head-commit "$EXPECTED_SHA"
 
           git fetch origin "refs/heads/main:refs/remotes/origin/main" --force
           git merge-base --is-ancestor "$EXPECTED_SHA" origin/main || {

--- a/.github/workflows/protected-release-main-advance.yml
+++ b/.github/workflows/protected-release-main-advance.yml
@@ -201,6 +201,30 @@ jobs:
             exit 1
           }
 
+          required_count=0
+          checks_json='[]'
+          for _ in $(seq 1 60); do
+            set +e
+            checks_json=$(gh pr checks "$PR_NUMBER" \
+              --required \
+              --json name,bucket,state 2>/dev/null)
+            checks_exit=$?
+            set -e
+            if [[ "$checks_exit" -eq 0 || "$checks_exit" -eq 8 ]]; then
+              required_count=$(jq 'length' <<< "$checks_json")
+              if [[ "$required_count" -gt 0 ]]; then
+                break
+              fi
+            fi
+            sleep 5
+          done
+          if [[ "$required_count" -eq 0 ]]; then
+            echo "::error::No required PR checks were registered for #$PR_NUMBER"
+            exit 1
+          fi
+          jq -r '.[] | "Required check registered: \(.name) [\(.bucket)]"' \
+            <<< "$checks_json"
+
           gh pr checks "$PR_NUMBER" --required --watch --fail-fast
 
           head_after=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')

--- a/.github/workflows/protected-release-main-advance.yml
+++ b/.github/workflows/protected-release-main-advance.yml
@@ -48,6 +48,26 @@ jobs:
           fetch-depth: 0
           token: ${{ github.token }}
 
+      - name: Set up Java 21
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Preserve Java release tooling
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./mvnw -B -pl taxonomy-tooling -am package -DskipTests
+          tooling_jar=$(find taxonomy-tooling/target -maxdepth 1 -type f \
+            -name 'taxonomy-tooling-*.jar' \
+            ! -name '*-sources.jar' \
+            ! -name '*-javadoc.jar' \
+            | head -n 1)
+          test -n "$tooling_jar"
+          cp "$tooling_jar" "$RUNNER_TEMP/taxonomy-tooling.jar"
+
       - name: Validate immutable handoff
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
@@ -93,8 +113,8 @@ jobs:
             exit 1
           }
           git checkout --detach "$EXPECTED_SHA"
-          python3 .github/scripts/check-version-state.py \
-            --mode development --expected-version "$NEXT_VERSION"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode development --expected-version "$NEXT_VERSION"
 
       - name: Create protected-main pull request
         id: pr
@@ -195,6 +215,6 @@ jobs:
             exit 1
           }
           git checkout --detach origin/main
-          python3 .github/scripts/check-version-state.py \
-            --mode development --expected-version "$NEXT_VERSION"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
+            --root . --mode development --expected-version "$NEXT_VERSION"
           git push origin ":refs/heads/${TEMP_BRANCH}" || true

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
@@ -44,19 +44,29 @@ class JavaToolingWorkflowRepositoryTest {
         String canonical = "- name: Run canonical verification on exact snapshot";
         String completeGates =
                 "- name: Wait for complete protected-main pull-request gates";
+        String registration = "required_count=0";
+        String watch =
+                "gh pr checks \"$PR_NUMBER\" --required --watch --fail-fast";
         String merge = "- name: Merge through protected main";
 
         assertThat(workflow)
                 .contains(canonical)
                 .contains(completeGates)
+                .contains(registration)
+                .contains("--json name,bucket,state")
+                .contains("checks_exit=$?")
+                .contains("checks_exit\" -eq 8")
+                .contains("No required PR checks were registered for #$PR_NUMBER")
+                .contains(watch)
                 .contains(merge)
-                .contains("gh pr checks \"$PR_NUMBER\" --required --watch --fail-fast")
                 .contains("head_before=$(gh pr view \"$PR_NUMBER\" --json headRefOid")
                 .contains("head_after=$(gh pr view \"$PR_NUMBER\" --json headRefOid")
                 .contains("gh pr merge \"$PR_NUMBER\" --merge --match-head-commit \"$EXPECTED_SHA\"");
         assertThat(workflow.indexOf(canonical))
                 .isLessThan(workflow.indexOf(completeGates));
-        assertThat(workflow.indexOf(completeGates))
+        assertThat(workflow.indexOf(registration))
+                .isLessThan(workflow.indexOf(watch));
+        assertThat(workflow.indexOf(watch))
                 .isLessThan(workflow.indexOf(merge));
     }
 

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaToolingWorkflowRepositoryTest {
+
+    @Test
+    void everyProductiveWorkflowBuildsAndValidatesTheToolingJar()
+            throws Exception {
+        Path root = findRepositoryRoot();
+
+        assertWorkflowBuild(
+                root.resolve(".github/workflows/ci-cd.yml"),
+                "Java release tooling jar was not produced");
+        assertWorkflowBuild(
+                root.resolve(".github/workflows/deploy-release.yml"),
+                "Java release tooling jar was not produced");
+        assertWorkflowBuild(
+                root.resolve(".github/workflows/protected-release-main-advance.yml"),
+                "Java release tooling jar was not produced");
+        assertWorkflowBuild(
+                root.resolve(".github/workflows/prepare-development-version.yml"),
+                "Java version tooling jar was not produced");
+
+        String releaseScript = read(root.resolve(".github/scripts/release.sh"));
+        assertThat(releaseScript)
+                .contains("${TOOLING_JAR:?TOOLING_JAR is required}")
+                .contains("! -name 'taxonomy-tooling-*.jar'");
+    }
+
+    private static void assertWorkflowBuild(Path workflow, String diagnostic)
+            throws Exception {
+        String text = read(workflow);
+        assertThat(text)
+                .contains("./mvnw -B -pl taxonomy-tooling -am package -DskipTests")
+                .contains("-name 'taxonomy-tooling-*.jar'")
+                .contains("if [[ -z \"$tooling_jar\" || ! -f \"$tooling_jar\" ]]")
+                .contains("::error::" + diagnostic)
+                .contains("$RUNNER_TEMP/taxonomy-tooling.jar");
+    }
+
+    private static String read(Path path) throws Exception {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            "taxonomy-tooling/pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/JavaToolingWorkflowRepositoryTest.java
@@ -34,6 +34,32 @@ class JavaToolingWorkflowRepositoryTest {
                 .contains("! -name 'taxonomy-tooling-*.jar'");
     }
 
+    @Test
+    void protectedMainAdvanceWaitsForEveryRequiredCheckOnTheExactHead()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String workflow = read(root.resolve(
+                ".github/workflows/protected-release-main-advance.yml"));
+
+        String canonical = "- name: Run canonical verification on exact snapshot";
+        String completeGates =
+                "- name: Wait for complete protected-main pull-request gates";
+        String merge = "- name: Merge through protected main";
+
+        assertThat(workflow)
+                .contains(canonical)
+                .contains(completeGates)
+                .contains(merge)
+                .contains("gh pr checks \"$PR_NUMBER\" --required --watch --fail-fast")
+                .contains("head_before=$(gh pr view \"$PR_NUMBER\" --json headRefOid")
+                .contains("head_after=$(gh pr view \"$PR_NUMBER\" --json headRefOid")
+                .contains("gh pr merge \"$PR_NUMBER\" --merge --match-head-commit \"$EXPECTED_SHA\"");
+        assertThat(workflow.indexOf(canonical))
+                .isLessThan(workflow.indexOf(completeGates));
+        assertThat(workflow.indexOf(completeGates))
+                .isLessThan(workflow.indexOf(merge));
+    }
+
     private static void assertWorkflowBuild(Path workflow, String diagnostic)
             throws Exception {
         String text = read(workflow);

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
@@ -33,5 +33,10 @@ class ReleasePlanStateNormalizationTest {
 
         assertThat(result.state()).isEqualTo("development");
         assertThat(result.pomCount()).isEqualTo(1);
+        assertThat(ReleasePlanValidator.expectedCurrentVersion(
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "\t release "))
+                .isEqualTo("1.3.0");
     }
 }


### PR DESCRIPTION
## Purpose

Fourth bounded #673 slice, stacked on #758. Connect the tested Java release core to canonical CI, the primary release transaction, protected-main advancement and manual development-version preparation.

## Scope

- build and preserve the dependency-free `taxonomy-tooling.jar` before checkout changes;
- use the same immutable JAR for parameter resolution, version checks, release-plan checks, semantic comparison and POM reads;
- route canonical CI, `deploy-release.yml`, `protected-release-main-advance.yml` and `prepare-development-version.yml` through that Java boundary;
- keep remaining metadata, SBOM companion, quality-site and delivery Python boundaries unchanged for later slices;
- exclude the build-only tooling JAR from product release artifacts;
- update release-delivery contracts for the new command and step ordering;
- preserve exact-SHA, draft, immutable-tag, image and protected-main safety contracts;
- build the module with `-pl taxonomy-tooling -am` and fail with actionable `::error::` diagnostics if its JAR is missing.

## Protected-main handoff

The next-development PR is merged only after:

- canonical CI has completed for the exact staged SHA;
- every configured required PR check has completed successfully through `gh pr checks --required --watch --fail-fast`;
- the PR head still equals the immutable staged SHA before and after gate waiting;
- the final merge uses `--match-head-commit` and rechecks that `main` has not moved.

A Maven/JUnit repository contract protects this complete gate order and exact-head binding.

The five replaced Python release-core files still exist in this PR but are no longer used by the migrated release/version workflows. #761 deletes them only after this routing layer is verified.

Base: `refactor/673-release-plan-java` / #758. Retarget to `main` only after #758 merges, then update to that exact base and run a fresh complete matrix.

Advances #673 and #711. This PR creates no release request, tag, artifact publication or deployment.