### PR TITLE
Generate the CycloneDX SBOM companion with Java tooling

### DIFF
--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/SbomCompanionGenerator.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/SbomCompanionGenerator.java
@@ -1,0 +1,366 @@
+package com.taxonomy.tooling;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Generates a CycloneDX SBOM companion without vulnerability or exploitability
+ * assertions. An empty vulnerabilities array explicitly means not assessed.
+ */
+public final class SbomCompanionGenerator {
+
+    static final String GENERATOR_NAME = "taxonomy-sbom-companion-generator";
+    static final String GENERATOR_VERSION = "2.0.0";
+    static final String ASSESSMENT_POLICY =
+            "No vulnerability scan or exploitability assessment is represented "
+                    + "by this document. An empty vulnerabilities array is not "
+                    + "evidence that the release has no known or exploitable "
+                    + "vulnerabilities.";
+
+    private SbomCompanionGenerator() {
+    }
+
+    /**
+     * Generates a reproducible companion whose timestamp and serial number are
+     * derived from the exact source SBOM.
+     */
+    public static Result generate(
+            Path sbomPath,
+            Path outputPath) throws IOException {
+        return generateInternal(
+                sbomPath,
+                outputPath,
+                null,
+                null,
+                true,
+                SbomCompanionGenerator::writeAtomically);
+    }
+
+    /** Generates a companion with an explicit identity for deterministic tests. */
+    public static Result generate(
+            Path sbomPath,
+            Path outputPath,
+            Instant timestamp,
+            UUID serialNumber) throws IOException {
+        return generateInternal(
+                sbomPath,
+                outputPath,
+                timestamp,
+                serialNumber,
+                false,
+                SbomCompanionGenerator::writeAtomically);
+    }
+
+    static Result generate(
+            Path sbomPath,
+            Path outputPath,
+            Instant timestamp,
+            UUID serialNumber,
+            CompanionWriter writer) throws IOException {
+        return generateInternal(
+                sbomPath,
+                outputPath,
+                timestamp,
+                serialNumber,
+                false,
+                writer);
+    }
+
+    private static Result generateInternal(
+            Path sbomPath,
+            Path outputPath,
+            Instant timestamp,
+            UUID serialNumber,
+            boolean deriveIdentity,
+            CompanionWriter writer) throws IOException {
+        Path sbom = sbomPath.toAbsolutePath().normalize();
+        Path output = outputPath.toAbsolutePath().normalize();
+        if (sbom.equals(output)) {
+            throw new IllegalArgumentException(
+                    "SBOM companion output must differ from the source SBOM");
+        }
+
+        try {
+            CompanionWriter effectiveWriter = Objects.requireNonNull(
+                    writer, "writer");
+            SourceData source = readSource(sbom);
+            Instant generatedAt = deriveIdentity
+                    ? requiredSourceTimestamp(source)
+                    : Objects.requireNonNull(timestamp, "timestamp")
+                            .truncatedTo(ChronoUnit.SECONDS);
+            UUID companionId = deriveIdentity
+                    ? deterministicSerial(source)
+                    : Objects.requireNonNull(serialNumber, "serialNumber");
+
+            LinkedHashMap<String, Object> companion = new LinkedHashMap<>();
+            companion.put("bomFormat", "CycloneDX");
+            companion.put("specVersion", "1.6");
+            companion.put("version", 1L);
+            companion.put("serialNumber", "urn:uuid:" + companionId);
+            companion.put("metadata", metadata(
+                    generatedAt,
+                    source.serialNumber(),
+                    source.version(),
+                    source.sha256()));
+            companion.put("vulnerabilities", List.of());
+
+            effectiveWriter.write(
+                    output, FlatJson.pretty(companion) + "\n");
+            return new Result(
+                    output,
+                    generatedAt,
+                    companionId,
+                    source.serialNumber(),
+                    source.version(),
+                    source.sha256(),
+                    source.componentCount());
+        } catch (IOException | RuntimeException failure) {
+            deleteStaleOutput(output, failure);
+            throw failure;
+        }
+    }
+
+    private static SourceData readSource(Path sbom) throws IOException {
+        if (!Files.isRegularFile(sbom)) {
+            throw new IllegalArgumentException(
+                    "CycloneDX SBOM file is missing: " + sbom);
+        }
+        byte[] bytes = Files.readAllBytes(sbom);
+        Map<String, Object> source = FlatJson.parseObject(
+                new String(bytes, StandardCharsets.UTF_8));
+        String sourceSerial = scalarText(
+                source.get("serialNumber"), "unknown", "serialNumber");
+        String sourceVersion = scalarText(
+                source.get("version"), "1", "version");
+        int componentCount = componentCount(source.get("components"));
+        Instant sourceTimestamp = optionalSourceTimestamp(source);
+        return new SourceData(
+                sourceSerial,
+                sourceVersion,
+                sha256(bytes),
+                componentCount,
+                sourceTimestamp);
+    }
+
+    private static Instant optionalSourceTimestamp(Map<String, Object> source) {
+        Object metadataValue = source.get("metadata");
+        if (metadataValue == null) {
+            return null;
+        }
+        if (!(metadataValue instanceof Map<?, ?> metadata)) {
+            throw new IllegalArgumentException(
+                    "CycloneDX SBOM metadata must be an object");
+        }
+        Object timestampValue = metadata.get("timestamp");
+        if (timestampValue == null) {
+            return null;
+        }
+        if (!(timestampValue instanceof String timestamp)) {
+            throw new IllegalArgumentException(
+                    "CycloneDX SBOM metadata.timestamp must be a string");
+        }
+        try {
+            return Instant.parse(timestamp).truncatedTo(ChronoUnit.SECONDS);
+        } catch (DateTimeException failure) {
+            throw new IllegalArgumentException(
+                    "CycloneDX SBOM metadata.timestamp is not an ISO instant: "
+                            + timestamp,
+                    failure);
+        }
+    }
+
+    private static Instant requiredSourceTimestamp(SourceData source) {
+        if (source.timestamp() == null) {
+            throw new IllegalArgumentException(
+                    "Reproducible SBOM companion generation requires "
+                            + "metadata.timestamp in the source SBOM");
+        }
+        if ("unknown".equals(source.serialNumber())) {
+            throw new IllegalArgumentException(
+                    "Reproducible SBOM companion generation requires "
+                            + "serialNumber in the source SBOM");
+        }
+        return source.timestamp();
+    }
+
+    private static UUID deterministicSerial(SourceData source) {
+        String name = GENERATOR_NAME + "|" + GENERATOR_VERSION + "|"
+                + source.serialNumber() + "|" + source.sha256();
+        return UUID.nameUUIDFromBytes(name.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String sha256(byte[] content) {
+        try {
+            return HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256").digest(content));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException(
+                    "JDK does not provide required SHA-256", impossible);
+        }
+    }
+
+    private static Map<String, Object> metadata(
+            Instant timestamp,
+            String sourceSerial,
+            String sourceVersion,
+            String sourceSha256) {
+        LinkedHashMap<String, Object> tools = new LinkedHashMap<>();
+        tools.put("components", List.of(toolComponent()));
+
+        LinkedHashMap<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("timestamp", timestamp.toString());
+        metadata.put("tools", tools);
+        metadata.put("component", applicationComponent());
+        metadata.put("properties", List.of(
+                property("taxonomy:sbom-ref", sourceSerial),
+                property("taxonomy:sbom-version", sourceVersion),
+                property("taxonomy:sbom-sha256", sourceSha256),
+                property("vex:assessment-status", "not-assessed"),
+                property("vex:policy", ASSESSMENT_POLICY)));
+        return metadata;
+    }
+
+    private static Map<String, Object> toolComponent() {
+        LinkedHashMap<String, Object> component = new LinkedHashMap<>();
+        component.put("type", "application");
+        component.put("name", GENERATOR_NAME);
+        component.put("version", GENERATOR_VERSION);
+        component.put(
+                "description",
+                "Links Taxonomy release metadata to its SBOM without making "
+                        + "vulnerability or exploitability assertions");
+        return component;
+    }
+
+    private static Map<String, Object> applicationComponent() {
+        LinkedHashMap<String, Object> supplier = new LinkedHashMap<>();
+        supplier.put("name", "Carsten Hammer");
+        supplier.put("url", List.of("https://github.com/carstenartur"));
+
+        LinkedHashMap<String, Object> component = new LinkedHashMap<>();
+        component.put("type", "application");
+        component.put("name", "Taxonomy Architecture Analyzer");
+        component.put("bom-ref", "taxonomy-app");
+        component.put("purl", "pkg:github/carstenartur/Taxonomy");
+        component.put("supplier", supplier);
+        return component;
+    }
+
+    private static Map<String, Object> property(String name, String value) {
+        LinkedHashMap<String, Object> property = new LinkedHashMap<>();
+        property.put("name", name);
+        property.put("value", value);
+        return property;
+    }
+
+    private static String scalarText(
+            Object value,
+            String fallback,
+            String field) {
+        if (value == null) {
+            return fallback;
+        }
+        if (value instanceof String
+                || value instanceof Number
+                || value instanceof Boolean) {
+            return String.valueOf(value);
+        }
+        throw new IllegalArgumentException(
+                "CycloneDX SBOM " + field + " must be a scalar value");
+    }
+
+    private static int componentCount(Object value) {
+        if (value == null) {
+            return 0;
+        }
+        if (value instanceof List<?> components) {
+            return components.size();
+        }
+        throw new IllegalArgumentException(
+                "CycloneDX SBOM components must be an array");
+    }
+
+    private static void deleteStaleOutput(Path output, Throwable failure) {
+        try {
+            Files.deleteIfExists(output);
+        } catch (IOException cleanupFailure) {
+            failure.addSuppressed(cleanupFailure);
+        }
+    }
+
+    private static void writeAtomically(Path output, String content)
+            throws IOException {
+        if (Files.isRegularFile(output)
+                && Files.readString(output, StandardCharsets.UTF_8)
+                        .equals(content)) {
+            return;
+        }
+        Path parent = output.getParent();
+        if (parent == null) {
+            throw new IllegalArgumentException(
+                    "SBOM companion output has no parent directory: " + output);
+        }
+        Files.createDirectories(parent);
+        Path temporary = Files.createTempFile(
+                parent, ".taxonomy-sbom-", ".tmp");
+        boolean moved = false;
+        try {
+            Files.writeString(temporary, content, StandardCharsets.UTF_8);
+            try {
+                Files.move(
+                        temporary,
+                        output,
+                        StandardCopyOption.ATOMIC_MOVE,
+                        StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException unsupported) {
+                Files.move(
+                        temporary,
+                        output,
+                        StandardCopyOption.REPLACE_EXISTING);
+            }
+            moved = true;
+        } finally {
+            if (!moved) {
+                Files.deleteIfExists(temporary);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface CompanionWriter {
+        void write(Path output, String content) throws IOException;
+    }
+
+    private record SourceData(
+            String serialNumber,
+            String version,
+            String sha256,
+            int componentCount,
+            Instant timestamp) {
+    }
+
+    public record Result(
+            Path output,
+            Instant timestamp,
+            UUID serialNumber,
+            String sourceSerialNumber,
+            String sourceVersion,
+            String sourceSha256,
+            int componentCount) {
+    }
+}

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/TaxonomyTooling.java
@@ -6,11 +6,13 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /** Entry point for dependency-free release and repository tooling. */
 public final class TaxonomyTooling {
@@ -62,6 +64,8 @@ public final class TaxonomyTooling {
             case "read-pom-version" -> readPomVersion(
                     commandArguments, workingDirectory, output, error);
             case "update-release-metadata" -> updateReleaseMetadata(
+                    commandArguments, workingDirectory, output, error);
+            case "generate-sbom-companion" -> generateSbomCompanion(
                     commandArguments, workingDirectory, output, error);
             default -> {
                 error.println("Unknown taxonomy-tooling command: " + command);
@@ -222,6 +226,46 @@ public final class TaxonomyTooling {
                     + (result.release() ? "release " + result.releaseDate()
                             : "development")
                     + ", " + result.updatedFiles().size() + " files).");
+            return 0;
+        } catch (IOException | IllegalArgumentException | DateTimeException failure) {
+            error.println("::error::" + failure.getMessage());
+            return 1;
+        }
+    }
+
+    private static int generateSbomCompanion(
+            String[] rawArguments,
+            Path workingDirectory,
+            PrintStream output,
+            PrintStream error) {
+        try {
+            Arguments arguments = Arguments.parse(rawArguments);
+            Path sbom = arguments.path(
+                    "sbom", workingDirectory.resolve("target/taxonomy-sbom.json"));
+            Path destination = arguments.path(
+                    "output", workingDirectory.resolve("target/taxonomy-vex.json"));
+            String timestampText = arguments.optional("timestamp");
+            String serialText = arguments.optional("serial-number");
+            if ((timestampText == null) != (serialText == null)) {
+                throw new IllegalArgumentException(
+                        "--timestamp and --serial-number must be supplied together");
+            }
+
+            SbomCompanionGenerator.Result result;
+            if (timestampText == null) {
+                result = SbomCompanionGenerator.generate(sbom, destination);
+            } else {
+                result = SbomCompanionGenerator.generate(
+                        sbom,
+                        destination,
+                        Instant.parse(timestampText),
+                        UUID.fromString(serialText));
+            }
+            output.println("SBOM companion document generated: " + result.output());
+            output.println("  Vulnerability assessment: not-assessed");
+            output.println("  SBOM serial: " + result.sourceSerialNumber());
+            output.println("  SBOM SHA-256: " + result.sourceSha256());
+            output.println("  Components in SBOM: " + result.componentCount());
             return 0;
         } catch (IOException | IllegalArgumentException | DateTimeException failure) {
             error.println("::error::" + failure.getMessage());

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionGeneratorTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionGeneratorTest.java
@@ -1,0 +1,258 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SbomCompanionGeneratorTest {
+
+    private static final Instant TIMESTAMP =
+            Instant.parse("2026-08-15T01:02:03.987Z");
+    private static final UUID SERIAL =
+            UUID.fromString("12345678-1234-5678-9abc-1234567890ab");
+
+    @Test
+    void generatesDeterministicNonAssertionCompanion(@TempDir Path root)
+            throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("nested/taxonomy-vex.json");
+        Files.writeString(sbom, """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "serialNumber": "urn:uuid:source-bom",
+                  "version": 7,
+                  "components": [
+                    {"name": "one"},
+                    {"name": "two"}
+                  ]
+                }
+                """, StandardCharsets.UTF_8);
+
+        SbomCompanionGenerator.Result result =
+                SbomCompanionGenerator.generate(
+                        sbom, output, TIMESTAMP, SERIAL);
+
+        assertThat(result.timestamp())
+                .isEqualTo(Instant.parse("2026-08-15T01:02:03Z"));
+        assertThat(result.sourceSerialNumber())
+                .isEqualTo("urn:uuid:source-bom");
+        assertThat(result.sourceVersion()).isEqualTo("7");
+        assertThat(result.sourceSha256())
+                .matches("[0-9a-f]{64}");
+        assertThat(result.componentCount()).isEqualTo(2);
+
+        Map<String, Object> companion = FlatJson.parseObject(
+                Files.readString(output, StandardCharsets.UTF_8));
+        assertThat(companion)
+                .containsEntry("bomFormat", "CycloneDX")
+                .containsEntry("specVersion", "1.6")
+                .containsEntry("version", 1L)
+                .containsEntry("serialNumber", "urn:uuid:" + SERIAL);
+        assertThat(companion.get("vulnerabilities"))
+                .isEqualTo(List.of());
+
+        Map<String, Object> metadata = object(companion.get("metadata"));
+        assertThat(metadata.get("timestamp"))
+                .isEqualTo("2026-08-15T01:02:03Z");
+        Map<String, String> properties = properties(metadata.get("properties"));
+        assertThat(properties)
+                .containsEntry("taxonomy:sbom-ref", "urn:uuid:source-bom")
+                .containsEntry("taxonomy:sbom-version", "7")
+                .containsEntry("taxonomy:sbom-sha256", result.sourceSha256())
+                .containsEntry("vex:assessment-status", "not-assessed")
+                .containsEntry(
+                        "vex:policy",
+                        SbomCompanionGenerator.ASSESSMENT_POLICY);
+
+        String rendered = Files.readString(output, StandardCharsets.UTF_8);
+        assertThat(rendered)
+                .contains("\"vulnerabilities\": []")
+                .contains("not-assessed")
+                .doesNotContain("\"state\": \"not_affected\"")
+                .doesNotContain("\"state\": \"resolved\"")
+                .doesNotContain("\"state\": \"exploitable\"")
+                .doesNotContain("\"analysis\":");
+        assertThat(FlatJson.pretty(companion) + "\n").isEqualTo(rendered);
+    }
+
+    @Test
+    void removesStaleOutputWhenSbomIsMissingOrMalformed(@TempDir Path root)
+            throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("taxonomy-vex.json");
+        Files.writeString(output, "stale", StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> SbomCompanionGenerator.generate(
+                sbom, output, TIMESTAMP, SERIAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("SBOM file is missing");
+        assertThat(output).doesNotExist();
+
+        Files.writeString(sbom, """
+                {
+                  "serialNumber": "urn:uuid:source",
+                  "components": {"not": "an array"}
+                }
+                """, StandardCharsets.UTF_8);
+        Files.writeString(output, "stale-again", StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> SbomCompanionGenerator.generate(
+                sbom, output, TIMESTAMP, SERIAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("components must be an array");
+        assertThat(output).doesNotExist();
+    }
+
+    @Test
+    void removesStaleOutputWhenFinalWriteFails(@TempDir Path root)
+            throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("taxonomy-vex.json");
+        Files.writeString(sbom, "{\"components\": []}\n", StandardCharsets.UTF_8);
+        Files.writeString(output, "stale", StandardCharsets.UTF_8);
+        IOException writeFailure = new IOException("simulated write failure");
+
+        assertThatThrownBy(() -> SbomCompanionGenerator.generate(
+                sbom,
+                output,
+                TIMESTAMP,
+                SERIAL,
+                (ignoredPath, ignoredContent) -> {
+                    throw writeFailure;
+                }))
+                .isSameAs(writeFailure);
+
+        assertThat(output).doesNotExist();
+    }
+
+    @Test
+    void supportsSingleCharacterOutputFileNames(@TempDir Path root)
+            throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("a");
+        Files.writeString(sbom, "{}\n", StandardCharsets.UTF_8);
+
+        SbomCompanionGenerator.Result result =
+                SbomCompanionGenerator.generate(
+                        sbom, output, TIMESTAMP, SERIAL);
+
+        assertThat(result.output())
+                .isEqualTo(output.toAbsolutePath().normalize());
+        assertThat(output).isRegularFile();
+    }
+
+    @Test
+    void rejectsSourceAndOutputAliasing(@TempDir Path root) throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Files.writeString(sbom, "{}", StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> SbomCompanionGenerator.generate(
+                sbom, sbom, TIMESTAMP, SERIAL))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must differ from the source SBOM");
+        assertThat(Files.readString(sbom, StandardCharsets.UTF_8))
+                .isEqualTo("{}");
+    }
+
+    @Test
+    void cliAcceptsExplicitIdentityAndReportsInvalidOrPartialIdentity(
+            @TempDir Path root) throws Exception {
+        Path sbom = root.resolve("source.json");
+        Path output = root.resolve("companion.json");
+        Files.writeString(sbom, """
+                {
+                  "serialNumber": "urn:uuid:source",
+                  "version": 2,
+                  "components": []
+                }
+                """, StandardCharsets.UTF_8);
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+        int success = TaxonomyTooling.run(
+                new String[]{
+                        "generate-sbom-companion",
+                        "--sbom", sbom.toString(),
+                        "--output", output.toString(),
+                        "--timestamp", "2026-08-15T01:02:03Z",
+                        "--serial-number", SERIAL.toString()},
+                root,
+                new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+
+        assertThat(success).isZero();
+        assertThat(stdout.toString(StandardCharsets.UTF_8))
+                .contains("SBOM companion document generated")
+                .contains("Vulnerability assessment: not-assessed")
+                .contains("SBOM serial: urn:uuid:source")
+                .contains("SBOM SHA-256:")
+                .contains("Components in SBOM: 0");
+        assertThat(stderr.toString(StandardCharsets.UTF_8)).isEmpty();
+
+        stderr.reset();
+        int invalid = TaxonomyTooling.run(
+                new String[]{
+                        "generate-sbom-companion",
+                        "--sbom", sbom.toString(),
+                        "--output", output.toString(),
+                        "--timestamp", "not-an-instant",
+                        "--serial-number", SERIAL.toString()},
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+        assertThat(invalid).isEqualTo(1);
+        assertThat(stderr.toString(StandardCharsets.UTF_8))
+                .startsWith("::error::")
+                .contains("not-an-instant");
+
+        stderr.reset();
+        int partial = TaxonomyTooling.run(
+                new String[]{
+                        "generate-sbom-companion",
+                        "--sbom", sbom.toString(),
+                        "--output", output.toString(),
+                        "--timestamp", "2026-08-15T01:02:03Z"},
+                root,
+                new PrintStream(OutputStream.nullOutputStream()),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+        assertThat(partial).isEqualTo(1);
+        assertThat(stderr.toString(StandardCharsets.UTF_8))
+                .contains("--timestamp and --serial-number must be supplied together");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> object(Object value) {
+        assertThat(value).isInstanceOf(Map.class);
+        return (Map<String, Object>) value;
+    }
+
+    private static Map<String, String> properties(Object value) {
+        assertThat(value).isInstanceOf(List.class);
+        List<?> entries = (List<?>) value;
+        LinkedHashMap<String, String> result = entries.stream()
+                .map(SbomCompanionGeneratorTest::object)
+                .collect(Collectors.toMap(
+                        entry -> String.valueOf(entry.get("name")),
+                        entry -> String.valueOf(entry.get("value")),
+                        (left, right) -> right,
+                        LinkedHashMap::new));
+        return result;
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionIdempotencyTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionIdempotencyTest.java
@@ -37,18 +37,23 @@ class SbomCompanionIdempotencyTest {
                 }
                 """, StandardCharsets.UTF_8);
 
-        SbomCompanionGenerator.generate(
-                sbom, output, timestamp, serial);
+        SbomCompanionGenerator.Result result =
+                SbomCompanionGenerator.generate(
+                        sbom, output, timestamp, serial);
         byte[] first = Files.readAllBytes(output);
         SbomCompanionGenerator.generate(
                 sbom, output, timestamp, serial);
 
+        String rendered = Files.readString(output, StandardCharsets.UTF_8);
         assertThat(Files.readAllBytes(output)).isEqualTo(first);
-        assertThat(Files.readString(output, StandardCharsets.UTF_8))
+        assertThat(result.componentCount()).isEqualTo(1);
+        assertThat(result.sourceSha256()).matches("[0-9a-f]{64}");
+        assertThat(rendered)
                 .contains("2031-08-15T10:11:12Z")
                 .contains("urn:uuid:" + serial)
+                .contains(result.sourceSha256())
                 .contains("taxonomy:sbom-sha256")
-                .contains("Größe");
+                .doesNotContain("Größe");
     }
 
     @Test

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionIdempotencyTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionIdempotencyTest.java
@@ -1,0 +1,121 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SbomCompanionIdempotencyTest {
+
+    @Test
+    void identicalSourceTimestampAndSerialProduceByteIdenticalOutput(
+            @TempDir Path root) throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("taxonomy-vex.json");
+        Instant timestamp = Instant.parse("2031-08-15T10:11:12.999Z");
+        UUID serial = UUID.fromString(
+                "76543210-4321-6789-abcd-0987654321ab");
+        Files.writeString(sbom, """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "serialNumber": "urn:uuid:source",
+                  "version": 3,
+                  "components": [
+                    {"name": "Größe"}
+                  ]
+                }
+                """, StandardCharsets.UTF_8);
+
+        SbomCompanionGenerator.generate(
+                sbom, output, timestamp, serial);
+        byte[] first = Files.readAllBytes(output);
+        SbomCompanionGenerator.generate(
+                sbom, output, timestamp, serial);
+
+        assertThat(Files.readAllBytes(output)).isEqualTo(first);
+        assertThat(Files.readString(output, StandardCharsets.UTF_8))
+                .contains("2031-08-15T10:11:12Z")
+                .contains("urn:uuid:" + serial)
+                .contains("taxonomy:sbom-sha256")
+                .contains("Größe");
+    }
+
+    @Test
+    void defaultCliGenerationIsStableAndBoundToTheExactSourceSbom(
+            @TempDir Path root) throws Exception {
+        Path sbom = root.resolve("taxonomy-sbom.json");
+        Path output = root.resolve("taxonomy-vex.json");
+        Files.writeString(sbom, """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.6",
+                  "serialNumber": "urn:uuid:stable-source",
+                  "version": 4,
+                  "metadata": {
+                    "timestamp": "2031-08-15T10:11:12.999Z"
+                  },
+                  "components": [
+                    {"name": "one"},
+                    {"name": "two"}
+                  ]
+                }
+                """, StandardCharsets.UTF_8);
+        String[] arguments = {
+                "generate-sbom-companion",
+                "--sbom", sbom.toString(),
+                "--output", output.toString()};
+        ByteArrayOutputStream firstOutput = new ByteArrayOutputStream();
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+        int firstExit = TaxonomyTooling.run(
+                arguments,
+                root,
+                new PrintStream(firstOutput, true, StandardCharsets.UTF_8),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+        byte[] first = Files.readAllBytes(output);
+        Map<String, Object> firstCompanion = FlatJson.parseObject(
+                Files.readString(output, StandardCharsets.UTF_8));
+        String firstSerial = String.valueOf(firstCompanion.get("serialNumber"));
+        FileTime retainedTimestamp = FileTime.from(
+                Instant.parse("2020-01-02T03:04:05Z"));
+        Files.setLastModifiedTime(output, retainedTimestamp);
+
+        int secondExit = TaxonomyTooling.run(
+                arguments,
+                root,
+                new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(errors, true, StandardCharsets.UTF_8));
+
+        assertThat(firstExit).isZero();
+        assertThat(secondExit).isZero();
+        assertThat(errors.toString(StandardCharsets.UTF_8)).isEmpty();
+        assertThat(Files.readAllBytes(output)).isEqualTo(first);
+        assertThat(Files.getLastModifiedTime(output))
+                .isEqualTo(retainedTimestamp);
+        assertThat(firstOutput.toString(StandardCharsets.UTF_8))
+                .contains("SBOM SHA-256:");
+        assertThat(firstSerial)
+                .matches("urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-"
+                        + "[89ab][0-9a-f]{3}-[0-9a-f]{12}");
+
+        Map<String, Object> companion = FlatJson.parseObject(
+                Files.readString(output, StandardCharsets.UTF_8));
+        assertThat(companion.get("serialNumber")).isEqualTo(firstSerial);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> metadata =
+                (Map<String, Object>) companion.get("metadata");
+        assertThat(metadata.get("timestamp"))
+                .isEqualTo("2031-08-15T10:11:12Z");
+    }
+}


### PR DESCRIPTION
## Purpose

Reconstruct the verified Java implementation slice from preserved #765 on the current protected `main`, without rewriting or repurposing the historical branch.

This advances #673 and #711 by replacing the implementation boundary of `.github/scripts/generate-vex.py` with dependency-free Java/JUnit tooling before any productive caller is switched.

## Java boundary

- add `SbomCompanionGenerator` to `taxonomy-tooling`;
- parse the CycloneDX SBOM through the existing strict JDK-only `FlatJson` boundary;
- produce a CycloneDX 1.6 companion bound to the source serial, source version and exact source SHA-256;
- state explicitly that vulnerability and exploitability were **not assessed** rather than treating an empty vulnerability list as proof of safety;
- expose `generate-sbom-companion` through the existing immutable `taxonomy-tooling.jar`;
- derive the productive timestamp from `metadata.timestamp` in the source SBOM and derive the companion UUID deterministically from generator version, source serial and source SHA-256;
- accept explicit timestamp/serial identity only as a paired deterministic fixture;
- avoid rewriting byte-identical output;
- write through a same-directory atomic replacement where supported;
- reject source/output aliasing and remove stale output after failed generation.

## JUnit evidence

- deterministic explicit identity and source-derived default identity;
- exact SHA-256 binding and stable UUID;
- stable JSON/property order and Unicode-safe source hashing;
- explicit absence of CycloneDX exploitability assertions;
- missing/malformed input and final-write failures remove stale evidence;
- source/output aliasing cannot destroy the SBOM;
- short output filenames remain valid;
- CLI diagnostics and invalid/partial identity handling;
- a second default invocation is byte-identical and preserves the output modification time.

The first exact-head run exposed an incorrect test expectation that source component names were copied into the companion. The companion intentionally binds the source SBOM by serial/version/SHA-256 and reports component count without duplicating the component inventory. Head `849935d17f767abeca0e1148709d6197d0d08324` corrects that assertion while retaining Unicode input in the source-hash fixture.

## Scope boundary

This PR deliberately does **not** alter `taxonomy-build/pom.xml`, `release.sh`, `deploy-release.yml` or delete `.github/scripts/generate-vex.py`. The subsequent bounded slice will switch Maven and release routing only after this Java implementation is green and reviewed.

## Concurrent-work safety

- exact base: protected `main` at `7c8fd546e9e5bd00836605f5e8012b8df1651bd9`;
- exact head: `849935d17f767abeca0e1148709d6197d0d08324`;
- five commits and exactly four intended files in `taxonomy-tooling`;
- PostgreSQL, Oracle, SQL Server, CodeQL and Security succeeded on the exact head; canonical CI/CD remains the final active gate;
- preserved #765/#766 branches remain unchanged;
- no overlap with #783 critical-coverage/security work or external #744 cache/search/index work;
- no release request, tag, publication, deployment or Python deletion.

Merge requires the unchanged exact head, completed green canonical CI/CD and no unresolved review finding.