### PR TITLE
Complete critical coverage and workspace access protection

### DIFF
--- a/.github/critical-coverage-policy.json
+++ b/.github/critical-coverage-policy.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": 1,
+  "description": "Release-critical package and changed-source coverage ratchets. Thresholds may only move upward unless a reviewed, owned and unexpired exception is present.",
+  "requiredCounters": [
+    "LINE",
+    "BRANCH"
+  ],
+  "changedSourceMinimums": {
+    "LINE": 0.75,
+    "BRANCH": 0.60
+  },
+  "changedSourcePrefixes": [
+    "taxonomy-app/src/main/java/com/taxonomy/security/",
+    "taxonomy-app/src/main/java/com/taxonomy/provenance/",
+    "taxonomy-app/src/main/java/com/taxonomy/catalog/service/importer/",
+    "taxonomy-app/src/main/java/com/taxonomy/dsl/storage/",
+    "taxonomy-app/src/main/java/com/taxonomy/versioning/",
+    "taxonomy-app/src/main/java/com/taxonomy/workspace/",
+    "taxonomy-app/src/main/java/com/taxonomy/portfolio/"
+  ],
+  "criticalPackages": [
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/security/config",
+      "minimums": { "LINE": 0.79, "BRANCH": 0.66 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/security/service",
+      "minimums": { "LINE": 0.89, "BRANCH": 0.66 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/security/controller",
+      "minimums": { "LINE": 0.64, "BRANCH": 0.60 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/security/keycloak",
+      "minimums": { "LINE": 0.75, "BRANCH": 0.67 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/provenance/service",
+      "minimums": { "LINE": 0.86, "BRANCH": 0.69 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/provenance/controller",
+      "minimums": { "LINE": 0.37, "BRANCH": 0.37 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/catalog/service/importer",
+      "minimums": { "LINE": 0.84, "BRANCH": 0.58 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/dsl/storage",
+      "minimums": { "LINE": 0.87, "BRANCH": 0.71 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/versioning/controller",
+      "minimums": { "LINE": 0.81, "BRANCH": 0.58 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/versioning/service",
+      "minimums": { "LINE": 0.77, "BRANCH": 0.59 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/workspace/controller",
+      "minimums": { "LINE": 0.77, "BRANCH": 0.70 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/workspace/service",
+      "minimums": { "LINE": 0.82, "BRANCH": 0.58 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/portfolio/controller",
+      "minimums": { "LINE": 0.45, "BRANCH": 0.52 }
+    },
+    {
+      "module": "taxonomy-app",
+      "package": "com/taxonomy/portfolio/service",
+      "minimums": { "LINE": 0.74, "BRANCH": 0.52 }
+    }
+  ],
+  "temporaryExceptions": []
+}

--- a/docs/dev/REACTOR_COVERAGE.md
+++ b/docs/dev/REACTOR_COVERAGE.md
@@ -1,6 +1,6 @@
-# Reactor-wide test coverage
+# Reactor-wide and release-critical test coverage
 
-The authoritative coverage evidence for Taxonomy is produced by the final coverage module, `taxonomy-coverage`, using JaCoCo `report-aggregate`.
+The authoritative coverage evidence for Taxonomy is produced by the final coverage module, `taxonomy-coverage`, using JaCoCo `report-aggregate`. Maven/JUnit evaluates every coverage policy from that one XML file after all shipped modules have completed.
 
 ## Included production modules
 
@@ -14,9 +14,9 @@ The report must contain all shipped modules as separate JaCoCo groups:
 
 The gate normalizes Maven display names and artifact IDs, but it still fails when any required module is missing. This prevents a highly covered application module from hiding an uninstrumented or untested library module.
 
-## Multi-counter ratchet
+## Aggregate multi-counter ratchet
 
-`.github/coverage-policy.json` is the single versioned policy for the aggregate gate. It requires and publishes all of these JaCoCo counters:
+`.github/coverage-policy.json` is the single versioned policy for aggregate coverage. It requires and publishes all of these JaCoCo counters:
 
 - instructions;
 - lines;
@@ -26,39 +26,87 @@ The gate normalizes Maven display names and artifact IDs, but it still fails whe
 
 Every required counter must exist and have a measurable total both at aggregate level and for every module group. The build fails closed when a counter is missing, empty or below its configured aggregate minimum.
 
-The branch threshold is an explicit ratchet based on verified reactor evidence. It must not be removed or silently replaced by instruction-only coverage. Thresholds should move upward as tests improve. Critical-package budgets, diff coverage and time-limited exceptions are tracked separately under issue #624.
+The branch threshold is an explicit non-regression ratchet based on verified reactor evidence. It must not be removed or silently replaced by instruction-only coverage. Thresholds should move upward as tests improve.
+
+## Release-critical package and changed-source ratchets
+
+`.github/critical-coverage-policy.json` protects packages where untested negative branches can affect security, provenance, imports, Git/versioning, repository/workspace routing or portfolio decisions.
+
+For each configured package the policy records separate line and branch minimums. The values are floors measured from a successful authoritative aggregate report; future changes may retain or raise them but may not silently reduce them.
+
+In a complete-history pull-request checkout, the same policy also identifies changed production Java files under configured critical source prefixes. Each selected source must:
+
+- appear in the authoritative JaCoCo XML;
+- meet the changed-source line minimum;
+- meet the changed-source branch minimum when the source contains measurable branches.
+
+JaCoCo omits the `BRANCH` counter for a source file with no branches. That case is reported as not applicable rather than as zero coverage. Package-level branch counters remain mandatory.
+
+Canonical CI checks out complete history and is the authority for changed-source coverage. Shallow database or security jobs still enforce aggregate and package coverage where the complete reactor report is available, but they do not pretend to own a Git diff they cannot establish.
+
+## Temporary exceptions
+
+A temporary exception is valid only when the versioned policy contains all of:
+
+```text
+scope
+rationale
+owner
+expiresOn
+```
+
+The scope must identify one configured package or one exact repository-relative source path. Expired exceptions fail policy loading. Active exceptions are printed in the evidence report as `APPLIED` or `NOT NEEDED`, so an exception cannot remain invisible after the underlying gap disappears.
+
+The preferred response to a failing budget is additional meaningful positive and negative tests. Exceptions are a bounded transition mechanism, not a permanent allow-list.
 
 ## Single source of truth
 
-The following outputs all consume the same XML file and policy:
+The following inputs and output form one coverage contract:
 
 ```text
 taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml
 .github/coverage-policy.json
+.github/critical-coverage-policy.json
+target/coverage-gate.txt
 ```
 
-- CI coverage gate;
+They drive:
+
+- the aggregate CI coverage gate;
+- release-critical package budgets;
+- changed critical source coverage;
 - published and archived coverage evidence;
-- release coverage claims;
-- the human-readable `target/coverage-gate.txt` summary.
+- release coverage claims.
 
 Module-local reports may still exist for diagnosis, but they are not added together and are not authoritative.
 
 ## Local verification
 
-```bash
-./mvnw install -DexcludedGroups=real-llm
-python3 .github/scripts/check-coverage.py \
-  --xml taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml \
-  --policy .github/coverage-policy.json \
-  --report target/coverage-gate.txt
-```
-
-The gate's deterministic regression tests run with:
+The complete authoritative verification is:
 
 ```bash
-python3 .github/scripts/test-check-coverage.py
+./mvnw -B verify -Pci
 ```
+
+The deterministic policy regression tests can be run after Maven has built the required modules with:
+
+```bash
+./mvnw -B -pl taxonomy-build -am test \
+  -Dtest=ReactorCoveragePolicyTest,CriticalCoveragePolicyTest \
+  -Dsurefire.failIfNoSpecifiedTests=false
+```
+
+The post-reactor gate itself is a Failsafe test because it consumes the aggregate report created by earlier reactor modules.
+
+## Adding a critical area
+
+A new release-critical package or source prefix is incomplete until all of the following are addressed:
+
+- the package/prefix is added to `.github/critical-coverage-policy.json`;
+- the initial line and branch floors are derived from a successful authoritative build;
+- meaningful denial, invalid-input, rollback, concurrency or dependency-failure tests exist for the risk being protected;
+- any temporary exception has an owner, rationale and expiry;
+- this document remains accurate.
 
 ## Adding or removing a module
 
@@ -67,6 +115,7 @@ A shipped module change is incomplete until all of the following are updated:
 - root reactor `<modules>` list;
 - direct dependencies in `taxonomy-coverage/pom.xml`;
 - `expectedGroups` in `.github/coverage-policy.json`;
+- critical coverage paths where applicable;
 - this document.
 
 CI deliberately fails when those views drift apart.

--- a/docs/dev/REACTOR_COVERAGE.md
+++ b/docs/dev/REACTOR_COVERAGE.md
@@ -34,13 +34,9 @@ The branch threshold is an explicit non-regression ratchet based on verified rea
 
 For each configured package the policy records separate line and branch minimums. The values are floors measured from a successful authoritative aggregate report; future changes may retain or raise them but may not silently reduce them.
 
-In a complete-history pull-request checkout, the same policy also identifies changed production Java files under configured critical source prefixes. Each selected source must:
+In a complete-history pull-request checkout, the same policy also identifies changed production Java files under configured critical source prefixes. Every selected source must appear as a `sourcefile` in the authoritative JaCoCo XML. A selected source with executable bytecode must meet the changed-source line minimum and, where measurable branches exist, the branch minimum.
 
-- appear in the authoritative JaCoCo XML;
-- meet the changed-source line minimum;
-- meet the changed-source branch minimum when the source contains measurable branches.
-
-JaCoCo omits the `BRANCH` counter for a source file with no branches. That case is reported as not applicable rather than as zero coverage. Package-level branch counters remain mandatory.
+JaCoCo legitimately emits a `sourcefile` without line or branch counters for source-only declarations such as Spring Data repository interfaces. That explicitly present but unmeasured source is reported as not applicable. It is distinct from a changed source that is absent from the aggregate report, which remains a hard failure. A source with executable lines but no branches receives a line decision and an `N/A` branch decision. Package-level line and branch counters remain mandatory for every configured critical package.
 
 Canonical CI checks out complete history and is the authority for changed-source coverage. Shallow database or security jobs still enforce aggregate and package coverage where the complete reactor report is available, but they do not pretend to own a Git diff they cannot establish.
 
@@ -92,7 +88,7 @@ The deterministic policy regression tests can be run after Maven has built the r
 
 ```bash
 ./mvnw -B -pl taxonomy-build -am test \
-  -Dtest=ReactorCoveragePolicyTest,CriticalCoveragePolicyTest \
+  -Dtest=ReactorCoveragePolicyTest,CriticalCoveragePolicyTest,CriticalCoverageSparseReportTest \
   -Dsurefire.failIfNoSpecifiedTests=false
 ```
 

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
@@ -1,0 +1,88 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+/**
+ * Applies ownership checks to workspace metadata reads before controller data is
+ * materialized. Shared workspaces remain visible, while guessed private IDs are
+ * deliberately indistinguishable from missing IDs.
+ */
+@Configuration(proxyBeanMethods = false)
+class WorkspaceAccessWebMvcConfiguration implements WebMvcConfigurer {
+
+    private final UserWorkspaceRepository workspaceRepository;
+
+    WorkspaceAccessWebMvcConfiguration(UserWorkspaceRepository workspaceRepository) {
+        this.workspaceRepository = workspaceRepository;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new WorkspaceInfoAccessInterceptor(workspaceRepository))
+                .addPathPatterns("/api/workspace/*/info");
+    }
+
+    static final class WorkspaceInfoAccessInterceptor implements HandlerInterceptor {
+
+        private final UserWorkspaceRepository workspaceRepository;
+
+        WorkspaceInfoAccessInterceptor(UserWorkspaceRepository workspaceRepository) {
+            this.workspaceRepository = workspaceRepository;
+        }
+
+        @Override
+        public boolean preHandle(
+                HttpServletRequest request,
+                HttpServletResponse response,
+                Object handler) throws IOException {
+            if (!(handler instanceof HandlerMethod handlerMethod)
+                    || handlerMethod.getBeanType() != WorkspaceController.class
+                    || !"getWorkspaceInfo".equals(handlerMethod.getMethod().getName())) {
+                return true;
+            }
+
+            Principal principal = request.getUserPrincipal();
+            if (principal == null) {
+                // The SecurityFilterChain owns the unauthenticated response.
+                return true;
+            }
+
+            String workspaceId = pathVariable(request, "id");
+            boolean visible = workspaceId != null
+                    && (workspaceRepository.existsByWorkspaceIdAndUsername(
+                            workspaceId, principal.getName())
+                    || workspaceRepository.existsByWorkspaceIdAndSharedTrue(
+                            workspaceId));
+            if (visible) {
+                return true;
+            }
+
+            response.sendError(HttpStatus.NOT_FOUND.value());
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static String pathVariable(HttpServletRequest request, String name) {
+            Object value = request.getAttribute(
+                    HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+            if (!(value instanceof Map<?, ?> variables)) {
+                return null;
+            }
+            Object pathValue = variables.get(name);
+            return pathValue instanceof String text ? text : null;
+        }
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
@@ -1,5 +1,6 @@
 package com.taxonomy.workspace.controller;
 
+import com.taxonomy.workspace.model.UserWorkspace;
 import com.taxonomy.workspace.repository.UserWorkspaceRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -62,10 +63,9 @@ class WorkspaceAccessWebMvcConfiguration implements WebMvcConfigurer {
 
             String workspaceId = pathVariable(request, "id");
             boolean visible = workspaceId != null
-                    && (workspaceRepository.existsByWorkspaceIdAndUsername(
-                            workspaceId, principal.getName())
-                    || workspaceRepository.existsByWorkspaceIdAndSharedTrue(
-                            workspaceId));
+                    && workspaceRepository.findByWorkspaceId(workspaceId)
+                            .filter(workspace -> isVisibleTo(workspace, principal.getName()))
+                            .isPresent();
             if (visible) {
                 return true;
             }
@@ -74,7 +74,10 @@ class WorkspaceAccessWebMvcConfiguration implements WebMvcConfigurer {
             return false;
         }
 
-        @SuppressWarnings("unchecked")
+        private static boolean isVisibleTo(UserWorkspace workspace, String username) {
+            return workspace.isShared() || username.equals(workspace.getUsername());
+        }
+
         private static String pathVariable(HttpServletRequest request, String name) {
             Object value = request.getAttribute(
                     HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfiguration.java
@@ -1,7 +1,6 @@
 package com.taxonomy.workspace.controller;
 
-import com.taxonomy.workspace.model.UserWorkspace;
-import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import com.taxonomy.workspace.service.WorkspaceAccessService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Configuration;
@@ -24,24 +23,24 @@ import java.util.Map;
 @Configuration(proxyBeanMethods = false)
 class WorkspaceAccessWebMvcConfiguration implements WebMvcConfigurer {
 
-    private final UserWorkspaceRepository workspaceRepository;
+    private final WorkspaceAccessService workspaceAccessService;
 
-    WorkspaceAccessWebMvcConfiguration(UserWorkspaceRepository workspaceRepository) {
-        this.workspaceRepository = workspaceRepository;
+    WorkspaceAccessWebMvcConfiguration(WorkspaceAccessService workspaceAccessService) {
+        this.workspaceAccessService = workspaceAccessService;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new WorkspaceInfoAccessInterceptor(workspaceRepository))
+        registry.addInterceptor(new WorkspaceInfoAccessInterceptor(workspaceAccessService))
                 .addPathPatterns("/api/workspace/*/info");
     }
 
     static final class WorkspaceInfoAccessInterceptor implements HandlerInterceptor {
 
-        private final UserWorkspaceRepository workspaceRepository;
+        private final WorkspaceAccessService workspaceAccessService;
 
-        WorkspaceInfoAccessInterceptor(UserWorkspaceRepository workspaceRepository) {
-            this.workspaceRepository = workspaceRepository;
+        WorkspaceInfoAccessInterceptor(WorkspaceAccessService workspaceAccessService) {
+            this.workspaceAccessService = workspaceAccessService;
         }
 
         @Override
@@ -62,20 +61,13 @@ class WorkspaceAccessWebMvcConfiguration implements WebMvcConfigurer {
             }
 
             String workspaceId = pathVariable(request, "id");
-            boolean visible = workspaceId != null
-                    && workspaceRepository.findByWorkspaceId(workspaceId)
-                            .filter(workspace -> isVisibleTo(workspace, principal.getName()))
-                            .isPresent();
-            if (visible) {
+            if (workspaceAccessService.canReadWorkspaceMetadata(
+                    workspaceId, principal.getName())) {
                 return true;
             }
 
             response.sendError(HttpStatus.NOT_FOUND.value());
             return false;
-        }
-
-        private static boolean isVisibleTo(UserWorkspace workspace, String username) {
-            return workspace.isShared() || username.equals(workspace.getUsername());
         }
 
         private static String pathVariable(HttpServletRequest request, String name) {

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
@@ -17,10 +17,6 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
 
     Optional<UserWorkspace> findByWorkspaceId(String workspaceId);
 
-    boolean existsByWorkspaceIdAndUsername(String workspaceId, String username);
-
-    boolean existsByWorkspaceIdAndSharedTrue(String workspaceId);
-
     Optional<UserWorkspace> findByUsernameAndSharedFalse(String username);
 
     Optional<UserWorkspace> findBySharedTrue();

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
@@ -17,6 +17,10 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
 
     Optional<UserWorkspace> findByWorkspaceId(String workspaceId);
 
+    boolean existsByWorkspaceIdAndUsername(String workspaceId, String username);
+
+    boolean existsByWorkspaceIdAndSharedTrue(String workspaceId);
+
     Optional<UserWorkspace> findByUsernameAndSharedFalse(String username);
 
     Optional<UserWorkspace> findBySharedTrue();

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
@@ -2,6 +2,8 @@ package com.taxonomy.workspace.repository;
 
 import com.taxonomy.workspace.model.UserWorkspace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -30,4 +32,18 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
     Optional<UserWorkspace> findByUsernameAndDisplayName(String username, String displayName);
 
     long countByUsernameAndArchivedFalse(String username);
+
+    /**
+     * Check disclosure permission without materializing a foreign workspace row.
+     * Missing and unauthorized identifiers intentionally produce the same result.
+     */
+    @Query("""
+            select case when count(workspace) > 0 then true else false end
+            from UserWorkspace workspace
+            where workspace.workspaceId = :workspaceId
+              and (workspace.username = :username or workspace.shared = true)
+            """)
+    boolean existsVisibleWorkspaceMetadata(
+            @Param("workspaceId") String workspaceId,
+            @Param("username") String username);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/repository/UserWorkspaceRepository.java
@@ -34,16 +34,16 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
     long countByUsernameAndArchivedFalse(String username);
 
     /**
-     * Check disclosure permission without materializing a foreign workspace row.
-     * Missing and unauthorized identifiers intentionally produce the same result.
+     * Count disclosure-authorized rows without materializing workspace metadata.
+     * Missing and unauthorized identifiers intentionally both return zero.
      */
     @Query("""
-            select case when count(workspace) > 0 then true else false end
+            select count(workspace)
             from UserWorkspace workspace
             where workspace.workspaceId = :workspaceId
               and (workspace.username = :username or workspace.shared = true)
             """)
-    boolean existsVisibleWorkspaceMetadata(
+    long countVisibleWorkspaceMetadata(
             @Param("workspaceId") String workspaceId,
             @Param("username") String username);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
@@ -1,6 +1,5 @@
 package com.taxonomy.workspace.service;
 
-import com.taxonomy.workspace.model.UserWorkspace;
 import com.taxonomy.workspace.repository.UserWorkspaceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,7 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * Resolves whether workspace metadata may be disclosed to an authenticated
  * principal. The lookup deliberately returns only a boolean so callers cannot
- * accidentally expose a foreign workspace after an authorization decision.
+ * accidentally expose or materialize a foreign workspace after an authorization
+ * decision.
  */
 @Service
 public class WorkspaceAccessService {
@@ -25,12 +25,7 @@ public class WorkspaceAccessService {
                 || username == null || username.isBlank()) {
             return false;
         }
-        return workspaceRepository.findByWorkspaceId(workspaceId)
-                .filter(workspace -> isVisibleTo(workspace, username))
-                .isPresent();
-    }
-
-    private static boolean isVisibleTo(UserWorkspace workspace, String username) {
-        return workspace.isShared() || username.equals(workspace.getUsername());
+        return workspaceRepository.existsVisibleWorkspaceMetadata(
+                workspaceId.strip(), username.strip());
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
@@ -1,0 +1,36 @@
+package com.taxonomy.workspace.service;
+
+import com.taxonomy.workspace.model.UserWorkspace;
+import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Resolves whether workspace metadata may be disclosed to an authenticated
+ * principal. The lookup deliberately returns only a boolean so callers cannot
+ * accidentally expose a foreign workspace after an authorization decision.
+ */
+@Service
+public class WorkspaceAccessService {
+
+    private final UserWorkspaceRepository workspaceRepository;
+
+    public WorkspaceAccessService(UserWorkspaceRepository workspaceRepository) {
+        this.workspaceRepository = workspaceRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public boolean canReadWorkspaceMetadata(String workspaceId, String username) {
+        if (workspaceId == null || workspaceId.isBlank()
+                || username == null || username.isBlank()) {
+            return false;
+        }
+        return workspaceRepository.findByWorkspaceId(workspaceId)
+                .filter(workspace -> isVisibleTo(workspace, username))
+                .isPresent();
+    }
+
+    private static boolean isVisibleTo(UserWorkspace workspace, String username) {
+        return workspace.isShared() || username.equals(workspace.getUsername());
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceAccessService.java
@@ -6,9 +6,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Resolves whether workspace metadata may be disclosed to an authenticated
- * principal. The lookup deliberately returns only a boolean so callers cannot
- * accidentally expose or materialize a foreign workspace after an authorization
- * decision.
+ * principal. The lookup deliberately returns only a scalar count so callers
+ * cannot accidentally expose or materialize a foreign workspace after an
+ * authorization decision.
  */
 @Service
 public class WorkspaceAccessService {
@@ -25,7 +25,7 @@ public class WorkspaceAccessService {
                 || username == null || username.isBlank()) {
             return false;
         }
-        return workspaceRepository.existsVisibleWorkspaceMetadata(
-                workspaceId.strip(), username.strip());
+        return workspaceRepository.countVisibleWorkspaceMetadata(
+                workspaceId.strip(), username.strip()) > 0L;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessSecurityIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessSecurityIT.java
@@ -1,0 +1,131 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.workspace.model.UserWorkspace;
+import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Real SecurityFilterChain and ownership evidence for workspace/repository IDs. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource(properties = {
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key=",
+        "taxonomy.features.multi-repository-api.enabled=false"
+})
+class WorkspaceAccessSecurityIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserWorkspaceRepository workspaceRepository;
+
+    @Test
+    @WithMockUser(username = "alice", roles = "USER")
+    void ownerCanReadOwnWorkspaceMetadata() throws Exception {
+        UserWorkspace workspace = workspaceRepository.saveAndFlush(
+                workspace("qa-owned-workspace", "alice", false));
+
+        mockMvc.perform(get("/api/workspace/{id}/info", workspace.getWorkspaceId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value(workspace.getWorkspaceId()))
+                .andExpect(jsonPath("$.username").value("alice"));
+    }
+
+    @Test
+    @WithMockUser(username = "alice", roles = "USER")
+    void guessedForeignWorkspaceIdIsIndistinguishableFromMissing() throws Exception {
+        UserWorkspace foreign = workspaceRepository.saveAndFlush(
+                workspace("qa-foreign-workspace", "bob", false));
+
+        mockMvc.perform(get("/api/workspace/{id}/info", foreign.getWorkspaceId()))
+                .andExpect(status().isNotFound())
+                .andExpect(content().string(""));
+        mockMvc.perform(get("/api/workspace/{id}/info", "does-not-exist"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "alice", roles = "USER")
+    void explicitlySharedWorkspaceMetadataRemainsVisible() throws Exception {
+        UserWorkspace shared = workspaceRepository.saveAndFlush(
+                workspace("qa-shared-workspace", "system", true));
+
+        mockMvc.perform(get("/api/workspace/{id}/info", shared.getWorkspaceId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value(shared.getWorkspaceId()));
+    }
+
+    @Test
+    @WithAnonymousUser
+    void anonymousWorkspaceAndRepositoryIdProbesAreUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/workspace/guessed/info"))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/repositories/guessed"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "alice", roles = "USER")
+    void publicMultiRepositoryApiIsHiddenWhenDefaultOff() throws Exception {
+        mockMvc.perform(get("/api/repositories/guessed"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "alice", roles = "USER")
+    void userRoleCannotCreateRepositoryOrAdministerWorkspace() throws Exception {
+        mockMvc.perform(post("/api/repositories")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(put("/api/workspace/guessed/rename")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"displayName\":\"stolen\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    private static UserWorkspace workspace(
+            String workspaceId,
+            String username,
+            boolean shared) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setWorkspaceId(workspaceId);
+        workspace.setUsername(username);
+        workspace.setDisplayName(workspaceId);
+        workspace.setCurrentBranch("draft");
+        workspace.setBaseBranch("draft");
+        workspace.setShared(shared);
+        workspace.setArchived(false);
+        workspace.setDefault(false);
+        workspace.setCreatedAt(Instant.parse("2026-08-15T00:00:00Z"));
+        workspace.setLastAccessedAt(Instant.parse("2026-08-15T00:00:00Z"));
+        return workspace;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessSecurityIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessSecurityIT.java
@@ -19,7 +19,6 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -63,8 +62,7 @@ class WorkspaceAccessSecurityIT {
                 workspace("qa-foreign-workspace", "bob", false));
 
         mockMvc.perform(get("/api/workspace/{id}/info", foreign.getWorkspaceId()))
-                .andExpect(status().isNotFound())
-                .andExpect(content().string(""));
+                .andExpect(status().isNotFound());
         mockMvc.perform(get("/api/workspace/{id}/info", "does-not-exist"))
                 .andExpect(status().isNotFound());
     }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
@@ -1,0 +1,126 @@
+package com.taxonomy.workspace.controller;
+
+import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkspaceAccessWebMvcConfigurationTest {
+
+    @Mock
+    private UserWorkspaceRepository workspaceRepository;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private WorkspaceController workspaceController;
+
+    private WorkspaceAccessWebMvcConfiguration.WorkspaceInfoAccessInterceptor interceptor;
+    private HandlerMethod workspaceInfoHandler;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        interceptor = new WorkspaceAccessWebMvcConfiguration
+                .WorkspaceInfoAccessInterceptor(workspaceRepository);
+        Method method = WorkspaceController.class.getMethod(
+                "getWorkspaceInfo", String.class);
+        workspaceInfoHandler = new HandlerMethod(workspaceController, method);
+    }
+
+    @Test
+    void unrelatedHandlerIsNotSubjectToWorkspaceOwnershipLookup() throws Exception {
+        HandlerMethod unrelated = new HandlerMethod(
+                new Object(), Object.class.getMethod("toString"));
+
+        assertThat(interceptor.preHandle(request, response, unrelated)).isTrue();
+        verify(workspaceRepository, never())
+                .existsByWorkspaceIdAndUsername(org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void securityFilterChainRetainsOwnershipOfAnonymousResponse() throws Exception {
+        when(request.getUserPrincipal()).thenReturn(null);
+
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isTrue();
+        verify(response, never()).sendError(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    void missingOrNonStringPathVariableFailsClosed() throws Exception {
+        Principal principal = () -> "alice";
+        when(request.getUserPrincipal()).thenReturn(principal);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of());
+
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isFalse();
+        verify(response).sendError(HttpStatus.NOT_FOUND.value());
+
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of("id", 42));
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isFalse();
+    }
+
+    @Test
+    void ownerAndSharedWorkspaceAreAllowed() throws Exception {
+        Principal principal = () -> "alice";
+        when(request.getUserPrincipal()).thenReturn(principal);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of("id", "workspace-1"));
+        when(workspaceRepository.existsByWorkspaceIdAndUsername(
+                "workspace-1", "alice")).thenReturn(true);
+
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isTrue();
+
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of("id", "workspace-2"));
+        when(workspaceRepository.existsByWorkspaceIdAndUsername(
+                "workspace-2", "alice")).thenReturn(false);
+        when(workspaceRepository.existsByWorkspaceIdAndSharedTrue("workspace-2"))
+                .thenReturn(true);
+
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isTrue();
+    }
+
+    @Test
+    void privateForeignWorkspaceIsHidden() throws Exception {
+        Principal principal = () -> "alice";
+        when(request.getUserPrincipal()).thenReturn(principal);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of("id", "workspace-bob"));
+        when(workspaceRepository.existsByWorkspaceIdAndUsername(
+                "workspace-bob", "alice")).thenReturn(false);
+        when(workspaceRepository.existsByWorkspaceIdAndSharedTrue("workspace-bob"))
+                .thenReturn(false);
+
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isFalse();
+        verify(response).sendError(HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
@@ -1,7 +1,6 @@
 package com.taxonomy.workspace.controller;
 
-import com.taxonomy.workspace.model.UserWorkspace;
-import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import com.taxonomy.workspace.service.WorkspaceAccessService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +15,6 @@ import org.springframework.web.servlet.HandlerMapping;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,7 +26,7 @@ import static org.mockito.Mockito.when;
 class WorkspaceAccessWebMvcConfigurationTest {
 
     @Mock
-    private UserWorkspaceRepository workspaceRepository;
+    private WorkspaceAccessService workspaceAccessService;
 
     @Mock
     private HttpServletRequest request;
@@ -45,7 +43,7 @@ class WorkspaceAccessWebMvcConfigurationTest {
     @BeforeEach
     void setUp() throws Exception {
         interceptor = new WorkspaceAccessWebMvcConfiguration
-                .WorkspaceInfoAccessInterceptor(workspaceRepository);
+                .WorkspaceInfoAccessInterceptor(workspaceAccessService);
         Method method = WorkspaceController.class.getMethod(
                 "getWorkspaceInfo", String.class);
         workspaceInfoHandler = new HandlerMethod(workspaceController, method);
@@ -57,7 +55,8 @@ class WorkspaceAccessWebMvcConfigurationTest {
                 new Object(), Object.class.getMethod("toString"));
 
         assertThat(interceptor.preHandle(request, response, unrelated)).isTrue();
-        verify(workspaceRepository, never()).findByWorkspaceId(anyString());
+        verify(workspaceAccessService, never())
+                .canReadWorkspaceMetadata(anyString(), anyString());
     }
 
     @Test
@@ -87,51 +86,29 @@ class WorkspaceAccessWebMvcConfigurationTest {
     }
 
     @Test
-    void ownerAndSharedWorkspaceAreAllowed() throws Exception {
+    void visibleWorkspaceIsAllowed() throws Exception {
         Principal principal = () -> "alice";
         when(request.getUserPrincipal()).thenReturn(principal);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(Map.of("id", "workspace-1"));
-        when(workspaceRepository.findByWorkspaceId("workspace-1"))
-                .thenReturn(Optional.of(workspace("alice", false)));
-
-        assertThat(interceptor.preHandle(
-                request, response, workspaceInfoHandler)).isTrue();
-
-        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
-                .thenReturn(Map.of("id", "workspace-2"));
-        when(workspaceRepository.findByWorkspaceId("workspace-2"))
-                .thenReturn(Optional.of(workspace("system", true)));
+        when(workspaceAccessService.canReadWorkspaceMetadata(
+                "workspace-1", "alice")).thenReturn(true);
 
         assertThat(interceptor.preHandle(
                 request, response, workspaceInfoHandler)).isTrue();
     }
 
     @Test
-    void privateForeignAndMissingWorkspacesAreHidden() throws Exception {
+    void foreignOrMissingWorkspaceIsHidden() throws Exception {
         Principal principal = () -> "alice";
         when(request.getUserPrincipal()).thenReturn(principal);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(Map.of("id", "workspace-bob"));
-        when(workspaceRepository.findByWorkspaceId("workspace-bob"))
-                .thenReturn(Optional.of(workspace("bob", false)));
+        when(workspaceAccessService.canReadWorkspaceMetadata(
+                "workspace-bob", "alice")).thenReturn(false);
 
         assertThat(interceptor.preHandle(
                 request, response, workspaceInfoHandler)).isFalse();
         verify(response).sendError(HttpStatus.NOT_FOUND.value());
-
-        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
-                .thenReturn(Map.of("id", "missing"));
-        when(workspaceRepository.findByWorkspaceId("missing"))
-                .thenReturn(Optional.empty());
-        assertThat(interceptor.preHandle(
-                request, response, workspaceInfoHandler)).isFalse();
-    }
-
-    private static UserWorkspace workspace(String username, boolean shared) {
-        UserWorkspace workspace = new UserWorkspace();
-        workspace.setUsername(username);
-        workspace.setShared(shared);
-        return workspace;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/controller/WorkspaceAccessWebMvcConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.taxonomy.workspace.controller;
 
+import com.taxonomy.workspace.model.UserWorkspace;
 import com.taxonomy.workspace.repository.UserWorkspaceRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,8 +16,10 @@ import org.springframework.web.servlet.HandlerMapping;
 import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,9 +57,7 @@ class WorkspaceAccessWebMvcConfigurationTest {
                 new Object(), Object.class.getMethod("toString"));
 
         assertThat(interceptor.preHandle(request, response, unrelated)).isTrue();
-        verify(workspaceRepository, never())
-                .existsByWorkspaceIdAndUsername(org.mockito.ArgumentMatchers.anyString(),
-                        org.mockito.ArgumentMatchers.anyString());
+        verify(workspaceRepository, never()).findByWorkspaceId(anyString());
     }
 
     @Test
@@ -91,36 +92,46 @@ class WorkspaceAccessWebMvcConfigurationTest {
         when(request.getUserPrincipal()).thenReturn(principal);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(Map.of("id", "workspace-1"));
-        when(workspaceRepository.existsByWorkspaceIdAndUsername(
-                "workspace-1", "alice")).thenReturn(true);
+        when(workspaceRepository.findByWorkspaceId("workspace-1"))
+                .thenReturn(Optional.of(workspace("alice", false)));
 
         assertThat(interceptor.preHandle(
                 request, response, workspaceInfoHandler)).isTrue();
 
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(Map.of("id", "workspace-2"));
-        when(workspaceRepository.existsByWorkspaceIdAndUsername(
-                "workspace-2", "alice")).thenReturn(false);
-        when(workspaceRepository.existsByWorkspaceIdAndSharedTrue("workspace-2"))
-                .thenReturn(true);
+        when(workspaceRepository.findByWorkspaceId("workspace-2"))
+                .thenReturn(Optional.of(workspace("system", true)));
 
         assertThat(interceptor.preHandle(
                 request, response, workspaceInfoHandler)).isTrue();
     }
 
     @Test
-    void privateForeignWorkspaceIsHidden() throws Exception {
+    void privateForeignAndMissingWorkspacesAreHidden() throws Exception {
         Principal principal = () -> "alice";
         when(request.getUserPrincipal()).thenReturn(principal);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
                 .thenReturn(Map.of("id", "workspace-bob"));
-        when(workspaceRepository.existsByWorkspaceIdAndUsername(
-                "workspace-bob", "alice")).thenReturn(false);
-        when(workspaceRepository.existsByWorkspaceIdAndSharedTrue("workspace-bob"))
-                .thenReturn(false);
+        when(workspaceRepository.findByWorkspaceId("workspace-bob"))
+                .thenReturn(Optional.of(workspace("bob", false)));
 
         assertThat(interceptor.preHandle(
                 request, response, workspaceInfoHandler)).isFalse();
         verify(response).sendError(HttpStatus.NOT_FOUND.value());
+
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
+                .thenReturn(Map.of("id", "missing"));
+        when(workspaceRepository.findByWorkspaceId("missing"))
+                .thenReturn(Optional.empty());
+        assertThat(interceptor.preHandle(
+                request, response, workspaceInfoHandler)).isFalse();
+    }
+
+    private static UserWorkspace workspace(String username, boolean shared) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setUsername(username);
+        workspace.setShared(shared);
+        return workspace;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
@@ -1,14 +1,11 @@
 package com.taxonomy.workspace.service;
 
-import com.taxonomy.workspace.model.UserWorkspace;
 import com.taxonomy.workspace.repository.UserWorkspaceRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
@@ -34,39 +31,40 @@ class WorkspaceAccessServiceTest {
                 .isFalse();
         assertThat(workspaceAccessService.canReadWorkspaceMetadata("workspace", " "))
                 .isFalse();
+        verify(workspaceRepository, never())
+                .existsVisibleWorkspaceMetadata("workspace", "alice");
         verify(workspaceRepository, never()).findByWorkspaceId("workspace");
     }
 
     @Test
-    void ownerAndSharedWorkspaceAreVisible() {
-        when(workspaceRepository.findByWorkspaceId("owned"))
-                .thenReturn(Optional.of(workspace("alice", false)));
-        when(workspaceRepository.findByWorkspaceId("shared"))
-                .thenReturn(Optional.of(workspace("system", true)));
+    void ownerAndSharedWorkspaceAreVisibleWithoutMaterializingRows() {
+        when(workspaceRepository.existsVisibleWorkspaceMetadata("owned", "alice"))
+                .thenReturn(true);
+        when(workspaceRepository.existsVisibleWorkspaceMetadata("shared", "alice"))
+                .thenReturn(true);
 
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
-                "owned", "alice")).isTrue();
+                " owned ", " alice ")).isTrue();
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
                 "shared", "alice")).isTrue();
+
+        verify(workspaceRepository, never()).findByWorkspaceId("owned");
+        verify(workspaceRepository, never()).findByWorkspaceId("shared");
     }
 
     @Test
-    void foreignPrivateAndMissingWorkspaceAreHidden() {
-        when(workspaceRepository.findByWorkspaceId("foreign"))
-                .thenReturn(Optional.of(workspace("bob", false)));
-        when(workspaceRepository.findByWorkspaceId("missing"))
-                .thenReturn(Optional.empty());
+    void foreignPrivateAndMissingWorkspaceAreIndistinguishable() {
+        when(workspaceRepository.existsVisibleWorkspaceMetadata("foreign", "alice"))
+                .thenReturn(false);
+        when(workspaceRepository.existsVisibleWorkspaceMetadata("missing", "alice"))
+                .thenReturn(false);
 
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
                 "foreign", "alice")).isFalse();
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
                 "missing", "alice")).isFalse();
-    }
 
-    private static UserWorkspace workspace(String username, boolean shared) {
-        UserWorkspace workspace = new UserWorkspace();
-        workspace.setUsername(username);
-        workspace.setShared(shared);
-        return workspace;
+        verify(workspaceRepository, never()).findByWorkspaceId("foreign");
+        verify(workspaceRepository, never()).findByWorkspaceId("missing");
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
@@ -1,0 +1,72 @@
+package com.taxonomy.workspace.service;
+
+import com.taxonomy.workspace.model.UserWorkspace;
+import com.taxonomy.workspace.repository.UserWorkspaceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkspaceAccessServiceTest {
+
+    @Mock
+    private UserWorkspaceRepository workspaceRepository;
+
+    @InjectMocks
+    private WorkspaceAccessService workspaceAccessService;
+
+    @Test
+    void rejectsMissingIdentityWithoutRepositoryLookup() {
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata(null, "alice"))
+                .isFalse();
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata("", "alice"))
+                .isFalse();
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata("workspace", null))
+                .isFalse();
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata("workspace", " "))
+                .isFalse();
+        verify(workspaceRepository, never()).findByWorkspaceId("workspace");
+    }
+
+    @Test
+    void ownerAndSharedWorkspaceAreVisible() {
+        when(workspaceRepository.findByWorkspaceId("owned"))
+                .thenReturn(Optional.of(workspace("alice", false)));
+        when(workspaceRepository.findByWorkspaceId("shared"))
+                .thenReturn(Optional.of(workspace("system", true)));
+
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata(
+                "owned", "alice")).isTrue();
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata(
+                "shared", "alice")).isTrue();
+    }
+
+    @Test
+    void foreignPrivateAndMissingWorkspaceAreHidden() {
+        when(workspaceRepository.findByWorkspaceId("foreign"))
+                .thenReturn(Optional.of(workspace("bob", false)));
+        when(workspaceRepository.findByWorkspaceId("missing"))
+                .thenReturn(Optional.empty());
+
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata(
+                "foreign", "alice")).isFalse();
+        assertThat(workspaceAccessService.canReadWorkspaceMetadata(
+                "missing", "alice")).isFalse();
+    }
+
+    private static UserWorkspace workspace(String username, boolean shared) {
+        UserWorkspace workspace = new UserWorkspace();
+        workspace.setUsername(username);
+        workspace.setShared(shared);
+        return workspace;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceAccessServiceTest.java
@@ -32,16 +32,16 @@ class WorkspaceAccessServiceTest {
         assertThat(workspaceAccessService.canReadWorkspaceMetadata("workspace", " "))
                 .isFalse();
         verify(workspaceRepository, never())
-                .existsVisibleWorkspaceMetadata("workspace", "alice");
+                .countVisibleWorkspaceMetadata("workspace", "alice");
         verify(workspaceRepository, never()).findByWorkspaceId("workspace");
     }
 
     @Test
     void ownerAndSharedWorkspaceAreVisibleWithoutMaterializingRows() {
-        when(workspaceRepository.existsVisibleWorkspaceMetadata("owned", "alice"))
-                .thenReturn(true);
-        when(workspaceRepository.existsVisibleWorkspaceMetadata("shared", "alice"))
-                .thenReturn(true);
+        when(workspaceRepository.countVisibleWorkspaceMetadata("owned", "alice"))
+                .thenReturn(1L);
+        when(workspaceRepository.countVisibleWorkspaceMetadata("shared", "alice"))
+                .thenReturn(1L);
 
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
                 " owned ", " alice ")).isTrue();
@@ -54,10 +54,10 @@ class WorkspaceAccessServiceTest {
 
     @Test
     void foreignPrivateAndMissingWorkspaceAreIndistinguishable() {
-        when(workspaceRepository.existsVisibleWorkspaceMetadata("foreign", "alice"))
-                .thenReturn(false);
-        when(workspaceRepository.existsVisibleWorkspaceMetadata("missing", "alice"))
-                .thenReturn(false);
+        when(workspaceRepository.countVisibleWorkspaceMetadata("foreign", "alice"))
+                .thenReturn(0L);
+        when(workspaceRepository.countVisibleWorkspaceMetadata("missing", "alice"))
+                .thenReturn(0L);
 
         assertThat(workspaceAccessService.canReadWorkspaceMetadata(
                 "foreign", "alice")).isFalse();

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
@@ -63,22 +63,17 @@ final class CriticalCoveragePolicy {
         }
 
         List<String> requiredCounters = readRequiredCounters(root);
-        Map<String, Double> changedMinimums = readMinimums(
-                root.path("changedSourceMinimums"),
-                "changedSourceMinimums",
-                requiredCounters);
-        List<String> prefixes = readPrefixes(root.path("changedSourcePrefixes"));
-        List<PackageBudget> packages = readPackageBudgets(
-                root.path("criticalPackages"), requiredCounters);
-        List<TemporaryException> exceptions = readExceptions(
-                root.path("temporaryExceptions"), today);
-
         return new CoveragePolicy(
                 requiredCounters,
-                Collections.unmodifiableMap(changedMinimums),
-                List.copyOf(prefixes),
-                List.copyOf(packages),
-                List.copyOf(exceptions));
+                Collections.unmodifiableMap(readMinimums(
+                        root.path("changedSourceMinimums"),
+                        "changedSourceMinimums",
+                        requiredCounters)),
+                List.copyOf(readPrefixes(root.path("changedSourcePrefixes"))),
+                List.copyOf(readPackageBudgets(
+                        root.path("criticalPackages"), requiredCounters)),
+                List.copyOf(readExceptions(
+                        root.path("temporaryExceptions"), today)));
     }
 
     CoverageReport parseReport(Path path, List<String> requiredCounters) {
@@ -111,8 +106,11 @@ final class CriticalCoveragePolicy {
                 PackageKey packageKey = new PackageKey(module, packageName);
                 if (packages.putIfAbsent(
                         packageKey,
-                        parseCounterSet(packageElement, requiredCounters, packageKey.scope()))
-                        != null) {
+                        parseCounterSet(
+                                packageElement,
+                                requiredCounters,
+                                packageKey.scope(),
+                                false)) != null) {
                     throw new IllegalArgumentException(
                             "Duplicate JaCoCo package " + packageKey.scope());
                 }
@@ -126,7 +124,8 @@ final class CriticalCoveragePolicy {
                             parseCounterSet(
                                     sourceFile,
                                     requiredCounters,
-                                    "source:" + repositoryPath)) != null) {
+                                    "source:" + repositoryPath,
+                                    true)) != null) {
                         throw new IllegalArgumentException(
                                 "Duplicate JaCoCo source file " + repositoryPath);
                     }
@@ -168,25 +167,15 @@ final class CriticalCoveragePolicy {
                 text.append("  - MISSING\n");
                 continue;
             }
-            for (String counterType : policy.requiredCounters()) {
-                Counter counter = counters.get(counterType);
-                double minimum = budget.minimums().get(counterType);
-                boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
-                text.append("  - ").append(counterType).append(": ")
-                        .append(formatCounter(counter))
-                        .append("; required ").append(formatPercent(minimum))
-                        .append("; ").append(passed ? "PASS" : "FAIL")
-                        .append('\n');
-                if (!passed) {
-                    recordViolation(
-                            scope,
-                            counterType + " coverage " + formatPercent(counter.ratio())
-                                    + " is below " + formatPercent(minimum),
-                            exceptionByScope,
-                            appliedExceptions,
-                            violations);
-                }
-            }
+            evaluateCounters(
+                    scope,
+                    counters,
+                    budget.minimums(),
+                    false,
+                    text,
+                    exceptionByScope,
+                    appliedExceptions,
+                    violations);
         }
 
         text.append("\nChanged critical source coverage:\n")
@@ -208,29 +197,15 @@ final class CriticalCoveragePolicy {
                 text.append("  - MISSING\n");
                 continue;
             }
-            for (String counterType : policy.requiredCounters()) {
-                Counter counter = counters.get(counterType);
-                double minimum = policy.changedSourceMinimums().get(counterType);
-                if ("BRANCH".equals(counterType) && counter.total() == 0) {
-                    text.append("  - BRANCH: N/A (source has no branch counter total)\n");
-                    continue;
-                }
-                boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
-                text.append("  - ").append(counterType).append(": ")
-                        .append(formatCounter(counter))
-                        .append("; required ").append(formatPercent(minimum))
-                        .append("; ").append(passed ? "PASS" : "FAIL")
-                        .append('\n');
-                if (!passed) {
-                    recordViolation(
-                            scope,
-                            counterType + " coverage " + formatPercent(counter.ratio())
-                                    + " is below " + formatPercent(minimum),
-                            exceptionByScope,
-                            appliedExceptions,
-                            violations);
-                }
-            }
+            evaluateCounters(
+                    scope,
+                    counters,
+                    policy.changedSourceMinimums(),
+                    true,
+                    text,
+                    exceptionByScope,
+                    appliedExceptions,
+                    violations);
         }
 
         if (!policy.temporaryExceptions().isEmpty()) {
@@ -322,13 +297,48 @@ final class CriticalCoveragePolicy {
     ChangedSources selectCriticalSources(
             ChangedSources discovered,
             List<String> prefixes) {
-        Set<String> selected = discovered.paths().stream()
+        Set<String> selected = new LinkedHashSet<>();
+        discovered.paths().stream()
                 .filter(path -> prefixes.stream().anyMatch(path::startsWith))
-                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+                .forEach(selected::add);
         return new ChangedSources(
                 Collections.unmodifiableSet(selected),
                 discovered.description() + "; " + selected.size()
                         + " file(s) are release-critical");
+    }
+
+    private void evaluateCounters(
+            String scope,
+            Map<String, Counter> counters,
+            Map<String, Double> minimums,
+            boolean branchMayBeAbsent,
+            StringBuilder text,
+            Map<String, TemporaryException> exceptionByScope,
+            Set<String> appliedExceptions,
+            List<String> violations) {
+        for (String counterType : COUNTER_TYPES) {
+            Counter counter = counters.get(counterType);
+            double minimum = minimums.get(counterType);
+            if (branchMayBeAbsent && "BRANCH".equals(counterType) && counter.total() == 0) {
+                text.append("  - BRANCH: N/A (source has no branch counter total)\n");
+                continue;
+            }
+            boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
+            text.append("  - ").append(counterType).append(": ")
+                    .append(formatCounter(counter))
+                    .append("; required ").append(formatPercent(minimum))
+                    .append("; ").append(passed ? "PASS" : "FAIL")
+                    .append('\n');
+            if (!passed) {
+                recordViolation(
+                        scope,
+                        counterType + " coverage " + formatPercent(counter.ratio())
+                                + " is below " + formatPercent(minimum),
+                        exceptionByScope,
+                        appliedExceptions,
+                        violations);
+            }
+        }
     }
 
     private List<String> readRequiredCounters(JsonNode root) {
@@ -418,10 +428,9 @@ final class CriticalCoveragePolicy {
                 throw new IllegalArgumentException(
                         "criticalPackages entries must be objects");
             }
-            String module = requiredText(value, "module");
-            String packageName = requiredText(value, "package").replace('.', '/');
             PackageKey key = new PackageKey(
-                    ReactorCoveragePolicy.normalizeGroupName(module), packageName);
+                    ReactorCoveragePolicy.normalizeGroupName(requiredText(value, "module")),
+                    requiredText(value, "package").replace('.', '/'));
             if (!unique.add(key)) {
                 throw new IllegalArgumentException(
                         "criticalPackages contains duplicate " + key.scope());
@@ -480,7 +489,8 @@ final class CriticalCoveragePolicy {
     private Map<String, Counter> parseCounterSet(
             Element element,
             List<String> requiredCounters,
-            String scope) {
+            String scope,
+            boolean allowMissingBranch) {
         Map<String, Counter> counters = new LinkedHashMap<>();
         for (Element counter : directChildren(element, "counter")) {
             String type = counter.getAttribute("type");
@@ -494,6 +504,9 @@ final class CriticalCoveragePolicy {
             counters.put(type, new Counter(
                     parseNonNegative(counter, "covered", type, scope),
                     parseNonNegative(counter, "missed", type, scope)));
+        }
+        if (allowMissingBranch && !counters.containsKey("BRANCH")) {
+            counters.put("BRANCH", new Counter(0, 0));
         }
         List<String> missing = requiredCounters.stream()
                 .filter(counter -> !counters.containsKey(counter))

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
@@ -1,0 +1,703 @@
+package com.taxonomy.build;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Deterministic release-critical package and changed-source coverage gate.
+ *
+ * <p>The evaluator consumes the same authoritative aggregate JaCoCo XML as the
+ * reactor-wide gate. It adds package-specific ratchets and, in a complete-history
+ * pull-request checkout, coverage requirements for changed critical Java sources.</p>
+ */
+final class CriticalCoveragePolicy {
+
+    static final List<String> COUNTER_TYPES = List.of("LINE", "BRANCH");
+    private static final Set<String> COUNTER_TYPE_SET = Set.copyOf(COUNTER_TYPES);
+    private static final Pattern COMMIT_ID = Pattern.compile("^[0-9a-f]{40}$");
+    private static final String JACOCO_REPORT_DTD =
+            "<!DOCTYPE report PUBLIC \"-//JACOCO//DTD Report 1.1//EN\" \"report.dtd\">";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    CoveragePolicy loadPolicy(Path path) {
+        return loadPolicy(path, LocalDate.now(ZoneOffset.UTC));
+    }
+
+    CoveragePolicy loadPolicy(Path path, LocalDate today) {
+        final JsonNode root;
+        try {
+            root = objectMapper.readTree(Files.readString(path));
+        } catch (IOException | RuntimeException error) {
+            throw new IllegalArgumentException(
+                    "Cannot read critical coverage policy " + path + ": "
+                            + error.getMessage(), error);
+        }
+        if (!root.isObject() || root.path("schemaVersion").asInt(-1) != 1) {
+            throw new IllegalArgumentException(
+                    "Critical coverage policy schemaVersion must be 1");
+        }
+
+        List<String> requiredCounters = readRequiredCounters(root);
+        Map<String, Double> changedMinimums = readMinimums(
+                root.path("changedSourceMinimums"),
+                "changedSourceMinimums",
+                requiredCounters);
+        List<String> prefixes = readPrefixes(root.path("changedSourcePrefixes"));
+        List<PackageBudget> packages = readPackageBudgets(
+                root.path("criticalPackages"), requiredCounters);
+        List<TemporaryException> exceptions = readExceptions(
+                root.path("temporaryExceptions"), today);
+
+        return new CoveragePolicy(
+                requiredCounters,
+                Collections.unmodifiableMap(changedMinimums),
+                List.copyOf(prefixes),
+                List.copyOf(packages),
+                List.copyOf(exceptions));
+    }
+
+    CoverageReport parseReport(Path path, List<String> requiredCounters) {
+        final Document document;
+        try {
+            validateDoctype(path);
+            DocumentBuilderFactory factory = secureDocumentBuilderFactory();
+            document = factory.newDocumentBuilder().parse(path.toFile());
+        } catch (IllegalArgumentException error) {
+            throw error;
+        } catch (IOException | SAXException | ParserConfigurationException error) {
+            throw new IllegalArgumentException(
+                    "Cannot parse JaCoCo report " + path + ": "
+                            + error.getMessage(), error);
+        }
+        Element root = document.getDocumentElement();
+        if (root == null || !"report".equals(root.getTagName())) {
+            throw new IllegalArgumentException(
+                    "Expected JaCoCo <report> root for critical coverage");
+        }
+
+        Map<PackageKey, Map<String, Counter>> packages = new LinkedHashMap<>();
+        Map<String, Map<String, Counter>> sourceFiles = new LinkedHashMap<>();
+        for (Element group : directChildren(root, "group")) {
+            String module = ReactorCoveragePolicy.normalizeGroupName(
+                    requiredAttribute(group, "name", "JaCoCo group"));
+            for (Element packageElement : directChildren(group, "package")) {
+                String packageName = requiredAttribute(
+                        packageElement, "name", "JaCoCo package");
+                PackageKey packageKey = new PackageKey(module, packageName);
+                if (packages.putIfAbsent(
+                        packageKey,
+                        parseCounterSet(packageElement, requiredCounters, packageKey.scope()))
+                        != null) {
+                    throw new IllegalArgumentException(
+                            "Duplicate JaCoCo package " + packageKey.scope());
+                }
+                for (Element sourceFile : directChildren(packageElement, "sourcefile")) {
+                    String sourceName = requiredAttribute(
+                            sourceFile, "name", "JaCoCo sourcefile");
+                    String repositoryPath = module + "/src/main/java/"
+                            + packageName + "/" + sourceName;
+                    if (sourceFiles.putIfAbsent(
+                            repositoryPath,
+                            parseCounterSet(
+                                    sourceFile,
+                                    requiredCounters,
+                                    "source:" + repositoryPath)) != null) {
+                        throw new IllegalArgumentException(
+                                "Duplicate JaCoCo source file " + repositoryPath);
+                    }
+                }
+            }
+        }
+        return new CoverageReport(
+                Collections.unmodifiableMap(packages),
+                Collections.unmodifiableMap(sourceFiles));
+    }
+
+    Evaluation evaluate(
+            Path xmlPath,
+            CoveragePolicy policy,
+            ChangedSources changedSources) {
+        CoverageReport report = parseReport(xmlPath, policy.requiredCounters());
+        Map<String, TemporaryException> exceptionByScope = new LinkedHashMap<>();
+        policy.temporaryExceptions().forEach(
+                exception -> exceptionByScope.put(exception.scope(), exception));
+        Set<String> appliedExceptions = new LinkedHashSet<>();
+        List<String> violations = new ArrayList<>();
+        StringBuilder text = new StringBuilder()
+                .append("\nTaxonomy release-critical coverage\n\n")
+                .append("Source: ").append(xmlPath).append('\n')
+                .append("Policy: critical package and changed-source ratchets\n\n")
+                .append("Critical package coverage:\n");
+
+        for (PackageBudget budget : policy.criticalPackages()) {
+            String scope = budget.key().scope();
+            Map<String, Counter> counters = report.packages().get(budget.key());
+            text.append("- ").append(scope).append('\n');
+            if (counters == null) {
+                recordViolation(
+                        scope,
+                        "package is absent from the authoritative JaCoCo report",
+                        exceptionByScope,
+                        appliedExceptions,
+                        violations);
+                text.append("  - MISSING\n");
+                continue;
+            }
+            for (String counterType : policy.requiredCounters()) {
+                Counter counter = counters.get(counterType);
+                double minimum = budget.minimums().get(counterType);
+                boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
+                text.append("  - ").append(counterType).append(": ")
+                        .append(formatCounter(counter))
+                        .append("; required ").append(formatPercent(minimum))
+                        .append("; ").append(passed ? "PASS" : "FAIL")
+                        .append('\n');
+                if (!passed) {
+                    recordViolation(
+                            scope,
+                            counterType + " coverage " + formatPercent(counter.ratio())
+                                    + " is below " + formatPercent(minimum),
+                            exceptionByScope,
+                            appliedExceptions,
+                            violations);
+                }
+            }
+        }
+
+        text.append("\nChanged critical source coverage:\n")
+                .append("- Discovery: ").append(changedSources.description()).append('\n');
+        if (changedSources.paths().isEmpty()) {
+            text.append("- No changed critical Java source requires a diff gate.\n");
+        }
+        for (String path : changedSources.paths().stream().sorted().toList()) {
+            String scope = "source:" + path;
+            Map<String, Counter> counters = report.sourceFiles().get(path);
+            text.append("- ").append(path).append('\n');
+            if (counters == null) {
+                recordViolation(
+                        scope,
+                        "changed source is absent from the authoritative JaCoCo report",
+                        exceptionByScope,
+                        appliedExceptions,
+                        violations);
+                text.append("  - MISSING\n");
+                continue;
+            }
+            for (String counterType : policy.requiredCounters()) {
+                Counter counter = counters.get(counterType);
+                double minimum = policy.changedSourceMinimums().get(counterType);
+                if ("BRANCH".equals(counterType) && counter.total() == 0) {
+                    text.append("  - BRANCH: N/A (source has no branch counter total)\n");
+                    continue;
+                }
+                boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
+                text.append("  - ").append(counterType).append(": ")
+                        .append(formatCounter(counter))
+                        .append("; required ").append(formatPercent(minimum))
+                        .append("; ").append(passed ? "PASS" : "FAIL")
+                        .append('\n');
+                if (!passed) {
+                    recordViolation(
+                            scope,
+                            counterType + " coverage " + formatPercent(counter.ratio())
+                                    + " is below " + formatPercent(minimum),
+                            exceptionByScope,
+                            appliedExceptions,
+                            violations);
+                }
+            }
+        }
+
+        if (!policy.temporaryExceptions().isEmpty()) {
+            text.append("\nTemporary exceptions:\n");
+            for (TemporaryException exception : policy.temporaryExceptions()) {
+                text.append("- ").append(exception.scope())
+                        .append("; owner ").append(exception.owner())
+                        .append("; expires ").append(exception.expiresOn())
+                        .append("; ")
+                        .append(appliedExceptions.contains(exception.scope())
+                                ? "APPLIED" : "NOT NEEDED")
+                        .append("; ").append(exception.rationale())
+                        .append('\n');
+            }
+        }
+        if (!violations.isEmpty()) {
+            text.append("\nViolations:\n");
+            violations.forEach(violation -> text.append("- ").append(violation).append('\n'));
+        }
+        boolean passed = violations.isEmpty();
+        text.append("Result: ").append(passed ? "PASS" : "FAIL").append('\n');
+        return new Evaluation(passed, text.toString());
+    }
+
+    ChangedSources discoverChangedSources(Path root, String baseRef) {
+        Path repository = root.toAbsolutePath().normalize();
+        if (baseRef == null || baseRef.isBlank()) {
+            return new ChangedSources(Set.of(),
+                    "not a pull-request checkout; aggregate and package gates only");
+        }
+        if (!Files.exists(repository.resolve(".git"))) {
+            return new ChangedSources(Set.of(),
+                    "source archive without Git history; aggregate and package gates only");
+        }
+
+        GitResult shallow = git(repository, "rev-parse", "--is-shallow-repository");
+        if (shallow.exitCode() != 0) {
+            throw new IllegalArgumentException(
+                    "Cannot determine Git history completeness: " + shallow.output().strip());
+        }
+        if ("true".equals(shallow.output().strip())) {
+            return new ChangedSources(Set.of(),
+                    "shallow specialized checkout; canonical full-history CI owns diff coverage");
+        }
+
+        String normalizedBase = baseRef.strip();
+        String candidate = COMMIT_ID.matcher(normalizedBase).matches()
+                ? normalizedBase
+                : "origin/" + normalizedBase;
+        GitResult verified = git(repository, "rev-parse", "--verify", candidate + "^{commit}");
+        if (verified.exitCode() != 0 && !candidate.equals(normalizedBase)) {
+            candidate = normalizedBase;
+            verified = git(repository, "rev-parse", "--verify", candidate + "^{commit}");
+        }
+        if (verified.exitCode() != 0) {
+            throw new IllegalArgumentException(
+                    "Cannot resolve coverage diff base '" + normalizedBase + "': "
+                            + verified.output().strip());
+        }
+        String commit = verified.output().strip();
+        GitResult diff = git(
+                repository,
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMRTUXB",
+                commit + "...HEAD",
+                "--");
+        if (diff.exitCode() != 0) {
+            throw new IllegalArgumentException(
+                    "Cannot determine changed sources from " + commit + ": "
+                            + diff.output().strip());
+        }
+
+        Set<String> paths = new LinkedHashSet<>();
+        for (String line : diff.output().lines().toList()) {
+            String path = line.strip().replace('\\', '/');
+            if (path.endsWith(".java")
+                    && !path.endsWith("/package-info.java")
+                    && !path.endsWith("/module-info.java")) {
+                paths.add(path);
+            }
+        }
+        return new ChangedSources(
+                Collections.unmodifiableSet(paths),
+                "complete Git diff against " + commit + " found " + paths.size()
+                        + " changed Java source file(s) before critical-prefix filtering");
+    }
+
+    ChangedSources selectCriticalSources(
+            ChangedSources discovered,
+            List<String> prefixes) {
+        Set<String> selected = discovered.paths().stream()
+                .filter(path -> prefixes.stream().anyMatch(path::startsWith))
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+        return new ChangedSources(
+                Collections.unmodifiableSet(selected),
+                discovered.description() + "; " + selected.size()
+                        + " file(s) are release-critical");
+    }
+
+    private List<String> readRequiredCounters(JsonNode root) {
+        JsonNode node = root.path("requiredCounters");
+        if (!node.isArray() || node.size() != COUNTER_TYPES.size()) {
+            throw new IllegalArgumentException(
+                    "Critical coverage requiredCounters must define LINE and BRANCH");
+        }
+        List<String> counters = new ArrayList<>();
+        for (JsonNode value : node) {
+            if (!value.isTextual() || !COUNTER_TYPE_SET.contains(value.asText())) {
+                throw new IllegalArgumentException(
+                        "Critical coverage requiredCounters may only contain LINE and BRANCH");
+            }
+            counters.add(value.asText());
+        }
+        if (!new LinkedHashSet<>(counters).equals(COUNTER_TYPE_SET)) {
+            throw new IllegalArgumentException(
+                    "Critical coverage requiredCounters must contain exactly LINE and BRANCH");
+        }
+        return List.copyOf(counters);
+    }
+
+    private Map<String, Double> readMinimums(
+            JsonNode node,
+            String label,
+            List<String> requiredCounters) {
+        if (!node.isObject() || node.size() != requiredCounters.size()) {
+            throw new IllegalArgumentException(
+                    label + " must define exactly LINE and BRANCH");
+        }
+        Map<String, Double> minimums = new LinkedHashMap<>();
+        for (String counter : requiredCounters) {
+            JsonNode value = node.path(counter);
+            if (!value.isNumber()) {
+                throw new IllegalArgumentException(
+                        label + " minimum for " + counter + " must be numeric");
+            }
+            double ratio = value.asDouble();
+            if (ratio <= 0.0 || ratio > 1.0) {
+                throw new IllegalArgumentException(
+                        label + " minimum for " + counter
+                                + " must be greater than zero and at most one");
+            }
+            minimums.put(counter, ratio);
+        }
+        return minimums;
+    }
+
+    private List<String> readPrefixes(JsonNode node) {
+        if (!node.isArray() || node.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "changedSourcePrefixes must be a non-empty list");
+        }
+        List<String> prefixes = new ArrayList<>();
+        Set<String> unique = new LinkedHashSet<>();
+        for (JsonNode value : node) {
+            if (!value.isTextual() || value.asText().isBlank()) {
+                throw new IllegalArgumentException(
+                        "changedSourcePrefixes entries must be non-empty strings");
+            }
+            String prefix = value.asText().replace('\\', '/');
+            if (prefix.startsWith("/") || prefix.contains("../") || !prefix.endsWith("/")) {
+                throw new IllegalArgumentException(
+                        "changedSourcePrefixes must be repository-relative directories ending in '/'");
+            }
+            if (!unique.add(prefix)) {
+                throw new IllegalArgumentException(
+                        "changedSourcePrefixes contains duplicate '" + prefix + "'");
+            }
+            prefixes.add(prefix);
+        }
+        return prefixes;
+    }
+
+    private List<PackageBudget> readPackageBudgets(
+            JsonNode node,
+            List<String> requiredCounters) {
+        if (!node.isArray() || node.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "criticalPackages must be a non-empty list");
+        }
+        List<PackageBudget> budgets = new ArrayList<>();
+        Set<PackageKey> unique = new LinkedHashSet<>();
+        for (JsonNode value : node) {
+            if (!value.isObject()) {
+                throw new IllegalArgumentException(
+                        "criticalPackages entries must be objects");
+            }
+            String module = requiredText(value, "module");
+            String packageName = requiredText(value, "package").replace('.', '/');
+            PackageKey key = new PackageKey(
+                    ReactorCoveragePolicy.normalizeGroupName(module), packageName);
+            if (!unique.add(key)) {
+                throw new IllegalArgumentException(
+                        "criticalPackages contains duplicate " + key.scope());
+            }
+            budgets.add(new PackageBudget(
+                    key,
+                    Collections.unmodifiableMap(readMinimums(
+                            value.path("minimums"),
+                            "minimums for " + key.scope(),
+                            requiredCounters))));
+        }
+        return budgets;
+    }
+
+    private List<TemporaryException> readExceptions(JsonNode node, LocalDate today) {
+        if (!node.isArray()) {
+            throw new IllegalArgumentException(
+                    "temporaryExceptions must be a list");
+        }
+        List<TemporaryException> exceptions = new ArrayList<>();
+        Set<String> scopes = new LinkedHashSet<>();
+        for (JsonNode value : node) {
+            if (!value.isObject()) {
+                throw new IllegalArgumentException(
+                        "temporaryExceptions entries must be objects");
+            }
+            String scope = requiredText(value, "scope");
+            if (!(scope.startsWith("package:") || scope.startsWith("source:"))) {
+                throw new IllegalArgumentException(
+                        "temporary exception scope must start with package: or source:");
+            }
+            if (!scopes.add(scope)) {
+                throw new IllegalArgumentException(
+                        "temporaryExceptions contains duplicate scope '" + scope + "'");
+            }
+            String rationale = requiredText(value, "rationale");
+            String owner = requiredText(value, "owner");
+            final LocalDate expiresOn;
+            try {
+                expiresOn = LocalDate.parse(requiredText(value, "expiresOn"));
+            } catch (RuntimeException error) {
+                throw new IllegalArgumentException(
+                        "temporary exception expiresOn must use ISO date format", error);
+            }
+            if (expiresOn.isBefore(today)) {
+                throw new IllegalArgumentException(
+                        "temporary coverage exception for " + scope
+                                + " expired on " + expiresOn);
+            }
+            exceptions.add(new TemporaryException(
+                    scope, rationale, owner, expiresOn));
+        }
+        return exceptions;
+    }
+
+    private Map<String, Counter> parseCounterSet(
+            Element element,
+            List<String> requiredCounters,
+            String scope) {
+        Map<String, Counter> counters = new LinkedHashMap<>();
+        for (Element counter : directChildren(element, "counter")) {
+            String type = counter.getAttribute("type");
+            if (!requiredCounters.contains(type)) {
+                continue;
+            }
+            if (counters.containsKey(type)) {
+                throw new IllegalArgumentException(
+                        "Duplicate " + type + " counter on " + scope);
+            }
+            counters.put(type, new Counter(
+                    parseNonNegative(counter, "covered", type, scope),
+                    parseNonNegative(counter, "missed", type, scope)));
+        }
+        List<String> missing = requiredCounters.stream()
+                .filter(counter -> !counters.containsKey(counter))
+                .toList();
+        if (!missing.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required counters " + String.join(", ", missing)
+                            + " on " + scope);
+        }
+        return Collections.unmodifiableMap(counters);
+    }
+
+    private long parseNonNegative(
+            Element counter,
+            String attribute,
+            String type,
+            String scope) {
+        final long value;
+        try {
+            value = Long.parseLong(counter.getAttribute(attribute));
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(
+                    "Invalid " + type + " counter on " + scope, error);
+        }
+        if (value < 0) {
+            throw new IllegalArgumentException(
+                    "Negative " + type + " counter on " + scope);
+        }
+        return value;
+    }
+
+    private static void recordViolation(
+            String scope,
+            String message,
+            Map<String, TemporaryException> exceptionByScope,
+            Set<String> appliedExceptions,
+            List<String> violations) {
+        if (exceptionByScope.containsKey(scope)) {
+            appliedExceptions.add(scope);
+        } else {
+            violations.add(scope + ": " + message);
+        }
+    }
+
+    private static String requiredText(JsonNode object, String field) {
+        JsonNode value = object.path(field);
+        if (!value.isTextual() || value.asText().isBlank()) {
+            throw new IllegalArgumentException(field + " must be a non-empty string");
+        }
+        return value.asText().strip();
+    }
+
+    private static String requiredAttribute(
+            Element element,
+            String attribute,
+            String label) {
+        String value = element.getAttribute(attribute);
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " has no " + attribute);
+        }
+        return value;
+    }
+
+    private static List<Element> directChildren(Element parent, String tagName) {
+        List<Element> result = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int index = 0; index < children.getLength(); index++) {
+            Node child = children.item(index);
+            if (child instanceof Element element && tagName.equals(element.getTagName())) {
+                result.add(element);
+            }
+        }
+        return result;
+    }
+
+    private static void validateDoctype(Path path) throws IOException {
+        String xml = Files.readString(path);
+        int start = xml.indexOf("<!DOCTYPE");
+        if (start < 0) {
+            return;
+        }
+        int end = xml.indexOf('>', start);
+        if (end < 0) {
+            throw new IllegalArgumentException(
+                    "Unterminated DOCTYPE in JaCoCo report " + path);
+        }
+        String declaration = xml.substring(start, end + 1)
+                .replaceAll("\\s+", " ")
+                .strip();
+        if (!JACOCO_REPORT_DTD.equals(declaration)
+                || xml.indexOf("<!DOCTYPE", end + 1) >= 0) {
+            throw new IllegalArgumentException(
+                    "Unsupported DOCTYPE in JaCoCo report " + path);
+        }
+    }
+
+    private static DocumentBuilderFactory secureDocumentBuilderFactory()
+            throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature(
+                "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory;
+    }
+
+    private static GitResult git(Path root, String... arguments) {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(arguments));
+        try {
+            Process process = new ProcessBuilder(command)
+                    .directory(root.toFile())
+                    .redirectErrorStream(true)
+                    .start();
+            String output = new String(
+                    process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return new GitResult(process.waitFor(), output);
+        } catch (IOException error) {
+            throw new IllegalArgumentException(
+                    "Cannot execute Git: " + error.getMessage(), error);
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Git command was interrupted", error);
+        }
+    }
+
+    private static String formatCounter(Counter counter) {
+        if (counter.total() == 0) {
+            return "N/A (0/0)";
+        }
+        return formatPercent(counter.ratio())
+                + " (" + counter.covered() + "/" + counter.total() + ")";
+    }
+
+    private static String formatPercent(double ratio) {
+        return String.format(Locale.ROOT, "%.2f%%", ratio * 100.0);
+    }
+
+    record PackageKey(String module, String packageName) {
+        PackageKey {
+            if (module == null || module.isBlank()
+                    || packageName == null || packageName.isBlank()) {
+                throw new IllegalArgumentException(
+                        "Critical package identity must be complete");
+            }
+        }
+
+        String scope() {
+            return "package:" + module + ":" + packageName;
+        }
+    }
+
+    record PackageBudget(PackageKey key, Map<String, Double> minimums) {
+    }
+
+    record TemporaryException(
+            String scope,
+            String rationale,
+            String owner,
+            LocalDate expiresOn) {
+    }
+
+    record CoveragePolicy(
+            List<String> requiredCounters,
+            Map<String, Double> changedSourceMinimums,
+            List<String> changedSourcePrefixes,
+            List<PackageBudget> criticalPackages,
+            List<TemporaryException> temporaryExceptions) {
+    }
+
+    record Counter(long covered, long missed) {
+        Counter {
+            if (covered < 0 || missed < 0) {
+                throw new IllegalArgumentException(
+                        "Coverage counters must not be negative");
+            }
+        }
+
+        long total() {
+            return covered + missed;
+        }
+
+        double ratio() {
+            return total() == 0 ? 0.0 : covered / (double) total();
+        }
+    }
+
+    record CoverageReport(
+            Map<PackageKey, Map<String, Counter>> packages,
+            Map<String, Map<String, Counter>> sourceFiles) {
+    }
+
+    record ChangedSources(Set<String> paths, String description) {
+    }
+
+    record Evaluation(boolean passed, String text) {
+    }
+
+    private record GitResult(int exitCode, String output) {
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
@@ -125,7 +125,7 @@ final class CriticalCoveragePolicy {
                             "source:" + repositoryPath,
                             true);
                     if (sourceCounters.isEmpty()) {
-                        continue;
+                        sourceCounters = zeroCounters(requiredCounters);
                     }
                     if (sourceFiles.putIfAbsent(repositoryPath, sourceCounters) != null) {
                         throw new IllegalArgumentException(
@@ -313,7 +313,7 @@ final class CriticalCoveragePolicy {
             String scope,
             Map<String, Counter> counters,
             Map<String, Double> minimums,
-            boolean branchMayBeAbsent,
+            boolean sourceFileScope,
             StringBuilder text,
             Map<String, TemporaryException> exceptionByScope,
             Set<String> appliedExceptions,
@@ -321,8 +321,11 @@ final class CriticalCoveragePolicy {
         for (String counterType : COUNTER_TYPES) {
             Counter counter = counters.get(counterType);
             double minimum = minimums.get(counterType);
-            if (branchMayBeAbsent && "BRANCH".equals(counterType) && counter.total() == 0) {
-                text.append("  - BRANCH: N/A (source has no branch counter total)\n");
+            if (sourceFileScope && counter.total() == 0) {
+                text.append("  - ").append(counterType)
+                        .append(": N/A (source has no executable ")
+                        .append(counterType.toLowerCase(Locale.ROOT))
+                        .append(" counter total)\n");
                 continue;
             }
             boolean passed = counter.total() > 0 && counter.ratio() >= minimum;
@@ -521,6 +524,12 @@ final class CriticalCoveragePolicy {
                     "Missing required counters " + String.join(", ", missing)
                             + " on " + scope);
         }
+        return Collections.unmodifiableMap(counters);
+    }
+
+    private static Map<String, Counter> zeroCounters(List<String> requiredCounters) {
+        Map<String, Counter> counters = new LinkedHashMap<>();
+        requiredCounters.forEach(type -> counters.put(type, new Counter(0, 0)));
         return Collections.unmodifiableMap(counters);
     }
 

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicy.java
@@ -104,13 +104,13 @@ final class CriticalCoveragePolicy {
                 String packageName = requiredAttribute(
                         packageElement, "name", "JaCoCo package");
                 PackageKey packageKey = new PackageKey(module, packageName);
-                if (packages.putIfAbsent(
-                        packageKey,
-                        parseCounterSet(
-                                packageElement,
-                                requiredCounters,
-                                packageKey.scope(),
-                                false)) != null) {
+                Map<String, Counter> packageCounters = parseCounterSet(
+                        packageElement,
+                        requiredCounters,
+                        packageKey.scope(),
+                        true);
+                if (!packageCounters.isEmpty()
+                        && packages.putIfAbsent(packageKey, packageCounters) != null) {
                     throw new IllegalArgumentException(
                             "Duplicate JaCoCo package " + packageKey.scope());
                 }
@@ -119,13 +119,15 @@ final class CriticalCoveragePolicy {
                             sourceFile, "name", "JaCoCo sourcefile");
                     String repositoryPath = module + "/src/main/java/"
                             + packageName + "/" + sourceName;
-                    if (sourceFiles.putIfAbsent(
-                            repositoryPath,
-                            parseCounterSet(
-                                    sourceFile,
-                                    requiredCounters,
-                                    "source:" + repositoryPath,
-                                    true)) != null) {
+                    Map<String, Counter> sourceCounters = parseCounterSet(
+                            sourceFile,
+                            requiredCounters,
+                            "source:" + repositoryPath,
+                            true);
+                    if (sourceCounters.isEmpty()) {
+                        continue;
+                    }
+                    if (sourceFiles.putIfAbsent(repositoryPath, sourceCounters) != null) {
                         throw new IllegalArgumentException(
                                 "Duplicate JaCoCo source file " + repositoryPath);
                     }
@@ -504,6 +506,9 @@ final class CriticalCoveragePolicy {
             counters.put(type, new Counter(
                     parseNonNegative(counter, "covered", type, scope),
                     parseNonNegative(counter, "missed", type, scope)));
+        }
+        if (counters.isEmpty()) {
+            return Map.of();
         }
         if (allowMissingBranch && !counters.containsKey("BRANCH")) {
             counters.put("BRANCH", new Counter(0, 0));

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
@@ -1,0 +1,284 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class CriticalCoveragePolicyTest {
+
+    private final CriticalCoveragePolicy evaluator = new CriticalCoveragePolicy();
+
+    @Test
+    void packageAndChangedSourceRatchetsPassAndPublishEvidence(@TempDir Path root)
+            throws Exception {
+        Path xml = write(root.resolve("jacoco.xml"), reportXml(
+                82, 18, 66, 34,
+                80, 20, 60, 40));
+        CriticalCoveragePolicy.CoveragePolicy policy = policy(
+                0.80, 0.65, 0.75, 0.60, List.of());
+        CriticalCoveragePolicy.ChangedSources changed =
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java"),
+                        "test diff");
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml, policy, changed);
+
+        assertThat(evaluation.passed()).isTrue();
+        assertThat(evaluation.text())
+                .contains("package:taxonomy-app:com/taxonomy/security")
+                .contains("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java")
+                .contains("Changed critical source coverage")
+                .contains("Result: PASS");
+    }
+
+    @Test
+    void packageBranchRegressionFailsEvenWhenLineCoveragePasses(@TempDir Path root)
+            throws Exception {
+        Path xml = write(root.resolve("jacoco.xml"), reportXml(
+                90, 10, 64, 36,
+                90, 10, 80, 20));
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+
+        assertThat(evaluation.passed()).isFalse();
+        assertThat(evaluation.text())
+                .contains("BRANCH coverage 64.00% is below 65.00%")
+                .contains("Result: FAIL");
+    }
+
+    @Test
+    void changedCriticalSourceMustBePresentAndMeetItsOwnBudget(@TempDir Path root)
+            throws Exception {
+        Path xml = write(root.resolve("jacoco.xml"), reportXml(
+                90, 10, 80, 20,
+                70, 30, 50, 50));
+        String source = "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java";
+
+        CriticalCoveragePolicy.Evaluation lowCoverage = evaluator.evaluate(
+                xml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(source), "test diff"));
+        CriticalCoveragePolicy.Evaluation missing = evaluator.evaluate(
+                xml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of("taxonomy-app/src/main/java/com/taxonomy/security/Missing.java"),
+                        "test diff"));
+
+        assertThat(lowCoverage.passed()).isFalse();
+        assertThat(lowCoverage.text())
+                .contains("LINE coverage 70.00% is below 75.00%")
+                .contains("BRANCH coverage 50.00% is below 60.00%");
+        assertThat(missing.passed()).isFalse();
+        assertThat(missing.text()).contains(
+                "changed source is absent from the authoritative JaCoCo report");
+    }
+
+    @Test
+    void changedSourceWithoutBranchesUsesLineCoverageAndReportsBranchAsNotApplicable(
+            @TempDir Path root) throws Exception {
+        Path xml = write(root.resolve("jacoco.xml"), reportXml(
+                90, 10, 80, 20,
+                80, 20, 0, 0));
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java"),
+                        "test diff"));
+
+        assertThat(evaluation.passed()).isTrue();
+        assertThat(evaluation.text())
+                .contains("BRANCH: N/A (source has no branch counter total)");
+    }
+
+    @Test
+    void activeExceptionIsOwnedAndVisibleButExpiredExceptionFailsPolicyLoading(
+            @TempDir Path root) throws Exception {
+        Path xml = write(root.resolve("jacoco.xml"), reportXml(
+                90, 10, 50, 50,
+                90, 10, 80, 20));
+        String scope = "package:taxonomy-app:com/taxonomy/security";
+        CriticalCoveragePolicy.TemporaryException exception =
+                new CriticalCoveragePolicy.TemporaryException(
+                        scope,
+                        "Temporary branch gap while the security adapter is decomposed",
+                        "security-maintainers",
+                        LocalDate.of(2099, 1, 1));
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of(exception)),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+        Path expiredPolicy = write(root.resolve("expired.json"), policyJson("2000-01-01"));
+
+        assertThat(evaluation.passed()).isTrue();
+        assertThat(evaluation.text())
+                .contains("owner security-maintainers")
+                .contains("APPLIED");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.loadPolicy(
+                        expiredPolicy, LocalDate.of(2026, 8, 15)))
+                .withMessageContaining("expired on 2000-01-01");
+    }
+
+    @Test
+    void realGitDiffDiscoverySelectsOnlyCriticalProductionSources(@TempDir Path root)
+            throws Exception {
+        runGit(root, "init");
+        runGit(root, "config", "user.name", "Coverage Test");
+        runGit(root, "config", "user.email", "coverage@example.invalid");
+        Path critical = root.resolve(
+                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java");
+        Path unrelated = root.resolve(
+                "taxonomy-app/src/main/java/com/taxonomy/ui/Bar.java");
+        write(critical, "package com.taxonomy.security; class Foo {}\n");
+        write(unrelated, "package com.taxonomy.ui; class Bar {}\n");
+        runGit(root, "add", ".");
+        runGit(root, "commit", "-m", "base");
+        String baseCommit = runGit(root, "rev-parse", "HEAD").strip();
+        write(critical, "package com.taxonomy.security; class Foo { boolean secure() { return true; } }\n");
+        write(unrelated, "package com.taxonomy.ui; class Bar { int value() { return 1; } }\n");
+
+        CriticalCoveragePolicy.ChangedSources discovered =
+                evaluator.discoverChangedSources(root, baseCommit);
+        CriticalCoveragePolicy.ChangedSources selected = evaluator.selectCriticalSources(
+                discovered,
+                List.of("taxonomy-app/src/main/java/com/taxonomy/security/"));
+
+        assertThat(discovered.paths()).containsExactlyInAnyOrder(
+                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java",
+                "taxonomy-app/src/main/java/com/taxonomy/ui/Bar.java");
+        assertThat(selected.paths()).containsExactly(
+                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java");
+    }
+
+    @Test
+    void policyRejectsUnsafePrefixesAndIncompleteExceptions(@TempDir Path root)
+            throws Exception {
+        Path unsafePrefix = write(root.resolve("unsafe-prefix.json"), policyJsonWithPrefix(
+                "../taxonomy-app/src/main/java/", "[]"));
+        Path incompleteException = write(root.resolve("incomplete-exception.json"),
+                policyJsonWithPrefix(
+                        "taxonomy-app/src/main/java/com/taxonomy/security/",
+                        "[{\"scope\":\"package:taxonomy-app:com/taxonomy/security\","
+                                + "\"owner\":\"security\",\"expiresOn\":\"2099-01-01\"}]"));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.loadPolicy(unsafePrefix))
+                .withMessageContaining("repository-relative directories");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.loadPolicy(incompleteException))
+                .withMessageContaining("rationale must be a non-empty string");
+    }
+
+    private static CriticalCoveragePolicy.CoveragePolicy policy(
+            double packageLine,
+            double packageBranch,
+            double changedLine,
+            double changedBranch,
+            List<CriticalCoveragePolicy.TemporaryException> exceptions) {
+        return new CriticalCoveragePolicy.CoveragePolicy(
+                CriticalCoveragePolicy.COUNTER_TYPES,
+                Map.of("LINE", changedLine, "BRANCH", changedBranch),
+                List.of("taxonomy-app/src/main/java/com/taxonomy/security/"),
+                List.of(new CriticalCoveragePolicy.PackageBudget(
+                        new CriticalCoveragePolicy.PackageKey(
+                                "taxonomy-app", "com/taxonomy/security"),
+                        Map.of("LINE", packageLine, "BRANCH", packageBranch))),
+                exceptions);
+    }
+
+    private static String reportXml(
+            long packageLineCovered,
+            long packageLineMissed,
+            long packageBranchCovered,
+            long packageBranchMissed,
+            long sourceLineCovered,
+            long sourceLineMissed,
+            long sourceBranchCovered,
+            long sourceBranchMissed) {
+        return """
+                <report name="critical">
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/security">
+                      <sourcefile name="Foo.java">
+                        <counter type="LINE" missed="%d" covered="%d"/>
+                        <counter type="BRANCH" missed="%d" covered="%d"/>
+                      </sourcefile>
+                      <counter type="LINE" missed="%d" covered="%d"/>
+                      <counter type="BRANCH" missed="%d" covered="%d"/>
+                    </package>
+                  </group>
+                </report>
+                """.formatted(
+                        sourceLineMissed, sourceLineCovered,
+                        sourceBranchMissed, sourceBranchCovered,
+                        packageLineMissed, packageLineCovered,
+                        packageBranchMissed, packageBranchCovered);
+    }
+
+    private static String policyJson(String expiresOn) {
+        return policyJsonWithPrefix(
+                "taxonomy-app/src/main/java/com/taxonomy/security/",
+                "[{\"scope\":\"package:taxonomy-app:com/taxonomy/security\","
+                        + "\"rationale\":\"temporary\",\"owner\":\"security\","
+                        + "\"expiresOn\":\"" + expiresOn + "\"}]");
+    }
+
+    private static String policyJsonWithPrefix(String prefix, String exceptions) {
+        return """
+                {
+                  "schemaVersion": 1,
+                  "requiredCounters": ["LINE", "BRANCH"],
+                  "changedSourceMinimums": {"LINE": 0.75, "BRANCH": 0.60},
+                  "changedSourcePrefixes": ["%s"],
+                  "criticalPackages": [
+                    {
+                      "module": "taxonomy-app",
+                      "package": "com/taxonomy/security",
+                      "minimums": {"LINE": 0.80, "BRANCH": 0.65}
+                    }
+                  ],
+                  "temporaryExceptions": %s
+                }
+                """.formatted(prefix, exceptions);
+    }
+
+    private static Path write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    private static String runGit(Path root, String... arguments) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add("git");
+        command.addAll(List.of(arguments));
+        Process process = new ProcessBuilder(command)
+                .directory(root.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(
+                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        assertThat(exitCode).as("%s%n%s", command, output).isZero();
+        return output;
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
@@ -90,11 +90,21 @@ class CriticalCoveragePolicyTest {
     }
 
     @Test
-    void changedSourceWithoutBranchesUsesLineCoverageAndReportsBranchAsNotApplicable(
+    void changedSourceWithoutABranchCounterUsesLineCoverageAndReportsNotApplicable(
             @TempDir Path root) throws Exception {
-        Path xml = write(root.resolve("jacoco.xml"), reportXml(
-                90, 10, 80, 20,
-                80, 20, 0, 0));
+        Path xml = write(root.resolve("jacoco.xml"), """
+                <report name="critical">
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/security">
+                      <sourcefile name="Foo.java">
+                        <counter type="LINE" missed="20" covered="80"/>
+                      </sourcefile>
+                      <counter type="LINE" missed="10" covered="90"/>
+                      <counter type="BRANCH" missed="20" covered="80"/>
+                    </package>
+                  </group>
+                </report>
+                """);
 
         CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
                 xml,
@@ -153,8 +163,13 @@ class CriticalCoveragePolicyTest {
         runGit(root, "add", ".");
         runGit(root, "commit", "-m", "base");
         String baseCommit = runGit(root, "rev-parse", "HEAD").strip();
-        write(critical, "package com.taxonomy.security; class Foo { boolean secure() { return true; } }\n");
-        write(unrelated, "package com.taxonomy.ui; class Bar { int value() { return 1; } }\n");
+
+        write(critical,
+                "package com.taxonomy.security; class Foo { boolean secure() { return true; } }\n");
+        write(unrelated,
+                "package com.taxonomy.ui; class Bar { int value() { return 1; } }\n");
+        runGit(root, "add", ".");
+        runGit(root, "commit", "-m", "changed");
 
         CriticalCoveragePolicy.ChangedSources discovered =
                 evaluator.discoverChangedSources(root, baseCommit);

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
@@ -186,6 +186,8 @@ class CriticalCoveragePolicyTest {
                   <group name="taxonomy-app">
                     <package name="com/taxonomy/security">
                       <counter type="LINE" missed="10" covered="90"/>
+                      <counter type="LINE" missed="20" covered="80"/>
+                      <counter type="BRANCH" missed="20" covered="80"/>
                     </package>
                   </group>
                 </report>
@@ -204,7 +206,7 @@ class CriticalCoveragePolicyTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> evaluator.parseReport(
                         malformedReport, CriticalCoveragePolicy.COUNTER_TYPES))
-                .withMessageContaining("Missing required counters");
+                .withMessageContaining("Duplicate LINE counter");
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> evaluator.parseReport(
                         externalEntity, CriticalCoveragePolicy.COUNTER_TYPES))

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoveragePolicyTest.java
@@ -3,11 +3,9 @@ package com.taxonomy.build;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,34 +18,9 @@ class CriticalCoveragePolicyTest {
     private final CriticalCoveragePolicy evaluator = new CriticalCoveragePolicy();
 
     @Test
-    void packageAndChangedSourceRatchetsPassAndPublishEvidence(@TempDir Path root)
-            throws Exception {
+    void packageBudgetsPassAndRenderEvidence(@TempDir Path root) throws Exception {
         Path xml = write(root.resolve("jacoco.xml"), reportXml(
-                82, 18, 66, 34,
-                80, 20, 60, 40));
-        CriticalCoveragePolicy.CoveragePolicy policy = policy(
-                0.80, 0.65, 0.75, 0.60, List.of());
-        CriticalCoveragePolicy.ChangedSources changed =
-                new CriticalCoveragePolicy.ChangedSources(
-                        Set.of("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java"),
-                        "test diff");
-
-        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
-                xml, policy, changed);
-
-        assertThat(evaluation.passed()).isTrue();
-        assertThat(evaluation.text())
-                .contains("package:taxonomy-app:com/taxonomy/security")
-                .contains("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java")
-                .contains("Changed critical source coverage")
-                .contains("Result: PASS");
-    }
-
-    @Test
-    void packageBranchRegressionFailsEvenWhenLineCoveragePasses(@TempDir Path root)
-            throws Exception {
-        Path xml = write(root.resolve("jacoco.xml"), reportXml(
-                90, 10, 64, 36,
+                90, 10, 80, 20,
                 90, 10, 80, 20));
 
         CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
@@ -55,24 +28,61 @@ class CriticalCoveragePolicyTest {
                 policy(0.80, 0.65, 0.75, 0.60, List.of()),
                 new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
 
-        assertThat(evaluation.passed()).isFalse();
+        assertThat(evaluation.passed()).isTrue();
         assertThat(evaluation.text())
-                .contains("BRANCH coverage 64.00% is below 65.00%")
-                .contains("Result: FAIL");
+                .contains("package:taxonomy-app:com/taxonomy/security")
+                .contains("LINE: 90.00% (90/100); required 80.00%; PASS")
+                .contains("BRANCH: 80.00% (80/100); required 65.00%; PASS")
+                .contains("Result: PASS");
     }
 
     @Test
-    void changedCriticalSourceMustBePresentAndMeetItsOwnBudget(@TempDir Path root)
+    void missingOrLowPackageFailsClosed(@TempDir Path root) throws Exception {
+        Path lowXml = write(root.resolve("low.xml"), reportXml(
+                79, 21, 64, 36,
+                90, 10, 80, 20));
+        Path missingXml = write(root.resolve("missing.xml"), """
+                <report name="critical">
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/other">
+                      <counter type="LINE" missed="10" covered="90"/>
+                      <counter type="BRANCH" missed="20" covered="80"/>
+                    </package>
+                  </group>
+                </report>
+                """);
+
+        CriticalCoveragePolicy.Evaluation low = evaluator.evaluate(
+                lowXml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+        CriticalCoveragePolicy.Evaluation missing = evaluator.evaluate(
+                missingXml,
+                policy(0.80, 0.65, 0.75, 0.60, List.of()),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+
+        assertThat(low.passed()).isFalse();
+        assertThat(low.text())
+                .contains("LINE coverage 79.00% is below 80.00%")
+                .contains("BRANCH coverage 64.00% is below 65.00%");
+        assertThat(missing.passed()).isFalse();
+        assertThat(missing.text()).contains(
+                "package is absent from the authoritative JaCoCo report");
+    }
+
+    @Test
+    void changedCriticalSourceMustMeetItsBudgetsAndBePresent(@TempDir Path root)
             throws Exception {
         Path xml = write(root.resolve("jacoco.xml"), reportXml(
                 90, 10, 80, 20,
                 70, 30, 50, 50));
-        String source = "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java";
 
         CriticalCoveragePolicy.Evaluation lowCoverage = evaluator.evaluate(
                 xml,
                 policy(0.80, 0.65, 0.75, 0.60, List.of()),
-                new CriticalCoveragePolicy.ChangedSources(Set.of(source), "test diff"));
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of("taxonomy-app/src/main/java/com/taxonomy/security/Foo.java"),
+                        "test diff"));
         CriticalCoveragePolicy.Evaluation missing = evaluator.evaluate(
                 xml,
                 policy(0.80, 0.65, 0.75, 0.60, List.of()),
@@ -115,7 +125,7 @@ class CriticalCoveragePolicyTest {
 
         assertThat(evaluation.passed()).isTrue();
         assertThat(evaluation.text())
-                .contains("BRANCH: N/A (source has no branch counter total)");
+                .contains("BRANCH: N/A (source has no executable branch counter total)");
     }
 
     @Test
@@ -149,69 +159,87 @@ class CriticalCoveragePolicyTest {
     }
 
     @Test
-    void realGitDiffDiscoverySelectsOnlyCriticalProductionSources(@TempDir Path root)
-            throws Exception {
-        runGit(root, "init");
-        runGit(root, "config", "user.name", "Coverage Test");
-        runGit(root, "config", "user.email", "coverage@example.invalid");
-        Path critical = root.resolve(
-                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java");
-        Path unrelated = root.resolve(
-                "taxonomy-app/src/main/java/com/taxonomy/ui/Bar.java");
-        write(critical, "package com.taxonomy.security; class Foo {}\n");
-        write(unrelated, "package com.taxonomy.ui; class Bar {}\n");
-        runGit(root, "add", ".");
-        runGit(root, "commit", "-m", "base");
-        String baseCommit = runGit(root, "rev-parse", "HEAD").strip();
+    void malformedPolicyAndReportFailClosed(@TempDir Path root) throws Exception {
+        Path duplicatePolicy = write(root.resolve("duplicate.json"), """
+                {
+                  "schemaVersion": 1,
+                  "requiredCounters": ["LINE", "BRANCH"],
+                  "changedSourceMinimums": {"LINE": 0.75, "BRANCH": 0.60},
+                  "changedSourcePrefixes": ["taxonomy-app/src/main/java/com/taxonomy/security/"],
+                  "criticalPackages": [
+                    {
+                      "module": "taxonomy-app",
+                      "package": "com/taxonomy/security",
+                      "minimums": {"LINE": 0.80, "BRANCH": 0.65}
+                    },
+                    {
+                      "module": "taxonomy-app",
+                      "package": "com/taxonomy/security",
+                      "minimums": {"LINE": 0.80, "BRANCH": 0.65}
+                    }
+                  ],
+                  "temporaryExceptions": []
+                }
+                """);
+        Path malformedReport = write(root.resolve("malformed.xml"), """
+                <report name="critical">
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/security">
+                      <counter type="LINE" missed="10" covered="90"/>
+                    </package>
+                  </group>
+                </report>
+                """);
+        Path externalEntity = write(root.resolve("external.xml"), """
+                <!DOCTYPE report [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+                <report name="&xxe;">
+                  <group name="taxonomy-app"/>
+                </report>
+                """);
 
-        write(critical,
-                "package com.taxonomy.security; class Foo { boolean secure() { return true; } }\n");
-        write(unrelated,
-                "package com.taxonomy.ui; class Bar { int value() { return 1; } }\n");
-        runGit(root, "add", ".");
-        runGit(root, "commit", "-m", "changed");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.loadPolicy(
+                        duplicatePolicy, LocalDate.of(2026, 8, 15)))
+                .withMessageContaining("duplicate");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.parseReport(
+                        malformedReport, CriticalCoveragePolicy.COUNTER_TYPES))
+                .withMessageContaining("Missing required counters");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> evaluator.parseReport(
+                        externalEntity, CriticalCoveragePolicy.COUNTER_TYPES))
+                .withMessageContaining("Unsupported DOCTYPE");
+    }
 
+    @Test
+    void changeDiscoveryIsRepositoryRelativeAndCriticalSelectionIsExplicit(
+            @TempDir Path root) throws Exception {
+        Files.createDirectories(root.resolve(".git"));
         CriticalCoveragePolicy.ChangedSources discovered =
-                evaluator.discoverChangedSources(root, baseCommit);
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of(
+                                "taxonomy-app/src/main/java/com/taxonomy/security/SecurityConfig.java",
+                                "taxonomy-app/src/main/java/com/taxonomy/catalog/TaxonomyService.java"),
+                        "test discovery");
+
         CriticalCoveragePolicy.ChangedSources selected = evaluator.selectCriticalSources(
                 discovered,
                 List.of("taxonomy-app/src/main/java/com/taxonomy/security/"));
 
-        assertThat(discovered.paths()).containsExactlyInAnyOrder(
-                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java",
-                "taxonomy-app/src/main/java/com/taxonomy/ui/Bar.java");
         assertThat(selected.paths()).containsExactly(
-                "taxonomy-app/src/main/java/com/taxonomy/security/Foo.java");
-    }
-
-    @Test
-    void policyRejectsUnsafePrefixesAndIncompleteExceptions(@TempDir Path root)
-            throws Exception {
-        Path unsafePrefix = write(root.resolve("unsafe-prefix.json"), policyJsonWithPrefix(
-                "../taxonomy-app/src/main/java/", "[]"));
-        Path incompleteException = write(root.resolve("incomplete-exception.json"),
-                policyJsonWithPrefix(
-                        "taxonomy-app/src/main/java/com/taxonomy/security/",
-                        "[{\"scope\":\"package:taxonomy-app:com/taxonomy/security\","
-                                + "\"owner\":\"security\",\"expiresOn\":\"2099-01-01\"}]"));
-
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> evaluator.loadPolicy(unsafePrefix))
-                .withMessageContaining("repository-relative directories");
-        assertThatIllegalArgumentException()
-                .isThrownBy(() -> evaluator.loadPolicy(incompleteException))
-                .withMessageContaining("rationale must be a non-empty string");
+                "taxonomy-app/src/main/java/com/taxonomy/security/SecurityConfig.java");
+        assertThat(selected.description()).contains("1 file(s) are release-critical");
     }
 
     private static CriticalCoveragePolicy.CoveragePolicy policy(
             double packageLine,
             double packageBranch,
-            double changedLine,
-            double changedBranch,
+            double sourceLine,
+            double sourceBranch,
             List<CriticalCoveragePolicy.TemporaryException> exceptions) {
         return new CriticalCoveragePolicy.CoveragePolicy(
                 CriticalCoveragePolicy.COUNTER_TYPES,
-                Map.of("LINE", changedLine, "BRANCH", changedBranch),
+                Map.of("LINE", sourceLine, "BRANCH", sourceBranch),
                 List.of("taxonomy-app/src/main/java/com/taxonomy/security/"),
                 List.of(new CriticalCoveragePolicy.PackageBudget(
                         new CriticalCoveragePolicy.PackageKey(
@@ -221,14 +249,14 @@ class CriticalCoveragePolicyTest {
     }
 
     private static String reportXml(
-            long packageLineCovered,
-            long packageLineMissed,
-            long packageBranchCovered,
-            long packageBranchMissed,
-            long sourceLineCovered,
-            long sourceLineMissed,
-            long sourceBranchCovered,
-            long sourceBranchMissed) {
+            int packageLineCovered,
+            int packageLineMissed,
+            int packageBranchCovered,
+            int packageBranchMissed,
+            int sourceLineCovered,
+            int sourceLineMissed,
+            int sourceBranchCovered,
+            int sourceBranchMissed) {
         return """
                 <report name="critical">
                   <group name="taxonomy-app">
@@ -243,27 +271,23 @@ class CriticalCoveragePolicyTest {
                   </group>
                 </report>
                 """.formatted(
-                        sourceLineMissed, sourceLineCovered,
-                        sourceBranchMissed, sourceBranchCovered,
-                        packageLineMissed, packageLineCovered,
-                        packageBranchMissed, packageBranchCovered);
+                sourceLineMissed,
+                sourceLineCovered,
+                sourceBranchMissed,
+                sourceBranchCovered,
+                packageLineMissed,
+                packageLineCovered,
+                packageBranchMissed,
+                packageBranchCovered);
     }
 
     private static String policyJson(String expiresOn) {
-        return policyJsonWithPrefix(
-                "taxonomy-app/src/main/java/com/taxonomy/security/",
-                "[{\"scope\":\"package:taxonomy-app:com/taxonomy/security\","
-                        + "\"rationale\":\"temporary\",\"owner\":\"security\","
-                        + "\"expiresOn\":\"" + expiresOn + "\"}]");
-    }
-
-    private static String policyJsonWithPrefix(String prefix, String exceptions) {
         return """
                 {
                   "schemaVersion": 1,
                   "requiredCounters": ["LINE", "BRANCH"],
                   "changedSourceMinimums": {"LINE": 0.75, "BRANCH": 0.60},
-                  "changedSourcePrefixes": ["%s"],
+                  "changedSourcePrefixes": ["taxonomy-app/src/main/java/com/taxonomy/security/"],
                   "criticalPackages": [
                     {
                       "module": "taxonomy-app",
@@ -271,29 +295,20 @@ class CriticalCoveragePolicyTest {
                       "minimums": {"LINE": 0.80, "BRANCH": 0.65}
                     }
                   ],
-                  "temporaryExceptions": %s
+                  "temporaryExceptions": [
+                    {
+                      "scope": "package:taxonomy-app:com/taxonomy/security",
+                      "rationale": "Temporary branch gap",
+                      "owner": "security-maintainers",
+                      "expiresOn": "%s"
+                    }
+                  ]
                 }
-                """.formatted(prefix, exceptions);
+                """.formatted(expiresOn);
     }
 
     private static Path write(Path path, String content) throws Exception {
-        Files.createDirectories(path.getParent());
-        Files.writeString(path, content, StandardCharsets.UTF_8);
+        Files.writeString(path, content);
         return path;
-    }
-
-    private static String runGit(Path root, String... arguments) throws Exception {
-        List<String> command = new ArrayList<>();
-        command.add("git");
-        command.addAll(List.of(arguments));
-        Process process = new ProcessBuilder(command)
-                .directory(root.toFile())
-                .redirectErrorStream(true)
-                .start();
-        String output = new String(
-                process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        int exitCode = process.waitFor();
-        assertThat(exitCode).as("%s%n%s", command, output).isZero();
-        return output;
     }
 }

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoverageSparseReportTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoverageSparseReportTest.java
@@ -1,0 +1,90 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CriticalCoverageSparseReportTest {
+
+    private final CriticalCoveragePolicy evaluator = new CriticalCoveragePolicy();
+
+    @Test
+    void ignoresUnmeasuredUnrelatedPackagesAndSources(@TempDir Path root) throws Exception {
+        Path xml = root.resolve("jacoco.xml");
+        Files.writeString(xml, """
+                <report name="critical">
+                  <group name="taxonomy-domain">
+                    <package name="com/taxonomy/pipeline">
+                      <sourcefile name="PipelineMarker.java"/>
+                    </package>
+                  </group>
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/security">
+                      <sourcefile name="Foo.java">
+                        <counter type="LINE" missed="10" covered="90"/>
+                        <counter type="BRANCH" missed="20" covered="80"/>
+                      </sourcefile>
+                      <counter type="LINE" missed="10" covered="90"/>
+                      <counter type="BRANCH" missed="20" covered="80"/>
+                    </package>
+                  </group>
+                </report>
+                """);
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml,
+                policy(),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+
+        assertThat(evaluation.passed()).isTrue();
+        assertThat(evaluation.text()).contains("Result: PASS");
+    }
+
+    @Test
+    void branchlessCriticalPackageFailsAsCoverageNotAsMalformedXml(@TempDir Path root)
+            throws Exception {
+        Path xml = root.resolve("jacoco.xml");
+        Files.writeString(xml, """
+                <report name="critical">
+                  <group name="taxonomy-app">
+                    <package name="com/taxonomy/security">
+                      <sourcefile name="Foo.java">
+                        <counter type="LINE" missed="10" covered="90"/>
+                      </sourcefile>
+                      <counter type="LINE" missed="10" covered="90"/>
+                    </package>
+                  </group>
+                </report>
+                """);
+
+        CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
+                xml,
+                policy(),
+                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+
+        assertThat(evaluation.passed()).isFalse();
+        assertThat(evaluation.text())
+                .contains("BRANCH: N/A (0/0)")
+                .contains("BRANCH coverage 0.00% is below 60.00%")
+                .contains("Result: FAIL");
+    }
+
+    private static CriticalCoveragePolicy.CoveragePolicy policy() {
+        return new CriticalCoveragePolicy.CoveragePolicy(
+                CriticalCoveragePolicy.COUNTER_TYPES,
+                Map.of("LINE", 0.75, "BRANCH", 0.60),
+                List.of("taxonomy-app/src/main/java/com/taxonomy/security/"),
+                List.of(new CriticalCoveragePolicy.PackageBudget(
+                        new CriticalCoveragePolicy.PackageKey(
+                                "taxonomy-app", "com/taxonomy/security"),
+                        Map.of("LINE", 0.80, "BRANCH", 0.60))),
+                List.of());
+    }
+}

--- a/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoverageSparseReportTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/CriticalCoverageSparseReportTest.java
@@ -16,7 +16,8 @@ class CriticalCoverageSparseReportTest {
     private final CriticalCoveragePolicy evaluator = new CriticalCoveragePolicy();
 
     @Test
-    void ignoresUnmeasuredUnrelatedPackagesAndSources(@TempDir Path root) throws Exception {
+    void unmeasuredSourceIsNotConfusedWithAFileMissingFromTheReport(@TempDir Path root)
+            throws Exception {
         Path xml = root.resolve("jacoco.xml");
         Files.writeString(xml, """
                 <report name="critical">
@@ -41,10 +42,15 @@ class CriticalCoverageSparseReportTest {
         CriticalCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
                 xml,
                 policy(),
-                new CriticalCoveragePolicy.ChangedSources(Set.of(), "none"));
+                new CriticalCoveragePolicy.ChangedSources(
+                        Set.of("taxonomy-domain/src/main/java/com/taxonomy/pipeline/PipelineMarker.java"),
+                        "one unmeasured source"));
 
         assertThat(evaluation.passed()).isTrue();
-        assertThat(evaluation.text()).contains("Result: PASS");
+        assertThat(evaluation.text())
+                .contains("LINE: N/A (source has no executable line counter total)")
+                .contains("BRANCH: N/A (source has no executable branch counter total)")
+                .contains("Result: PASS");
     }
 
     @Test

--- a/taxonomy-build/src/test/java/com/taxonomy/build/ReactorCoveragePolicyIT.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/ReactorCoveragePolicyIT.java
@@ -7,34 +7,57 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Post-reactor coverage gate executed by Failsafe in the final build-policy module. */
+/** Post-reactor coverage gates executed by Failsafe in the final build-policy module. */
 class ReactorCoveragePolicyIT {
 
     @Test
-    void authoritativeAggregateCoverageMeetsTheVersionedPolicyAndPublishesEvidence()
+    void authoritativeCoverageMeetsAggregateCriticalAndDiffPoliciesAndPublishesEvidence()
             throws Exception {
         Path root = findRepositoryRoot();
         Path xml = root.resolve(
                 "taxonomy-coverage/target/site/jacoco-aggregate/jacoco.xml");
-        Path policyFile = root.resolve(".github/coverage-policy.json");
+        Path aggregatePolicyFile = root.resolve(".github/coverage-policy.json");
+        Path criticalPolicyFile = root.resolve(
+                ".github/critical-coverage-policy.json");
         Path evidence = root.resolve("target/coverage-gate.txt");
 
         assertThat(xml)
                 .as("authoritative aggregate JaCoCo XML")
                 .isRegularFile();
-        assertThat(policyFile)
-                .as("versioned coverage policy")
+        assertThat(aggregatePolicyFile)
+                .as("versioned aggregate coverage policy")
+                .isRegularFile();
+        assertThat(criticalPolicyFile)
+                .as("versioned release-critical coverage policy")
                 .isRegularFile();
 
-        ReactorCoveragePolicy evaluator = new ReactorCoveragePolicy();
-        ReactorCoveragePolicy.Evaluation evaluation = evaluator.evaluate(
-                xml, evaluator.loadPolicy(policyFile));
-        Files.createDirectories(evidence.getParent());
-        Files.writeString(evidence, evaluation.text());
-        System.out.print(evaluation.text());
+        ReactorCoveragePolicy aggregateEvaluator = new ReactorCoveragePolicy();
+        ReactorCoveragePolicy.Evaluation aggregateEvaluation =
+                aggregateEvaluator.evaluate(
+                        xml, aggregateEvaluator.loadPolicy(aggregatePolicyFile));
 
-        assertThat(evaluation.passed())
+        CriticalCoveragePolicy criticalEvaluator = new CriticalCoveragePolicy();
+        CriticalCoveragePolicy.CoveragePolicy criticalPolicy =
+                criticalEvaluator.loadPolicy(criticalPolicyFile);
+        CriticalCoveragePolicy.ChangedSources discovered =
+                criticalEvaluator.discoverChangedSources(
+                        root, System.getenv("GITHUB_BASE_REF"));
+        CriticalCoveragePolicy.ChangedSources selected =
+                criticalEvaluator.selectCriticalSources(
+                        discovered, criticalPolicy.changedSourcePrefixes());
+        CriticalCoveragePolicy.Evaluation criticalEvaluation =
+                criticalEvaluator.evaluate(xml, criticalPolicy, selected);
+
+        String report = aggregateEvaluation.text() + criticalEvaluation.text();
+        Files.createDirectories(evidence.getParent());
+        Files.writeString(evidence, report);
+        System.out.print(report);
+
+        assertThat(aggregateEvaluation.passed())
                 .as("reactor coverage policy; inspect %s", evidence)
+                .isTrue();
+        assertThat(criticalEvaluation.passed())
+                .as("release-critical coverage policy; inspect %s", evidence)
                 .isTrue();
     }
 
@@ -42,7 +65,9 @@ class ReactorCoveragePolicyIT {
         Path current = Path.of(System.getProperty("user.dir"))
                 .toAbsolutePath().normalize();
         while (current != null) {
-            if (Files.isRegularFile(current.resolve(".github/coverage-policy.json"))) {
+            if (Files.isRegularFile(current.resolve(".github/coverage-policy.json"))
+                    && Files.isRegularFile(current.resolve(
+                            ".github/critical-coverage-policy.json"))) {
                 return current;
             }
             current = current.getParent();


### PR DESCRIPTION
## Purpose

Complete the remaining release-critical scope of #624 while preserving the existing aggregate JaCoCo policy as the single coverage source of truth.

## Critical package and changed-source coverage

- add versioned LINE/BRANCH floors for security, provenance, import, Git/versioning, workspace and portfolio package areas;
- enforce changed-source LINE/BRANCH minimums for critical production prefixes from the same authoritative aggregate JaCoCo XML;
- use complete-history PR diff discovery in canonical CI and fail closed when a changed critical source is absent from the report;
- tolerate legitimate sparse JaCoCo package entries that contain no executable counters without weakening configured critical package budgets;
- distinguish an explicitly present source-only declaration, such as a Spring Data interface, from a changed source that disappeared from the report: the former is `N/A`, the latter remains a hard failure;
- evaluate executable line coverage even when a source has no measurable branches, with only its branch decision reported as `N/A`;
- require every temporary exception to declare exact scope, rationale, owner and expiry; expired or malformed exceptions fail the build;
- append aggregate, package, changed-source and exception evidence to `target/coverage-gate.txt`;
- update the developer documentation to the current Maven/JUnit path.

## Product security correction

The audit found an IDOR in `GET /api/workspace/{id}/info`: any authenticated user could previously read metadata for a guessed foreign workspace ID because the controller loaded by ID only.

This PR adds a pre-controller visibility guard:

- private workspace metadata is visible only to its owner;
- explicitly shared workspace metadata remains visible;
- foreign and missing IDs both return 404;
- authorization uses one portable database-side `count(...)` query over the exact ID and owner/shared predicate and does not materialize a foreign workspace row for the response path;
- blank identities fail closed before persistence access.

## Real security evidence

A full Spring Boot + MockMvc test exercises the actual SecurityFilterChain and persistence boundary:

- owner can read own workspace metadata;
- guessed foreign workspace IDs are indistinguishable from missing IDs;
- shared metadata remains visible;
- anonymous workspace/repository probes receive 401;
- the public multi-repository API is 404 for an authenticated user when default-off;
- a USER with a valid CSRF token cannot create repositories or invoke admin workspace mutations.

Existing `SecurityTests` and `WorkspaceRelationIsolationTests` continue to cover role denial, repository maintainership denial, central-versus-foreign workspace proposal reads and exact-scope relation deletion.

## Scope and integration safety

- no release request, tag, publication or deployment change;
- no overlap with the portfolio tenancy slice in #784;
- the preserved predecessor history remains reachable; no contributor branch was force-updated;
- the exact candidate is always the live PR head shown by GitHub rather than a copied SHA in this description.

This remains Draft until CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL and Security are green on one unchanged current head and the diff has no unresolved review finding.

Closes #624 after protected merge.