### PR TITLE
Prove constrained Kubernetes startup and restrict chart egress

### DIFF
--- a/.github/workflows/kubernetes-constrained-smoke.yml
+++ b/.github/workflows/kubernetes-constrained-smoke.yml
@@ -1,0 +1,132 @@
+name: Kubernetes Constrained Smoke
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - 'pom.xml'
+      - 'taxonomy-tooling/**'
+      - 'taxonomy-domain/**'
+      - 'taxonomy-dsl/**'
+      - 'taxonomy-export/**'
+      - 'taxonomy-extension-api/**'
+      - 'taxonomy-app/**'
+      - 'deploy/helm/taxonomy/**'
+      - '.github/workflows/kubernetes-constrained-smoke.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - 'pom.xml'
+      - 'taxonomy-tooling/**'
+      - 'taxonomy-domain/**'
+      - 'taxonomy-dsl/**'
+      - 'taxonomy-export/**'
+      - 'taxonomy-extension-api/**'
+      - 'taxonomy-app/**'
+      - 'deploy/helm/taxonomy/**'
+      - '.github/workflows/kubernetes-constrained-smoke.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: taxonomy-kubernetes-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  constrained-smoke:
+    name: ResourceQuota, readiness and restricted egress
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Verify Docker availability
+        run: docker info
+
+      - name: Install verified kind 0.31.0
+        env:
+          KIND_VERSION: v0.31.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="kind-linux-amd64"
+          base="https://kind.sigs.k8s.io/dl/${KIND_VERSION}"
+          curl -fsSLo "$RUNNER_TEMP/kind" "${base}/${asset}"
+          curl -fsSLo "$RUNNER_TEMP/kind.sha256sum" \
+            "${base}/${asset}.sha256sum"
+          expected=$(tr -d '[:space:]' < "$RUNNER_TEMP/kind.sha256sum")
+          test "${#expected}" -eq 64
+          printf '%s  %s\n' "$expected" "$RUNNER_TEMP/kind" \
+            | sha256sum -c -
+          sudo install -m 0755 "$RUNNER_TEMP/kind" /usr/local/bin/kind
+          kind version
+
+      - name: Install verified kubectl 1.35.0
+        env:
+          KUBECTL_VERSION: v1.35.0
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64"
+          curl -fsSLo "$RUNNER_TEMP/kubectl" "${base}/kubectl"
+          curl -fsSLo "$RUNNER_TEMP/kubectl.sha256" "${base}/kubectl.sha256"
+          expected=$(tr -d '[:space:]' < "$RUNNER_TEMP/kubectl.sha256")
+          test "${#expected}" -eq 64
+          printf '%s  %s\n' "$expected" "$RUNNER_TEMP/kubectl" \
+            | sha256sum -c -
+          sudo install -m 0755 "$RUNNER_TEMP/kubectl" /usr/local/bin/kubectl
+          kubectl version --client
+
+      - name: Install verified Helm 3.21.0
+        env:
+          HELM_VERSION: v3.21.0
+        shell: bash
+        run: bash .github/scripts/install-helm.sh
+
+      - name: Create constrained kind cluster
+        shell: bash
+        run: kind create cluster --name taxonomy-smoke --wait 180s
+
+      - name: Build, install and verify Taxonomy under quota
+        env:
+          KIND_CLUSTER_NAME: taxonomy-smoke
+          SOURCE_SHA: ${{ github.sha }}
+          KEEP_RESOURCES: 'true'
+        shell: bash
+        run: bash deploy/helm/taxonomy/constrained-smoke.sh
+
+      - name: Collect cluster diagnostics
+        if: always()
+        shell: bash
+        run: |
+          mkdir -p target/kubernetes-smoke
+          kubectl cluster-info dump --all-namespaces \
+            --output-directory=target/kubernetes-smoke/cluster-dump \
+            >/dev/null 2>&1 || true
+          kubectl get nodes -o wide \
+            > target/kubernetes-smoke/nodes.txt 2>&1 || true
+          kubectl get events --all-namespaces --sort-by=.lastTimestamp \
+            > target/kubernetes-smoke/events.txt 2>&1 || true
+
+      - name: Upload constrained-cluster evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: kubernetes-constrained-smoke
+          path: target/kubernetes-smoke/**
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 90
+
+      - name: Delete kind cluster
+        if: always()
+        shell: bash
+        run: kind delete cluster --name taxonomy-smoke || true

--- a/.github/workflows/kubernetes-constrained-smoke.yml
+++ b/.github/workflows/kubernetes-constrained-smoke.yml
@@ -62,7 +62,7 @@ jobs:
           curl -fsSLo "$RUNNER_TEMP/kind" "${base}/${asset}"
           curl -fsSLo "$RUNNER_TEMP/kind.sha256sum" \
             "${base}/${asset}.sha256sum"
-          expected=$(tr -d '[:space:]' < "$RUNNER_TEMP/kind.sha256sum")
+          expected=$(awk 'NF {print $1; exit}' "$RUNNER_TEMP/kind.sha256sum")
           test "${#expected}" -eq 64
           printf '%s  %s\n' "$expected" "$RUNNER_TEMP/kind" \
             | sha256sum -c -
@@ -78,7 +78,7 @@ jobs:
           base="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64"
           curl -fsSLo "$RUNNER_TEMP/kubectl" "${base}/kubectl"
           curl -fsSLo "$RUNNER_TEMP/kubectl.sha256" "${base}/kubectl.sha256"
-          expected=$(tr -d '[:space:]' < "$RUNNER_TEMP/kubectl.sha256")
+          expected=$(awk 'NF {print $1; exit}' "$RUNNER_TEMP/kubectl.sha256")
           test "${#expected}" -eq 64
           printf '%s  %s\n' "$expected" "$RUNNER_TEMP/kubectl" \
             | sha256sum -c -

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN chmod +x mvnw
 
 # Copy the reactor descriptors first so dependency downloads remain cacheable.
 COPY pom.xml .
+COPY taxonomy-tooling/pom.xml taxonomy-tooling/pom.xml
 COPY taxonomy-domain/pom.xml taxonomy-domain/pom.xml
 COPY taxonomy-dsl/pom.xml taxonomy-dsl/pom.xml
 COPY taxonomy-export/pom.xml taxonomy-export/pom.xml
@@ -30,8 +31,10 @@ COPY taxonomy-app/pom.xml taxonomy-app/pom.xml
 COPY taxonomy-coverage/pom.xml taxonomy-coverage/pom.xml
 COPY taxonomy-build/pom.xml taxonomy-build/pom.xml
 
-# Copy all inputs required by the packaged application. In particular, the app
-# Maven module embeds Markdown help, screenshots and legal notices in the JAR.
+# Copy all inputs required by the packaged application and every main-source
+# reactor module. In particular, the app Maven module embeds Markdown help,
+# screenshots and legal notices in the JAR.
+COPY taxonomy-tooling/src taxonomy-tooling/src
 COPY taxonomy-domain/src taxonomy-domain/src
 COPY taxonomy-dsl/src taxonomy-dsl/src
 COPY taxonomy-export/src taxonomy-export/src

--- a/deploy/helm/taxonomy/CAPACITY.md
+++ b/deploy/helm/taxonomy/CAPACITY.md
@@ -1,0 +1,148 @@
+# Kubernetes capacity and constrained-cluster evidence
+
+This document separates **verified deployment envelopes** from resource declarations that have not yet completed representative workload benchmarking.
+
+## Supported 1.4.0 deployment floor
+
+The release-candidate floor is the single-replica constrained/evaluation profile. It proves that the packaged production image can be scheduled, started and used for a minimal HTTP workflow inside a namespace with an explicit `ResourceQuota`, `LimitRange`, read-only root filesystem and restricted NetworkPolicy egress.
+
+| Profile | Purpose | Requests | Limits | Optional embeddings | Database | Validation status |
+|---|---|---:|---:|---|---|---|
+| `values-constrained-smoke.yaml` | automated cluster proof only | 100 mCPU / 512 MiB | 500 mCPU / 1 GiB | disabled | packaged HSQLDB | live kind smoke on every relevant change |
+| `values-small.yaml` | evaluation and functional validation | 100 mCPU / 768 MiB | 500 mCPU / 1536 MiB | disabled | operator-supplied | chart-verified; constrained envelope, not throughput capacity |
+| `values-rancher-rke2.yaml` | Rancher/RKE2 evaluation behind `/taxonomy/` | 100 mCPU / 512 MiB | 500 mCPU / 1536 MiB | disabled by default | operator-supplied | chart-verified; ingress selectors and restricted egress tested |
+| default values | starting point for a standard single replica | 250 mCPU / 768 MiB | 2 CPU / 2 GiB | disabled by default | operator-supplied | declaration only; not yet a measured standard workload envelope |
+| large | import/analysis/optional local-model workload | not fixed | not fixed | workload-dependent | operator-supplied | unsupported until the remaining #638 benchmark matrix is complete |
+
+Do not advertise the default or a locally invented large override as a measured production capacity envelope. The remaining work must measure startup, import, search, standard analysis and optional ONNX workloads before those profiles receive supported throughput or concurrency claims.
+
+## Reproducible constrained-cluster test
+
+The `Kubernetes Constrained Smoke` workflow performs these operations on one exact source SHA:
+
+1. installs checksum-verified, version-pinned `kind`, `kubectl` and Helm binaries;
+2. builds the production `Dockerfile` and records its immutable local image ID;
+3. loads that image into an isolated kind cluster;
+4. applies `constrained-smoke-prerequisites.yaml`, including namespace, quota and limit range;
+5. renders and installs the chart with `values-constrained-smoke.yaml`;
+6. waits for startup, readiness and rollout completion;
+7. verifies the readiness endpoint and the application home page through the Kubernetes Service;
+8. records source commit/tree, image IDs, Kubernetes/kind/Helm versions, readiness duration, restart count and rendered/cluster resources;
+9. uploads the complete evidence directory even when the smoke test fails.
+
+The local equivalent is:
+
+```bash
+kind create cluster --name taxonomy-smoke --wait 180s
+HELM_VERSION=v3.21.0 bash .github/scripts/install-helm.sh
+KIND_CLUSTER_NAME=taxonomy-smoke \
+  SOURCE_SHA="$(git rev-parse HEAD)" \
+  bash deploy/helm/taxonomy/constrained-smoke.sh
+kind delete cluster --name taxonomy-smoke
+```
+
+The evidence is written below `target/kubernetes-smoke/`. A passing `evidence.json` contains both the exact Git source identity and the immutable local image ID used by the pod. Release publication later binds the equivalent proof to the published OCI digest.
+
+## Explicit NetworkPolicy egress
+
+The portable chart now defaults to:
+
+```yaml
+networkPolicy:
+  enabled: true
+  egressMode: restricted
+  allowSameNamespaceEgress: true
+  dns:
+    enabled: true
+  egress: []
+```
+
+This generates only:
+
+- same-namespace pod egress, needed for an in-cluster database or other explicitly colocated dependency;
+- DNS to selected CoreDNS/kube-dns pods in `kube-system` on TCP/UDP port 53;
+- additional reviewed rules supplied under `networkPolicy.egress`.
+
+An external PostgreSQL example using a controlled private CIDR is:
+
+```yaml
+networkPolicy:
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.40.0.0/16
+      ports:
+        - protocol: TCP
+          port: 5432
+```
+
+Equivalent explicit rules can be added for:
+
+- an in-cluster Keycloak/OIDC namespace and pod selector;
+- an OTLP collector namespace and port;
+- a private LLM gateway;
+- an operator-controlled model mirror.
+
+Portable Kubernetes NetworkPolicy does not support provider FQDNs. Public SaaS endpoints with rotating addresses require one of:
+
+- a controlled egress proxy with a stable CIDR;
+- a CNI-specific, separately managed FQDN policy;
+- an explicitly reviewed `ipBlock` lifecycle outside the chart.
+
+Do not encode unstable public provider IP ranges into release values.
+
+`networkPolicy.egressMode=open` remains an explicit diagnostic/legacy escape hatch. It renders unrestricted egress visibly and is not used by the supported small, Rancher or constrained-smoke profiles. An empty `{}` rule is rejected when restricted mode is selected.
+
+## Diagnosing resource pressure
+
+### Scheduling failure
+
+Typical indicators:
+
+- `exceeded quota` in pod events;
+- `Insufficient cpu` or `Insufficient memory` from the scheduler;
+- a `LimitRange` default that conflicts with chart requests/limits.
+
+Inspect:
+
+```bash
+kubectl -n taxonomy describe resourcequota
+kubectl -n taxonomy describe limitrange
+kubectl -n taxonomy describe pod -l app.kubernetes.io/name=taxonomy
+```
+
+### CPU throttling
+
+Symptoms include slow startup without increasing resident memory, long analysis latency and elevated container CPU throttling counters. Do not increase concurrency first. Compare requested/limited CPU with measured steady-state and peak evidence, then change one profile at a time.
+
+### Memory pressure or OOM
+
+Symptoms include exit code 137, `OOMKilled`, repeated startup and missing readiness. The JVM heap is only part of container memory; Lucene, metaspace, native libraries, thread stacks and filesystem cache also consume the limit. Preserve headroom rather than setting `MaxRAMPercentage` near 100%.
+
+### Readiness timeout
+
+Distinguish a scheduling delay from application initialization:
+
+```bash
+kubectl -n taxonomy get pods -w
+kubectl -n taxonomy describe pod <pod>
+kubectl -n taxonomy logs <pod>
+kubectl -n taxonomy get events --sort-by=.lastTimestamp
+```
+
+The automated evidence archive retains the same diagnostics.
+
+## Remaining benchmark work
+
+Issue #638 remains open until all of the following are measured and reproducible for named standard and large profiles:
+
+- startup and readiness distribution;
+- representative taxonomy import;
+- full-text and graph/search latency;
+- standard LLM-backed analysis with a controlled mock/provider boundary;
+- optional local ONNX/model loading;
+- CPU throttling, resident/anonymous memory and lifetime peak;
+- steady-state and peak requests/limits derived from the evidence;
+- RKE2/K3s and ingress-controller label variants beyond the kind release floor.
+
+Any future capacity table must name source SHA, immutable image digest, cluster version, node capacity, workload fixture and measurement method. A resource declaration without those fields is not benchmark evidence.

--- a/deploy/helm/taxonomy/constrained-smoke-prerequisites.yaml
+++ b/deploy/helm/taxonomy/constrained-smoke-prerequisites.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: taxonomy-smoke
+  labels:
+    kubernetes.io/metadata.name: taxonomy-smoke
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: taxonomy-smoke-quota
+  namespace: taxonomy-smoke
+spec:
+  hard:
+    requests.cpu: "750m"
+    requests.memory: 1280Mi
+    limits.cpu: "1500m"
+    limits.memory: 2Gi
+    pods: "4"
+    services: "4"
+    configmaps: "8"
+    secrets: "8"
+    persistentvolumeclaims: "0"
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: taxonomy-smoke-limits
+  namespace: taxonomy-smoke
+spec:
+  limits:
+    - type: Container
+      defaultRequest:
+        cpu: 100m
+        memory: 256Mi
+      default:
+        cpu: 500m
+        memory: 1Gi
+      min:
+        cpu: 25m
+        memory: 64Mi
+      max:
+        cpu: "1"
+        memory: 1536Mi
+    - type: Pod
+      max:
+        cpu: "1"
+        memory: 1536Mi

--- a/deploy/helm/taxonomy/constrained-smoke.sh
+++ b/deploy/helm/taxonomy/constrained-smoke.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+CHART_DIR="${ROOT_DIR}/deploy/helm/taxonomy"
+NAMESPACE=${TAXONOMY_SMOKE_NAMESPACE:-taxonomy-smoke}
+RELEASE=${TAXONOMY_SMOKE_RELEASE:-taxonomy}
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-taxonomy-smoke}
+SOURCE_SHA=${SOURCE_SHA:-$(git -C "${ROOT_DIR}" rev-parse HEAD)}
+IMAGE_REPOSITORY=${IMAGE_REPOSITORY:-taxonomy-smoke}
+IMAGE_TAG=${IMAGE_TAG:-sha-${SOURCE_SHA}}
+IMAGE_REFERENCE="${IMAGE_REPOSITORY}:${IMAGE_TAG}"
+EVIDENCE_DIR=${EVIDENCE_DIR:-"${ROOT_DIR}/target/kubernetes-smoke"}
+KEEP_RESOURCES=${KEEP_RESOURCES:-false}
+PORT_FORWARD_PID=""
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "${PORT_FORWARD_PID}" ]]; then
+    kill "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+    wait "${PORT_FORWARD_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ "${KEEP_RESOURCES}" != "true" ]]; then
+    helm uninstall "${RELEASE}" --namespace "${NAMESPACE}" >/dev/null 2>&1 || true
+    kubectl delete namespace "${NAMESPACE}" --wait=false >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+for command in docker kind kubectl helm curl jq; do
+  command -v "${command}" >/dev/null 2>&1 \
+    || fail "${command} is required for the constrained-cluster smoke test"
+done
+if ! [[ "${SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "SOURCE_SHA must be a full 40-character Git commit ID"
+fi
+if ! [[ "${IMAGE_TAG}" =~ ^sha-[0-9a-f]{40}$ ]]; then
+  fail "IMAGE_TAG must use sha-<40 lowercase hex>"
+fi
+if [[ "${KEEP_RESOURCES}" != "true" && "${KEEP_RESOURCES}" != "false" ]]; then
+  fail "KEEP_RESOURCES must be true or false"
+fi
+
+mkdir -p "${EVIDENCE_DIR}"
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+START_EPOCH=$(date +%s)
+BUILD_DATE=$(git -C "${ROOT_DIR}" show -s --format=%cI "${SOURCE_SHA}")
+VERSION=$(./mvnw -q -f "${ROOT_DIR}/pom.xml" -DforceStdout help:evaluate \
+  -Dexpression=project.version)
+
+printf 'Building constrained-smoke image %s from %s\n' \
+  "${IMAGE_REFERENCE}" "${SOURCE_SHA}"
+docker build \
+  --build-arg "BUILD_DATE=${BUILD_DATE}" \
+  --build-arg "VCS_REF=${SOURCE_SHA}" \
+  --build-arg "VERSION=${VERSION}" \
+  --tag "${IMAGE_REFERENCE}" \
+  "${ROOT_DIR}"
+IMAGE_ID=$(docker image inspect "${IMAGE_REFERENCE}" --format '{{.Id}}')
+if ! [[ "${IMAGE_ID}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  fail "Docker did not return an immutable local image ID"
+fi
+
+kind get clusters | grep -Fxq "${KIND_CLUSTER_NAME}" \
+  || fail "kind cluster ${KIND_CLUSTER_NAME} does not exist"
+kind load docker-image "${IMAGE_REFERENCE}" --name "${KIND_CLUSTER_NAME}"
+
+kubectl apply -f "${CHART_DIR}/constrained-smoke-prerequisites.yaml"
+kubectl wait --for=jsonpath='{.status.phase}'=Active \
+  "namespace/${NAMESPACE}" --timeout=60s
+
+helm lint "${CHART_DIR}" \
+  --values "${CHART_DIR}/values-constrained-smoke.yaml" \
+  --set "image.repository=${IMAGE_REPOSITORY}" \
+  --set "image.tag=${IMAGE_TAG}" \
+  --set-json secretEnv='{}'
+
+RENDERED_MANIFEST="${EVIDENCE_DIR}/rendered.yaml"
+helm template "${RELEASE}" "${CHART_DIR}" \
+  --namespace "${NAMESPACE}" \
+  --values "${CHART_DIR}/values-constrained-smoke.yaml" \
+  --set "image.repository=${IMAGE_REPOSITORY}" \
+  --set "image.tag=${IMAGE_TAG}" \
+  --set-json secretEnv='{}' \
+  >"${RENDERED_MANIFEST}"
+
+if grep -A3 '^  egress:' "${RENDERED_MANIFEST}" | grep -Fq -- '- {}'; then
+  fail "constrained smoke manifest contains unrestricted NetworkPolicy egress"
+fi
+grep -Fq 'kind: ResourceQuota' \
+  "${CHART_DIR}/constrained-smoke-prerequisites.yaml"
+grep -Fq 'kind: LimitRange' \
+  "${CHART_DIR}/constrained-smoke-prerequisites.yaml"
+grep -Fq 'kubernetes.io/metadata.name: kube-system' "${RENDERED_MANIFEST}"
+grep -Fq 'protocol: UDP' "${RENDERED_MANIFEST}"
+grep -Fq 'protocol: TCP' "${RENDERED_MANIFEST}"
+
+helm upgrade --install "${RELEASE}" "${CHART_DIR}" \
+  --namespace "${NAMESPACE}" \
+  --values "${CHART_DIR}/values-constrained-smoke.yaml" \
+  --set "image.repository=${IMAGE_REPOSITORY}" \
+  --set "image.tag=${IMAGE_TAG}" \
+  --set-json secretEnv='{}' \
+  --atomic \
+  --wait \
+  --timeout 12m
+
+kubectl rollout status "deployment/${RELEASE}" \
+  --namespace "${NAMESPACE}" --timeout=2m
+READY_EPOCH=$(date +%s)
+READINESS_SECONDS=$((READY_EPOCH - START_EPOCH))
+POD=$(kubectl get pod --namespace "${NAMESPACE}" \
+  -l app.kubernetes.io/instance="${RELEASE}" \
+  -o jsonpath='{.items[0].metadata.name}')
+[[ -n "${POD}" ]] || fail "Taxonomy pod was not created"
+
+kubectl get resourcequota,limitrange,pod,service,networkpolicy \
+  --namespace "${NAMESPACE}" -o yaml \
+  >"${EVIDENCE_DIR}/cluster-resources.yaml"
+kubectl describe pod "${POD}" --namespace "${NAMESPACE}" \
+  >"${EVIDENCE_DIR}/pod-describe.txt"
+kubectl logs "${POD}" --namespace "${NAMESPACE}" \
+  >"${EVIDENCE_DIR}/application.log"
+
+kubectl port-forward --namespace "${NAMESPACE}" \
+  "service/${RELEASE}" 18080:80 \
+  >"${EVIDENCE_DIR}/port-forward.log" 2>&1 &
+PORT_FORWARD_PID=$!
+for _ in $(seq 1 60); do
+  if curl --fail --silent --show-error \
+      http://127.0.0.1:18080/actuator/health/readiness \
+      >"${EVIDENCE_DIR}/readiness.json"; then
+    break
+  fi
+  sleep 2
+done
+curl --fail --silent --show-error http://127.0.0.1:18080/ \
+  >"${EVIDENCE_DIR}/home.html"
+grep -Fq 'Taxonomy' "${EVIDENCE_DIR}/home.html"
+jq -e '.status == "UP"' "${EVIDENCE_DIR}/readiness.json" >/dev/null
+
+POD_IMAGE_ID=$(kubectl get pod "${POD}" --namespace "${NAMESPACE}" \
+  -o jsonpath='{.status.containerStatuses[0].imageID}')
+RESTARTS=$(kubectl get pod "${POD}" --namespace "${NAMESPACE}" \
+  -o jsonpath='{.status.containerStatuses[0].restartCount}')
+NODE=$(kubectl get pod "${POD}" --namespace "${NAMESPACE}" \
+  -o jsonpath='{.spec.nodeName}')
+KUBERNETES_VERSION=$(kubectl version -o json \
+  | jq -r '.serverVersion.gitVersion')
+KIND_VERSION=$(kind version | awk '{print $2}')
+HELM_VERSION=$(helm version --short)
+COMPLETED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+jq -n \
+  --arg sourceSha "${SOURCE_SHA}" \
+  --arg sourceTree "$(git -C "${ROOT_DIR}" rev-parse "${SOURCE_SHA}^{tree}")" \
+  --arg image "${IMAGE_REFERENCE}" \
+  --arg imageId "${IMAGE_ID}" \
+  --arg podImageId "${POD_IMAGE_ID}" \
+  --arg namespace "${NAMESPACE}" \
+  --arg pod "${POD}" \
+  --arg node "${NODE}" \
+  --arg startedAt "${STARTED_AT}" \
+  --arg completedAt "${COMPLETED_AT}" \
+  --arg kubernetesVersion "${KUBERNETES_VERSION}" \
+  --arg kindVersion "${KIND_VERSION}" \
+  --arg helmVersion "${HELM_VERSION}" \
+  --argjson readinessSeconds "${READINESS_SECONDS}" \
+  --argjson restartCount "${RESTARTS}" \
+  '{
+    schemaVersion: 1,
+    result: "passed",
+    source: {commit: $sourceSha, tree: $sourceTree},
+    image: {reference: $image, localImageId: $imageId, podImageId: $podImageId},
+    cluster: {
+      kind: $kindVersion,
+      kubernetes: $kubernetesVersion,
+      helm: $helmVersion,
+      namespace: $namespace,
+      node: $node
+    },
+    workload: {
+      pod: $pod,
+      readinessSeconds: $readinessSeconds,
+      restartCount: $restartCount,
+      resourceQuota: true,
+      limitRange: true,
+      restrictedEgress: true,
+      minimalHttpWorkflow: true
+    },
+    startedAt: $startedAt,
+    completedAt: $completedAt
+  }' >"${EVIDENCE_DIR}/evidence.json"
+
+printf 'Constrained Kubernetes smoke passed in %s seconds. Evidence: %s\n' \
+  "${READINESS_SECONDS}" "${EVIDENCE_DIR}/evidence.json"

--- a/deploy/helm/taxonomy/templates/resources.yaml
+++ b/deploy/helm/taxonomy/templates/resources.yaml
@@ -243,8 +243,31 @@ spec:
   {{- else }}
   ingress: []
   {{- end }}
+  {{- $egressMode := .Values.networkPolicy.egressMode | default "restricted" }}
+  {{- if eq $egressMode "open" }}
   egress:
-    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+    - {}
+  {{- else if or .Values.networkPolicy.allowSameNamespaceEgress .Values.networkPolicy.dns.enabled (gt (len .Values.networkPolicy.egress) 0) }}
+  egress:
+    {{- if .Values.networkPolicy.allowSameNamespaceEgress }}
+    - to:
+        - podSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.dns.enabled }}
+    - to:
+        - namespaceSelector:
+            {{- toYaml .Values.networkPolicy.dns.namespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml .Values.networkPolicy.dns.podSelector | nindent 12 }}
+      ports:
+        {{- toYaml .Values.networkPolicy.dns.ports | nindent 8 }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  egress: []
+  {{- end }}
 {{- end }}
 {{- if .Values.ingress.enabled }}
 ---

--- a/deploy/helm/taxonomy/templates/validation.yaml
+++ b/deploy/helm/taxonomy/templates/validation.yaml
@@ -29,6 +29,30 @@
 {{- if and .Values.ingress.enabled .Values.networkPolicy.enabled (eq (len .Values.networkPolicy.ingressFrom) 0) -}}
 {{- fail "ingress.enabled with NetworkPolicy requires networkPolicy.ingressFrom rules for the ingress controller" -}}
 {{- end -}}
+{{- if .Values.networkPolicy.enabled -}}
+{{- $egressMode := .Values.networkPolicy.egressMode | default "restricted" -}}
+{{- if not (has $egressMode (list "restricted" "open")) -}}
+{{- fail "networkPolicy.egressMode must be restricted or open" -}}
+{{- end -}}
+{{- if and (eq $egressMode "restricted") .Values.networkPolicy.dns.enabled -}}
+{{- if empty .Values.networkPolicy.dns.namespaceSelector -}}
+{{- fail "restricted DNS egress requires networkPolicy.dns.namespaceSelector" -}}
+{{- end -}}
+{{- if empty .Values.networkPolicy.dns.podSelector -}}
+{{- fail "restricted DNS egress requires networkPolicy.dns.podSelector" -}}
+{{- end -}}
+{{- if eq (len .Values.networkPolicy.dns.ports) 0 -}}
+{{- fail "restricted DNS egress requires networkPolicy.dns.ports" -}}
+{{- end -}}
+{{- end -}}
+{{- if eq $egressMode "restricted" -}}
+{{- range $index, $rule := .Values.networkPolicy.egress -}}
+{{- if eq (toJson $rule) "{}" -}}
+{{- fail (printf "networkPolicy.egress[%d] must not be an unrestricted empty rule in restricted mode" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.authorization.enabled -}}
 {{- $metricsSecret := include "taxonomy.metricsSecretName" . | trim -}}
 {{- if empty $metricsSecret -}}

--- a/deploy/helm/taxonomy/values-constrained-smoke.yaml
+++ b/deploy/helm/taxonomy/values-constrained-smoke.yaml
@@ -22,7 +22,9 @@ resources:
     cpu: "500m"
     memory: 1Gi
 
-secretEnv: {}
+# Helm deep-merges maps. Null is deliberate here: it replaces the chart's
+# credential map rather than leaving inherited database/API keys behind.
+secretEnv: null
 existingSecret: ""
 
 networkPolicy:

--- a/deploy/helm/taxonomy/values-constrained-smoke.yaml
+++ b/deploy/helm/taxonomy/values-constrained-smoke.yaml
@@ -1,0 +1,60 @@
+# Live constrained-cluster smoke profile.
+#
+# This profile is not a production database recommendation. It uses the packaged
+# HSQLDB default so scheduling, probes, security contexts, NetworkPolicy and a
+# minimal HTTP workflow can be proven without introducing a second database pod
+# into the namespace quota. Production profiles continue to require the reviewed
+# external database Secret and explicit egress rule.
+
+replicaCount: 1
+
+image:
+  repository: taxonomy-smoke
+  tag: ""
+  digest: ""
+  pullPolicy: Never
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    cpu: "500m"
+    memory: 1Gi
+
+secretEnv: {}
+existingSecret: ""
+
+networkPolicy:
+  enabled: true
+  allowSameNamespace: true
+  egressMode: restricted
+  allowSameNamespaceEgress: true
+  egress: []
+
+config:
+  SPRING_PROFILES_ACTIVE: hsqldb,kubernetes
+  TAXONOMY_INIT_ASYNC: "true"
+  TAXONOMY_INIT_RELOAD_EXISTING: "false"
+  TAXONOMY_DDL_AUTO: create
+  TAXONOMY_SEARCH_DIRECTORY_TYPE: local-heap
+  TAXONOMY_SEARCH_SYNC_STRATEGY: sync
+  TAXONOMY_SPRINGDOC_ENABLED: "false"
+  TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
+  TAXONOMY_EMBEDDING_ENABLED: "false"
+  TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
+  TAXONOMY_THYMELEAF_CACHE: "true"
+  JAVA_OPTS: -XX:+UseSerialGC -XX:MaxRAMPercentage=60.0 -XX:InitialRAMPercentage=15.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp
+
+startupProbe:
+  failureThreshold: 90
+  periodSeconds: 5
+  timeoutSeconds: 3
+readinessProbe:
+  failureThreshold: 9
+  periodSeconds: 5
+  timeoutSeconds: 3
+livenessProbe:
+  failureThreshold: 3
+  periodSeconds: 20
+  timeoutSeconds: 3

--- a/deploy/helm/taxonomy/values-rancher-rke2.yaml
+++ b/deploy/helm/taxonomy/values-rancher-rke2.yaml
@@ -28,9 +28,15 @@ ingress:
 # RKE2 normally runs ingress-nginx in kube-system. A separately installed
 # controller commonly runs in ingress-nginx. Retain only the selector that
 # matches the target cluster.
+#
+# Egress stays in the chart's restricted mode. Same-namespace traffic and DNS
+# are generated centrally; add reviewed database/LLM/OIDC/OTLP ipBlock or
+# namespace/pod-selector rules under networkPolicy.egress for the real cluster.
 networkPolicy:
   enabled: true
   allowSameNamespace: true
+  egressMode: restricted
+  allowSameNamespaceEgress: true
   ingressFrom:
     - namespaceSelector:
         matchLabels:
@@ -46,5 +52,4 @@ networkPolicy:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
-  egress:
-    - {}
+  egress: []

--- a/deploy/helm/taxonomy/values-small.yaml
+++ b/deploy/helm/taxonomy/values-small.yaml
@@ -15,6 +15,11 @@ resources:
     cpu: "500m"
     memory: 1536Mi
 
+networkPolicy:
+  egressMode: restricted
+  allowSameNamespaceEgress: true
+  egress: []
+
 config:
   TAXONOMY_INIT_ASYNC: "true"
   TAXONOMY_SEARCH_DIRECTORY_TYPE: local-heap

--- a/deploy/helm/taxonomy/values.yaml
+++ b/deploy/helm/taxonomy/values.yaml
@@ -96,16 +96,42 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
 
-# The default policy permits application access only from the same namespace.
-# When ingress is enabled, add the ingress-controller namespace/pod selectors to
-# ingressFrom. Egress remains open because PostgreSQL, LLM and optional model
-# endpoints are deployment-specific; replace it with explicit rules as required.
+# Default-deny ingress/egress with explicit, composable exceptions.
+#
+# restricted: permit only the generated same-namespace and DNS rules plus the
+#             deployment-specific entries supplied in `egress`.
+# open:       render one unrestricted egress rule. This is an explicit legacy or
+#             diagnostic opt-in and is rejected by the supported small/Rancher
+#             verification profiles.
+#
+# Kubernetes NetworkPolicy does not resolve FQDNs. External database, LLM, OIDC,
+# OTLP or model-download destinations must therefore be represented by reviewed
+# ipBlock, namespaceSelector and/or podSelector rules. CNI-specific FQDN policies
+# belong in separately managed resources, not in this portable chart.
 networkPolicy:
   enabled: true
   allowSameNamespace: true
   ingressFrom: []
-  egress:
-    - {}
+  egressMode: restricted
+  allowSameNamespaceEgress: true
+  dns:
+    enabled: true
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    podSelector:
+      matchExpressions:
+        - key: k8s-app
+          operator: In
+          values: [kube-dns, coredns]
+    ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+  # Additional explicit Kubernetes NetworkPolicy egress rules. Examples and
+  # operational guidance are documented in README.md and RANCHER.md.
+  egress: []
 
 # Existing Secret containing the keys referenced by secretEnv. Required while
 # secretEnv is non-empty; credentials are never rendered into chart values.

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -30,6 +30,28 @@ expect_failure() {
   fi
 }
 
+assert_restricted_egress() {
+  local manifest=$1
+  local profile=$2
+  if grep -Fq -- '- {}' "${manifest}"; then
+    echo "${profile} must not render unrestricted NetworkPolicy egress" >&2
+    exit 1
+  fi
+  for required in \
+    'kubernetes.io/metadata.name: kube-system' \
+    'operator: In' \
+    'kube-dns' \
+    'coredns' \
+    'port: 53' \
+    'protocol: UDP' \
+    'protocol: TCP'; do
+    if ! grep -Fq "${required}" "${manifest}"; then
+      echo "${profile} is missing restricted DNS egress contract: ${required}" >&2
+      exit 1
+    fi
+  done
+}
+
 helm lint "${CHART_DIR}" "${COMMON_VALUES[@]}"
 helm template taxonomy "${CHART_DIR}" \
   "${COMMON_VALUES[@]}" \
@@ -55,6 +77,7 @@ for required in \
     exit 1
   fi
 done
+assert_restricted_egress "${OUTPUT_FILE}" 'default profile'
 
 PRERELEASE_OUTPUT="${TMP_DIR}/prerelease.yaml"
 helm template taxonomy "${CHART_DIR}" \
@@ -111,6 +134,7 @@ if grep -Fq 'cpu: "2"' "${SMALL_OUTPUT}"; then
   echo "Small profile must not inherit the universal two-CPU limit" >&2
   exit 1
 fi
+assert_restricted_egress "${SMALL_OUTPUT}" 'small profile'
 
 RANCHER_OUTPUT="${TMP_DIR}/rancher.yaml"
 RANCHER_EVIDENCE="${ROOT_DIR}/target/taxonomy-helm-rancher-rke2-rendered.yaml"
@@ -136,6 +160,57 @@ for required in \
     exit 1
   fi
 done
+assert_restricted_egress "${RANCHER_OUTPUT}" 'Rancher profile'
+
+CONSTRAINED_OUTPUT="${TMP_DIR}/constrained.yaml"
+helm lint "${CHART_DIR}" \
+  --values "${CHART_DIR}/values-constrained-smoke.yaml" \
+  --set "image.tag=${VALID_TAG}" \
+  --set-json secretEnv='{}'
+helm template taxonomy "${CHART_DIR}" \
+  --namespace taxonomy-smoke \
+  --values "${CHART_DIR}/values-constrained-smoke.yaml" \
+  --set "image.tag=${VALID_TAG}" \
+  --set-json secretEnv='{}' \
+  >"${CONSTRAINED_OUTPUT}"
+for required in \
+  'imagePullPolicy: Never' \
+  'cpu: 100m' \
+  'cpu: 500m' \
+  'memory: 512Mi' \
+  'memory: 1Gi' \
+  'name: SPRING_PROFILES_ACTIVE' \
+  'value: "hsqldb,kubernetes"'; do
+  if ! grep -Fq "${required}" "${CONSTRAINED_OUTPUT}"; then
+    echo "Rendered constrained profile is missing required contract: ${required}" >&2
+    exit 1
+  fi
+done
+if grep -Fq 'secretKeyRef:' "${CONSTRAINED_OUTPUT}"; then
+  echo "Constrained HSQLDB smoke profile must not render credential Secret references" >&2
+  exit 1
+fi
+assert_restricted_egress "${CONSTRAINED_OUTPUT}" 'constrained smoke profile'
+for prerequisite in 'kind: Namespace' 'kind: ResourceQuota' 'kind: LimitRange'; do
+  grep -Fq "${prerequisite}" \
+    "${CHART_DIR}/constrained-smoke-prerequisites.yaml"
+done
+
+EXPLICIT_EGRESS_OUTPUT="${TMP_DIR}/explicit-egress.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  "${COMMON_VALUES[@]}" \
+  --set-json networkPolicy.egress='[{"to":[{"ipBlock":{"cidr":"10.40.0.0/16"}}],"ports":[{"protocol":"TCP","port":5432}]}]' \
+  >"${EXPLICIT_EGRESS_OUTPUT}"
+grep -Fq 'cidr: 10.40.0.0/16' "${EXPLICIT_EGRESS_OUTPUT}"
+grep -Fq 'port: 5432' "${EXPLICIT_EGRESS_OUTPUT}"
+assert_restricted_egress "${EXPLICIT_EGRESS_OUTPUT}" 'explicit database egress profile'
+
+OPEN_EGRESS_OUTPUT="${TMP_DIR}/open-egress.yaml"
+helm template taxonomy "${CHART_DIR}" \
+  "${COMMON_VALUES[@]}" \
+  --set networkPolicy.egressMode=open \
+  >"${OPEN_EGRESS_OUTPUT}"
+grep -Fq -- '- {}' "${OPEN_EGRESS_OUTPUT}"
 
 PERSISTENCE_OUTPUT="${TMP_DIR}/persistence.yaml"
 helm template taxonomy "${CHART_DIR}" \
@@ -196,5 +271,14 @@ expect_failure 'ServiceMonitor authorization without a Secret' \
     --set "image.tag=${VALID_TAG}" \
     --set-json secretEnv='{}' \
     --set serviceMonitor.enabled=true
+expect_failure 'unknown egress mode' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set networkPolicy.egressMode=automatic
+expect_failure 'unrestricted rule hidden inside restricted egress list' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set-json networkPolicy.egress='[{}]'
+expect_failure 'restricted DNS without a namespace selector' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" --set-json networkPolicy.dns.namespaceSelector='{}'
 
 printf 'Helm chart verification passed. Rendered evidence: %s\n' "${OUTPUT_FILE}"

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ContainerReactorContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ContainerReactorContractTest.java
@@ -1,0 +1,65 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Keeps the production Docker build aligned with the declared Maven reactor. */
+class ContainerReactorContractTest {
+
+    private static final Pattern MODULE = Pattern.compile(
+            "<module>\\s*([^<]+?)\\s*</module>");
+
+    @Test
+    void productionDockerfileCopiesEveryReactorDescriptorAndMainSourceTree()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String pom = Files.readString(root.resolve("pom.xml"), StandardCharsets.UTF_8);
+        String dockerfile = Files.readString(
+                root.resolve("Dockerfile"), StandardCharsets.UTF_8);
+        List<String> modules = modules(pom);
+
+        assertThat(modules).isNotEmpty();
+        for (String module : modules) {
+            assertThat(dockerfile)
+                    .as("Dockerfile reactor descriptor for %s", module)
+                    .contains("COPY " + module + "/pom.xml " + module + "/pom.xml");
+            if (Files.isDirectory(root.resolve(module + "/src/main"))) {
+                assertThat(dockerfile)
+                        .as("Dockerfile main source tree for %s", module)
+                        .contains("COPY " + module + "/src " + module + "/src");
+            }
+        }
+        assertThat(dockerfile)
+                .contains("./mvnw -q -DskipTests package")
+                .doesNotContain("-pl taxonomy-app");
+    }
+
+    private static List<String> modules(String pom) {
+        Matcher matcher = MODULE.matcher(pom);
+        return matcher.results()
+                .map(result -> result.group(1).strip())
+                .toList();
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve("Dockerfile"))
+                    && Files.isDirectory(current.resolve("deploy/helm/taxonomy"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/HelmConstrainedSmokeContractTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/HelmConstrainedSmokeContractTest.java
@@ -1,0 +1,103 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Fast repository contract for the constrained Kubernetes release floor. */
+class HelmConstrainedSmokeContractTest {
+
+    @Test
+    void supportedProfilesUseRestrictedExplicitEgress() throws Exception {
+        Path root = findRepositoryRoot();
+        String defaults = read(root.resolve("deploy/helm/taxonomy/values.yaml"));
+        String small = read(root.resolve("deploy/helm/taxonomy/values-small.yaml"));
+        String rancher = read(root.resolve(
+                "deploy/helm/taxonomy/values-rancher-rke2.yaml"));
+        String constrained = read(root.resolve(
+                "deploy/helm/taxonomy/values-constrained-smoke.yaml"));
+        String resources = read(root.resolve(
+                "deploy/helm/taxonomy/templates/resources.yaml"));
+        String validation = read(root.resolve(
+                "deploy/helm/taxonomy/templates/validation.yaml"));
+
+        assertThat(defaults)
+                .contains("egressMode: restricted")
+                .contains("allowSameNamespaceEgress: true")
+                .contains("kubernetes.io/metadata.name: kube-system")
+                .contains("values: [kube-dns, coredns]")
+                .doesNotContain("egress:\n    - {}");
+        assertThat(small).contains("egressMode: restricted");
+        assertThat(rancher)
+                .contains("egressMode: restricted")
+                .doesNotContain("egress:\n    - {}");
+        assertThat(constrained)
+                .contains("egressMode: restricted")
+                .contains("SPRING_PROFILES_ACTIVE: hsqldb,kubernetes")
+                .contains("pullPolicy: Never");
+        assertThat(resources)
+                .contains("if eq $egressMode \"open\"")
+                .contains("networkPolicy.dns.namespaceSelector")
+                .contains("networkPolicy.dns.podSelector")
+                .contains("networkPolicy.dns.ports");
+        assertThat(validation)
+                .contains("networkPolicy.egressMode must be restricted or open")
+                .contains("must not be an unrestricted empty rule in restricted mode");
+    }
+
+    @Test
+    void liveSmokeIsQuotaBoundDigestAwareAndPythonFree() throws Exception {
+        Path root = findRepositoryRoot();
+        String prerequisites = read(root.resolve(
+                "deploy/helm/taxonomy/constrained-smoke-prerequisites.yaml"));
+        String script = read(root.resolve(
+                "deploy/helm/taxonomy/constrained-smoke.sh"));
+        String workflow = read(root.resolve(
+                ".github/workflows/kubernetes-constrained-smoke.yml"));
+
+        assertThat(prerequisites)
+                .contains("kind: ResourceQuota")
+                .contains("kind: LimitRange")
+                .contains("requests.cpu")
+                .contains("limits.memory");
+        assertThat(script)
+                .contains("docker build")
+                .contains("kind load docker-image")
+                .contains("helm upgrade --install")
+                .contains("/actuator/health/readiness")
+                .contains("localImageId")
+                .contains("sourceSha")
+                .contains("restrictedEgress: true")
+                .doesNotContain("python")
+                .doesNotContain("pip");
+        assertThat(workflow)
+                .contains("KIND_VERSION: v0.31.0")
+                .contains("KUBECTL_VERSION: v1.35.0")
+                .contains("sha256sum -c -")
+                .contains("bash deploy/helm/taxonomy/constrained-smoke.sh")
+                .contains("kubernetes-constrained-smoke")
+                .doesNotContain("setup-python");
+    }
+
+    private static String read(Path path) throws Exception {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            "deploy/helm/taxonomy/values.yaml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Purpose

Implement the 1.4.0 deployment-safety floor from #638 without overlapping the active #774 metadata migration, #775 coverage policy, #776 large-result UI work, or contributor work associated with #744.

The chart previously rendered unrestricted NetworkPolicy egress (`- {}`) in every supported profile and had no live ResourceQuota/LimitRange installation proof. This PR makes egress explicit and adds a reproducible constrained-cluster workflow tied to exact source and image identity.

## Explicit portable egress

- default `networkPolicy.egressMode` is `restricted`;
- generated rules permit same-namespace dependencies and selected CoreDNS/kube-dns pods only;
- database, LLM gateway, OIDC, OTLP and model-mirror traffic must be supplied as reviewed Kubernetes NetworkPolicy rules;
- restricted mode rejects an empty `{}` rule and invalid DNS selector/port configuration;
- `egressMode=open` remains a visible diagnostic/legacy opt-in, but is absent from the supported small, Rancher and constrained profiles;
- chart verification renders default, small, Rancher, constrained, explicit-database and deliberate-open profiles and tests invalid configurations.

Portable NetworkPolicy cannot safely express rotating SaaS FQDNs; operator documentation therefore requires a stable egress proxy, CNI-specific FQDN policy or reviewed `ipBlock` lifecycle rather than embedding unstable provider addresses.

## Live constrained-cluster proof

A path-scoped `Kubernetes Constrained Smoke` workflow:

- installs checksum-verified pinned kind, kubectl and Helm binaries;
- builds the production Dockerfile from the exact GitHub SHA;
- loads the immutable local image into kind;
- applies an explicit namespace, `ResourceQuota` and `LimitRange`;
- installs `values-constrained-smoke.yaml` with restricted egress;
- waits for startup/readiness and exercises readiness plus the application home page through the Service;
- records source commit/tree, local and pod image IDs, cluster/tool versions, readiness duration, restarts, rendered manifests and diagnostics;
- uploads evidence even on failure.

The smoke profile deliberately uses packaged HSQLDB to prove the application/container/cluster boundary without consuming quota for an unrelated database pod. Production profiles still require an operator-supplied database and explicit egress.

## Additional release correction

The root Maven reactor now includes `taxonomy-tooling`, but the production Dockerfile did not copy its POM or source tree. This PR corrects that build-context drift and adds a Maven/JUnit contract that derives every required Docker `COPY` from the root module list.

## Operator evidence

`CAPACITY.md` distinguishes the supported constrained/evaluation floor from the unmeasured default and large profiles, documents quota/throttling/OOM diagnosis, the exact smoke procedure, egress examples and evidence requirements. It deliberately does not invent standard/large throughput claims.

## Scope and remaining work

- exact base: protected `main` at `6733674034e13f75013be1aae6dbd0c57e87ebab`;
- exact head: `ad85d627b559e537f348eb37d0603793715a567b`;
- zero commits behind and 14 intended deployment, evidence and test files;
- no application domain behavior, release request, Python migration, multi-repository persistence, cache/search-index, tag, publication or deployment-hook change;
- #774, #775, #776 and contributor branches remain untouched.

This implements the release-critical constrained-cluster and explicit-egress floor. #638 remains open for measured standard and large workload envelopes, ONNX capacity, RKE2/K3s variants and production OCI-digest evidence. The PR remains Draft until Helm/static contracts, the new live cluster workflow, the ordinary exact-head matrix and review are green.