### PR TITLE
Move Maven release-plan validation to Java tooling

### DIFF
--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleasePlanValidator.java
@@ -1,0 +1,546 @@
+package com.taxonomy.tooling;
+
+import org.w3c.dom.Element;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Validates the declared Maven reactor and release transition without SCM writes. */
+public final class ReleasePlanValidator {
+
+    private static final Pattern PROPERTY = Pattern.compile("\\$\\{([^}]+)}");
+    private static final Set<String> STATES = Set.of(
+            "development", "release", "advanced");
+
+    private ReleasePlanValidator() {
+    }
+
+    public static Result validate(
+            Path root,
+            String currentVersion,
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state,
+            boolean requireClean) throws IOException {
+        Path repository = root.toRealPath();
+        String release = VersionNumbers.normalizeRelease(
+                releaseVersion, "releaseVersion");
+        String next = VersionNumbers.normalizeDevelopment(
+                nextDevelopmentVersion,
+                "nextDevelopmentVersion",
+                false);
+        String current = Objects.requireNonNull(
+                currentVersion, "currentVersion").strip();
+        String normalizedState = Objects.requireNonNull(
+                state, "state").strip();
+        if (!STATES.contains(normalizedState)) {
+            throw new IllegalArgumentException(
+                    "releaseCheckCurrentState must be one of "
+                            + STATES.stream().sorted().toList());
+        }
+        VersionNumbers.requireNewer(release, next);
+
+        String expected = expectedCurrentVersion(
+                release, next, normalizedState);
+        if (!current.equals(expected)) {
+            throw new IllegalArgumentException(
+                    "release state " + normalizedState
+                            + " expects project version " + expected
+                            + ", but Maven resolved " + current);
+        }
+
+        List<Path> paths = reactorPomPaths(repository);
+        List<PomModel> models = new ArrayList<>();
+        for (Path path : paths) {
+            models.add(modelFor(path));
+        }
+        if (!models.getFirst().path().equals(repository.resolve("pom.xml"))) {
+            throw new IllegalArgumentException(
+                    "reactor discovery did not start at the root pom.xml");
+        }
+
+        Map<Coordinate, PomModel> byCoordinate = modelsByCoordinate(models);
+        Set<Coordinate> internalCoordinates = byCoordinate.keySet();
+        Map<Path, Map<String, String>> propertyCache = new HashMap<>();
+        List<String> failures = new ArrayList<>();
+
+        for (PomModel model : models) {
+            String relative = relative(repository, model.path());
+            Map<String, String> properties = effectiveProperties(
+                    model, byCoordinate, propertyCache, new HashSet<>());
+            String resolvedModelVersion = resolveProperties(
+                    model.version(), properties);
+            if (PROPERTY.matcher(resolvedModelVersion).find()) {
+                failures.add(relative + ": reactor version '" + model.version()
+                        + "' contains an unresolved version property (resolved as '"
+                        + resolvedModelVersion + "')");
+            } else if (!resolvedModelVersion.equals(current)) {
+                failures.add(relative + ": reactor version '" + resolvedModelVersion
+                        + "' differs from " + current);
+            }
+
+            for (VersionedElement versioned : versionedElements(model)) {
+                if ("forbidden-plugin".equals(versioned.kind())) {
+                    failures.add(relative
+                            + ": maven-release-plugin would create a second SCM release authority");
+                    continue;
+                }
+                Coordinate coordinate = resolveCoordinate(
+                        versioned.coordinate(), properties);
+                String coordinateText = coordinate == null
+                        ? ""
+                        : " " + coordinate.groupId() + ":"
+                                + coordinate.artifactId();
+                if (coordinate != null
+                        && (PROPERTY.matcher(coordinate.groupId()).find()
+                                || PROPERTY.matcher(coordinate.artifactId()).find())) {
+                    failures.add(relative + ": " + versioned.kind()
+                            + coordinateText
+                            + " uses unresolved coordinate property");
+                    continue;
+                }
+
+                String resolved = resolveProperties(
+                        versioned.rawVersion(), properties);
+                if (PROPERTY.matcher(resolved).find()) {
+                    failures.add(relative + ": " + versioned.kind()
+                            + coordinateText + " uses unresolved version property '"
+                            + versioned.rawVersion() + "' (resolved as '"
+                            + resolved + "')");
+                    continue;
+                }
+                if (!resolved.toUpperCase().contains("SNAPSHOT")) {
+                    continue;
+                }
+                boolean internalSnapshot = ("dependency".equals(versioned.kind())
+                        || "parent".equals(versioned.kind()))
+                        && internalCoordinates.contains(coordinate)
+                        && resolved.equals(current)
+                        && ("development".equals(normalizedState)
+                                || "advanced".equals(normalizedState));
+                if (!internalSnapshot) {
+                    failures.add(relative + ": external " + versioned.kind()
+                            + coordinateText + " uses snapshot version '"
+                            + versioned.rawVersion() + "' (resolved as '"
+                            + resolved + "')");
+                }
+            }
+        }
+
+        if (Files.exists(repository.resolve("release.properties"))) {
+            failures.add(
+                    "release.properties: stale Maven Release Plugin state is present");
+        }
+        collectReleaseBackups(repository, failures);
+
+        if (!failures.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "release plan validation failed:\n- "
+                            + String.join("\n- ", failures));
+        }
+        if (requireClean) {
+            checkGitClean(repository);
+        }
+        return new Result(
+                current, release, next, normalizedState, models.size());
+    }
+
+    public static String expectedCurrentVersion(
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state) {
+        String normalizedState = Objects.requireNonNull(
+                state, "state").strip();
+        return switch (normalizedState) {
+            case "development" -> releaseVersion + "-SNAPSHOT";
+            case "release" -> releaseVersion;
+            case "advanced" -> nextDevelopmentVersion;
+            default -> throw new IllegalArgumentException(
+                    "releaseCheckCurrentState must be one of "
+                            + STATES.stream().sorted().toList());
+        };
+    }
+
+    static List<Path> reactorPomPaths(Path root) throws IOException {
+        Path repository = root.toRealPath();
+        Path rootPom = repository.resolve("pom.xml").toAbsolutePath().normalize();
+        if (!Files.isRegularFile(rootPom)) {
+            throw new IllegalArgumentException(
+                    "root pom.xml does not exist below " + repository);
+        }
+        Path realRootPom = rootPom.toRealPath();
+        if (!realRootPom.equals(rootPom) || !realRootPom.startsWith(repository)) {
+            throw new IllegalArgumentException(
+                    "root pom.xml must be a real file inside " + repository);
+        }
+
+        Deque<Path> pending = new ArrayDeque<>();
+        pending.add(realRootPom);
+        List<Path> discovered = new ArrayList<>();
+        Set<Path> seen = new LinkedHashSet<>();
+        while (!pending.isEmpty()) {
+            Path declaredPom = pending.removeFirst()
+                    .toAbsolutePath().normalize();
+            if (!declaredPom.startsWith(repository)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module escapes repository root: "
+                                + declaredPom);
+            }
+            if (!Files.isRegularFile(declaredPom)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module POM does not exist: "
+                                + declaredPom);
+            }
+            Path pom = declaredPom.toRealPath();
+            if (!pom.startsWith(repository) || !pom.equals(declaredPom)) {
+                throw new IllegalArgumentException(
+                        "declared Maven module must not traverse a symbolic link "
+                                + "or escape the repository: " + declaredPom);
+            }
+            if (!seen.add(pom)) {
+                continue;
+            }
+
+            Element project = XmlSupport.parse(pom).getDocumentElement();
+            discovered.add(pom);
+            Element modules = XmlSupport.child(project, "modules");
+            for (Element moduleElement : XmlSupport.children(modules, "module")) {
+                String module = XmlSupport.text(moduleElement);
+                if (module.isBlank()) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " contains an empty Maven module declaration");
+                }
+                Path modulePath = pom.getParent().resolve(module)
+                        .toAbsolutePath().normalize();
+                if (!modulePath.startsWith(repository)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' outside the repository");
+                }
+                Path moduleFileName = modulePath.getFileName();
+                Path modulePom = moduleFileName != null
+                        && "pom.xml".equals(moduleFileName.toString())
+                                ? modulePath
+                                : modulePath.resolve("pom.xml")
+                                        .toAbsolutePath().normalize();
+                if (!modulePom.startsWith(repository)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' outside the repository");
+                }
+                if (!Files.isRegularFile(modulePom)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module + "', but "
+                            + relative(repository, modulePom) + " does not exist");
+                }
+                Path realModulePom = modulePom.toRealPath();
+                if (!realModulePom.startsWith(repository)
+                        || !realModulePom.equals(modulePom)) {
+                    throw new IllegalArgumentException(relative(repository, pom)
+                            + " declares module '" + module
+                            + "' through a symbolic link or outside the repository");
+                }
+                pending.add(realModulePom);
+            }
+        }
+        return discovered;
+    }
+
+    private static PomModel modelFor(Path path) throws IOException {
+        Element project = XmlSupport.parse(path).getDocumentElement();
+        Element parent = XmlSupport.child(project, "parent");
+        Coordinate parentCoordinate = null;
+        String groupId = XmlSupport.childText(project, "groupId");
+        String version = XmlSupport.childText(project, "version");
+        if (parent != null) {
+            parentCoordinate = new Coordinate(
+                    XmlSupport.childText(parent, "groupId"),
+                    XmlSupport.childText(parent, "artifactId"));
+            if (groupId.isBlank()) {
+                groupId = parentCoordinate.groupId();
+            }
+            if (version.isBlank()) {
+                version = XmlSupport.childText(parent, "version");
+            }
+        }
+        String artifactId = XmlSupport.childText(project, "artifactId");
+        if (groupId.isBlank() || artifactId.isBlank() || version.isBlank()) {
+            throw new IllegalArgumentException(path
+                    + ": Maven coordinates must provide effective groupId, "
+                    + "artifactId and version");
+        }
+
+        LinkedHashMap<String, String> properties = new LinkedHashMap<>();
+        Element propertyRoot = XmlSupport.child(project, "properties");
+        if (propertyRoot != null) {
+            for (int index = 0;
+                    index < propertyRoot.getChildNodes().getLength();
+                    index++) {
+                if (propertyRoot.getChildNodes().item(index)
+                        instanceof Element property) {
+                    properties.put(
+                            property.getLocalName(), XmlSupport.text(property));
+                }
+            }
+        }
+        properties.put("project.groupId", groupId);
+        properties.put("pom.groupId", groupId);
+        properties.put("project.artifactId", artifactId);
+        properties.put("pom.artifactId", artifactId);
+        properties.put("project.version", version);
+        properties.put("pom.version", version);
+        if (parent != null) {
+            properties.put("project.parent.groupId", parentCoordinate.groupId());
+            properties.put("project.parent.artifactId", parentCoordinate.artifactId());
+            properties.put("project.parent.version",
+                    XmlSupport.childText(parent, "version"));
+        }
+        return new PomModel(
+                path, project, groupId, artifactId, version,
+                Map.copyOf(properties), parentCoordinate);
+    }
+
+    private static Map<Coordinate, PomModel> modelsByCoordinate(
+            List<PomModel> models) {
+        LinkedHashMap<Coordinate, PomModel> result = new LinkedHashMap<>();
+        for (PomModel model : models) {
+            Coordinate coordinate = new Coordinate(
+                    model.groupId(), model.artifactId());
+            PomModel previous = result.putIfAbsent(coordinate, model);
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "duplicate Maven reactor coordinate "
+                                + coordinate.groupId() + ":" + coordinate.artifactId()
+                                + ": " + previous.path() + " and " + model.path());
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, String> effectiveProperties(
+            PomModel model,
+            Map<Coordinate, PomModel> models,
+            Map<Path, Map<String, String>> cache,
+            Set<Path> visiting) {
+        Map<String, String> cached = cache.get(model.path());
+        if (cached != null) {
+            return cached;
+        }
+        if (!visiting.add(model.path())) {
+            throw new IllegalArgumentException(
+                    "cyclic Maven parent relationship involving " + model.path());
+        }
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        if (model.parentCoordinate() != null) {
+            PomModel parent = models.get(model.parentCoordinate());
+            if (parent != null) {
+                result.putAll(effectiveProperties(
+                        parent, models, cache, visiting));
+            }
+        }
+        result.putAll(model.properties());
+        visiting.remove(model.path());
+        Map<String, String> immutable = Map.copyOf(result);
+        cache.put(model.path(), immutable);
+        return immutable;
+    }
+
+    private static String resolveProperties(
+            String value,
+            Map<String, String> properties) {
+        String result = value.strip();
+        for (int round = 0; round < 12; round++) {
+            Matcher matcher = PROPERTY.matcher(result);
+            StringBuffer buffer = new StringBuffer();
+            boolean changed = false;
+            while (matcher.find()) {
+                String replacement = properties.get(matcher.group(1));
+                if (replacement == null) {
+                    matcher.appendReplacement(buffer,
+                            Matcher.quoteReplacement(matcher.group()));
+                } else {
+                    matcher.appendReplacement(buffer,
+                            Matcher.quoteReplacement(replacement));
+                    changed = true;
+                }
+            }
+            matcher.appendTail(buffer);
+            result = buffer.toString();
+            if (!changed) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    private static Coordinate resolveCoordinate(
+            Coordinate coordinate,
+            Map<String, String> properties) {
+        if (coordinate == null) {
+            return null;
+        }
+        return new Coordinate(
+                resolveProperties(coordinate.groupId(), properties),
+                resolveProperties(coordinate.artifactId(), properties));
+    }
+
+    private static List<VersionedElement> versionedElements(PomModel model) {
+        List<VersionedElement> result = new ArrayList<>();
+        Element parent = XmlSupport.child(model.project(), "parent");
+        if (parent != null) {
+            String version = XmlSupport.childText(parent, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "parent", model.parentCoordinate(), version));
+            }
+        }
+        for (Element dependency : XmlSupport.descendants(
+                model.project(), "dependency")) {
+            String version = XmlSupport.childText(dependency, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "dependency",
+                        new Coordinate(
+                                XmlSupport.childText(dependency, "groupId"),
+                                XmlSupport.childText(dependency, "artifactId")),
+                        version));
+            }
+        }
+        for (Element plugin : XmlSupport.descendants(model.project(), "plugin")) {
+            String artifactId = XmlSupport.childText(plugin, "artifactId");
+            String version = XmlSupport.childText(plugin, "version");
+            if ("maven-release-plugin".equals(artifactId)) {
+                result.add(new VersionedElement(
+                        "forbidden-plugin", null,
+                        version.isBlank() ? "<managed>" : version));
+            } else if (!version.isBlank()) {
+                String groupId = XmlSupport.childText(plugin, "groupId");
+                result.add(new VersionedElement(
+                        "plugin",
+                        new Coordinate(
+                                groupId.isBlank()
+                                        ? "org.apache.maven.plugins"
+                                        : groupId,
+                                artifactId),
+                        version));
+            }
+        }
+        for (Element extension : XmlSupport.descendants(
+                model.project(), "extension")) {
+            String version = XmlSupport.childText(extension, "version");
+            if (!version.isBlank()) {
+                result.add(new VersionedElement(
+                        "build extension",
+                        new Coordinate(
+                                XmlSupport.childText(extension, "groupId"),
+                                XmlSupport.childText(extension, "artifactId")),
+                        version));
+            }
+        }
+        return result;
+    }
+
+    private static void collectReleaseBackups(
+            Path repository,
+            List<String> failures) throws IOException {
+        Files.walkFileTree(repository, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(
+                    Path directory,
+                    BasicFileAttributes attributes) {
+                if (!directory.equals(repository)
+                        && ignoredDirectory(directory)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(
+                    Path file,
+                    BasicFileAttributes attributes) {
+                if (attributes.isRegularFile()
+                        && "pom.xml.releaseBackup".equals(
+                                file.getFileName().toString())) {
+                    failures.add(relative(repository, file)
+                            + ": stale Maven Release Plugin backup is present");
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static boolean ignoredDirectory(Path directory) {
+        Path fileName = directory.getFileName();
+        if (fileName == null) {
+            return false;
+        }
+        String name = fileName.toString();
+        return ".git".equals(name) || "target".equals(name);
+    }
+
+    private static void checkGitClean(Path root) {
+        if (!Files.exists(root.resolve(".git"))) {
+            return;
+        }
+        GitSupport.Result result = GitSupport.run(root, "status", "--porcelain");
+        if (result.exitCode() != 0) {
+            throw new IllegalArgumentException(
+                    "git status failed: " + result.stderr().strip());
+        }
+        if (!result.stdout().strip().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "release verification requires a clean checkout; "
+                            + "commit or stash local changes");
+        }
+    }
+
+    private static String relative(Path root, Path path) {
+        return root.relativize(path.toAbsolutePath().normalize())
+                .toString().replace('\\', '/');
+    }
+
+    public record Result(
+            String currentVersion,
+            String releaseVersion,
+            String nextDevelopmentVersion,
+            String state,
+            int pomCount) {
+    }
+
+    private record Coordinate(String groupId, String artifactId) {
+    }
+
+    private record PomModel(
+            Path path,
+            Element project,
+            String groupId,
+            String artifactId,
+            String version,
+            Map<String, String> properties,
+            Coordinate parentCoordinate) {
+    }
+
+    private record VersionedElement(
+            String kind,
+            Coordinate coordinate,
+            String rawVersion) {
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -8,7 +8,7 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-/** Entry point for dependency-free release parameter and version tooling. */
+/** Entry point for dependency-free release and repository tooling. */
 public final class TaxonomyTooling {
 
     private TaxonomyTooling() {
@@ -51,6 +51,8 @@ public final class TaxonomyTooling {
             case "resolve-release-parameters" -> resolveReleaseParameters(
                     commandArguments, environment, workingDirectory, error);
             case "check-version-state" -> checkVersionState(
+                    commandArguments, workingDirectory, output, error);
+            case "check-release-plan" -> checkReleasePlan(
                     commandArguments, workingDirectory, output, error);
             case "compare-versions" -> compareVersions(commandArguments, error);
             case "read-pom-version" -> readPomVersion(
@@ -106,6 +108,34 @@ public final class TaxonomyTooling {
             return 0;
         } catch (IOException | IllegalArgumentException failure) {
             error.println("Version-state check failed: " + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int checkReleasePlan(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path root = arguments.path("root", workingDirectory)
+                    .toAbsolutePath().normalize();
+            ReleasePlanValidator.Result result = ReleasePlanValidator.validate(
+                    root,
+                    arguments.required("current-version"),
+                    arguments.required("release-version"),
+                    arguments.required("next-development-version"),
+                    arguments.optionalOrDefault("state", "development"),
+                    arguments.booleanValue("require-clean", true));
+            output.println("Maven release check passed: "
+                    + result.currentVersion() + " -> " + result.releaseVersion()
+                    + " -> " + result.nextDevelopmentVersion() + " ("
+                    + result.state() + ", " + result.pomCount()
+                    + " reactor POMs).");
+            return 0;
+        } catch (IOException | IllegalArgumentException failure) {
+            error.println("Release check failed: " + failure.getMessage());
             return 1;
         }
     }
@@ -198,7 +228,8 @@ public final class TaxonomyTooling {
         String required(String name) {
             String value = values.get(name);
             if (value == null) {
-                throw new IllegalArgumentException("--" + name + " is required");
+                throw new IllegalArgumentException(
+                        "--" + name + " is required");
             }
             return value;
         }
@@ -207,9 +238,29 @@ public final class TaxonomyTooling {
             return values.get(name);
         }
 
+        String optionalOrDefault(String name, String fallback) {
+            String value = values.get(name);
+            return value == null ? fallback : value;
+        }
+
         Path path(String name, Path fallback) {
             String value = values.get(name);
             return value == null ? fallback : Path.of(value);
+        }
+
+        boolean booleanValue(String name, boolean fallback) {
+            String value = values.get(name);
+            if (value == null) {
+                return fallback;
+            }
+            if ("true".equalsIgnoreCase(value)) {
+                return true;
+            }
+            if ("false".equalsIgnoreCase(value)) {
+                return false;
+            }
+            throw new IllegalArgumentException(
+                    "--" + name + " must be true or false");
         }
 
         boolean flag(String name) {

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanCoordinatePropertyTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanCoordinatePropertyTest.java
@@ -1,0 +1,99 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanCoordinatePropertyTest {
+
+    @Test
+    void resolvesInternalDependencyCoordinatesFromMavenProperties(
+            @TempDir Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <internal.module>module-a</internal.module>
+                  </properties>
+                  <modules><module>module-a</module></modules>
+                  <dependencies>
+                    <dependency>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>${internal.module}</artifactId>
+                      <version>${project.version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """);
+        write(root.resolve("module-a/pom.xml"), modulePom());
+
+        ReleasePlanValidator.Result result = validate(root);
+
+        assertThat(result.pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void reportsUnresolvedCoordinatePropertiesBeforeSnapshotClassification(
+            @TempDir Path root) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>${missing.group}</groupId>
+                      <artifactId>external</artifactId>
+                      <version>9.0.0-SNAPSHOT</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """);
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unresolved coordinate property")
+                .hasMessageContaining("${missing.group}:external");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static String modulePom() {
+        return """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>1.3.0-SNAPSHOT</version>
+                  </parent>
+                  <artifactId>module-a</artifactId>
+                </project>
+                """;
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanStateNormalizationTest.java
@@ -1,0 +1,42 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReleasePlanStateNormalizationTest {
+
+    @Test
+    void trimsLifecycleStateBeforeValidation(@TempDir Path root)
+            throws Exception {
+        Files.writeString(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>fixture</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                </project>
+                """, StandardCharsets.UTF_8);
+
+        ReleasePlanValidator.Result result = ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "  development\n",
+                false);
+
+        assertThat(result.state()).isEqualTo("development");
+        assertThat(result.pomCount()).isEqualTo(1);
+        assertThat(ReleasePlanValidator.expectedCurrentVersion(
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "\t release "))
+                .isEqualTo("1.3.0");
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
@@ -44,8 +44,12 @@ class ReleasePlanTraversalSecurityTest {
         assertThatThrownBy(() -> validate(root))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("outside the repository")
-                .satisfies(error -> assertThat(error.getCause())
-                        .isNotInstanceOf(NullPointerException.class));
+                .satisfies(error -> {
+                    if (error.getCause() != null) {
+                        assertThat(error.getCause())
+                                .isNotInstanceOf(NullPointerException.class);
+                    }
+                });
     }
 
     @Test

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
@@ -1,0 +1,114 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanTraversalSecurityTest {
+
+    @Test
+    void rejectsDeclaredModuleThatEscapesThroughASymbolicLink(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, "linked-module");
+        Path outside = root.resolveSibling(
+                root.getFileName() + "-outside-module");
+        writeModulePom(outside);
+        try {
+            Files.createSymbolicLink(root.resolve("linked-module"), outside);
+        } catch (UnsupportedOperationException | IOException failure) {
+            Assumptions.assumeTrue(
+                    false,
+                    () -> "Symbolic links are unavailable: " + failure);
+            return;
+        }
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symbolic link")
+                .hasMessageContaining("linked-module");
+    }
+
+    @Test
+    void rejectsAbsoluteModulePathWithAnActionableDiagnostic(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, root.getRoot().toString());
+
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("outside the repository")
+                .doesNotHaveCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void prunesGitAndGeneratedTreesWhenLookingForReleaseBackups(
+            @TempDir Path root) throws Exception {
+        writeRootPom(root, null);
+        write(root.resolve(".git/objects/pom.xml.releaseBackup"), "ignored");
+        write(root.resolve("target/generated/pom.xml.releaseBackup"), "ignored");
+
+        assertThat(validate(root).pomCount()).isEqualTo(1);
+
+        write(root.resolve("src/pom.xml.releaseBackup"), "stale");
+        assertThatThrownBy(() -> validate(root))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("src/pom.xml.releaseBackup")
+                .hasMessageContaining("stale Maven Release Plugin backup");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static void writeRootPom(Path root, String module)
+            throws Exception {
+        String modules = module == null
+                ? ""
+                : "<modules><module>" + module + "</module></modules>";
+        write(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.3.0-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  %s
+                </project>
+                """.formatted(modules));
+    }
+
+    private static void writeModulePom(Path module) throws Exception {
+        write(module.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>com.taxonomy</groupId>
+                    <artifactId>taxonomy</artifactId>
+                    <version>1.3.0-SNAPSHOT</version>
+                  </parent>
+                  <artifactId>linked-module</artifactId>
+                </project>
+                """);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanTraversalSecurityTest.java
@@ -44,7 +44,8 @@ class ReleasePlanTraversalSecurityTest {
         assertThatThrownBy(() -> validate(root))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("outside the repository")
-                .doesNotHaveCauseInstanceOf(NullPointerException.class);
+                .satisfies(error -> assertThat(error.getCause())
+                        .isNotInstanceOf(NullPointerException.class));
     }
 
     @Test

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
@@ -1,0 +1,384 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleasePlanValidatorTest {
+
+    @Test
+    void developmentPlanAllowsTheInternalSnapshotReactor(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+
+        var result = validate(root);
+
+        assertThat(result.pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void discoversNestedDeclaredModulesAndInheritedProperties(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Path aggregator = root.resolve("module-a/pom.xml");
+        Files.writeString(aggregator,
+                Files.readString(aggregator).replace(
+                        "</project>",
+                        "<properties><nested.external.version>9.0.0"
+                                + "</nested.external.version></properties>"
+                                + "<modules><module>nested</module></modules></project>"),
+                StandardCharsets.UTF_8);
+        writeModule(
+                root,
+                "module-a/nested",
+                "com.taxonomy",
+                "module-a",
+                "1.3.0-SNAPSHOT",
+                "nested",
+                "",
+                "",
+                """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>nested-stable</artifactId>
+                          <version>${nested.external.version}</version>
+                        </dependency>
+                        """,
+                "");
+
+        assertThat(validate(root).pomCount()).isEqualTo(3);
+    }
+
+    @Test
+    void rejectsNestedExternalSnapshotAndUnresolvedProperty(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Path aggregator = root.resolve("module-a/pom.xml");
+        Files.writeString(aggregator,
+                Files.readString(aggregator).replace(
+                        "</project>",
+                        "<properties><nested.external.version>9.0.0-SNAPSHOT"
+                                + "</nested.external.version></properties>"
+                                + "<modules><module>nested</module></modules></project>"),
+                StandardCharsets.UTF_8);
+        writeModule(
+                root,
+                "module-a/nested",
+                "com.taxonomy",
+                "module-a",
+                "1.3.0-SNAPSHOT",
+                "nested",
+                "",
+                "",
+                """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>nested-unstable</artifactId>
+                          <version>${nested.external.version}</version>
+                        </dependency>
+                        """,
+                "");
+
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external dependency example:nested-unstable");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"),
+                "", """
+                        <dependency>
+                          <groupId>example</groupId>
+                          <artifactId>unknown</artifactId>
+                          <version>${missing.version}</version>
+                        </dependency>
+                        """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("unresolved version property");
+    }
+
+    @Test
+    void rejectsDuplicateCoordinatesAndMissingOrEscapingModules(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("module-a", "module-b"), "", "");
+        writeModule(root, "module-b", "com.taxonomy", "taxonomy",
+                "1.3.0-SNAPSHOT", "module-a", "", "", "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("duplicate Maven reactor coordinate");
+
+        Path missing = root.resolve("missing-case");
+        Files.createDirectories(missing);
+        writeProject(missing, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("missing"), "", "");
+        Files.delete(missing.resolve("missing/pom.xml"));
+        assertThatThrownBy(() -> validate(missing))
+                .hasMessageContaining("does not exist");
+
+        Path escaped = root.resolve("escaped-case");
+        Files.createDirectories(escaped);
+        writeProject(escaped, "1.3.0-SNAPSHOT", "1.0.0",
+                List.of("../outside"), "", "");
+        Files.createDirectories(root.resolve("outside"));
+        Files.writeString(root.resolve("outside/pom.xml"), "<project/>");
+        assertThatThrownBy(() -> validate(escaped))
+                .hasMessageContaining("outside the repository");
+    }
+
+    @Test
+    void ignoresUnrelatedPomOutsideTheDeclaredReactor(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Files.createDirectories(root.resolve("examples"));
+        Files.writeString(root.resolve("examples/pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>example</groupId><artifactId>unrelated</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </project>
+                """);
+
+        assertThat(validate(root).pomCount()).isEqualTo(2);
+    }
+
+    @Test
+    void supportsMajorAdvanceAndReleaseAndAdvancedStates(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "2.0.0-SNAPSHOT",
+                "development",
+                false).nextDevelopmentVersion()).isEqualTo("2.0.0-SNAPSHOT");
+
+        writeProject(root, "1.3.0", "1.0.0", List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.0", "1.3.0", "1.3.1-SNAPSHOT",
+                "release", false).state()).isEqualTo("release");
+
+        writeProject(root, "1.3.1-SNAPSHOT", "1.0.0",
+                List.of("module-a"), "", "");
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.1-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "advanced", false).state()).isEqualTo("advanced");
+    }
+
+    @Test
+    void rejectsNonAdvancingVersionAndReactorVersionMismatch(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.0-SNAPSHOT",
+                "development", false))
+                .hasMessageContaining("must be newer");
+
+        writeModule(root, "module-a", "com.taxonomy", "taxonomy",
+                "1.3.0-SNAPSHOT", "module-a", "org.other",
+                "1.2.9-SNAPSHOT", "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("reactor version");
+    }
+
+    @Test
+    void rejectsExternalSnapshotParentDependencyPluginAndExtension(
+            @TempDir Path root) throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "9.0.0-SNAPSHOT",
+                List.of("module-a"), "", "");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external parent org.example:external-parent");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"),
+                "<external.version>9.0.0-SNAPSHOT</external.version>",
+                """
+                        <dependency><groupId>example</groupId>
+                          <artifactId>unstable</artifactId>
+                          <version>${external.version}</version></dependency>
+                        """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external dependency example:unstable");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><plugins><plugin><groupId>example</groupId>
+                  <artifactId>unstable-plugin</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </plugin></plugins></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("external plugin example:unstable-plugin");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><extensions><extension><groupId>example</groupId>
+                  <artifactId>unstable-extension</artifactId>
+                  <version>9.0.0-SNAPSHOT</version>
+                </extension></extensions></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining(
+                        "external build extension example:unstable-extension");
+    }
+
+    @Test
+    void rejectsMavenReleasePluginAndStaleState(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        appendRoot(root, """
+                <build><plugins><plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-release-plugin</artifactId>
+                  <version>3.1.1</version>
+                </plugin></plugins></build>
+                """);
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("second SCM release authority");
+
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        Files.writeString(root.resolve("release.properties"), "stale");
+        Files.writeString(root.resolve("module-a/pom.xml.releaseBackup"), "stale");
+        assertThatThrownBy(() -> validate(root))
+                .hasMessageContaining("stale Maven Release Plugin");
+    }
+
+    @Test
+    void enforcesCleanOrdinaryAndLinkedWorktreeCheckouts(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        commitProject(root);
+        assertThat(ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true).pomCount()).isEqualTo(2);
+
+        Files.writeString(root.resolve("untracked.txt"), "dirty");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true))
+                .hasMessageContaining("clean checkout");
+
+        Files.delete(root.resolve("untracked.txt"));
+        Path worktree = root.getParent().resolve("linked-worktree");
+        TestGit.run(root, "worktree", "add", "-q", "-b", "qa-worktree",
+                worktree.toString());
+        Files.writeString(worktree.resolve("untracked.txt"), "dirty");
+        assertThat(Files.isRegularFile(worktree.resolve(".git"))).isTrue();
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                worktree, "1.3.0-SNAPSHOT", "1.3.0", "1.3.1-SNAPSHOT",
+                "development", true))
+                .hasMessageContaining("clean checkout");
+    }
+
+    @Test
+    void unresolvedReleaseArgumentIsReportedClearly(@TempDir Path root)
+            throws Exception {
+        writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
+        assertThatThrownBy(() -> ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "${releaseVersion}",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false))
+                .hasMessageContaining("was not supplied");
+    }
+
+    private static ReleasePlanValidator.Result validate(Path root)
+            throws Exception {
+        return ReleasePlanValidator.validate(
+                root,
+                "1.3.0-SNAPSHOT",
+                "1.3.0",
+                "1.3.1-SNAPSHOT",
+                "development",
+                false);
+    }
+
+    private static void writeProject(
+            Path root,
+            String version,
+            String externalParentVersion,
+            List<String> modules,
+            String properties,
+            String dependency) throws Exception {
+        Files.createDirectories(root);
+        String moduleText = modules.stream()
+                .map(module -> "<module>" + module + "</module>")
+                .reduce("", String::concat);
+        Files.writeString(root.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>org.example</groupId>
+                    <artifactId>external-parent</artifactId>
+                    <version>%s</version><relativePath/></parent>
+                  <groupId>com.taxonomy</groupId><artifactId>taxonomy</artifactId>
+                  <version>%s</version><packaging>pom</packaging>
+                  <properties>%s</properties>
+                  <modules>%s</modules>
+                </project>
+                """.formatted(externalParentVersion, version, properties, moduleText),
+                StandardCharsets.UTF_8);
+        for (String module : modules) {
+            writeModule(root, module, "com.taxonomy", "taxonomy", version,
+                    Path.of(module).getFileName().toString(), "", "",
+                    dependency, "");
+        }
+    }
+
+    private static void writeModule(
+            Path root,
+            String path,
+            String parentGroup,
+            String parentArtifact,
+            String parentVersion,
+            String artifact,
+            String ownGroup,
+            String ownVersion,
+            String dependency,
+            String extra) throws Exception {
+        Path directory = root.resolve(path);
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve("pom.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent><groupId>%s</groupId><artifactId>%s</artifactId>
+                    <version>%s</version></parent>
+                  %s<artifactId>%s</artifactId>%s
+                  <dependencies>
+                    <dependency><groupId>com.taxonomy</groupId>
+                      <artifactId>taxonomy</artifactId>
+                      <version>${project.version}</version></dependency>
+                    %s
+                  </dependencies>%s
+                </project>
+                """.formatted(
+                        parentGroup,
+                        parentArtifact,
+                        parentVersion,
+                        ownGroup.isBlank() ? "" : "<groupId>" + ownGroup + "</groupId>",
+                        artifact,
+                        ownVersion.isBlank() ? "" : "<version>" + ownVersion + "</version>",
+                        dependency,
+                        extra), StandardCharsets.UTF_8);
+    }
+
+    private static void appendRoot(Path root, String content) throws Exception {
+        Path pom = root.resolve("pom.xml");
+        Files.writeString(pom, Files.readString(pom).replace(
+                "</project>", content + "</project>"), StandardCharsets.UTF_8);
+    }
+
+    private static void commitProject(Path root) throws Exception {
+        TestGit.run(root, "init", "-q");
+        TestGit.run(root, "add", ".");
+        TestGit.run(root, "-c", "user.name=Release QA",
+                "-c", "user.email=qa@example.invalid",
+                "commit", "-qm", "initial");
+    }
+}


### PR DESCRIPTION
## Purpose

Reconstruct the intended #758 release-plan slice directly on protected `main` after #757, without force-updating or rewriting the existing stacked branch.

## Changes

- add dependency-free `ReleasePlanValidator` to `taxonomy-tooling`;
- traverse only the declared Maven reactor, including nested modules;
- resolve inherited version properties and property-based internal coordinates;
- reject missing, duplicate, lexical, absolute and symbolic-link module escapes;
- distinguish legal internal development snapshots from external parent, dependency, plugin and extension snapshots;
- reject unresolved version/coordinate properties, Maven Release Plugin dual authority and stale release state;
- prune `.git` and generated `target` subtrees when checking stale backups;
- enforce clean ordinary and linked-worktree checkouts;
- normalize the lifecycle state before validation;
- expose `check-release-plan` through the existing Java CLI.

## Evidence

The focused JUnit suite covers positive and negative reactor/state transitions, inherited properties, nested modules, symlink/absolute escapes, duplicate coordinates, snapshot rules, stale release state and linked worktrees. The two earlier Copilot findings are incorporated: lifecycle state is normalized and the dead `<properties>` traversal loop is removed.

Two follow-up commits changed only test assertions for the repository's AssertJ version and an intentionally absent exception cause. Productive code did not change. The current exact-head database matrix, CodeQL and Security Scan are green; canonical CI/CD is the remaining protected gate. Copilot reviewed all six files and produced no comments.

## Concurrency-safe reconstruction

- exact base: `08dd130e5cdcf31e3f033ab36767322d94158652`;
- exact head: `e6d03055a92efd0b9209fe0dee5809b0d325b115`;
- three commits, zero commits behind at the final code update;
- exactly six intended files;
- the original `refactor/673-release-plan-java` branch remains preserved and was not force-updated.

Supersedes #758 as the Direct-to-`main` integration path. Advances #673 and #711. Auto-merge is enabled but remains fully gated by the repository's required checks. No release request, tag, artifact publication or deployment is created.