### PR TITLE
Bind portfolio data to repository workspace and branch

### DIFF
--- a/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
+++ b/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
@@ -21,25 +21,36 @@ Lengths are Unicode code-point counts. This avoids delimiter collisions and allo
 
 ## Request boundary
 
-`WorkspaceResolver` resolves and caches one `RepositoryContext` per HTTP request. Its legacy `WorkspaceContext` view is constructed from that same object, so portfolio services that still expose compatibility signatures cannot observe another repository or a branch different from the request's canonical selection.
+`WorkspaceResolver` resolves and caches one `RepositoryContext` per HTTP request. Its legacy `WorkspaceContext` view is enriched from that same object, so portfolio services that still expose compatibility signatures cannot observe another repository or a stale branch.
 
-Direct legacy three-argument contexts remain a bounded compatibility path outside productive request resolution. Repository-sensitive code should continue migrating to `RepositoryContext` explicitly.
+A mismatch between the legacy workspace and the canonical repository context fails closed.
+
+## Synchronization boundary
+
+Portfolio-to-Git synchronization carries the same identity through pull, publish and materialisation:
+
+- active-user synchronization resolves `RepositoryContext`, not the legacy user/workspace-only context;
+- explicitly addressed workspace endpoints derive the repository ID from persisted `source_repository_id` provenance;
+- a request context that disagrees with that persisted source repository fails before Git or portfolio mutation;
+- central synchronization opens the selected logical repository rather than the primary-repository compatibility handle;
+- publishing a workspace materialises both the workspace and the exact central `(repositoryId, CENTRAL, sourceBranch)` scope, including non-primary repositories;
+- `WorkspaceContext.SHARED` is not used as portfolio authority in these productive synchronization paths.
+
+Direct three-argument `WorkspaceContext` construction remains only as a bounded compatibility API for callers that have not yet migrated. It must not be introduced into repository-sensitive production paths.
 
 ## Persistence and migration
 
 PostgreSQL migration `V12__scope_portfolio_by_repository_branch.sql`:
 
-1. permits a fresh empty application schema before the repository-catalog initializer creates the first catalogue row;
-2. rejects more than one primary repository;
-3. requires exactly one primary repository when existing central portfolio rows need deterministic repository and branch provenance;
-4. allows workspace-only historic rows without a primary repository only when every referenced workspace already identifies a valid source repository and current branch;
-5. rejects portfolio rows that reference an unknown workspace or incomplete workspace provenance;
-6. backfills repository, workspace scope and branch from `user_workspace` or the unambiguous primary repository;
-7. rejects ambiguous historic central project, solution or product business keys;
-8. rewrites legacy scope keys to the reversible v2 identity;
-9. makes all tenant columns mandatory and adds repository foreign keys, consistency checks and tenant indexes.
+1. permits a fresh empty installation before the repository-catalog initializer creates its first row;
+2. permits workspace-only historic data when every workspace already has exact repository and branch provenance;
+3. rejects more than one primary repository and requires exactly one when existing central portfolio rows need deterministic backfill;
+4. rejects portfolio rows that reference an unknown workspace or incomplete workspace repository/branch provenance;
+5. backfills repository, workspace scope and branch from `user_workspace` or the unambiguous primary repository;
+6. rewrites legacy scope keys to the reversible v2 identity;
+7. makes all tenant columns mandatory and adds repository foreign keys and tenant indexes.
 
-The migration neither deletes portfolio rows nor drops tables. Other supported databases derive the same columns from the JPA mappings and are exercised by the database compatibility matrix.
+Other supported databases derive the same columns from the JPA mappings and are exercised by the database compatibility matrix.
 
 ## Central migration safety
 
@@ -47,4 +58,4 @@ Historic central portfolio data was user-scoped. Central state is now owned by `
 
 ## Remaining work
 
-This boundary isolates the portfolio roots by repository, workspace or central scope, and branch. #743 remains open for tenant-bound composite foreign keys and exact-context authority checks across every subordinate analysis, decision, provenance and audit row; exact job staleness identity; lifecycle purge/copy evidence; audit and status telemetry; and reviewed migration rollback evidence.
+This boundary prevents cross-repository, cross-workspace and cross-branch addressing for the three portfolio roots and their Git materialisation. #743 remains open for tenant-bound composite foreign keys across every subordinate requirement, analysis, decision, provenance and audit row; exact job staleness identity; export/deletion/copy lifecycle evidence; audit/status telemetry; and reviewed migration rollback evidence.

--- a/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
+++ b/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
@@ -1,0 +1,46 @@
+# Multi-repository portfolio tenancy
+
+Portfolio data is owned by an exact logical architecture context. The isolation key is not a user name and is not inferred from a nullable workspace.
+
+## Identity
+
+Every project, reusable solution and product catalogue entry stores:
+
+- `repository_id` — the selected logical `SystemRepository`;
+- `workspace_scope` — `WORKSPACE:<workspaceId>` or the explicit central scope `CENTRAL`;
+- `branch_name` — the exact selected Git branch;
+- `scope_key` — a reversible, length-prefixed representation of those three values.
+
+The encoded format is:
+
+```text
+v2|r<length>:<repositoryId>|s<length>:<workspaceScope>|b<length>:<branch>
+```
+
+Lengths are Unicode code-point counts. This avoids delimiter collisions and allows the PostgreSQL migration and Java parser to produce identical values.
+
+## Request boundary
+
+`WorkspaceResolver` resolves and caches one `RepositoryContext` per HTTP request. Its legacy `WorkspaceContext` view is enriched from that same object, so portfolio services that still expose compatibility signatures cannot observe another repository or a stale branch.
+
+A mismatch between the legacy workspace and the canonical repository context fails closed.
+
+## Persistence and migration
+
+PostgreSQL migration `V12__scope_portfolio_by_repository_branch.sql`:
+
+1. verifies that exactly one primary repository exists;
+2. rejects portfolio rows that reference an unknown workspace;
+3. backfills repository, workspace scope and branch from `user_workspace` or the primary repository;
+4. rewrites legacy scope keys to the reversible v2 identity;
+5. makes all tenant columns mandatory and adds repository foreign keys and tenant indexes.
+
+Other supported databases derive the same columns from the JPA mappings and are exercised by the database compatibility matrix.
+
+## Central migration safety
+
+Historic central portfolio data was user-scoped. Central state is now owned by `(repositoryId, CENTRAL, branch)`, independent of the requesting user. Before merging those legacy scopes, the migration rejects case-insensitive duplicate project, solution or product business keys rather than silently selecting one user's row. Operators must resolve such ambiguous records deliberately before retrying the migration.
+
+## Remaining work
+
+This boundary prevents cross-repository, cross-workspace and cross-branch portfolio reads. #743 remains open for tenant-bound composite foreign keys across every subordinate analysis/decision row, exact job staleness identity, audit/status telemetry and reviewed migration rollback evidence.

--- a/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
+++ b/docs/dev/MULTI_REPOSITORY_PORTFOLIO_TENANCY.md
@@ -21,21 +21,25 @@ Lengths are Unicode code-point counts. This avoids delimiter collisions and allo
 
 ## Request boundary
 
-`WorkspaceResolver` resolves and caches one `RepositoryContext` per HTTP request. Its legacy `WorkspaceContext` view is enriched from that same object, so portfolio services that still expose compatibility signatures cannot observe another repository or a stale branch.
+`WorkspaceResolver` resolves and caches one `RepositoryContext` per HTTP request. Its legacy `WorkspaceContext` view is constructed from that same object, so portfolio services that still expose compatibility signatures cannot observe another repository or a branch different from the request's canonical selection.
 
-A mismatch between the legacy workspace and the canonical repository context fails closed.
+Direct legacy three-argument contexts remain a bounded compatibility path outside productive request resolution. Repository-sensitive code should continue migrating to `RepositoryContext` explicitly.
 
 ## Persistence and migration
 
 PostgreSQL migration `V12__scope_portfolio_by_repository_branch.sql`:
 
-1. verifies that exactly one primary repository exists;
-2. rejects portfolio rows that reference an unknown workspace;
-3. backfills repository, workspace scope and branch from `user_workspace` or the primary repository;
-4. rewrites legacy scope keys to the reversible v2 identity;
-5. makes all tenant columns mandatory and adds repository foreign keys and tenant indexes.
+1. permits a fresh empty application schema before the repository-catalog initializer creates the first catalogue row;
+2. rejects more than one primary repository;
+3. requires exactly one primary repository when existing central portfolio rows need deterministic repository and branch provenance;
+4. allows workspace-only historic rows without a primary repository only when every referenced workspace already identifies a valid source repository and current branch;
+5. rejects portfolio rows that reference an unknown workspace or incomplete workspace provenance;
+6. backfills repository, workspace scope and branch from `user_workspace` or the unambiguous primary repository;
+7. rejects ambiguous historic central project, solution or product business keys;
+8. rewrites legacy scope keys to the reversible v2 identity;
+9. makes all tenant columns mandatory and adds repository foreign keys, consistency checks and tenant indexes.
 
-Other supported databases derive the same columns from the JPA mappings and are exercised by the database compatibility matrix.
+The migration neither deletes portfolio rows nor drops tables. Other supported databases derive the same columns from the JPA mappings and are exercised by the database compatibility matrix.
 
 ## Central migration safety
 
@@ -43,4 +47,4 @@ Historic central portfolio data was user-scoped. Central state is now owned by `
 
 ## Remaining work
 
-This boundary prevents cross-repository, cross-workspace and cross-branch portfolio reads. #743 remains open for tenant-bound composite foreign keys across every subordinate analysis/decision row, exact job staleness identity, audit/status telemetry and reviewed migration rollback evidence.
+This boundary isolates the portfolio roots by repository, workspace or central scope, and branch. #743 remains open for tenant-bound composite foreign keys and exact-context authority checks across every subordinate analysis, decision, provenance and audit row; exact job staleness identity; lifecycle purge/copy evidence; audit and status telemetry; and reviewed migration rollback evidence.

--- a/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/DslGitRepositoryFactory.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/dsl/storage/DslGitRepositoryFactory.java
@@ -136,14 +136,28 @@ public class DslGitRepositoryFactory implements AutoCloseable {
     }
 
     /**
-     * Resolve the legacy workspace context.
+     * Resolve the compatibility workspace context.
+     *
+     * <p>Request-bound compatibility contexts carry an exact repository ID and
+     * are routed with the same fail-closed semantics as {@link RepositoryContext}.
+     * Only direct legacy callers using {@link WorkspaceContext#LEGACY_REPOSITORY_ID}
+     * retain the historic primary-repository fallback.</p>
      *
      * @deprecated use {@link #resolveRepository(RepositoryContext)} when repository
      *             identity is available.
      */
     @Deprecated(forRemoval = false)
     public DslGitRepository resolveRepository(WorkspaceContext context) {
-        if (context == null || context.workspaceId() == null) {
+        if (context == null) {
+            return getSystemRepository();
+        }
+        if (!WorkspaceContext.LEGACY_REPOSITORY_ID.equals(context.repositoryId())) {
+            if (context.workspaceId() != null) {
+                return openWorkspaceRepository(context.workspaceId());
+            }
+            return getCentralRepository(context.repositoryId());
+        }
+        if (context.workspaceId() == null) {
             return getSystemRepository();
         }
         return getWorkspaceRepository(context.workspaceId());

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ArchitectureProject.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ArchitectureProject.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
@@ -20,14 +22,16 @@ import java.time.LocalDate;
 /**
  * Project boundary for requirements, analyses, solution decisions and products.
  *
- * <p>{@code scopeKey} is a normalized workspace/user scope populated by the
- * application service. It avoids database-specific NULL uniqueness semantics
- * and is the authoritative isolation discriminator.</p>
+ * <p>{@code scopeKey} is the reversible repository/workspace/branch identity.
+ * Explicit tenant columns are synchronized from it before every write so
+ * operational queries and database evidence never have to infer tenancy from a
+ * user name or nullable workspace alone.</p>
  */
 @Entity
 @Table(name = "arch_project", indexes = {
         @Index(name = "idx_proj_scope", columnList = "scope_key"),
-        @Index(name = "idx_proj_status", columnList = "scope_key,status")
+        @Index(name = "idx_proj_status", columnList = "scope_key,status"),
+        @Index(name = "idx_proj_tenant", columnList = "repository_id,workspace_scope,branch_name")
 }, uniqueConstraints = {
         @UniqueConstraint(name = "uq_proj_scope_key", columnNames = {"scope_key", "project_key"})
 })
@@ -37,8 +41,17 @@ public class ArchitectureProject {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "scope_key", nullable = false, length = 160)
+    @Column(name = "scope_key", nullable = false, length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
+
+    @Column(name = "repository_id", nullable = false, length = 255)
+    private String repositoryId;
+
+    @Column(name = "workspace_scope", nullable = false, length = 320)
+    private String workspaceScope;
+
+    @Column(name = "branch_name", nullable = false, length = 255)
+    private String branchName;
 
     @Column(name = "workspace_id", length = 120)
     private String workspaceId;
@@ -101,6 +114,7 @@ public class ArchitectureProject {
         this.status = status != null ? status : ProjectStatus.PLANNING;
         this.createdAt = now;
         this.updatedAt = now;
+        synchronizeTenantIdentityIfEncoded();
     }
 
     public void update(String title,
@@ -121,8 +135,33 @@ public class ArchitectureProject {
         this.updatedAt = now;
     }
 
+    @PrePersist
+    @PreUpdate
+    private void synchronizeTenantIdentity() {
+        PortfolioTenantIdentity identity = PortfolioTenantIdentity.parse(scopeKey);
+        String expectedWorkspaceScope = workspaceId == null || workspaceId.isBlank()
+                ? PortfolioTenantIdentity.CENTRAL_SCOPE
+                : PortfolioTenantIdentity.WORKSPACE_SCOPE_PREFIX + workspaceId.strip();
+        if (!expectedWorkspaceScope.equals(identity.workspaceScope())) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key does not match workspaceId");
+        }
+        repositoryId = identity.repositoryId();
+        workspaceScope = identity.workspaceScope();
+        branchName = identity.branch();
+    }
+
+    private void synchronizeTenantIdentityIfEncoded() {
+        if (PortfolioTenantIdentity.isEncoded(scopeKey)) {
+            synchronizeTenantIdentity();
+        }
+    }
+
     public Long getId() { return id; }
     public String getScopeKey() { return scopeKey; }
+    public String getRepositoryId() { return repositoryId; }
+    public String getWorkspaceScope() { return workspaceScope; }
+    public String getBranchName() { return branchName; }
     public String getWorkspaceId() { return workspaceId; }
     public String getOwnerUsername() { return ownerUsername; }
     public String getProjectKey() { return projectKey; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/PortfolioTenantIdentity.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/PortfolioTenantIdentity.java
@@ -1,0 +1,131 @@
+package com.taxonomy.portfolio.model;
+
+import java.util.Objects;
+
+/**
+ * Exact, reversible portfolio tenancy identity.
+ *
+ * <p>The length-prefixed representation is collision-free even when repository,
+ * workspace or branch identifiers contain separators. Lengths are Unicode code
+ * point counts so the Java representation matches PostgreSQL {@code char_length}
+ * during migration backfills.</p>
+ */
+public record PortfolioTenantIdentity(
+        String repositoryId,
+        String workspaceScope,
+        String branch
+) {
+    public static final String PREFIX = "v2|";
+    public static final String CENTRAL_SCOPE = "CENTRAL";
+    public static final String WORKSPACE_SCOPE_PREFIX = "WORKSPACE:";
+    public static final int MAX_SCOPE_KEY_LENGTH = 1024;
+
+    public PortfolioTenantIdentity {
+        repositoryId = requireText(repositoryId, "repositoryId", 255);
+        workspaceScope = requireText(workspaceScope, "workspaceScope", 320);
+        if (!CENTRAL_SCOPE.equals(workspaceScope)
+                && (!workspaceScope.startsWith(WORKSPACE_SCOPE_PREFIX)
+                || workspaceScope.length() == WORKSPACE_SCOPE_PREFIX.length())) {
+            throw new IllegalArgumentException(
+                    "workspaceScope must be CENTRAL or WORKSPACE:<workspaceId>");
+        }
+        branch = requireText(branch, "branch", 255);
+    }
+
+    public String scopeKey() {
+        StringBuilder key = new StringBuilder(PREFIX);
+        append(key, 'r', repositoryId);
+        key.append('|');
+        append(key, 's', workspaceScope);
+        key.append('|');
+        append(key, 'b', branch);
+        if (key.codePointCount(0, key.length()) > MAX_SCOPE_KEY_LENGTH) {
+            throw new IllegalArgumentException(
+                    "Encoded portfolio scope exceeds " + MAX_SCOPE_KEY_LENGTH + " characters");
+        }
+        return key.toString();
+    }
+
+    public static boolean isEncoded(String value) {
+        return value != null && value.startsWith(PREFIX);
+    }
+
+    public static PortfolioTenantIdentity parse(String scopeKey) {
+        Objects.requireNonNull(scopeKey, "scopeKey");
+        if (!scopeKey.startsWith(PREFIX)) {
+            throw new IllegalArgumentException("Portfolio scope key is not a v2 tenant identity");
+        }
+        Component repository = component(scopeKey, PREFIX.length(), 'r');
+        requireSeparator(scopeKey, repository.nextIndex());
+        Component scope = component(scopeKey, repository.nextIndex() + 1, 's');
+        requireSeparator(scopeKey, scope.nextIndex());
+        Component branch = component(scopeKey, scope.nextIndex() + 1, 'b');
+        if (branch.nextIndex() != scopeKey.length()) {
+            throw new IllegalArgumentException("Portfolio scope key contains trailing data");
+        }
+        return new PortfolioTenantIdentity(
+                repository.value(), scope.value(), branch.value());
+    }
+
+    private static void append(StringBuilder target, char label, String value) {
+        target.append(label)
+                .append(value.codePointCount(0, value.length()))
+                .append(':')
+                .append(value);
+    }
+
+    private static Component component(String value, int start, char expectedLabel) {
+        if (start >= value.length() || value.charAt(start) != expectedLabel) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key is missing component " + expectedLabel);
+        }
+        int colon = value.indexOf(':', start + 1);
+        if (colon < 0) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key component " + expectedLabel + " has no length delimiter");
+        }
+        int codePoints;
+        try {
+            codePoints = Integer.parseInt(value.substring(start + 1, colon));
+        } catch (NumberFormatException error) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key component " + expectedLabel + " has an invalid length",
+                    error);
+        }
+        if (codePoints < 1) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key component " + expectedLabel + " is empty");
+        }
+        int valueStart = colon + 1;
+        final int valueEnd;
+        try {
+            valueEnd = value.offsetByCodePoints(valueStart, codePoints);
+        } catch (IndexOutOfBoundsException error) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key component " + expectedLabel + " is truncated",
+                    error);
+        }
+        return new Component(value.substring(valueStart, valueEnd), valueEnd);
+    }
+
+    private static void requireSeparator(String value, int index) {
+        if (index >= value.length() || value.charAt(index) != '|') {
+            throw new IllegalArgumentException("Portfolio scope key has an invalid component boundary");
+        }
+    }
+
+    private static String requireText(String value, String label, int maximumCodePoints) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " must not be blank");
+        }
+        String normalized = value.strip();
+        if (normalized.codePointCount(0, normalized.length()) > maximumCodePoints) {
+            throw new IllegalArgumentException(
+                    label + " exceeds " + maximumCodePoints + " characters");
+        }
+        return normalized;
+    }
+
+    private record Component(String value, int nextIndex) {
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProductCatalogEntry.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProductCatalogEntry.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Lob;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
@@ -23,14 +25,15 @@ import java.time.LocalDate;
  * Sourced and dated catalogue entry for a concrete product/version.
  *
  * <p>A product claim is deliberately incomplete until {@code sourceReference}
- * and {@code verifiedAt} are populated. Consumers must expose that provenance
- * rather than presenting stale product metadata as current fact.</p>
+ * and {@code verifiedAt} are populated. Tenant identity is explicit for the
+ * selected repository, workspace scope and branch.</p>
  */
 @Entity
 @Table(name = "product_catalog", indexes = {
         @Index(name = "idx_prod_scope", columnList = "scope_key"),
         @Index(name = "idx_prod_status", columnList = "scope_key,product_status"),
-        @Index(name = "idx_prod_eos", columnList = "end_of_support")
+        @Index(name = "idx_prod_eos", columnList = "end_of_support"),
+        @Index(name = "idx_prod_tenant", columnList = "repository_id,workspace_scope,branch_name")
 }, uniqueConstraints = {
         @UniqueConstraint(name = "uq_prod_scope_key", columnNames = {"scope_key", "product_key"})
 })
@@ -40,8 +43,17 @@ public class ProductCatalogEntry {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "scope_key", nullable = false, length = 160)
+    @Column(name = "scope_key", nullable = false, length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
+
+    @Column(name = "repository_id", nullable = false, length = 255)
+    private String repositoryId;
+
+    @Column(name = "workspace_scope", nullable = false, length = 320)
+    private String workspaceScope;
+
+    @Column(name = "branch_name", nullable = false, length = 255)
+    private String branchName;
 
     @Column(name = "workspace_id", length = 120)
     private String workspaceId;
@@ -159,6 +171,7 @@ public class ProductCatalogEntry {
         this.createdBy = createdBy;
         this.createdAt = now;
         this.updatedAt = now;
+        synchronizeTenantIdentityIfEncoded();
     }
 
     public void update(String manufacturer,
@@ -197,8 +210,33 @@ public class ProductCatalogEntry {
         this.updatedAt = now;
     }
 
+    @PrePersist
+    @PreUpdate
+    private void synchronizeTenantIdentity() {
+        PortfolioTenantIdentity identity = PortfolioTenantIdentity.parse(scopeKey);
+        String expectedWorkspaceScope = workspaceId == null || workspaceId.isBlank()
+                ? PortfolioTenantIdentity.CENTRAL_SCOPE
+                : PortfolioTenantIdentity.WORKSPACE_SCOPE_PREFIX + workspaceId.strip();
+        if (!expectedWorkspaceScope.equals(identity.workspaceScope())) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key does not match workspaceId");
+        }
+        repositoryId = identity.repositoryId();
+        workspaceScope = identity.workspaceScope();
+        branchName = identity.branch();
+    }
+
+    private void synchronizeTenantIdentityIfEncoded() {
+        if (PortfolioTenantIdentity.isEncoded(scopeKey)) {
+            synchronizeTenantIdentity();
+        }
+    }
+
     public Long getId() { return id; }
     public String getScopeKey() { return scopeKey; }
+    public String getRepositoryId() { return repositoryId; }
+    public String getWorkspaceScope() { return workspaceScope; }
+    public String getBranchName() { return branchName; }
     public String getWorkspaceId() { return workspaceId; }
     public String getProductKey() { return productKey; }
     public String getManufacturer() { return manufacturer; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/SolutionDefinition.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/SolutionDefinition.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
@@ -18,11 +20,12 @@ import jakarta.persistence.Version;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-/** Reusable, workspace-scoped solution definition independent of a project. */
+/** Reusable solution definition isolated by repository, workspace scope and branch. */
 @Entity
 @Table(name = "solution_definition", indexes = {
         @Index(name = "idx_sol_scope", columnList = "scope_key"),
-        @Index(name = "idx_sol_lifecycle", columnList = "scope_key,lifecycle_status")
+        @Index(name = "idx_sol_lifecycle", columnList = "scope_key,lifecycle_status"),
+        @Index(name = "idx_sol_tenant", columnList = "repository_id,workspace_scope,branch_name")
 }, uniqueConstraints = {
         @UniqueConstraint(name = "uq_sol_scope_key", columnNames = {"scope_key", "solution_key"})
 })
@@ -32,8 +35,17 @@ public class SolutionDefinition {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "scope_key", nullable = false, length = 160)
+    @Column(name = "scope_key", nullable = false, length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
+
+    @Column(name = "repository_id", nullable = false, length = 255)
+    private String repositoryId;
+
+    @Column(name = "workspace_scope", nullable = false, length = 320)
+    private String workspaceScope;
+
+    @Column(name = "branch_name", nullable = false, length = 255)
+    private String branchName;
 
     @Column(name = "workspace_id", length = 120)
     private String workspaceId;
@@ -121,6 +133,7 @@ public class SolutionDefinition {
         this.responsibleOrganization = responsibleOrganization;
         this.createdAt = now;
         this.updatedAt = now;
+        synchronizeTenantIdentityIfEncoded();
     }
 
     public void update(String title,
@@ -153,8 +166,33 @@ public class SolutionDefinition {
         this.updatedAt = now;
     }
 
+    @PrePersist
+    @PreUpdate
+    private void synchronizeTenantIdentity() {
+        PortfolioTenantIdentity identity = PortfolioTenantIdentity.parse(scopeKey);
+        String expectedWorkspaceScope = workspaceId == null || workspaceId.isBlank()
+                ? PortfolioTenantIdentity.CENTRAL_SCOPE
+                : PortfolioTenantIdentity.WORKSPACE_SCOPE_PREFIX + workspaceId.strip();
+        if (!expectedWorkspaceScope.equals(identity.workspaceScope())) {
+            throw new IllegalArgumentException(
+                    "Portfolio scope key does not match workspaceId");
+        }
+        repositoryId = identity.repositoryId();
+        workspaceScope = identity.workspaceScope();
+        branchName = identity.branch();
+    }
+
+    private void synchronizeTenantIdentityIfEncoded() {
+        if (PortfolioTenantIdentity.isEncoded(scopeKey)) {
+            synchronizeTenantIdentity();
+        }
+    }
+
     public Long getId() { return id; }
     public String getScopeKey() { return scopeKey; }
+    public String getRepositoryId() { return repositoryId; }
+    public String getWorkspaceScope() { return workspaceScope; }
+    public String getBranchName() { return branchName; }
     public String getWorkspaceId() { return workspaceId; }
     public String getSolutionKey() { return solutionKey; }
     public String getTitle() { return title; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioScope.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioScope.java
@@ -1,20 +1,35 @@
 package com.taxonomy.portfolio.service;
 
+import com.taxonomy.portfolio.model.PortfolioTenantIdentity;
 import com.taxonomy.workspace.service.WorkspaceContext;
 
 import java.util.Locale;
 
-/** Normalizes the request-bound workspace context into a stable persistence scope. */
+/** Normalizes the request-bound repository/workspace/branch into a stable persistence scope. */
 public final class PortfolioScope {
+
+    public static final String CENTRAL_SCOPE = PortfolioTenantIdentity.CENTRAL_SCOPE;
+    private static final String WORKSPACE_PREFIX =
+            PortfolioTenantIdentity.WORKSPACE_SCOPE_PREFIX;
 
     private PortfolioScope() {
     }
 
     public static String key(String username, WorkspaceContext context) {
-        if (context != null && context.workspaceId() != null && !context.workspaceId().isBlank()) {
-            return "workspace:" + context.workspaceId().strip().toLowerCase(Locale.ROOT);
+        return identity(username, context).scopeKey();
+    }
+
+    public static PortfolioTenantIdentity identity(
+            String username,
+            WorkspaceContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("workspace context is required");
         }
-        return "user:" + normalizedUsername(username, context);
+        String repositoryId = requireText(context.repositoryId(), "repositoryId");
+        String workspaceScope = workspaceId(context) != null
+                ? WORKSPACE_PREFIX + workspaceId(context)
+                : CENTRAL_SCOPE;
+        return new PortfolioTenantIdentity(repositoryId, workspaceScope, branch(context));
     }
 
     public static String username(String username, WorkspaceContext context) {
@@ -27,8 +42,18 @@ public final class PortfolioScope {
     }
 
     public static String branch(WorkspaceContext context) {
-        return context != null && context.currentBranch() != null && !context.currentBranch().isBlank()
-                ? context.currentBranch().strip() : "draft";
+        if (context == null || context.currentBranch() == null
+                || context.currentBranch().isBlank()) {
+            throw new IllegalArgumentException("currentBranch is required");
+        }
+        return context.currentBranch().strip();
+    }
+
+    public static String repositoryId(WorkspaceContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("workspace context is required");
+        }
+        return requireText(context.repositoryId(), "repositoryId");
     }
 
     private static String normalizedUsername(String username, WorkspaceContext context) {
@@ -40,5 +65,12 @@ public final class PortfolioScope {
             candidate = "anonymous";
         }
         return candidate.strip().toLowerCase(Locale.ROOT);
+    }
+
+    private static String requireText(String value, String label) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(label + " is required");
+        }
+        return value.strip();
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationService.java
@@ -21,9 +21,9 @@ import java.time.Instant;
  * <p>Before pull or push, durable project decisions are projected into the
  * branch DSL through a workspace-owned port. Isolated repositories use a
  * tracked three-way semantic base instead of replacing the complete
- * architecture file. Every isolated workspace resolves its central source from
- * persistent provenance; synchronization never falls back to the global primary
- * repository once a workspace ID is known.</p>
+ * architecture file. Every synchronization path carries the exact logical
+ * repository, workspace/central scope and branch into both Git and portfolio
+ * materialisation.</p>
  */
 @Service
 @Primary
@@ -62,7 +62,8 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
     public String syncFromShared(String username, String userBranch) throws IOException {
         WorkspaceContext context = resolveWorkspaceContext(username, userBranch);
         if (context.workspaceId() == null) {
-            return mergeWithinRepository(username, context.currentBranch(), true);
+            return mergeWithinRepository(
+                    username, context, context.currentBranch(), true);
         }
         return pullAcrossRepositories(username, context, context.currentBranch());
     }
@@ -71,25 +72,26 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
     public String publishToShared(String username, String userBranch) throws IOException {
         WorkspaceContext context = resolveWorkspaceContext(username, userBranch);
         if (context.workspaceId() == null) {
-            return mergeWithinRepository(username, context.currentBranch(), false);
+            return mergeWithinRepository(
+                    username, context, context.currentBranch(), false);
         }
         return publishAcrossRepositories(username, context, context.currentBranch());
     }
 
     @Override
-    public String syncFromSharedToWorkspace(String username, String workspaceId) throws IOException {
-        return pullAcrossRepositories(
-                username,
-                new WorkspaceContext(username, workspaceId, WORKSPACE_BRANCH),
-                WORKSPACE_BRANCH);
+    public String syncFromSharedToWorkspace(String username, String workspaceId)
+            throws IOException {
+        WorkspaceContext context = resolveExplicitWorkspaceContext(
+                username, workspaceId, WORKSPACE_BRANCH);
+        return pullAcrossRepositories(username, context, WORKSPACE_BRANCH);
     }
 
     @Override
-    public String publishFromWorkspaceToShared(String username, String workspaceId) throws IOException {
-        return publishAcrossRepositories(
-                username,
-                new WorkspaceContext(username, workspaceId, WORKSPACE_BRANCH),
-                WORKSPACE_BRANCH);
+    public String publishFromWorkspaceToShared(String username, String workspaceId)
+            throws IOException {
+        WorkspaceContext context = resolveExplicitWorkspaceContext(
+                username, workspaceId, WORKSPACE_BRANCH);
+        return publishAcrossRepositories(username, context, WORKSPACE_BRANCH);
     }
 
     @Override
@@ -108,6 +110,7 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
                                           String userBranch) throws IOException {
         UserWorkspace workspaceMetadata = requireWorkspace(context.workspaceId());
         SystemRepository sourceMetadata = requireSourceRepository(workspaceMetadata);
+        requireMatchingRepository(context, sourceMetadata);
         String sourceBranch = sourceBranch(workspaceMetadata, sourceMetadata);
         DslGitRepository sourceRepository =
                 repositoryFactory.getCentralRepository(sourceMetadata.getRepositoryId());
@@ -152,6 +155,7 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
                                              String userBranch) throws IOException {
         UserWorkspace workspaceMetadata = requireWorkspace(context.workspaceId());
         SystemRepository sourceMetadata = requireSourceRepository(workspaceMetadata);
+        requireMatchingRepository(context, sourceMetadata);
         String sourceBranch = sourceBranch(workspaceMetadata, sourceMetadata);
         DslGitRepository sourceRepository =
                 repositoryFactory.getCentralRepository(sourceMetadata.getRepositoryId());
@@ -187,13 +191,13 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
                 "Integrate source changes after publish");
         trackBase(workspaceGit, merge.mergedText(), username);
 
-        // Central relational projection is still represented by the legacy primary
-        // context until repository_id is added to those projection entities. The
-        // JGit target itself is already explicit and tenant-safe here.
-        if (sourceMetadata.isPrimaryRepo()) {
-            portfolioGitPort.materializePortfolio(
-                    merge.mergedText(), "shared", WorkspaceContext.SHARED);
-        }
+        WorkspaceContext centralContext = new WorkspaceContext(
+                "shared",
+                null,
+                sourceBranch,
+                requireRepositoryId(sourceMetadata));
+        portfolioGitPort.materializePortfolio(
+                merge.mergedText(), "shared", centralContext);
         portfolioGitPort.materializePortfolio(
                 merge.mergedText(), username, context);
 
@@ -209,10 +213,15 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
     }
 
     private String mergeWithinRepository(String username,
+                                         WorkspaceContext context,
                                          String userBranch,
                                          boolean pull) throws IOException {
-        WorkspaceContext context = WorkspaceContext.SHARED;
-        DslGitRepository repository = repositoryFactory.getSystemRepository();
+        if (context.workspaceId() != null) {
+            throw new IllegalArgumentException(
+                    "Central synchronization must not carry a workspaceId");
+        }
+        DslGitRepository repository =
+                repositoryFactory.getCentralRepository(context.repositoryId());
         portfolioGitPort.commitPortfolio(userBranch,
                 pull ? "Project requirements before sync from shared"
                         : "Project requirements before publish",
@@ -271,31 +280,50 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
         return new WorkspaceMergeState(commonBase);
     }
 
-    /** Resolve the persistent active branch for the current user's workspace. */
+    /** Resolve the exact persistent repository and active branch for one user. */
     private WorkspaceContext resolveWorkspaceContext(String username, String requestedBranch) {
-        WorkspaceContext persistent = contextResolver.resolveForUser(username);
+        RepositoryContext persistent =
+                contextResolver.resolveRepositoryContextForUser(username);
         if (persistent.workspaceId() == null) {
-            return WorkspaceContext.SHARED;
+            return new WorkspaceContext(
+                    persistent.username(),
+                    null,
+                    persistent.branch(),
+                    persistent.repositoryId());
         }
         String branch = requestedBranch;
         if (branch == null || branch.isBlank()
                 || (SEEDED_BRANCH.equals(branch)
-                && persistent.currentBranch() != null
-                && !persistent.currentBranch().isBlank()
-                && !SEEDED_BRANCH.equals(persistent.currentBranch()))) {
-            branch = persistent.currentBranch();
+                && !SEEDED_BRANCH.equals(persistent.branch()))) {
+            branch = persistent.branch();
         }
         if (branch == null || branch.isBlank()) {
             branch = WORKSPACE_BRANCH;
         }
-        return new WorkspaceContext(username, persistent.workspaceId(), branch);
+        return new WorkspaceContext(
+                persistent.username(),
+                persistent.workspaceId(),
+                branch,
+                persistent.repositoryId());
+    }
+
+    /** Resolve an explicitly addressed workspace without inventing repository provenance. */
+    private WorkspaceContext resolveExplicitWorkspaceContext(
+            String username, String workspaceId, String branch) {
+        UserWorkspace workspace = requireWorkspace(workspaceId);
+        SystemRepository source = requireSourceRepository(workspace);
+        return new WorkspaceContext(
+                username,
+                workspace.getWorkspaceId(),
+                branch,
+                requireRepositoryId(source));
     }
 
     private UserWorkspace requireWorkspace(String workspaceId) {
         if (workspaceId == null || workspaceId.isBlank()) {
             throw new IllegalArgumentException("workspaceId must not be blank");
         }
-        return workspaceRepository.findByWorkspaceId(workspaceId)
+        return workspaceRepository.findByWorkspaceId(workspaceId.strip())
                 .orElseThrow(() -> new IllegalStateException(
                         "Workspace metadata not found: " + workspaceId));
     }
@@ -306,7 +334,24 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
             throw new IllegalStateException(
                     "Workspace has no sourceRepositoryId: " + workspace.getWorkspaceId());
         }
-        return systemRepositoryService.getRepository(repositoryId);
+        return systemRepositoryService.getRepository(repositoryId.strip());
+    }
+
+    private static void requireMatchingRepository(
+            WorkspaceContext context, SystemRepository sourceRepository) {
+        String sourceRepositoryId = requireRepositoryId(sourceRepository);
+        if (!sourceRepositoryId.equals(context.repositoryId())) {
+            throw new IllegalStateException(
+                    "Workspace repository context does not match persisted source provenance");
+        }
+    }
+
+    private static String requireRepositoryId(SystemRepository repository) {
+        if (repository == null || repository.getRepositoryId() == null
+                || repository.getRepositoryId().isBlank()) {
+            throw new IllegalStateException("Source repository has no repositoryId");
+        }
+        return repository.getRepositoryId().strip();
     }
 
     private static String sourceBranch(
@@ -385,7 +430,8 @@ public class GitNativeSyncIntegrationService extends SyncIntegrationService {
     }
 
     private static void requireSuccess(String operation,
-                                       SemanticGitMergeService.MergeOutcome outcome) throws IOException {
+                                       SemanticGitMergeService.MergeOutcome outcome)
+            throws IOException {
         if (!outcome.success()) {
             throw new IOException(operation + " has semantic conflicts: "
                     + String.join(", ", outcome.conflicts()));

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContext.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceContext.java
@@ -1,37 +1,43 @@
 package com.taxonomy.workspace.service;
 
 /**
- * Immutable value object representing the current workspace context for a user.
+ * Immutable compatibility view of the current workspace context for a user.
  *
- * <p>Carries the {@code username}, {@code workspaceId}, and {@code currentBranch}
- * needed to scope data operations (relations, hypotheses, proposals, commit search)
- * to the active workspace.
- *
- * <p>A special {@link #SHARED} instance represents the system-wide / legacy scope
- * where no per-user isolation applies. Its {@code workspaceId} is {@code null},
- * which maps directly to the {@code workspace_id IS NULL} condition in OR-null
- * queries — ensuring that SHARED callers see all legacy/shared data without
- * accidental workspace filtering.
+ * <p>Productive request handling enriches this value with the exact logical
+ * {@code repositoryId} through {@link WorkspaceResolver}. Repository-sensitive
+ * code should prefer {@link RepositoryContext}; this record remains for callers
+ * whose public service signatures have not yet been migrated.</p>
  *
  * @param username      the authenticated user's username
- * @param workspaceId   the unique workspace identifier (from {@link com.taxonomy.workspace.model.UserWorkspace}),
- *                      or {@code null} for the shared / legacy scope
- * @param currentBranch the Git branch the user is currently working on
+ * @param workspaceId   the selected workspace identifier, or {@code null} for a central scope
+ * @param currentBranch the exact selected Git branch
+ * @param repositoryId  the exact selected logical repository
  */
 public record WorkspaceContext(
         String username,
         String workspaceId,
-        String currentBranch
+        String currentBranch,
+        String repositoryId
 ) {
     /**
-     * Shared / legacy context — used when no per-user workspace is active.
-     *
-     * <p>{@code workspaceId} is {@code null} so that downstream services skip
-     * workspace filtering and return all data (shared + legacy). The
-     * {@code currentBranch} is set to the conventional default; callers that
-     * need the configurable shared branch should resolve it via
-     * {@link SystemRepositoryService#getSharedBranch()}.
+     * Stable compatibility identity used only by direct legacy constructors,
+     * predominantly focused tests outside a request. Productive HTTP requests
+     * replace it with the catalog repository ID in {@link WorkspaceResolver}.
      */
+    public static final String LEGACY_REPOSITORY_ID = "legacy-primary";
+
+    /** Source-compatible constructor retained while legacy signatures are migrated. */
+    public WorkspaceContext(String username, String workspaceId, String currentBranch) {
+        this(username, workspaceId, currentBranch, LEGACY_REPOSITORY_ID);
+    }
+
+    public WorkspaceContext {
+        if (repositoryId == null || repositoryId.isBlank()) {
+            throw new IllegalArgumentException("repositoryId must not be blank");
+        }
+    }
+
+    /** Shared compatibility context for non-request callers. */
     public static final WorkspaceContext SHARED =
-            new WorkspaceContext("system", null, "draft");
+            new WorkspaceContext("system", null, "draft", LEGACY_REPOSITORY_ID);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/workspace/service/WorkspaceResolver.java
@@ -38,8 +38,12 @@ public class WorkspaceResolver {
     }
 
     /**
-     * Resolve the legacy workspace context for the current request.
-     * Resolver failures propagate; this method never manufactures a fallback.
+     * Resolve the compatibility workspace context for the current request.
+     *
+     * <p>The returned value is enriched from the same request-stable
+     * {@link RepositoryContext}. Legacy callers therefore cannot lose the logical
+     * repository identity or continue with a branch that differs from the
+     * canonical repository selection.</p>
      */
     public WorkspaceContext resolveCurrentContext() {
         RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
@@ -51,10 +55,12 @@ public class WorkspaceResolver {
             }
         }
 
-        WorkspaceContext resolved = contextResolver.resolveCurrentContext();
-        if (resolved == null) {
-            throw new IllegalStateException("Workspace context resolver returned null");
-        }
+        RepositoryContext repository = resolveCurrentRepositoryContext();
+        WorkspaceContext resolved = new WorkspaceContext(
+                repository.username(),
+                repository.workspaceId(),
+                repository.branch(),
+                repository.repositoryId());
         cache(attributes, REQUEST_CONTEXT_ATTRIBUTE, resolved);
         return resolved;
     }

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V12__scope_portfolio_by_repository_branch.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V12__scope_portfolio_by_repository_branch.sql
@@ -20,9 +20,28 @@ alter table product_catalog
     add column branch_name varchar(255);
 
 do $$
+declare
+    primary_repository_count integer;
 begin
-    if (select count(*) from system_repository where primary_repo) <> 1 then
-        raise exception 'Portfolio tenancy migration requires exactly one primary repository';
+    select count(*)
+    into primary_repository_count
+    from system_repository
+    where primary_repo;
+
+    if primary_repository_count > 1 then
+        raise exception 'Portfolio tenancy migration found more than one primary repository';
+    end if;
+
+    -- A fresh installation legitimately has no repository catalogue row yet: the
+    -- catalogue initializer creates it after Flyway has established the schema.
+    -- Existing central portfolio rows, however, need one unambiguous repository
+    -- and branch for deterministic backfill.
+    if primary_repository_count = 0 and (
+        exists (select 1 from arch_project where workspace_id is null)
+        or exists (select 1 from solution_definition where workspace_id is null)
+        or exists (select 1 from product_catalog where workspace_id is null)
+    ) then
+        raise exception 'Portfolio tenancy migration requires exactly one primary repository for existing central portfolio rows';
     end if;
 
     if exists (

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V12__scope_portfolio_by_repository_branch.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V12__scope_portfolio_by_repository_branch.sql
@@ -1,0 +1,191 @@
+-- Bind portfolio roots to the exact logical repository, workspace/central scope and branch.
+-- Central state is repository-owned. Ambiguous legacy per-user duplicates fail closed instead
+-- of being merged or discarded implicitly.
+
+alter table arch_project alter column scope_key type varchar(1024);
+alter table solution_definition alter column scope_key type varchar(1024);
+alter table product_catalog alter column scope_key type varchar(1024);
+
+alter table arch_project
+    add column repository_id varchar(255),
+    add column workspace_scope varchar(320),
+    add column branch_name varchar(255);
+alter table solution_definition
+    add column repository_id varchar(255),
+    add column workspace_scope varchar(320),
+    add column branch_name varchar(255);
+alter table product_catalog
+    add column repository_id varchar(255),
+    add column workspace_scope varchar(320),
+    add column branch_name varchar(255);
+
+do $$
+begin
+    if (select count(*) from system_repository where primary_repo) <> 1 then
+        raise exception 'Portfolio tenancy migration requires exactly one primary repository';
+    end if;
+
+    if exists (
+        select 1
+        from arch_project p
+        left join user_workspace w on w.workspace_id = p.workspace_id
+        where p.workspace_id is not null and w.id is null
+    ) or exists (
+        select 1
+        from solution_definition s
+        left join user_workspace w on w.workspace_id = s.workspace_id
+        where s.workspace_id is not null and w.id is null
+    ) or exists (
+        select 1
+        from product_catalog p
+        left join user_workspace w on w.workspace_id = p.workspace_id
+        where p.workspace_id is not null and w.id is null
+    ) then
+        raise exception 'Portfolio tenancy migration found an unknown workspace_id';
+    end if;
+
+    if exists (
+        select 1
+        from user_workspace w
+        left join system_repository r on r.repository_id = w.source_repository_id
+        where w.workspace_id in (
+            select workspace_id from arch_project where workspace_id is not null
+            union
+            select workspace_id from solution_definition where workspace_id is not null
+            union
+            select workspace_id from product_catalog where workspace_id is not null
+        )
+        and (r.id is null or nullif(btrim(w.current_branch), '') is null)
+    ) then
+        raise exception 'Portfolio tenancy migration found incomplete workspace repository provenance';
+    end if;
+
+    if exists (
+        select lower(btrim(project_key))
+        from arch_project
+        where workspace_id is null
+        group by lower(btrim(project_key))
+        having count(*) > 1
+    ) then
+        raise exception 'Portfolio tenancy migration found ambiguous central project keys';
+    end if;
+    if exists (
+        select lower(btrim(solution_key))
+        from solution_definition
+        where workspace_id is null
+        group by lower(btrim(solution_key))
+        having count(*) > 1
+    ) then
+        raise exception 'Portfolio tenancy migration found ambiguous central solution keys';
+    end if;
+    if exists (
+        select lower(btrim(product_key))
+        from product_catalog
+        where workspace_id is null
+        group by lower(btrim(product_key))
+        having count(*) > 1
+    ) then
+        raise exception 'Portfolio tenancy migration found ambiguous central product keys';
+    end if;
+end $$;
+
+update arch_project p
+set repository_id = btrim(coalesce(
+        (select w.source_repository_id
+         from user_workspace w
+         where w.workspace_id = p.workspace_id),
+        (select r.repository_id from system_repository r where r.primary_repo))),
+    workspace_scope = case
+        when p.workspace_id is not null then 'WORKSPACE:' || btrim(p.workspace_id)
+        else 'CENTRAL'
+    end,
+    branch_name = btrim(coalesce(
+        (select w.current_branch
+         from user_workspace w
+         where w.workspace_id = p.workspace_id),
+        (select r.default_branch from system_repository r where r.primary_repo)));
+
+update solution_definition s
+set repository_id = btrim(coalesce(
+        (select w.source_repository_id
+         from user_workspace w
+         where w.workspace_id = s.workspace_id),
+        (select r.repository_id from system_repository r where r.primary_repo))),
+    workspace_scope = case
+        when s.workspace_id is not null then 'WORKSPACE:' || btrim(s.workspace_id)
+        else 'CENTRAL'
+    end,
+    branch_name = btrim(coalesce(
+        (select w.current_branch
+         from user_workspace w
+         where w.workspace_id = s.workspace_id),
+        (select r.default_branch from system_repository r where r.primary_repo)));
+
+update product_catalog p
+set repository_id = btrim(coalesce(
+        (select w.source_repository_id
+         from user_workspace w
+         where w.workspace_id = p.workspace_id),
+        (select r.repository_id from system_repository r where r.primary_repo))),
+    workspace_scope = case
+        when p.workspace_id is not null then 'WORKSPACE:' || btrim(p.workspace_id)
+        else 'CENTRAL'
+    end,
+    branch_name = btrim(coalesce(
+        (select w.current_branch
+         from user_workspace w
+         where w.workspace_id = p.workspace_id),
+        (select r.default_branch from system_repository r where r.primary_repo)));
+
+update arch_project
+set scope_key = 'v2|r' || char_length(repository_id)::text || ':' || repository_id
+        || '|s' || char_length(workspace_scope)::text || ':' || workspace_scope
+        || '|b' || char_length(branch_name)::text || ':' || branch_name;
+update solution_definition
+set scope_key = 'v2|r' || char_length(repository_id)::text || ':' || repository_id
+        || '|s' || char_length(workspace_scope)::text || ':' || workspace_scope
+        || '|b' || char_length(branch_name)::text || ':' || branch_name;
+update product_catalog
+set scope_key = 'v2|r' || char_length(repository_id)::text || ':' || repository_id
+        || '|s' || char_length(workspace_scope)::text || ':' || workspace_scope
+        || '|b' || char_length(branch_name)::text || ':' || branch_name;
+
+alter table arch_project
+    alter column repository_id set not null,
+    alter column workspace_scope set not null,
+    alter column branch_name set not null,
+    add constraint fk_proj_repository foreign key (repository_id)
+        references system_repository (repository_id),
+    add constraint ck_proj_workspace_scope check (
+        (workspace_id is null and workspace_scope = 'CENTRAL')
+        or (workspace_id is not null and workspace_scope = 'WORKSPACE:' || btrim(workspace_id))
+    ),
+    add constraint ck_proj_scope_key_v2 check (scope_key like 'v2|r%');
+
+alter table solution_definition
+    alter column repository_id set not null,
+    alter column workspace_scope set not null,
+    alter column branch_name set not null,
+    add constraint fk_sol_repository foreign key (repository_id)
+        references system_repository (repository_id),
+    add constraint ck_sol_workspace_scope check (
+        (workspace_id is null and workspace_scope = 'CENTRAL')
+        or (workspace_id is not null and workspace_scope = 'WORKSPACE:' || btrim(workspace_id))
+    ),
+    add constraint ck_sol_scope_key_v2 check (scope_key like 'v2|r%');
+
+alter table product_catalog
+    alter column repository_id set not null,
+    alter column workspace_scope set not null,
+    alter column branch_name set not null,
+    add constraint fk_prod_repository foreign key (repository_id)
+        references system_repository (repository_id),
+    add constraint ck_prod_workspace_scope check (
+        (workspace_id is null and workspace_scope = 'CENTRAL')
+        or (workspace_id is not null and workspace_scope = 'WORKSPACE:' || btrim(workspace_id))
+    ),
+    add constraint ck_prod_scope_key_v2 check (scope_key like 'v2|r%');
+
+create index idx_proj_tenant on arch_project (repository_id, workspace_scope, branch_name);
+create index idx_sol_tenant on solution_definition (repository_id, workspace_scope, branch_name);
+create index idx_prod_tenant on product_catalog (repository_id, workspace_scope, branch_name);

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/DslGitRepositoryFactoryRepositoryAwareCompatibilityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/DslGitRepositoryFactoryRepositoryAwareCompatibilityTest.java
@@ -1,13 +1,20 @@
 package com.taxonomy.dsl.storage;
 
+import com.taxonomy.workspace.model.SystemRepository;
+import com.taxonomy.workspace.service.RepositoryContext;
+import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceContext;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DslGitRepositoryFactoryRepositoryAwareCompatibilityTest {
 
@@ -36,5 +43,54 @@ class DslGitRepositoryFactoryRepositoryAwareCompatibilityTest {
 
         assertSame(factory.openWorkspaceRepository("workspace-a"), selected);
         assertNull(selected.getDslAtHead("draft"));
+    }
+
+    @Test
+    void catalogReservedStorageIsValidatedAndReused() {
+        SystemRepositoryService catalog = mock(SystemRepositoryService.class);
+        SystemRepository metadata = new SystemRepository();
+        metadata.setRepositoryId("repo-a");
+        metadata.setStorageRepositoryName("central-repo-a");
+        when(catalog.getRepository("repo-a")).thenReturn(metadata);
+        DslGitRepositoryFactory factory = new DslGitRepositoryFactory(null, catalog);
+
+        DslGitRepository created = factory.createCentralRepository(
+                "repo-a", "central-repo-a");
+
+        assertSame(created, factory.getCentralRepository("repo-a"));
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.createCentralRepository("repo-a", "wrong-storage"));
+    }
+
+    @Test
+    void legacyCompatibilityRemainsBoundedToPrimaryRouting() throws IOException {
+        DslGitRepositoryFactory factory = new DslGitRepositoryFactory(null);
+        DslGitRepository primary = factory.getSystemRepository();
+        primary.commitDsl(
+                "draft", "meta { language: \"legacy\"; }", "system", "primary");
+
+        assertSame(primary, factory.resolveRepository((WorkspaceContext) null));
+        assertSame(primary, factory.resolveRepository(
+                new WorkspaceContext("alice", null, "draft")));
+
+        DslGitRepository legacyWorkspace = factory.resolveRepository(
+                new WorkspaceContext("alice", "legacy-workspace", "draft"));
+        assertEquals(
+                "meta { language: \"legacy\"; }",
+                legacyWorkspace.getDslAtHead("draft"));
+    }
+
+    @Test
+    void invalidExplicitIdentitiesFailBeforeOpeningStorage() {
+        DslGitRepositoryFactory factory = new DslGitRepositoryFactory(null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.resolveRepository((RepositoryContext) null));
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.getCentralRepository(" "));
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.openWorkspaceRepository(null));
+        assertThrows(IllegalArgumentException.class,
+                () -> factory.createCentralRepository("repo-a", " "));
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/DslGitRepositoryFactoryRepositoryAwareCompatibilityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/DslGitRepositoryFactoryRepositoryAwareCompatibilityTest.java
@@ -1,0 +1,40 @@
+package com.taxonomy.dsl.storage;
+
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class DslGitRepositoryFactoryRepositoryAwareCompatibilityTest {
+
+    @Test
+    void exactCentralCompatibilityContextDoesNotFallBackToPrimaryRepository() {
+        DslGitRepositoryFactory factory = new DslGitRepositoryFactory(null);
+        WorkspaceContext context = new WorkspaceContext(
+                "alice", null, "main", "repo-a");
+
+        DslGitRepository selected = factory.resolveRepository(context);
+
+        assertSame(factory.getCentralRepository("repo-a"), selected);
+        assertNotSame(factory.getSystemRepository(), selected);
+    }
+
+    @Test
+    void exactWorkspaceCompatibilityContextNeverSeedsFromPrimaryRepository()
+            throws IOException {
+        DslGitRepositoryFactory factory = new DslGitRepositoryFactory(null);
+        factory.getSystemRepository().commitDsl(
+                "draft", "meta { language: \"primary\"; }", "system", "primary");
+        WorkspaceContext context = new WorkspaceContext(
+                "alice", "workspace-a", "main", "repo-a");
+
+        DslGitRepository selected = factory.resolveRepository(context);
+
+        assertSame(factory.openWorkspaceRepository("workspace-a"), selected);
+        assertNull(selected.getDslAtHead("draft"));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -138,7 +138,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "0", "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11");
+                        "6", "7", "8", "9", "10", "11", "12");
     }
 
     @Test
@@ -169,14 +169,10 @@ class TaxonomySchemaPostgresMigrationIT {
                 .isTrue();
         assertThat(columnExists(dataSource, "user_workspace", "source_repository_id"))
                 .isTrue();
-        assertThat(columnExists(dataSource, "user_workspace", "source_branch"))
-                .isTrue();
-        assertThat(columnExists(dataSource, "taxonomy_relation", "repository_id"))
-                .isTrue();
-        assertThat(columnExists(dataSource, "relation_proposal", "repository_id"))
-                .isTrue();
-        assertThat(columnExists(dataSource, "relation_hypothesis", "repository_id"))
-                .isTrue();
+        assertThat(columnExists(dataSource, "user_workspace", "source_branch")).isTrue();
+        assertThat(columnExists(dataSource, "taxonomy_relation", "repository_id")).isTrue();
+        assertThat(columnExists(dataSource, "relation_proposal", "repository_id")).isTrue();
+        assertThat(columnExists(dataSource, "relation_hypothesis", "repository_id")).isTrue();
         assertThat(columnExists(
                 dataSource, "architecture_commit_index", "repository_id"))
                 .isTrue();
@@ -213,7 +209,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11");
+                        "6", "7", "8", "9", "10", "11", "12");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioRepositoryBranchIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioRepositoryBranchIsolationTest.java
@@ -1,0 +1,117 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.ProjectView;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.repository.ArchitectureProjectRepository;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.model.RepositoryVisibility;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class PortfolioRepositoryBranchIsolationTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private ArchitectureProjectRepository projectRepository;
+
+    @Autowired
+    private SystemRepositoryService systemRepositoryService;
+
+    @Test
+    void identicalBusinessKeysRemainExactTenantAndBranchLocal() {
+        String repositoryA = repository("Tenant A");
+        String repositoryB = repository("Tenant B");
+        WorkspaceContext centralAMain = context(repositoryA, null, "main");
+        WorkspaceContext centralADraft = context(repositoryA, null, "draft");
+        WorkspaceContext centralBMain = context(repositoryB, null, "main");
+        WorkspaceContext repositoryAMain = context(repositoryA, "workspace-1", "main");
+        WorkspaceContext repositoryADraft = context(repositoryA, "workspace-1", "draft");
+        WorkspaceContext repositoryBMain = context(repositoryB, "workspace-1", "main");
+        WorkspaceContext repositoryASecondWorkspace = context(repositoryA, "workspace-2", "main");
+
+        ProjectView centralA = create(centralAMain, "SAME-KEY");
+        ProjectView centralDraft = create(centralADraft, "SAME-KEY");
+        ProjectView centralB = create(centralBMain, "SAME-KEY");
+        ProjectView aMain = create(repositoryAMain, "SAME-KEY");
+        ProjectView aDraft = create(repositoryADraft, "SAME-KEY");
+        ProjectView bMain = create(repositoryBMain, "SAME-KEY");
+        ProjectView aSecondWorkspace = create(repositoryASecondWorkspace, "SAME-KEY");
+
+        assertThat(List.of(centralA.id(), centralDraft.id(), centralB.id(),
+                aMain.id(), aDraft.id(), bMain.id(), aSecondWorkspace.id()))
+                .doesNotHaveDuplicates();
+        assertThat(projectService.listProjects("another-user", centralAMain))
+                .extracting(ProjectView::id).containsExactly(centralA.id());
+        assertThat(projectService.listProjects("architect", centralADraft))
+                .extracting(ProjectView::id).containsExactly(centralDraft.id());
+        assertThat(projectService.listProjects("architect", centralBMain))
+                .extracting(ProjectView::id).containsExactly(centralB.id());
+        assertThat(projectService.listProjects("architect", repositoryAMain))
+                .extracting(ProjectView::id).containsExactly(aMain.id());
+        assertThat(projectService.listProjects("architect", repositoryADraft))
+                .extracting(ProjectView::id).containsExactly(aDraft.id());
+        assertThat(projectService.listProjects("architect", repositoryBMain))
+                .extracting(ProjectView::id).containsExactly(bMain.id());
+        assertThat(projectService.listProjects("architect", repositoryASecondWorkspace))
+                .extracting(ProjectView::id).containsExactly(aSecondWorkspace.id());
+
+        assertThatThrownBy(() -> projectService.getProject(
+                aMain.id(), "architect", repositoryBMain))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("Project not found");
+
+        var stored = projectRepository.findById(aMain.id()).orElseThrow();
+        assertThat(stored.getRepositoryId()).isEqualTo(repositoryA);
+        assertThat(stored.getWorkspaceScope()).isEqualTo("WORKSPACE:workspace-1");
+        assertThat(stored.getBranchName()).isEqualTo("main");
+    }
+
+    private ProjectView create(WorkspaceContext context, String projectKey) {
+        return projectService.createProject(
+                new CreateProjectRequest(
+                        projectKey,
+                        "Tenant-local project",
+                        "Multi-repository isolation evidence",
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                "architect",
+                context);
+    }
+
+    private String repository(String displayName) {
+        String discriminator = UUID.randomUUID().toString();
+        return systemRepositoryService.createCentralRepository(
+                displayName,
+                "tenant-" + discriminator,
+                "Portfolio isolation fixture",
+                RepositoryVisibility.PRIVATE,
+                "architect",
+                "main").getRepositoryId();
+    }
+
+    private static WorkspaceContext context(
+            String repositoryId,
+            String workspaceId,
+            String branch) {
+        return new WorkspaceContext("architect", workspaceId, branch, repositoryId);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantIdentityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantIdentityTest.java
@@ -1,0 +1,78 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.model.PortfolioTenantIdentity;
+import com.taxonomy.portfolio.service.PortfolioScope;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PortfolioTenantIdentityTest {
+
+    @Test
+    void repositoryWorkspaceAndBranchAreIndependentIsolationDimensions() {
+        String repositoryAWorkspaceMain = PortfolioScope.key(
+                "architect", context("repo-a", "workspace-1", "main"));
+        String repositoryBWorkspaceMain = PortfolioScope.key(
+                "architect", context("repo-b", "workspace-1", "main"));
+        String repositoryAWorkspaceDraft = PortfolioScope.key(
+                "architect", context("repo-a", "workspace-1", "draft"));
+        String repositoryASecondWorkspace = PortfolioScope.key(
+                "architect", context("repo-a", "workspace-2", "main"));
+
+        assertThat(Set.of(
+                repositoryAWorkspaceMain,
+                repositoryBWorkspaceMain,
+                repositoryAWorkspaceDraft,
+                repositoryASecondWorkspace)).hasSize(4);
+        assertThat(PortfolioTenantIdentity.parse(repositoryAWorkspaceMain))
+                .isEqualTo(new PortfolioTenantIdentity(
+                        "repo-a", "WORKSPACE:workspace-1", "main"));
+    }
+
+    @Test
+    void centralScopeIsRepositoryAndBranchOwnedRatherThanUserOwned() {
+        WorkspaceContext repositoryAMain = context("repo-a", null, "main");
+        WorkspaceContext repositoryBMain = context("repo-b", null, "main");
+        WorkspaceContext repositoryADraft = context("repo-a", null, "draft");
+
+        assertThat(PortfolioScope.key("alice", repositoryAMain))
+                .isEqualTo(PortfolioScope.key("bob", repositoryAMain));
+        assertThat(PortfolioScope.key("alice", repositoryAMain))
+                .isNotEqualTo(PortfolioScope.key("alice", repositoryBMain))
+                .isNotEqualTo(PortfolioScope.key("alice", repositoryADraft));
+        assertThat(PortfolioTenantIdentity.parse(PortfolioScope.key("alice", repositoryAMain))
+                .workspaceScope()).isEqualTo(PortfolioScope.CENTRAL_SCOPE);
+    }
+
+    @Test
+    void lengthPrefixRoundTripsSeparatorsAndUnicode() {
+        PortfolioTenantIdentity identity = new PortfolioTenantIdentity(
+                "repo|ä", "WORKSPACE:ws|一", "feature/a|β");
+
+        assertThat(PortfolioTenantIdentity.parse(identity.scopeKey())).isEqualTo(identity);
+    }
+
+    @Test
+    void missingRepositoryOrMalformedEncodingFailsClosed() {
+        assertThatThrownBy(() -> PortfolioScope.key(
+                "alice", new WorkspaceContext("alice", "ws", "main", " ")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("repositoryId");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("workspace:ws"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("v2");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|r6:repo-a|s2:x"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static WorkspaceContext context(
+            String repositoryId,
+            String workspaceId,
+            String branch) {
+        return new WorkspaceContext("architect", workspaceId, branch, repositoryId);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantIdentityTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantIdentityTest.java
@@ -57,16 +57,65 @@ class PortfolioTenantIdentityTest {
     }
 
     @Test
-    void missingRepositoryOrMalformedEncodingFailsClosed() {
+    void compatibilityHelpersNormalizeOptionalUserAndWorkspaceValues() {
+        WorkspaceContext contextualUser = new WorkspaceContext(
+                " Alice ", "  ", " main ", " repo-a ");
+
+        assertThat(PortfolioScope.username(null, contextualUser)).isEqualTo("alice");
+        assertThat(PortfolioScope.username(" BOB ", contextualUser)).isEqualTo("bob");
+        assertThat(PortfolioScope.username(null, null)).isEqualTo("anonymous");
+        assertThat(PortfolioScope.workspaceId(contextualUser)).isNull();
+        assertThat(PortfolioScope.repositoryId(contextualUser)).isEqualTo("repo-a");
+        assertThat(PortfolioScope.branch(contextualUser)).isEqualTo("main");
+    }
+
+    @Test
+    void missingContextRepositoryOrBranchFailsClosed() {
+        assertThatThrownBy(() -> PortfolioScope.identity("alice", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("workspace context");
+        assertThatThrownBy(() -> PortfolioScope.repositoryId(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("workspace context");
         assertThatThrownBy(() -> PortfolioScope.key(
                 "alice", new WorkspaceContext("alice", "ws", "main", " ")))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("repositoryId");
+        assertThatThrownBy(() -> PortfolioScope.branch(
+                new WorkspaceContext("alice", "ws", " ", "repo-a")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("currentBranch");
+    }
+
+    @Test
+    void malformedTenantComponentsAndEncodingsFailClosed() {
+        assertThatThrownBy(() -> new PortfolioTenantIdentity(
+                "repo-a", "WORKSPACE:", "main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("workspaceScope");
+        assertThatThrownBy(() -> new PortfolioTenantIdentity(
+                "repo-a", "OTHER", "main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("workspaceScope");
         assertThatThrownBy(() -> PortfolioTenantIdentity.parse("workspace:ws"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("v2");
-        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|r6:repo-a|s2:x"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|x6:repo-a|s7:CENTRAL|b4:main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("component r");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|rX:repo-a|s7:CENTRAL|b4:main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid length");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|r0:|s7:CENTRAL|b4:main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse("v2|r6:repo-a|s7:CENTRAL|b9:main"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("truncated");
+        assertThatThrownBy(() -> PortfolioTenantIdentity.parse(
+                "v2|r6:repo-a|s7:CENTRAL|b4:main-extra"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("trailing data");
     }
 
     private static WorkspaceContext context(

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantMigrationContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantMigrationContractTest.java
@@ -14,7 +14,7 @@ class PortfolioTenantMigrationContractTest {
                     + "V12__scope_portfolio_by_repository_branch.sql");
 
     @Test
-    void migrationBackfillsEveryPortfolioRootAndFailsClosedOnUnknownWorkspaces()
+    void migrationBackfillsEveryPortfolioRootAndFailsClosedOnAmbiguousProvenance()
             throws Exception {
         String sql = Files.readString(MIGRATION);
 
@@ -25,6 +25,9 @@ class PortfolioTenantMigrationContractTest {
                 .contains("repository_id varchar(255)")
                 .contains("workspace_scope varchar(320)")
                 .contains("branch_name varchar(255)")
+                .contains("primary_repository_count > 1")
+                .contains("primary_repository_count = 0")
+                .contains("requires exactly one primary repository for existing central portfolio rows")
                 .contains("Portfolio tenancy migration found an unknown workspace_id")
                 .contains("Portfolio tenancy migration found incomplete workspace repository provenance")
                 .contains("Portfolio tenancy migration found ambiguous central project keys")

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantMigrationContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/PortfolioTenantMigrationContractTest.java
@@ -1,0 +1,42 @@
+package com.taxonomy.portfolio;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PortfolioTenantMigrationContractTest {
+
+    private static final Path MIGRATION = Path.of(
+            "src/main/resources/db/migration/taxonomy/postgresql/"
+                    + "V12__scope_portfolio_by_repository_branch.sql");
+
+    @Test
+    void migrationBackfillsEveryPortfolioRootAndFailsClosedOnUnknownWorkspaces()
+            throws Exception {
+        String sql = Files.readString(MIGRATION);
+
+        assertThat(sql)
+                .contains("alter table arch_project")
+                .contains("alter table solution_definition")
+                .contains("alter table product_catalog")
+                .contains("repository_id varchar(255)")
+                .contains("workspace_scope varchar(320)")
+                .contains("branch_name varchar(255)")
+                .contains("Portfolio tenancy migration found an unknown workspace_id")
+                .contains("Portfolio tenancy migration found incomplete workspace repository provenance")
+                .contains("Portfolio tenancy migration found ambiguous central project keys")
+                .contains("Portfolio tenancy migration found ambiguous central solution keys")
+                .contains("Portfolio tenancy migration found ambiguous central product keys")
+                .contains("workspace_scope = 'CENTRAL'")
+                .contains("foreign key (repository_id)")
+                .contains("char_length(repository_id)::text")
+                .contains("char_length(workspace_scope)::text")
+                .contains("char_length(branch_name)::text")
+                .contains("alter column repository_id set not null")
+                .doesNotContain("drop table")
+                .doesNotContain("delete from");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProductCatalogEntryTenantLifecycleTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProductCatalogEntryTenantLifecycleTest.java
@@ -1,0 +1,149 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.model.PortfolioTenantIdentity;
+import com.taxonomy.portfolio.model.ProductCatalogEntry;
+import com.taxonomy.portfolio.model.PortfolioTypes.OperatingModel;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProductStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProductCatalogEntryTenantLifecycleTest {
+
+    @Test
+    void encodedTenantAndDefaultVocabularyAreMaterializedAtConstruction() {
+        Instant now = Instant.parse("2026-08-16T00:00:00Z");
+        String scopeKey = new PortfolioTenantIdentity(
+                "repo-a", "WORKSPACE:workspace-a", "main").scopeKey();
+
+        ProductCatalogEntry entry = entry(
+                scopeKey, "workspace-a", null, null, now);
+
+        assertThat(entry.getRepositoryId()).isEqualTo("repo-a");
+        assertThat(entry.getWorkspaceScope()).isEqualTo("WORKSPACE:workspace-a");
+        assertThat(entry.getBranchName()).isEqualTo("main");
+        assertThat(entry.getProductStatus()).isEqualTo(ProductStatus.CANDIDATE);
+        assertThat(entry.getOperatingModel()).isEqualTo(OperatingModel.UNSPECIFIED);
+        assertThat(entry.getCreatedAt()).isEqualTo(now);
+        assertThat(entry.getUpdatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void completeAndSparseUpdatesExerciseEveryOptionalFieldWithoutDataLoss() {
+        Instant created = Instant.parse("2026-08-16T00:00:00Z");
+        Instant verified = Instant.parse("2026-08-16T01:00:00Z");
+        Instant updated = Instant.parse("2026-08-16T02:00:00Z");
+        Instant touched = Instant.parse("2026-08-16T03:00:00Z");
+        ProductCatalogEntry entry = entry(
+                new PortfolioTenantIdentity("repo-a", "CENTRAL", "draft").scopeKey(),
+                null,
+                ProductStatus.ACTIVE,
+                OperatingModel.ON_PREMISES,
+                created);
+
+        entry.update(
+                "Updated manufacturer",
+                "Updated family",
+                "Updated product",
+                "2026.2",
+                ProductStatus.DEPRECATED,
+                LocalDate.of(2030, 12, 31),
+                "subscription",
+                OperatingModel.SAAS,
+                "Linux, Windows",
+                "MFA, encryption",
+                "BSI, ISO 27001",
+                new BigDecimal("123.45"),
+                "EUR",
+                "per user/month",
+                "catalogue-42",
+                verified,
+                updated);
+
+        assertThat(entry.getManufacturer()).isEqualTo("Updated manufacturer");
+        assertThat(entry.getProductFamily()).isEqualTo("Updated family");
+        assertThat(entry.getProductName()).isEqualTo("Updated product");
+        assertThat(entry.getEditionVersion()).isEqualTo("2026.2");
+        assertThat(entry.getProductStatus()).isEqualTo(ProductStatus.DEPRECATED);
+        assertThat(entry.getEndOfSupport()).isEqualTo(LocalDate.of(2030, 12, 31));
+        assertThat(entry.getLicenseModel()).isEqualTo("subscription");
+        assertThat(entry.getOperatingModel()).isEqualTo(OperatingModel.SAAS);
+        assertThat(entry.getSupportedPlatforms()).isEqualTo("Linux, Windows");
+        assertThat(entry.getSecurityFeatures()).isEqualTo("MFA, encryption");
+        assertThat(entry.getComplianceFeatures()).isEqualTo("BSI, ISO 27001");
+        assertThat(entry.getCostAmount()).isEqualByComparingTo("123.45");
+        assertThat(entry.getCostCurrency()).isEqualTo("EUR");
+        assertThat(entry.getCostBasis()).isEqualTo("per user/month");
+        assertThat(entry.getSourceReference()).isEqualTo("catalogue-42");
+        assertThat(entry.getVerifiedAt()).isEqualTo(verified);
+        assertThat(entry.getCreatedBy()).isEqualTo("architect");
+        assertThat(entry.getUpdatedAt()).isEqualTo(updated);
+
+        entry.update(
+                null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, touched);
+
+        assertThat(entry.getManufacturer()).isEqualTo("Updated manufacturer");
+        assertThat(entry.getProductFamily()).isEqualTo("Updated family");
+        assertThat(entry.getProductName()).isEqualTo("Updated product");
+        assertThat(entry.getEditionVersion()).isEqualTo("2026.2");
+        assertThat(entry.getProductStatus()).isEqualTo(ProductStatus.DEPRECATED);
+        assertThat(entry.getOperatingModel()).isEqualTo(OperatingModel.SAAS);
+        assertThat(entry.getUpdatedAt()).isEqualTo(touched);
+    }
+
+    @Test
+    void mismatchedWorkspaceScopeFailsClosedAndLegacyScopeDoesNotPretendToBeExact() {
+        Instant now = Instant.parse("2026-08-16T00:00:00Z");
+        String central = new PortfolioTenantIdentity(
+                "repo-a", "CENTRAL", "main").scopeKey();
+
+        assertThatThrownBy(() -> entry(
+                central, "workspace-a", ProductStatus.ACTIVE,
+                OperatingModel.HYBRID, now))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match workspaceId");
+
+        ProductCatalogEntry legacy = entry(
+                "workspace:legacy", "legacy", ProductStatus.ACTIVE,
+                OperatingModel.HYBRID, now);
+        assertThat(legacy.getRepositoryId()).isNull();
+        assertThat(legacy.getWorkspaceScope()).isNull();
+        assertThat(legacy.getBranchName()).isNull();
+    }
+
+    private static ProductCatalogEntry entry(
+            String scopeKey,
+            String workspaceId,
+            ProductStatus status,
+            OperatingModel operatingModel,
+            Instant now) {
+        return new ProductCatalogEntry(
+                scopeKey,
+                workspaceId,
+                "PRODUCT-1",
+                "Initial manufacturer",
+                "Initial family",
+                "Initial product",
+                "1.0",
+                status,
+                LocalDate.of(2029, 1, 1),
+                "perpetual",
+                operatingModel,
+                "Linux",
+                "encryption",
+                "ISO 27001",
+                new BigDecimal("10.00"),
+                "EUR",
+                "per instance",
+                "catalogue-1",
+                Instant.parse("2026-08-15T23:00:00Z"),
+                "architect",
+                now);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/versioning/service/WorkspaceRequestIsolationTest.java
@@ -32,16 +32,22 @@ class WorkspaceRequestIsolationTest {
     }
 
     @Test
-    void workspaceContextIsResolvedOnlyOncePerRequest() {
+    void workspaceAndRepositoryContextAreResolvedOnlyOncePerRequest() {
         WorkspaceContextResolver contextResolver = mock(WorkspaceContextResolver.class);
-        WorkspaceContext expected = new WorkspaceContext("architect", "workspace-1", "draft");
-        when(contextResolver.resolveCurrentContext()).thenReturn(expected);
+        when(contextResolver.resolveRepositoryContextForUser("anonymous"))
+                .thenReturn(RepositoryContext.workspace(
+                        "repository-a", "workspace-1", "draft", "architect"));
         WorkspaceResolver resolver = new WorkspaceResolver(contextResolver);
         bindRequest();
 
-        assertThat(resolver.resolveCurrentContext()).isSameAs(expected);
-        assertThat(resolver.resolveCurrentContext()).isSameAs(expected);
-        verify(contextResolver, times(1)).resolveCurrentContext();
+        WorkspaceContext first = resolver.resolveCurrentContext();
+        WorkspaceContext second = resolver.resolveCurrentContext();
+
+        assertThat(first).isSameAs(second);
+        assertThat(first.repositoryId()).isEqualTo("repository-a");
+        assertThat(first.currentBranch()).isEqualTo("draft");
+        verify(contextResolver, times(0)).resolveCurrentContext();
+        verify(contextResolver, times(1)).resolveRepositoryContextForUser("anonymous");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
@@ -279,7 +279,8 @@ class GitNativeSyncIntegrationServiceTest {
     }
 
     @Test
-    void contextRepositoryMismatchFailsBeforeGitOrPortfolioMutation() {
+    void contextRepositoryMismatchFailsBeforeGitOrPortfolioMutation()
+            throws Exception {
         when(contextResolver.resolveRepositoryContextForUser("alice"))
                 .thenReturn(RepositoryContext.workspace(
                         "repo-b", "workspace-a", "feature/alice", "alice"));

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
@@ -313,7 +313,7 @@ class GitNativeSyncIntegrationServiceTest {
                 "alice", null, "draft", "repo-a");
         assertThat(commit).isEqualTo("central-head");
         verify(repositoryFactory).getCentralRepository("repo-a");
-        verify(repositoryFactory, never()).getSystemRepository();
+        verify(repositoryFactory, times(1)).getSystemRepository();
         verify(portfolioGitPort).commitPortfolio(
                 eq("draft"), any(String.class), eq("alice"), eq(context));
         verify(portfolioGitPort).materializePortfolioHead(

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/GitNativeSyncIntegrationServiceTest.java
@@ -86,8 +86,9 @@ class GitNativeSyncIntegrationServiceTest {
                 .thenReturn(Optional.of(workspace));
         when(workspaceRepository.save(any(UserWorkspace.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
-        when(contextResolver.resolveForUser("alice"))
-                .thenReturn(new WorkspaceContext("alice", "workspace-a", "feature/alice"));
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.workspace(
+                        "repo-a", "workspace-a", "feature/alice", "alice"));
         when(systemRepositoryService.getRepository("repo-a")).thenReturn(sourceMetadata);
         when(repositoryFactory.getCentralRepository("repo-a")).thenReturn(sourceRepository);
         when(repositoryFactory.openWorkspaceRepository("workspace-a"))
@@ -119,6 +120,8 @@ class GitNativeSyncIntegrationServiceTest {
 
         String commit = service.syncFromShared("alice", "feature/alice");
 
+        WorkspaceContext exactContext = new WorkspaceContext(
+                "alice", "workspace-a", "feature/alice", "repo-a");
         assertThat(commit).isEqualTo("local-merge-commit");
         verify(repositoryFactory).getCentralRepository("repo-a");
         verify(sourceRepository).getDslAtHead("draft");
@@ -126,6 +129,9 @@ class GitNativeSyncIntegrationServiceTest {
         verify(isolatedWorkspaceRepository, times(2)).getDslAtHead("feature/alice");
         verify(semanticMergeService).mergeContent(base, ours, theirs);
         verify(semanticMergeService, never()).mergeBranches(any(), any(), any(), any());
+        verify(portfolioGitPort).commitPortfolio(
+                eq("feature/alice"), any(String.class), eq("alice"), eq(exactContext));
+        verify(portfolioGitPort).materializePortfolio(merged, "alice", exactContext);
         assertThat(state.getLastSyncedCommitId()).isEqualTo("source-head");
         assertThat(workspace.getLastFetchedCommit()).isEqualTo("source-head");
         assertThat(workspace.getLastIntegratedCommit()).isEqualTo("source-head");
@@ -135,8 +141,9 @@ class GitNativeSyncIntegrationServiceTest {
     void staleDraftFromVolatileUiStateIsReplacedByPersistentMainBranch()
             throws Exception {
         workspace.setCurrentBranch("main");
-        when(contextResolver.resolveForUser("alice"))
-                .thenReturn(new WorkspaceContext("alice", "workspace-a", "main"));
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.workspace(
+                        "repo-a", "workspace-a", "main", "alice"));
         String base = "requirement REQ-BASE {\n  text: \"base\";\n}\n";
         String ours = base + "requirement REQ-LOCAL {\n  text: \"local\";\n}\n";
         String theirs = base + "requirement REQ-SHARED {\n  text: \"shared\";\n}\n";
@@ -162,11 +169,12 @@ class GitNativeSyncIntegrationServiceTest {
         verify(isolatedWorkspaceRepository, never()).getDslAtHead("draft");
         verify(portfolioGitPort).commitPortfolio(
                 eq("main"), any(String.class), eq("alice"),
-                eq(new WorkspaceContext("alice", "workspace-a", "main")));
+                eq(new WorkspaceContext(
+                        "alice", "workspace-a", "main", "repo-a")));
     }
 
     @Test
-    void normalPublishEndpointWritesToRecordedSourceRepository()
+    void normalPublishEndpointWritesAndMaterializesTheRecordedSourceRepository()
             throws Exception {
         String base = "requirement P-1.REQ-0 {\n  text: \"base\";\n}\n";
         String shared = base + "requirement P-1.REQ-B {\n  text: \"Bob\";\n}\n";
@@ -197,16 +205,18 @@ class GitNativeSyncIntegrationServiceTest {
                 eq("draft"), eq(merged), eq("alice"), any(String.class));
         verify(primaryRepository, never()).commitDsl(any(), any(), any(), any());
         verify(portfolioGitPort).materializePortfolio(
-                eq(merged), eq("shared"), eq(WorkspaceContext.SHARED));
+                eq(merged), eq("shared"),
+                eq(new WorkspaceContext("shared", null, "draft", "repo-a")));
         verify(portfolioGitPort).materializePortfolio(
                 eq(merged), eq("alice"),
-                eq(new WorkspaceContext("alice", "workspace-a", "feature/alice")));
+                eq(new WorkspaceContext(
+                        "alice", "workspace-a", "feature/alice", "repo-a")));
         assertThat(state.getLastPublishedCommitId()).isEqualTo("source-merge-commit");
         assertThat(workspace.getCurrentCommit()).isEqualTo("workspace-sync-commit");
     }
 
     @Test
-    void nonPrimaryRepositoryDoesNotProjectIntoLegacyGlobalSharedScope()
+    void nonPrimaryRepositoryProjectsIntoItsOwnCentralScope()
             throws Exception {
         sourceMetadata.setPrimaryRepo(false);
         sourceMetadata.setDefaultBranch("main");
@@ -230,8 +240,83 @@ class GitNativeSyncIntegrationServiceTest {
 
         service.publishToShared("alice", "feature/alice");
 
+        verify(portfolioGitPort).materializePortfolio(
+                local,
+                "shared",
+                new WorkspaceContext("shared", null, "main", "repo-a"));
         verify(portfolioGitPort, never()).materializePortfolio(
                 any(), eq("shared"), eq(WorkspaceContext.SHARED));
+    }
+
+    @Test
+    void explicitlyAddressedWorkspaceCarriesPersistedRepositoryIdentity()
+            throws Exception {
+        String base = "requirement R0 { text: \"base\"; }\n";
+        String local = base + "requirement R1 { text: \"local\"; }\n";
+        String shared = base + "requirement R2 { text: \"shared\"; }\n";
+        String merged = local + "requirement R2 { text: \"shared\"; }\n";
+
+        when(isolatedWorkspaceRepository.getDslAtHead("sync-base")).thenReturn(base);
+        when(isolatedWorkspaceRepository.getDslAtHead("main")).thenReturn(local);
+        when(sourceRepository.getDslAtHead("draft")).thenReturn(shared);
+        when(semanticMergeService.mergeContent(base, local, shared))
+                .thenReturn(new TaxDslMergeResult(merged, List.of()));
+        when(isolatedWorkspaceRepository.commitDsl(
+                eq("main"), eq(merged), eq("alice"), any(String.class)))
+                .thenReturn("local-head");
+        when(isolatedWorkspaceRepository.commitDsl(
+                eq("sync-base"), eq(merged), eq("alice"), any(String.class)))
+                .thenReturn("tracking-head");
+        when(sourceRepository.getHeadCommit("draft")).thenReturn("source-head");
+
+        service.syncFromSharedToWorkspace("alice", "workspace-a");
+
+        verify(portfolioGitPort).commitPortfolio(
+                eq("main"), any(String.class), eq("alice"),
+                eq(new WorkspaceContext(
+                        "alice", "workspace-a", "main", "repo-a")));
+        verify(contextResolver, never()).resolveForUser(any());
+    }
+
+    @Test
+    void contextRepositoryMismatchFailsBeforeGitOrPortfolioMutation() {
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.workspace(
+                        "repo-b", "workspace-a", "feature/alice", "alice"));
+
+        assertThatThrownBy(() -> service.syncFromShared("alice", "feature/alice"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("does not match persisted source provenance");
+
+        verify(repositoryFactory, never()).getCentralRepository(any());
+        verify(portfolioGitPort, never()).commitPortfolio(
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void centralSynchronizationUsesExactRepositoryInsteadOfLegacyPrimarySentinel()
+            throws Exception {
+        when(contextResolver.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.centralRead(
+                        "repo-a", "draft", "alice"));
+        when(systemRepositoryService.getSharedBranch()).thenReturn("draft");
+        when(semanticMergeService.mergeBranches(
+                sourceRepository, "draft", "draft", "alice"))
+                .thenReturn(new SemanticGitMergeService.MergeOutcome(
+                        true, "central-head", false, List.of(), null));
+        when(sourceRepository.getHeadCommit("draft")).thenReturn("central-head");
+
+        String commit = service.syncFromShared("alice", null);
+
+        WorkspaceContext context = new WorkspaceContext(
+                "alice", null, "draft", "repo-a");
+        assertThat(commit).isEqualTo("central-head");
+        verify(repositoryFactory).getCentralRepository("repo-a");
+        verify(repositoryFactory, never()).getSystemRepository();
+        verify(portfolioGitPort).commitPortfolio(
+                eq("draft"), any(String.class), eq("alice"), eq(context));
+        verify(portfolioGitPort).materializePortfolioHead(
+                "draft", "alice", context);
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceResolverPortfolioContextTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/workspace/service/WorkspaceResolverPortfolioContextTest.java
@@ -1,0 +1,69 @@
+package com.taxonomy.workspace.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WorkspaceResolverPortfolioContextTest {
+
+    @AfterEach
+    void clearContexts() {
+        RequestContextHolder.resetRequestAttributes();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void compatibilityContextUsesTheSameRequestStableRepositoryAndBranch() {
+        WorkspaceContextResolver delegate = mock(WorkspaceContextResolver.class);
+        WorkspaceResolver resolver = new WorkspaceResolver(delegate);
+        authenticate("alice");
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(new MockHttpServletRequest()));
+        when(delegate.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.workspace(
+                        "repo-a", "workspace-a", "feature/current", "alice"));
+
+        WorkspaceContext first = resolver.resolveCurrentContext();
+        WorkspaceContext second = resolver.resolveCurrentContext();
+
+        assertThat(first).isSameAs(second);
+        assertThat(first.repositoryId()).isEqualTo("repo-a");
+        assertThat(first.workspaceId()).isEqualTo("workspace-a");
+        assertThat(first.currentBranch()).isEqualTo("feature/current");
+        verify(delegate, times(0)).resolveCurrentContext();
+        verify(delegate, times(1)).resolveRepositoryContextForUser("alice");
+    }
+
+    @Test
+    void centralCompatibilityContextRetainsExactRepositoryAndBranch() {
+        WorkspaceContextResolver delegate = mock(WorkspaceContextResolver.class);
+        WorkspaceResolver resolver = new WorkspaceResolver(delegate);
+        authenticate("alice");
+        when(delegate.resolveRepositoryContextForUser("alice"))
+                .thenReturn(RepositoryContext.centralRead("repo-a", "main", "alice"));
+
+        WorkspaceContext context = resolver.resolveCurrentContext();
+
+        assertThat(context.repositoryId()).isEqualTo("repo-a");
+        assertThat(context.workspaceId()).isNull();
+        assertThat(context.currentBranch()).isEqualTo("main");
+        verify(delegate, times(0)).resolveCurrentContext();
+    }
+
+    private static void authenticate(String username) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(username, "n/a", List.of()));
+    }
+}


### PR DESCRIPTION
## Purpose

Implement the first substantive persistence and Git-routing slice of #743.

The existing portfolio boundary used only `workspace:<id>` or `user:<name>` as its scope key. It therefore omitted both the logical repository and the selected branch. Two repositories, or `main` and `draft` inside one repository, could address the same projects, requirements, solutions, products and decisions. Several synchronization paths also still constructed repository-blind compatibility contexts even after selecting the correct Git repository.

## Exact tenant identity

- extend the request-bound compatibility `WorkspaceContext` with the already resolved logical repository ID;
- derive it from the single request-cached `RepositoryContext`, including the canonical branch;
- remove the separate legacy-context lookup from productive request resolution, avoiding an artificial workspace-switch race;
- replace user/workspace-only portfolio scopes with a reversible identity over `repositoryId + CENTRAL/WORKSPACE:<id> + branch`;
- use Unicode code-point length prefixes so repository, workspace and branch names may contain separators without collisions;
- make central portfolio state repository-owned rather than user-owned.

## Persistence authority

`ArchitectureProject`, `SolutionDefinition` and `ProductCatalogEntry` now persist:

- `repository_id`;
- normalized `workspace_scope`;
- `branch_name`;
- the reversible `scope_key`.

The JPA lifecycle validates that the encoded tenant agrees with `workspace_id` and materializes the explicit columns before every write. Existing composite business-key uniqueness remains scoped by the exact tenant identity.

## PostgreSQL migration

`V12__scope_portfolio_by_repository_branch.sql`:

1. permits a fresh empty installation before the repository-catalog initializer creates its first row;
2. permits workspace-only historic data when every workspace already has exact repository and branch provenance;
3. rejects more than one primary repository and requires exactly one when existing central portfolio rows need deterministic backfill;
4. rejects unknown workspaces and incomplete workspace repository/branch provenance;
5. rejects ambiguous historic central project, solution or product keys instead of silently merging user-scoped records;
6. backfills exact repository, workspace/central scope and branch and rewrites scope keys to the reversible v2 representation;
7. makes tenant columns mandatory and adds repository foreign keys, checks and tenant indexes;
8. contains no deletion or table-drop path.

The PostgreSQL fresh-install and adoption tests include V12 explicitly. Other supported databases receive the mapped tenant columns through JPA and remain covered by the database compatibility matrix.

## Git and synchronization correction

Repository-sensitive synchronization now carries the same exact context into Git and portfolio operations:

- active-user synchronization resolves `RepositoryContext` rather than `resolveForUser`;
- explicitly addressed workspace endpoints derive repository identity from persisted `source_repository_id`;
- a context/source mismatch fails before any Git or portfolio mutation;
- central synchronization opens the selected logical repository, not the primary compatibility handle;
- workspace publication materialises the exact central `(repositoryId, CENTRAL, sourceBranch)` scope for primary and non-primary repositories;
- exact workspace contexts never seed from the primary repository;
- only direct legacy three-argument compatibility callers retain the historic fallback.

## Evidence

- identical project keys coexist in central repository A/B, central `main`/`draft`, workspace A1/A2 and the same synthetic workspace ID in different repository contexts;
- foreign repository/database IDs return the same not-found result as missing projects;
- persisted root rows expose the expected repository, workspace scope and branch;
- request resolution performs one canonical repository lookup and never invokes the legacy context resolver;
- normal, explicitly addressed, stale-UI-branch, central and non-primary sync paths carry the exact repository identity;
- mismatched persistent/request repository provenance fails before mutation;
- migration contracts cover all three roots, empty-schema adoption and ambiguity guards;
- identity tests cover delimiter collisions, Unicode, normalization and malformed input;
- product lifecycle tests cover tenant materialisation, defaults, full/sparse updates and workspace mismatch.

## Scope boundary

This PR **advances but does not close #743**. Remaining work includes tenant-bound composite foreign keys and authority checks for every subordinate analysis/decision/provenance/audit row, exact analysis-job staleness identity, export/deletion/copy lifecycle evidence, migration rollback/operational telemetry and the complete all-database negative matrix. It also does not claim completion of #741, #742 or #744–#749.

## Current integration state

- protected base: `main` at `62f73f3b1f3eeb706b0b1ecab7f30e28ecafb435` after #783;
- exact head: `9d8e23554de42a220ad5bd63b9a1b4a1a953e35d`;
- the branch contains a normal two-parent merge of that exact `main`, without rebase or force-push;
- zero commits behind `main`, exactly 20 intended files relative to `main`;
- the combined tree was verified independently to equal the #783 tree plus precisely the #784 delta;
- fresh CI/CD, PostgreSQL, Oracle, SQL Server, JGit consumer, CodeQL and Security runs are required for this exact head;
- no release request, tag, publication, image or deployment change;
- no contributor branch was rebased, force-updated or deleted.

This remains Draft until the fresh exact-head matrix is green and there is no unresolved review finding. It will then be marked ready and merged normally. Advances #743 and #609.