### PR TITLE
Route productive release metadata through Java tooling

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 : "${RELEASE_VERSION:?RELEASE_VERSION is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-: "${METADATA_HELPER:?METADATA_HELPER is required}"
 : "${TOOLING_JAR:?TOOLING_JAR is required}"
 : "${VEX_HELPER:?VEX_HELPER is required}"
 : "${RELEASE_NOTES_VALIDATOR:?RELEASE_NOTES_VALIDATOR is required}"
@@ -53,6 +52,15 @@ run_release_plan_check() {
 
 check_version_state() {
   java -jar "$TOOLING_JAR" check-version-state --root . "$@"
+}
+
+update_release_metadata() {
+  local version=$1
+  shift
+  java -jar "$TOOLING_JAR" update-release-metadata \
+    --root . \
+    --version "$version" \
+    "$@"
 }
 
 stage_version_metadata() {
@@ -280,7 +288,7 @@ run_release_plan_check "$RELEASE_CHECK_STATE" true
 
 if [[ "$STATE" == "new" ]]; then
   ./mvnw -B versions:set -DnewVersion="$RELEASE_VERSION" -DgenerateBackupPoms=false
-  python3 "$METADATA_HELPER" "$RELEASE_VERSION" --release
+  update_release_metadata "$RELEASE_VERSION" --release
   check_version_state --mode release --expected-version "$RELEASE_VERSION"
   # Validate the actual release-state reactor before committing it. The clean-check
   # is disabled only for this deliberate, uncommitted transition; the committed
@@ -324,7 +332,7 @@ if [[ "$MAIN_ALREADY_ADVANCED" == "true" ]]; then
 else
   git checkout --detach "$RELEASE_COMMIT"
   ./mvnw -B versions:set -DnewVersion="$NEXT_VERSION" -DgenerateBackupPoms=false
-  python3 "$METADATA_HELPER" "$NEXT_VERSION"
+  update_release_metadata "$NEXT_VERSION"
   check_version_state --mode development --expected-version "$NEXT_VERSION"
   stage_version_metadata
   git commit -m "Prepare next development version $NEXT_VERSION"

--- a/.github/workflows/prepare-development-version.yml
+++ b/.github/workflows/prepare-development-version.yml
@@ -120,7 +120,9 @@ jobs:
           ./mvnw -B versions:set \
             -DnewVersion="$NEXT_VERSION" \
             -DgenerateBackupPoms=false
-          python3 .github/scripts/update-release-metadata.py "$NEXT_VERSION"
+          java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" update-release-metadata \
+            --root . \
+            --version "$NEXT_VERSION"
           java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-version-state \
             --root . --mode development --expected-version "$NEXT_VERSION"
           java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-release-plan \

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataRoutingRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleaseMetadataRoutingRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReleaseMetadataRoutingRepositoryTest {
+
+    @Test
+    void productiveMetadataTransitionsUseTheVerifiedJavaBoundary()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String releaseScript = read(root.resolve(".github/scripts/release.sh"));
+        String developmentWorkflow = read(root.resolve(
+                ".github/workflows/prepare-development-version.yml"));
+        String toolingCli = read(root.resolve(
+                "taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java"));
+
+        assertThat(toolingCli)
+                .contains("case \"update-release-metadata\"")
+                .contains("ReleaseMetadataUpdater.update");
+        assertThat(releaseScript)
+                .contains("update_release_metadata()")
+                .contains("java -jar \"$TOOLING_JAR\" update-release-metadata")
+                .contains("update_release_metadata \"$RELEASE_VERSION\" --release")
+                .contains("update_release_metadata \"$NEXT_VERSION\"")
+                .doesNotContain("METADATA_HELPER")
+                .doesNotContain("python3 \"$METADATA_HELPER\"");
+        assertThat(developmentWorkflow)
+                .contains("java -jar \"$RUNNER_TEMP/taxonomy-tooling.jar\" update-release-metadata")
+                .contains("--root .")
+                .contains("--version \"$NEXT_VERSION\"")
+                .doesNotContain("python3 .github/scripts/update-release-metadata.py");
+    }
+
+    @Test
+    void bothReleaseTransitionsTransformBeforeCoherentStaging()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String script = read(root.resolve(".github/scripts/release.sh"));
+
+        assertThat(script)
+                .contains("git add -- \"${tracked_poms[@]}\" CITATION.cff CITATION.md .zenodo.json codemeta.json")
+                .contains("git add -- deploy/helm/taxonomy/Chart.yaml");
+
+        int releaseUpdate = script.indexOf(
+                "update_release_metadata \"$RELEASE_VERSION\" --release");
+        int releaseStage = script.indexOf(
+                "stage_version_metadata", releaseUpdate);
+        int nextUpdate = script.indexOf(
+                "update_release_metadata \"$NEXT_VERSION\"");
+        int nextStage = script.indexOf(
+                "stage_version_metadata", nextUpdate);
+
+        assertThat(releaseUpdate).isGreaterThanOrEqualTo(0);
+        assertThat(releaseStage).isGreaterThan(releaseUpdate);
+        assertThat(nextUpdate).isGreaterThan(releaseStage);
+        assertThat(nextStage).isGreaterThan(nextUpdate);
+    }
+
+    private static String read(Path path) throws Exception {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            "taxonomy-tooling/pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Purpose

Connect the reviewed Java metadata implementation from #771 to the two productive version-transition paths without copying the stale full #764 workflow or deleting the Python helper prematurely.

## Scope

- `release.sh` uses `taxonomy-tooling.jar update-release-metadata` for both the immutable release state and the next development snapshot;
- the manual development-version workflow uses the same Java command;
- both transformations still occur before the existing coherent Maven/CFF/Citation/Zenodo/CodeMeta/Helm staging boundary;
- all current exact-SHA, clean immutable release-plan, draft-release, image, Helm and protected-main safety logic remains unchanged;
- a Maven/JUnit repository contract proves productive routing and ordering.

## Deliberate two-step removal

This PR does **not** yet delete `.github/scripts/update-release-metadata.py` or remove its now-dead preservation/environment wiring from `deploy-release.yml`. That cleanup will be a separate small follow-up after this routing slice is verified. Splitting the change avoids replacing the current hardened release workflow with the stale #764 whole-file state and keeps the review surface at exactly three files.

## Concurrency-safe stack

- exact stacked base: #771 head `0cfb8817d5344f74bd8c4b22fb618d00d9c53b05`;
- exact head: `02c439483db20136e69ff5cbe24392d86e80b5d6`;
- three commits, zero behind, exactly three intended files;
- original #764 branch remains untouched;
- independent of #772 and of #744 cache/search work;
- no release request, tag, publication or deployment is created.

This remains Draft until #771 merges, then it will be retargeted to the resulting protected `main`, merged forward without rewriting history, and run through a fresh exact-head matrix. Advances #673 and #711.