### PR TITLE
Keep the public multi-repository API opt-in for 1.4.0

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/ArchitectureRepositoryController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/ArchitectureRepositoryController.java
@@ -12,6 +12,7 @@ import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceResolver;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -29,6 +30,11 @@ import java.util.List;
 import java.util.Map;
 
 /** REST catalog for central architecture repositories and their working copies/forks. */
+@ConditionalOnProperty(
+        prefix = "taxonomy.features.multi-repository-api",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = false)
 @RestController
 @RequestMapping("/api/repositories")
 @Tag(name = "Architecture Repositories")

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ArchitectureRepositoryFeatureFlagTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/ArchitectureRepositoryFeatureFlagTest.java
@@ -1,0 +1,76 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.workspace.service.ArchitectureRepositoryProvisioningService;
+import com.taxonomy.workspace.service.RepositoryMembershipService;
+import com.taxonomy.workspace.service.RepositoryWorkspaceService;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceResolver;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ArchitectureRepositoryFeatureFlagTest {
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner()
+                    .withUserConfiguration(FeatureFlagContext.class);
+
+    @Test
+    void publicMultiRepositoryApiIsAbsentByDefault() {
+        contextRunner.run(context -> assertThat(context)
+                .doesNotHaveBean(ArchitectureRepositoryController.class));
+    }
+
+    @Test
+    void explicitFalseKeepsPublicMultiRepositoryApiAbsent() {
+        contextRunner
+                .withPropertyValues(
+                        "taxonomy.features.multi-repository-api.enabled=false")
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(ArchitectureRepositoryController.class));
+    }
+
+    @Test
+    void publicMultiRepositoryApiRequiresExplicitOptIn() {
+        contextRunner
+                .withPropertyValues(
+                        "taxonomy.features.multi-repository-api.enabled=true")
+                .run(context -> assertThat(context)
+                        .hasSingleBean(ArchitectureRepositoryController.class));
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(ArchitectureRepositoryController.class)
+    static class FeatureFlagContext {
+
+        @Bean
+        SystemRepositoryService systemRepositoryService() {
+            return mock(SystemRepositoryService.class);
+        }
+
+        @Bean
+        ArchitectureRepositoryProvisioningService provisioningService() {
+            return mock(ArchitectureRepositoryProvisioningService.class);
+        }
+
+        @Bean
+        RepositoryWorkspaceService repositoryWorkspaceService() {
+            return mock(RepositoryWorkspaceService.class);
+        }
+
+        @Bean
+        RepositoryMembershipService repositoryMembershipService() {
+            return mock(RepositoryMembershipService.class);
+        }
+
+        @Bean
+        WorkspaceResolver workspaceResolver() {
+            return mock(WorkspaceResolver.class);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Reconstruct the narrow 1.4.0 support boundary from #768 directly on the current protected `main`, without rewriting or reusing the historical branch.

## Default-safe behavior

- create `ArchitectureRepositoryController` only when `taxonomy.features.multi-repository-api.enabled=true`;
- keep the property absent/false by default, so `/api/repositories/**` is not mapped and is absent from generated OpenAPI output;
- leave the internal primary-repository catalogue and established single-repository/workspace behavior operational;
- do not alter repository persistence, JGit routing, authorization rules, caches, Hibernate Search, embeddings, recovery or index lifecycles.

The environment variable equivalent is `TAXONOMY_FEATURES_MULTI_REPOSITORY_API_ENABLED=true`.

## Executable evidence

`ArchitectureRepositoryFeatureFlagTest` uses a real Spring application context and proves:

- missing property -> no public controller bean;
- explicit `false` -> no public controller bean;
- explicit `true` -> exactly one public controller bean.

## Current exact state

- exact base: protected `main` at `1db4bb51449f6ee7f951f46a924ca983e6d3626c` after #770;
- exact head: `1c47c1935d2472cce758004a9793a1f34021eec7`;
- two commits, zero behind, exactly two intended files;
- CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL and Security Scan succeeded on that exact head;
- original #768 branch remains untouched and is retained for history;
- independent of #771 and of the external #744 cache/search contribution;
- no release request, tag, artifact publication or deployment is created.

This PR is ready for review. It will not be merged while the current `main` verification rerun is unresolved. Merge also requires no unresolved review finding and a final unchanged-head/base check. Advances #609 and #711 without claiming that #741–#749 are complete.