### PR TITLE
Add Java release metadata transformation

### DIFF
--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
@@ -44,7 +44,7 @@ final class FlatJson {
         } else if (value instanceof Boolean bool) {
             output.append(bool);
         } else if (value instanceof BigDecimal decimal) {
-            output.append(decimal.toPlainString());
+            output.append(decimal);
         } else if (value instanceof Number number) {
             output.append(number);
         } else if (value instanceof Map<?, ?> map) {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
@@ -1,6 +1,7 @@
 package com.taxonomy.tooling;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -238,7 +239,14 @@ final class FlatJson {
 
         String token = source.substring(start, index);
         try {
-            return decimal ? new BigDecimal(token) : Long.valueOf(token);
+            if (decimal) {
+                return new BigDecimal(token);
+            }
+            try {
+                return Long.valueOf(token);
+            } catch (NumberFormatException outsideLongRange) {
+                return new BigInteger(token);
+            }
         } catch (NumberFormatException error) {
             throw error("JSON number is out of range");
         }

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/FlatJson.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Strict dependency-free JSON reader for release and archive metadata. */
+/** Strict dependency-free JSON reader and deterministic pretty writer. */
 final class FlatJson {
 
     private final String source;
@@ -24,6 +24,114 @@ final class FlatJson {
             throw parser.error("Unexpected content after JSON object");
         }
         return result;
+    }
+
+    static String pretty(Object value) {
+        StringBuilder output = new StringBuilder();
+        writeValue(value, output, 0);
+        return output.toString();
+    }
+
+    private static void writeValue(
+            Object value,
+            StringBuilder output,
+            int depth) {
+        if (value == null) {
+            output.append("null");
+        } else if (value instanceof String text) {
+            writeString(text, output);
+        } else if (value instanceof Boolean bool) {
+            output.append(bool);
+        } else if (value instanceof BigDecimal decimal) {
+            output.append(decimal.toPlainString());
+        } else if (value instanceof Number number) {
+            output.append(number);
+        } else if (value instanceof Map<?, ?> map) {
+            writeObject(map, output, depth);
+        } else if (value instanceof Iterable<?> iterable) {
+            writeArray(iterable, output, depth);
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported JSON value type: " + value.getClass().getName());
+        }
+    }
+
+    private static void writeObject(
+            Map<?, ?> map,
+            StringBuilder output,
+            int depth) {
+        output.append('{');
+        if (!map.isEmpty()) {
+            output.append('\n');
+            int index = 0;
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String key)) {
+                    throw new IllegalArgumentException(
+                            "JSON object keys must be strings");
+                }
+                indent(output, depth + 1);
+                writeString(key, output);
+                output.append(": ");
+                writeValue(entry.getValue(), output, depth + 1);
+                if (++index < map.size()) {
+                    output.append(',');
+                }
+                output.append('\n');
+            }
+            indent(output, depth);
+        }
+        output.append('}');
+    }
+
+    private static void writeArray(
+            Iterable<?> iterable,
+            StringBuilder output,
+            int depth) {
+        List<Object> values = new ArrayList<>();
+        iterable.forEach(values::add);
+        output.append('[');
+        if (!values.isEmpty()) {
+            output.append('\n');
+            for (int index = 0; index < values.size(); index++) {
+                indent(output, depth + 1);
+                writeValue(values.get(index), output, depth + 1);
+                if (index + 1 < values.size()) {
+                    output.append(',');
+                }
+                output.append('\n');
+            }
+            indent(output, depth);
+        }
+        output.append(']');
+    }
+
+    private static void writeString(String value, StringBuilder output) {
+        output.append('"');
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '"' -> output.append("\\\"");
+                case '\\' -> output.append("\\\\");
+                case '\b' -> output.append("\\b");
+                case '\f' -> output.append("\\f");
+                case '\n' -> output.append("\\n");
+                case '\r' -> output.append("\\r");
+                case '\t' -> output.append("\\t");
+                default -> {
+                    if (character < 0x20) {
+                        output.append("\\u")
+                                .append(String.format("%04x", (int) character));
+                    } else {
+                        output.append(character);
+                    }
+                }
+            }
+        }
+        output.append('"');
+    }
+
+    private static void indent(StringBuilder output, int depth) {
+        output.append("  ".repeat(depth));
     }
 
     private Map<String, Object> object() {

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseMetadataUpdater.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/ReleaseMetadataUpdater.java
@@ -1,0 +1,340 @@
+package com.taxonomy.tooling;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Applies one coherent release or development version to repository metadata. */
+public final class ReleaseMetadataUpdater {
+
+    static final String ORCID_ID = "0009-0005-1047-6381";
+    static final String ORCID_URL = "https://orcid.org/" + ORCID_ID;
+
+    private static final Pattern CFF_VERSION = Pattern.compile(
+            "(?m)^version: .*$");
+    private static final Pattern CFF_RELEASE_DATE = Pattern.compile(
+            "(?m)^date-released: .*\\R?");
+    private static final Pattern CITATION_PREFERRED = Pattern.compile(
+            "(Carsten Hammer\\. \\*\\*Taxonomy Architecture Analyzer\\*\\*\\. "
+                    + "Version )[0-9A-Za-z.-]+(\\. [0-9]{4}\\.)");
+    private static final Pattern CITATION_BIBTEX_VERSION = Pattern.compile(
+            "(?m)^(  version\\s+= \\{)[^}]+(},)$");
+    private static final Pattern CITATION_BIBTEX_DATE = Pattern.compile(
+            "(?m)^  date\\s+= \\{[^}]+},\\R?");
+    private static final Pattern CITATION_AUTHOR = Pattern.compile(
+            "(?m)^(  author\\s+= \\{Hammer, Carsten},)$");
+    private static final Pattern CITATION_ORCID = Pattern.compile(
+            "(?m)^  orcid\\s+= \\{[^}]+},$");
+    private static final Pattern CHART_APP_VERSION = Pattern.compile(
+            "(?m)^appVersion:\\s*.*$");
+
+    private ReleaseMetadataUpdater() {
+    }
+
+    public static Result update(
+            Path root,
+            String requestedVersion,
+            boolean release,
+            LocalDate releaseDate) throws IOException {
+        return update(
+                root,
+                requestedVersion,
+                release,
+                releaseDate,
+                ReleaseMetadataUpdater::moveReplacing);
+    }
+
+    static Result update(
+            Path root,
+            String requestedVersion,
+            boolean release,
+            LocalDate releaseDate,
+            FileReplacer replacer) throws IOException {
+        Path repository = root.toRealPath();
+        String version = release
+                ? VersionNumbers.normalizeRelease(requestedVersion, "version")
+                : VersionNumbers.normalizeDevelopment(
+                        requestedVersion, "version", false);
+        LocalDate effectiveDate = release
+                ? Objects.requireNonNull(releaseDate,
+                        "releaseDate is required in release mode")
+                : null;
+        FileReplacer effectiveReplacer = Objects.requireNonNull(
+                replacer, "replacer");
+
+        Path citationCff = repository.resolve("CITATION.cff");
+        Path citationMarkdown = repository.resolve("CITATION.md");
+        Path zenodo = repository.resolve(".zenodo.json");
+        Path codemeta = repository.resolve("codemeta.json");
+        Path chart = repository.resolve("deploy/helm/taxonomy/Chart.yaml");
+
+        LinkedHashMap<Path, String> originals = new LinkedHashMap<>();
+        originals.put(citationCff, readRequired(citationCff));
+        originals.put(zenodo, readRequired(zenodo));
+        originals.put(codemeta, readRequired(codemeta));
+        originals.put(citationMarkdown, readRequired(citationMarkdown));
+        originals.put(chart, readRequired(chart));
+
+        LinkedHashMap<Path, String> planned = new LinkedHashMap<>();
+        planned.put(citationCff, transformCitationCff(
+                originals.get(citationCff), version, effectiveDate));
+        planned.put(zenodo, transformJsonMetadata(
+                originals.get(zenodo), version, effectiveDate,
+                "publication_date"));
+        planned.put(codemeta, transformJsonMetadata(
+                originals.get(codemeta), version, effectiveDate,
+                "datePublished"));
+        planned.put(citationMarkdown, transformCitationMarkdown(
+                originals.get(citationMarkdown), version, effectiveDate));
+        planned.put(chart, transformChart(
+                originals.get(chart), version, chart));
+
+        replaceTransactionally(originals, planned, effectiveReplacer);
+        return new Result(
+                version,
+                release,
+                effectiveDate,
+                planned.keySet().stream()
+                        .map(repository::relativize)
+                        .map(path -> path.toString().replace('\\', '/'))
+                        .toList());
+    }
+
+    private static void replaceTransactionally(
+            Map<Path, String> originals,
+            Map<Path, String> planned,
+            FileReplacer replacer) throws IOException {
+        LinkedHashMap<Path, Path> staged = new LinkedHashMap<>();
+        LinkedHashMap<Path, Path> backups = new LinkedHashMap<>();
+        List<Path> replaced = new ArrayList<>();
+        Set<Path> retainedBackups = new LinkedHashSet<>();
+        try {
+            for (Map.Entry<Path, String> entry : planned.entrySet()) {
+                Path target = entry.getKey();
+                staged.put(target, stage(target, entry.getValue(), ".new"));
+                backups.put(target, stage(
+                        target, originals.get(target), ".backup"));
+            }
+
+            for (Path target : planned.keySet()) {
+                replacer.replace(staged.get(target), target);
+                replaced.add(target);
+            }
+        } catch (IOException | RuntimeException failure) {
+            rollback(replaced, backups, retainedBackups, failure);
+            throw failure;
+        } finally {
+            cleanup(staged.values(), Set.of());
+            cleanup(backups.values(), retainedBackups);
+        }
+    }
+
+    private static Path stage(Path target, String content, String suffix)
+            throws IOException {
+        Path parent = target.toAbsolutePath().normalize().getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException(
+                    "Release metadata path has no parent: " + target);
+        }
+        Path temporary = Files.createTempFile(
+                parent, ".taxonomy-metadata-", suffix);
+        boolean written = false;
+        try {
+            Files.writeString(temporary, content, StandardCharsets.UTF_8);
+            written = true;
+            return temporary;
+        } finally {
+            if (!written) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    private static void rollback(
+            List<Path> replaced,
+            Map<Path, Path> backups,
+            Set<Path> retainedBackups,
+            Throwable failure) {
+        List<Path> reverse = new ArrayList<>(replaced);
+        Collections.reverse(reverse);
+        for (Path target : reverse) {
+            Path backup = backups.get(target);
+            try {
+                moveReplacing(backup, target);
+            } catch (IOException | RuntimeException rollbackFailure) {
+                retainedBackups.add(backup);
+                failure.addSuppressed(rollbackFailure);
+            }
+        }
+    }
+
+    private static void cleanup(
+            Iterable<Path> paths,
+            Set<Path> retained) {
+        for (Path path : paths) {
+            if (retained.contains(path)) {
+                continue;
+            }
+            try {
+                Files.deleteIfExists(path);
+            } catch (IOException ignored) {
+                // Cleanup failure must not hide the original transactional result.
+            }
+        }
+    }
+
+    private static void moveReplacing(Path source, Path target)
+            throws IOException {
+        try {
+            Files.move(
+                    source,
+                    target,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            Files.move(
+                    source,
+                    target,
+                    StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private static String transformCitationCff(
+            String text,
+            String version,
+            LocalDate releaseDate) {
+        String updated = replaceRequired(
+                CFF_VERSION,
+                text,
+                "version: \"" + version + "\"",
+                "CITATION.cff has no version field");
+        updated = CFF_RELEASE_DATE.matcher(updated).replaceAll("");
+        if (releaseDate != null) {
+            updated = ensureTerminalNewline(updated)
+                    + "date-released: \"" + releaseDate + "\"\n";
+        }
+        return updated;
+    }
+
+    private static String transformJsonMetadata(
+            String text,
+            String version,
+            LocalDate releaseDate,
+            String dateKey) {
+        Map<String, Object> parsed = FlatJson.parseObject(text);
+        parsed.put("version", version);
+        if (releaseDate == null) {
+            parsed.remove(dateKey);
+        } else {
+            parsed.put(dateKey, releaseDate.toString());
+        }
+        return FlatJson.pretty(parsed) + "\n";
+    }
+
+    private static String transformCitationMarkdown(
+            String text,
+            String version,
+            LocalDate releaseDate) {
+        String updated = replaceRequired(
+                CITATION_PREFERRED,
+                text,
+                "$1" + Matcher.quoteReplacement(version) + "$2",
+                "CITATION.md has no preferred citation version");
+        updated = replaceRequired(
+                CITATION_BIBTEX_VERSION,
+                updated,
+                "$1" + Matcher.quoteReplacement(version) + "$2",
+                "CITATION.md has no BibTeX version");
+        updated = CITATION_BIBTEX_DATE.matcher(updated).replaceAll("");
+        if (releaseDate != null) {
+            updated = replaceRequired(
+                    CITATION_BIBTEX_VERSION,
+                    updated,
+                    "$1" + Matcher.quoteReplacement(version)
+                            + "$2\n  date         = {" + releaseDate + "},",
+                    "CITATION.md has no BibTeX version for the release date");
+        }
+
+        if (!updated.contains("ORCID")) {
+            String marker = "## What to cite\n";
+            if (!updated.contains(marker)) {
+                throw new IllegalArgumentException(
+                        "CITATION.md has no 'What to cite' marker for ORCID insertion");
+            }
+            updated = updated.replace(
+                    marker,
+                    "## Author identifier\n\nCarsten Hammer's ORCID iD is ["
+                            + ORCID_URL + "](" + ORCID_URL + ").\n\n"
+                            + marker);
+        }
+        if (!CITATION_ORCID.matcher(updated).find()) {
+            updated = replaceRequired(
+                    CITATION_AUTHOR,
+                    updated,
+                    "$1\n  orcid        = {" + ORCID_URL + "},",
+                    "CITATION.md has no BibTeX author for ORCID insertion");
+        }
+        return updated;
+    }
+
+    private static String transformChart(
+            String text,
+            String version,
+            Path path) {
+        return replaceRequired(
+                CHART_APP_VERSION,
+                text,
+                "appVersion: \"" + version + "\"",
+                path + " has no appVersion field");
+    }
+
+    private static String replaceRequired(
+            Pattern pattern,
+            String text,
+            String replacement,
+            String failure) {
+        Matcher matcher = pattern.matcher(text);
+        if (!matcher.find()) {
+            throw new IllegalArgumentException(failure);
+        }
+        return matcher.replaceAll(replacement);
+    }
+
+    private static String ensureTerminalNewline(String text) {
+        return text.endsWith("\n") ? text : text + "\n";
+    }
+
+    private static String readRequired(Path path) throws IOException {
+        if (!Files.isRegularFile(path)) {
+            throw new IllegalArgumentException(
+                    "Required release metadata file is missing: " + path);
+        }
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    @FunctionalInterface
+    interface FileReplacer {
+        void replace(Path staged, Path target) throws IOException;
+    }
+
+    public record Result(
+            String version,
+            boolean release,
+            LocalDate releaseDate,
+            List<String> updatedFiles) {
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -5,8 +5,12 @@ import org.w3c.dom.Element;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /** Entry point for dependency-free release and repository tooling. */
 public final class TaxonomyTooling {
@@ -56,6 +60,8 @@ public final class TaxonomyTooling {
                     commandArguments, workingDirectory, output, error);
             case "compare-versions" -> compareVersions(commandArguments, error);
             case "read-pom-version" -> readPomVersion(
+                    commandArguments, workingDirectory, output, error);
+            case "update-release-metadata" -> updateReleaseMetadata(
                     commandArguments, workingDirectory, output, error);
             default -> {
                 error.println("Unknown taxonomy-tooling command: " + command);
@@ -188,7 +194,44 @@ public final class TaxonomyTooling {
         }
     }
 
+    private static int updateReleaseMetadata(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            boolean release = arguments.flag("release");
+            String dateText = arguments.optional("date");
+            if (!release && dateText != null) {
+                throw new IllegalArgumentException(
+                        "--date is valid only together with --release");
+            }
+            LocalDate releaseDate = release
+                    ? dateText == null
+                            ? LocalDate.now(ZoneOffset.UTC)
+                            : LocalDate.parse(dateText)
+                    : null;
+            ReleaseMetadataUpdater.Result result = ReleaseMetadataUpdater.update(
+                    arguments.path("root", workingDirectory),
+                    arguments.required("version"),
+                    release,
+                    releaseDate);
+            output.println("Release metadata updated: "
+                    + result.version() + " ("
+                    + (result.release() ? "release " + result.releaseDate()
+                            : "development")
+                    + ", " + result.updatedFiles().size() + " files).");
+            return 0;
+        } catch (IOException | IllegalArgumentException | DateTimeException failure) {
+            error.println("::error::" + failure.getMessage());
+            return 1;
+        }
+    }
+
     private static final class Arguments {
+        private static final Set<String> FLAGS = Set.of("stdin", "release");
+
         private final Map<String, String> values;
         private final Map<String, Boolean> flags;
 
@@ -209,8 +252,11 @@ public final class TaxonomyTooling {
                             "Expected --option, got " + token);
                 }
                 String name = token.substring(2);
-                if ("stdin".equals(name)) {
-                    flags.put(name, Boolean.TRUE);
+                if (FLAGS.contains(name)) {
+                    if (flags.putIfAbsent(name, Boolean.TRUE) != null) {
+                        throw new IllegalArgumentException(
+                                "Duplicate flag --" + name);
+                    }
                     continue;
                 }
                 if (index + 1 >= raw.length || raw[index + 1].startsWith("--")) {

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/FlatJsonTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/FlatJsonTest.java
@@ -1,0 +1,39 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlatJsonTest {
+
+    @Test
+    void deterministicWriterRoundTripsNestedUnicodeMetadata() {
+        String source = """
+                {
+                  "name": "Größe & Qualität",
+                  "active": true,
+                  "score": 1.25,
+                  "items": [
+                    {
+                      "id": 7,
+                      "text": "line one\\nline two"
+                    },
+                    null
+                  ]
+                }
+                """;
+
+        Map<String, Object> parsed = FlatJson.parseObject(source);
+        String rendered = FlatJson.pretty(parsed);
+
+        assertThat(rendered)
+                .contains("\"name\": \"Größe & Qualität\"")
+                .contains("\"text\": \"line one\\nline two\"")
+                .doesNotContain("\\u00f6");
+        assertThat(FlatJson.parseObject(rendered)).isEqualTo(parsed);
+        assertThat(FlatJson.pretty(FlatJson.parseObject(rendered)))
+                .isEqualTo(rendered);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/FlatJsonTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/FlatJsonTest.java
@@ -2,6 +2,7 @@ package com.taxonomy.tooling;
 
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,5 +36,27 @@ class FlatJsonTest {
         assertThat(FlatJson.parseObject(rendered)).isEqualTo(parsed);
         assertThat(FlatJson.pretty(FlatJson.parseObject(rendered)))
                 .isEqualTo(rendered);
+    }
+
+    @Test
+    void exponentNumbersKeepTheirScaleWithoutPathologicalExpansion() {
+        String source = """
+                {
+                  "ordinary": 1e3,
+                  "large": 9.5e100000
+                }
+                """;
+
+        Map<String, Object> parsed = FlatJson.parseObject(source);
+        String rendered = FlatJson.pretty(parsed);
+
+        assertThat(parsed)
+                .containsEntry("ordinary", new BigDecimal("1e3"))
+                .containsEntry("large", new BigDecimal("9.5e100000"));
+        assertThat(rendered)
+                .contains("\"ordinary\": 1E+3")
+                .contains("\"large\": 9.5E+100000")
+                .hasSizeLessThan(100);
+        assertThat(FlatJson.parseObject(rendered)).isEqualTo(parsed);
     }
 }

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataEdgeCaseTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataEdgeCaseTest.java
@@ -1,0 +1,152 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseMetadataEdgeCaseTest {
+
+    @Test
+    void missingHelmChartFailsBeforeAnyMetadataWrite(@TempDir Path root)
+            throws Exception {
+        writeRequiredMetadata(root, "2031");
+        Map<Path, String> before = snapshot(root);
+
+        assertThatThrownBy(() -> ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2031, 8, 15)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Required release metadata file is missing")
+                .hasMessageContaining("Chart.yaml");
+
+        assertThat(snapshot(root)).isEqualTo(before);
+    }
+
+    @Test
+    void preservesTheCitationYearWhileReplacingOnlyTheVersion(@TempDir Path root)
+            throws Exception {
+        writeRequiredMetadata(root, "2031");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "old"
+                """);
+
+        ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2031, 8, 15));
+
+        assertThat(read(root.resolve("CITATION.md")))
+                .contains("Version 1.4.0. 2031.")
+                .doesNotContain("Version old.");
+    }
+
+    @Test
+    void invalidIsoDateReturnsControlledCliError(@TempDir Path root)
+            throws Exception {
+        writeRequiredMetadata(root, "2031");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "old"
+                """);
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int exitCode = TaxonomyTooling.run(
+                new String[]{
+                        "update-release-metadata",
+                        "--root", root.toString(),
+                        "--version", "1.4.0",
+                        "--release",
+                        "--date", "not-a-date"},
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(exitCode).isEqualTo(1);
+        assertThat(errors.toString(StandardCharsets.UTF_8))
+                .startsWith("::error::")
+                .contains("not-a-date");
+    }
+
+    private static void writeRequiredMetadata(Path root, String year)
+            throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>1.4.0</version>
+                </project>
+                """);
+        write(root.resolve("CITATION.cff"), """
+                cff-version: 1.2.0
+                title: Taxonomy
+                version: "old"
+                """);
+        write(root.resolve("CITATION.md"), """
+                # Citation
+
+                ## Author identifier
+
+                ORCID: https://orcid.org/0009-0005-1047-6381
+
+                ## What to cite
+
+                Carsten Hammer. **Taxonomy Architecture Analyzer**. Version old. %s.
+
+                ```bibtex
+                @software{taxonomy,
+                  author       = {Hammer, Carsten},
+                  orcid        = {https://orcid.org/0009-0005-1047-6381},
+                  version      = {old},
+                }
+                ```
+                """.formatted(year));
+        write(root.resolve(".zenodo.json"), """
+                {
+                  "title": "Taxonomy",
+                  "version": "old"
+                }
+                """);
+        write(root.resolve("codemeta.json"), """
+                {
+                  "@type": "SoftwareSourceCode",
+                  "version": "old"
+                }
+                """);
+    }
+
+    private static Map<Path, String> snapshot(Path root) throws Exception {
+        LinkedHashMap<Path, String> result = new LinkedHashMap<>();
+        for (Path path : java.util.List.of(
+                root.resolve("CITATION.cff"),
+                root.resolve("CITATION.md"),
+                root.resolve(".zenodo.json"),
+                root.resolve("codemeta.json"))) {
+            result.put(path, read(path));
+        }
+        return result;
+    }
+
+    private static String read(Path path) throws Exception {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataEdgeCaseTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataEdgeCaseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,6 +51,39 @@ class ReleaseMetadataEdgeCaseTest {
         assertThat(read(root.resolve("CITATION.md")))
                 .contains("Version 1.4.0. 2031.")
                 .doesNotContain("Version old.");
+    }
+
+    @Test
+    void preservesUnknownArbitraryPrecisionJsonValues(@TempDir Path root)
+            throws Exception {
+        writeRequiredMetadata(root, "2031");
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "old"
+                """);
+        String identifier = "1234567890123456789012345678901234567890";
+        write(root.resolve(".zenodo.json"), """
+                {
+                  "title": "Taxonomy",
+                  "version": "old",
+                  "external": {
+                    "identifier": %s
+                  }
+                }
+                """.formatted(identifier));
+
+        ReleaseMetadataUpdater.update(
+                root, "1.4.1-SNAPSHOT", false, null);
+
+        Map<String, Object> zenodo = FlatJson.parseObject(
+                read(root.resolve(".zenodo.json")));
+        assertThat(zenodo).containsEntry("version", "1.4.1-SNAPSHOT");
+        assertThat(zenodo.get("external")).isInstanceOfSatisfying(
+                Map.class,
+                external -> assertThat(external.get("identifier"))
+                        .isEqualTo(new BigInteger(identifier)));
     }
 
     @Test

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataIdempotencyTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataIdempotencyTest.java
@@ -1,0 +1,129 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReleaseMetadataIdempotencyTest {
+
+    @Test
+    void repeatedReleaseTransformationIsByteIdentical(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.0");
+
+        ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2031, 8, 15));
+        Map<String, String> first = snapshot(root);
+        ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2031, 8, 15));
+
+        assertThat(snapshot(root)).isEqualTo(first);
+    }
+
+    @Test
+    void repeatedDevelopmentTransformationIsByteIdentical(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.1-SNAPSHOT");
+
+        ReleaseMetadataUpdater.update(
+                root, "1.4.1-SNAPSHOT", false, null);
+        Map<String, String> first = snapshot(root);
+        ReleaseMetadataUpdater.update(
+                root, "1.4.1-SNAPSHOT", false, null);
+
+        assertThat(snapshot(root)).isEqualTo(first);
+    }
+
+    private static void writeFixture(Path root, String projectVersion)
+            throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(projectVersion));
+        write(root.resolve("CITATION.cff"), """
+                cff-version: 1.2.0
+                title: Taxonomy
+                version: "old"
+                date-released: "2026-01-01"
+                """);
+        write(root.resolve("CITATION.md"), """
+                # Citation
+
+                ## Author identifier
+
+                ORCID: https://orcid.org/0009-0005-1047-6381
+
+                ## What to cite
+
+                Carsten Hammer. **Taxonomy Architecture Analyzer**. Version old. 2031.
+
+                ```bibtex
+                @software{taxonomy,
+                  author       = {Hammer, Carsten},
+                  orcid        = {https://orcid.org/0009-0005-1047-6381},
+                  version      = {old},
+                  date         = {2026-01-01},
+                }
+                ```
+                """);
+        write(root.resolve(".zenodo.json"), """
+                {
+                  "title": "Taxonomy",
+                  "nested": {
+                    "text": "Größe"
+                  },
+                  "version": "old",
+                  "publication_date": "2026-01-01"
+                }
+                """);
+        write(root.resolve("codemeta.json"), """
+                {
+                  "@type": "SoftwareSourceCode",
+                  "keywords": [
+                    "architecture",
+                    "taxonomy"
+                  ],
+                  "version": "old",
+                  "datePublished": "2026-01-01"
+                }
+                """);
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "old"
+                """);
+    }
+
+    private static Map<String, String> snapshot(Path root) throws Exception {
+        LinkedHashMap<String, String> result = new LinkedHashMap<>();
+        for (String path : List.of(
+                "CITATION.cff",
+                "CITATION.md",
+                ".zenodo.json",
+                "codemeta.json",
+                "deploy/helm/taxonomy/Chart.yaml")) {
+            result.put(path, Files.readString(
+                    root.resolve(path), StandardCharsets.UTF_8));
+        }
+        return result;
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataTransactionTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataTransactionTest.java
@@ -1,0 +1,123 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseMetadataTransactionTest {
+
+    @Test
+    void restoresEveryFileWhenAReplacementFailsMidTransaction(
+            @TempDir Path root) throws Exception {
+        writeFixture(root);
+        Map<Path, String> before = snapshot(root);
+        AtomicInteger replacements = new AtomicInteger();
+        IOException failure = new IOException("simulated third replacement failure");
+
+        assertThatThrownBy(() -> ReleaseMetadataUpdater.update(
+                root,
+                "1.4.0",
+                true,
+                LocalDate.of(2026, 8, 15),
+                (staged, target) -> {
+                    if (replacements.incrementAndGet() == 3) {
+                        throw failure;
+                    }
+                    Files.move(
+                            staged,
+                            target,
+                            StandardCopyOption.REPLACE_EXISTING);
+                }))
+                .isSameAs(failure);
+
+        assertThat(replacements).hasValue(3);
+        assertThat(snapshot(root)).isEqualTo(before);
+        try (var paths = Files.walk(root)) {
+            assertThat(paths
+                    .filter(Files::isRegularFile)
+                    .map(path -> path.getFileName().toString())
+                    .filter(name -> name.startsWith(".taxonomy-metadata-"))
+                    .toList())
+                    .isEmpty();
+        }
+    }
+
+    private static Map<Path, String> snapshot(Path root) throws Exception {
+        LinkedHashMap<Path, String> result = new LinkedHashMap<>();
+        for (Path path : metadataPaths(root)) {
+            result.put(path, Files.readString(path, StandardCharsets.UTF_8));
+        }
+        return result;
+    }
+
+    private static java.util.List<Path> metadataPaths(Path root) {
+        return java.util.List.of(
+                root.resolve("CITATION.cff"),
+                root.resolve(".zenodo.json"),
+                root.resolve("codemeta.json"),
+                root.resolve("CITATION.md"),
+                root.resolve("deploy/helm/taxonomy/Chart.yaml"));
+    }
+
+    private static void writeFixture(Path root) throws Exception {
+        write(root.resolve("CITATION.cff"), """
+                cff-version: 1.2.0
+                title: Taxonomy
+                version: "1.4.0-SNAPSHOT"
+                """);
+        write(root.resolve(".zenodo.json"), """
+                {
+                  "title": "Taxonomy",
+                  "version": "1.4.0-SNAPSHOT"
+                }
+                """);
+        write(root.resolve("codemeta.json"), """
+                {
+                  "@type": "SoftwareSourceCode",
+                  "version": "1.4.0-SNAPSHOT"
+                }
+                """);
+        write(root.resolve("CITATION.md"), """
+                # Citation
+
+                ## Author identifier
+
+                ORCID: https://orcid.org/0009-0005-1047-6381
+
+                ## What to cite
+
+                Carsten Hammer. **Taxonomy Architecture Analyzer**. Version 1.4.0-SNAPSHOT. 2026.
+
+                ```bibtex
+                @software{taxonomy,
+                  author       = {Hammer, Carsten},
+                  orcid        = {https://orcid.org/0009-0005-1047-6381},
+                  version      = {1.4.0-SNAPSHOT},
+                }
+                ```
+                """);
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "1.4.0-SNAPSHOT"
+                """);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataUpdaterTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataUpdaterTest.java
@@ -1,0 +1,247 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReleaseMetadataUpdaterTest {
+
+    @Test
+    void appliesOneCoherentReleaseStateWithExplicitDate(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.0", false, true);
+
+        ReleaseMetadataUpdater.Result result = ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2026, 8, 15));
+
+        assertThat(result.updatedFiles()).containsExactly(
+                "CITATION.cff",
+                ".zenodo.json",
+                "codemeta.json",
+                "CITATION.md",
+                "deploy/helm/taxonomy/Chart.yaml");
+        assertThat(read(root.resolve("CITATION.cff")))
+                .contains("version: \"1.4.0\"")
+                .contains("date-released: \"2026-08-15\"");
+        assertThat(read(root.resolve("CITATION.md")))
+                .contains("Version 1.4.0. 2026.")
+                .contains("version      = {1.4.0},")
+                .contains("date         = {2026-08-15},")
+                .contains(ReleaseMetadataUpdater.ORCID_URL);
+        assertThat(readJson(root.resolve(".zenodo.json")))
+                .containsEntry("version", "1.4.0")
+                .containsEntry("publication_date", "2026-08-15")
+                .containsEntry("description", "Größe und Qualität");
+        assertThat(readJson(root.resolve("codemeta.json")))
+                .containsEntry("version", "1.4.0")
+                .containsEntry("datePublished", "2026-08-15");
+        assertThat(read(root.resolve("deploy/helm/taxonomy/Chart.yaml")))
+                .contains("appVersion: \"1.4.0\"");
+        assertThat(VersionStateVerifier.verify(
+                root, "release", "1.4.0", "v1.4.0").failures())
+                .isEmpty();
+    }
+
+    @Test
+    void removesReleaseOnlyDatesForDevelopmentSnapshot(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.1-SNAPSHOT", true, false);
+
+        ReleaseMetadataUpdater.update(
+                root, "1.4.1-SNAPSHOT", false, null);
+
+        assertThat(read(root.resolve("CITATION.cff")))
+                .contains("version: \"1.4.1-SNAPSHOT\"")
+                .doesNotContain("date-released:");
+        assertThat(read(root.resolve("CITATION.md")))
+                .contains("Version 1.4.1-SNAPSHOT. 2026.")
+                .contains("version      = {1.4.1-SNAPSHOT},")
+                .doesNotContain("date         = {");
+        assertThat(readJson(root.resolve(".zenodo.json")))
+                .containsEntry("version", "1.4.1-SNAPSHOT")
+                .doesNotContainKey("publication_date");
+        assertThat(readJson(root.resolve("codemeta.json")))
+                .containsEntry("version", "1.4.1-SNAPSHOT")
+                .doesNotContainKey("datePublished");
+        assertThat(VersionStateVerifier.verify(
+                root,
+                "development",
+                "1.4.1-SNAPSHOT",
+                null).failures()).isEmpty();
+    }
+
+    @Test
+    void validatesEveryTransformationBeforeWritingAnyFile(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.0", false, false);
+        Path chart = root.resolve("deploy/helm/taxonomy/Chart.yaml");
+        Files.writeString(chart, "apiVersion: v2\nname: taxonomy\n");
+        Map<Path, String> before = snapshot(root);
+
+        assertThatThrownBy(() -> ReleaseMetadataUpdater.update(
+                root, "1.4.0", true, LocalDate.of(2026, 8, 15)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("has no appVersion field");
+
+        assertThat(snapshot(root)).isEqualTo(before);
+    }
+
+    @Test
+    void cliUsesExplicitDateAndRejectsDateForDevelopment(@TempDir Path root)
+            throws Exception {
+        writeFixture(root, "1.4.0", false, false);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int releaseExit = TaxonomyTooling.run(
+                new String[]{
+                        "update-release-metadata",
+                        "--root", root.toString(),
+                        "--version", "1.4.0",
+                        "--release",
+                        "--date", "2026-08-15"},
+                root,
+                new PrintStream(output, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(releaseExit).isZero();
+        assertThat(output.toString(StandardCharsets.UTF_8))
+                .contains("1.4.0")
+                .contains("release 2026-08-15")
+                .contains("5 files");
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+
+        errors.reset();
+        int invalidExit = TaxonomyTooling.run(
+                new String[]{
+                        "update-release-metadata",
+                        "--root", root.toString(),
+                        "--version", "1.4.1-SNAPSHOT",
+                        "--date", "2026-08-16"},
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+        assertThat(invalidExit).isEqualTo(1);
+        assertThat(errors.toString(StandardCharsets.UTF_8))
+                .contains("--date is valid only together with --release");
+    }
+
+    private static void writeFixture(
+            Path root,
+            String projectVersion,
+            boolean includeReleaseDates,
+            boolean omitOrcid) throws Exception {
+        write(root.resolve("pom.xml"), """
+                <project xmlns="http://maven.apache.org/POM/4.0.0">
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.taxonomy</groupId>
+                  <artifactId>taxonomy</artifactId>
+                  <version>%s</version>
+                </project>
+                """.formatted(projectVersion));
+        write(root.resolve("CITATION.cff"),
+                "cff-version: 1.2.0\n"
+                        + "title: Taxonomy\n"
+                        + "version: \"old\"\n"
+                        + (includeReleaseDates
+                                ? "date-released: \"2026-01-01\"\n"
+                                : ""));
+        String authorIdentifier = omitOrcid
+                ? ""
+                : "## Author identifier\n\nORCID: "
+                        + ReleaseMetadataUpdater.ORCID_URL + "\n\n";
+        String bibtexOrcid = omitOrcid
+                ? ""
+                : "  orcid        = {" + ReleaseMetadataUpdater.ORCID_URL + "},\n";
+        write(root.resolve("CITATION.md"), """
+                # Citation
+
+                %s## What to cite
+
+                Carsten Hammer. **Taxonomy Architecture Analyzer**. Version old. 2026.
+
+                ```bibtex
+                @software{taxonomy,
+                  author       = {Hammer, Carsten},
+                %s  version      = {old},
+                %s}
+                ```
+                """.formatted(
+                        authorIdentifier,
+                        bibtexOrcid,
+                        includeReleaseDates
+                                ? "  date         = {2026-01-01},\n"
+                                : ""));
+        write(root.resolve(".zenodo.json"), """
+                {
+                  "title": "Taxonomy",
+                  "description": "Größe und Qualität",
+                  "creators": [
+                    {
+                      "name": "Hammer, Carsten",
+                      "orcid": "0009-0005-1047-6381"
+                    }
+                  ],
+                  "version": "old"%s
+                }
+                """.formatted(includeReleaseDates
+                        ? ",\n  \"publication_date\": \"2026-01-01\""
+                        : ""));
+        write(root.resolve("codemeta.json"), """
+                {
+                  "@type": "SoftwareSourceCode",
+                  "author": {
+                    "givenName": "Carsten",
+                    "familyName": "Hammer"
+                  },
+                  "version": "old"%s
+                }
+                """.formatted(includeReleaseDates
+                        ? ",\n  \"datePublished\": \"2026-01-01\""
+                        : ""));
+        write(root.resolve("deploy/helm/taxonomy/Chart.yaml"), """
+                apiVersion: v2
+                name: taxonomy
+                version: 1.4.0
+                appVersion: "old"
+                """);
+    }
+
+    private static Map<Path, String> snapshot(Path root) throws Exception {
+        LinkedHashMap<Path, String> result = new LinkedHashMap<>();
+        for (Path path : java.util.List.of(
+                root.resolve("CITATION.cff"),
+                root.resolve(".zenodo.json"),
+                root.resolve("codemeta.json"),
+                root.resolve("CITATION.md"),
+                root.resolve("deploy/helm/taxonomy/Chart.yaml"))) {
+            result.put(path, read(path));
+        }
+        return result;
+    }
+
+    private static Map<String, Object> readJson(Path path) throws Exception {
+        return FlatJson.parseObject(read(path));
+    }
+
+    private static String read(Path path) throws Exception {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Purpose

Add the Java release-metadata implementation directly after the completed release-core Python removal, without modifying the preserved historical #763/#764 branches.

## Additive Java boundary

- deterministic dependency-free JSON output preserving key order, nested data, Unicode, arbitrary-precision integers and exponent-form decimals;
- transactional `ReleaseMetadataUpdater` for mandatory `CITATION.cff`, `CITATION.md`, `.zenodo.json`, `codemeta.json` and Helm `Chart.yaml`;
- validation and complete transformation before the first write;
- adjacent staging/backups, atomic replacement where supported and reverse-order rollback;
- `update-release-metadata` CLI with release/development modes and deterministic optional release dates;
- flexible four-digit citation years and ORCID restoration.

## JUnit evidence

- release and development transformations plus version-state verification;
- missing Helm chart or `appVersion` fails before any write;
- nested Unicode JSON and unknown integers beyond `long` range survive;
- exponent values such as `1e3` keep their `BigDecimal` scale and `9.5e100000` remains a bounded exponent token;
- repeated transformations are byte-identical;
- invalid CLI dates/flags are controlled errors;
- simulated mid-transaction failure restores every file and cleans temporary state.

## Review incorporation

Preserved #763 findings are incorporated: mandatory Helm metadata, non-hard-coded citation years and controlled date parsing. Copilot's current #771 review additionally identified `BigDecimal.toPlainString()` as unsafe for exponent input. Commits `a11fa1df8d2f89bf12f3a434766966b3a865ec54` and `0cfb8817d5344f74bd8c4b22fb618d00d9c53b05` replace it with canonical exponent-preserving rendering and add the large-exponent regression test. The thread is resolved.

## Current exact state

- exact protected base: `1db4bb51449f6ee7f951f46a924ca983e6d3626c` / merged #770;
- exact head: `0cfb8817d5344f74bd8c4b22fb618d00d9c53b05`;
- seven commits, zero behind, exactly eight intended `taxonomy-tooling` files;
- CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL and Security Scan succeeded on that exact head;
- no workflow, shell, Python file, release request, tag, publication or deployment is changed;
- #774 is the single atomic dependent Draft for productive routing plus helper deletion; former intermediate #773 is closed with its branch preserved;
- original #763/#764 branches remain unchanged;
- #772 and external #744 work remain independent.

This PR is ready for protected integration, but it will not merge while the unchanged `main` verification rerun is unresolved. Merge also requires a final unchanged-head/base check and no unresolved review finding. Advances #673 and #711 without claiming that the repository is fully Python-free.