### PR TITLE
Bind requirements and immutable versions to exact tenant scope

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ArchitectureProject.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ArchitectureProject.java
@@ -33,7 +33,8 @@ import java.time.LocalDate;
         @Index(name = "idx_proj_status", columnList = "scope_key,status"),
         @Index(name = "idx_proj_tenant", columnList = "repository_id,workspace_scope,branch_name")
 }, uniqueConstraints = {
-        @UniqueConstraint(name = "uq_proj_scope_key", columnNames = {"scope_key", "project_key"})
+        @UniqueConstraint(name = "uq_proj_scope_key", columnNames = {"scope_key", "project_key"}),
+        @UniqueConstraint(name = "uq_proj_id_scope", columnNames = {"id", "scope_key"})
 })
 public class ArchitectureProject {
 

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
@@ -86,12 +86,16 @@ public class ProjectRequirement {
     private Long currentVersionId;
 
     /**
-     * Read-only tenant-bound association used by portfolio list queries to fetch
-     * the current immutable version in the same SQL statement as the requirement.
+     * Read-only tenant- and requirement-bound association used by portfolio list
+     * queries to fetch the current immutable version in the same SQL statement.
+     * The requirement's own ID participates in the join, so a version from a
+     * sibling requirement in the same tenant cannot be selected.
      */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumns({
             @JoinColumn(name = "current_version_id", referencedColumnName = "id",
+                    insertable = false, updatable = false),
+            @JoinColumn(name = "id", referencedColumnName = "requirement_id",
                     insertable = false, updatable = false),
             @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
                     insertable = false, updatable = false)

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
@@ -23,6 +23,7 @@ import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 
 import java.time.Instant;
+import java.util.Objects;
 
 /** Stable requirement identity within one exact project tenant. Text changes create versions. */
 @Entity
@@ -45,9 +46,14 @@ public class ProjectRequirement {
             length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
 
+    /** Writable parent identity; the composite association below is deliberately read-only. */
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumns({
-            @JoinColumn(name = "project_id", referencedColumnName = "id", nullable = false),
+            @JoinColumn(name = "project_id", referencedColumnName = "id",
+                    nullable = false, insertable = false, updatable = false),
             @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
                     nullable = false, insertable = false, updatable = false)
     })
@@ -140,7 +146,7 @@ public class ProjectRequirement {
         this.ownerUsername = ownerUsername;
         this.createdAt = now;
         this.updatedAt = now;
-        synchronizeTenantAuthority();
+        synchronizeTenantAuthority(false);
     }
 
     public void updateMetadata(String title,
@@ -175,6 +181,10 @@ public class ProjectRequirement {
     @PrePersist
     @PreUpdate
     private void synchronizeTenantAuthority() {
+        synchronizeTenantAuthority(true);
+    }
+
+    private void synchronizeTenantAuthority(boolean requirePersistentParent) {
         if (project == null || project.getScopeKey() == null
                 || project.getScopeKey().isBlank()) {
             throw new IllegalArgumentException(
@@ -187,10 +197,25 @@ public class ProjectRequirement {
                     "Requirement tenant scope does not match its project");
         }
         scopeKey = projectScope;
+
+        Long persistentProjectId = project.getId();
+        if (persistentProjectId == null) {
+            if (requirePersistentParent) {
+                throw new IllegalArgumentException(
+                        "Requirement project must be persisted before the requirement");
+            }
+            return;
+        }
+        if (projectId != null && !Objects.equals(projectId, persistentProjectId)) {
+            throw new IllegalArgumentException(
+                    "Requirement project ID does not match its association");
+        }
+        projectId = persistentProjectId;
     }
 
     public Long getId() { return id; }
     public String getScopeKey() { return scopeKey; }
+    public Long getProjectId() { return projectId; }
     public ArchitectureProject getProject() { return project; }
     public String getRequirementKey() { return requirementKey; }
     public String getTitle() { return title; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
@@ -46,17 +46,12 @@ public class ProjectRequirement {
             length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
 
-    /** Writable parent identity; the composite association below is deliberately read-only. */
-    @Column(name = "project_id", nullable = false)
+    /** Read-only scalar parent identity for scoped queries without initializing the association. */
+    @Column(name = "project_id", nullable = false, insertable = false, updatable = false)
     private Long projectId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumns({
-            @JoinColumn(name = "project_id", referencedColumnName = "id",
-                    nullable = false, insertable = false, updatable = false),
-            @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
-                    nullable = false, insertable = false, updatable = false)
-    })
+    @JoinColumn(name = "project_id", nullable = false)
     private ArchitectureProject project;
 
     @Column(name = "requirement_key", nullable = false, length = 64)

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirement.java
@@ -14,20 +14,26 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 
 import java.time.Instant;
 
-/** Stable requirement identity within a project. Text changes create versions. */
+/** Stable requirement identity within one exact project tenant. Text changes create versions. */
 @Entity
 @Table(name = "project_requirement", indexes = {
         @Index(name = "idx_req_project", columnList = "project_id"),
-        @Index(name = "idx_req_status", columnList = "project_id,status")
+        @Index(name = "idx_req_status", columnList = "scope_key,project_id,status"),
+        @Index(name = "idx_req_scope", columnList = "scope_key")
 }, uniqueConstraints = {
-        @UniqueConstraint(name = "uq_req_project_key", columnNames = {"project_id", "requirement_key"})
+        @UniqueConstraint(name = "uq_req_project_key",
+                columnNames = {"scope_key", "project_id", "requirement_key"}),
+        @UniqueConstraint(name = "uq_req_id_scope", columnNames = {"id", "scope_key"})
 })
 public class ProjectRequirement {
 
@@ -35,8 +41,16 @@ public class ProjectRequirement {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "scope_key", nullable = false,
+            length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
+    private String scopeKey;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_id", nullable = false)
+    @JoinColumns({
+            @JoinColumn(name = "project_id", referencedColumnName = "id", nullable = false),
+            @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
+                    nullable = false, insertable = false, updatable = false)
+    })
     private ArchitectureProject project;
 
     @Column(name = "requirement_key", nullable = false, length = 64)
@@ -72,11 +86,16 @@ public class ProjectRequirement {
     private Long currentVersionId;
 
     /**
-     * Read-only association used by portfolio list queries to fetch the current
-     * immutable version in the same SQL statement as the requirement identity.
+     * Read-only tenant-bound association used by portfolio list queries to fetch
+     * the current immutable version in the same SQL statement as the requirement.
      */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "current_version_id", insertable = false, updatable = false)
+    @JoinColumns({
+            @JoinColumn(name = "current_version_id", referencedColumnName = "id",
+                    insertable = false, updatable = false),
+            @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
+                    insertable = false, updatable = false)
+    })
     private ProjectRequirementVersion currentVersion;
 
     /** Points at the immutable current analysis snapshot. */
@@ -117,6 +136,7 @@ public class ProjectRequirement {
         this.ownerUsername = ownerUsername;
         this.createdAt = now;
         this.updatedAt = now;
+        synchronizeTenantAuthority();
     }
 
     public void updateMetadata(String title,
@@ -148,7 +168,25 @@ public class ProjectRequirement {
         this.updatedAt = now;
     }
 
+    @PrePersist
+    @PreUpdate
+    private void synchronizeTenantAuthority() {
+        if (project == null || project.getScopeKey() == null
+                || project.getScopeKey().isBlank()) {
+            throw new IllegalArgumentException(
+                    "Requirement project must expose an exact tenant scope");
+        }
+        String projectScope = project.getScopeKey().strip();
+        if (scopeKey != null && !scopeKey.isBlank()
+                && !projectScope.equals(scopeKey.strip())) {
+            throw new IllegalArgumentException(
+                    "Requirement tenant scope does not match its project");
+        }
+        scopeKey = projectScope;
+    }
+
     public Long getId() { return id; }
+    public String getScopeKey() { return scopeKey; }
     public ArchitectureProject getProject() { return project; }
     public String getRequirementKey() { return requirementKey; }
     public String getTitle() { return title; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
@@ -8,21 +8,28 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import java.time.Instant;
 
-/** Immutable text/provenance version of a project requirement. */
+/** Immutable text/provenance version of a project requirement in one exact tenant. */
 @Entity
 @Table(name = "project_req_version", indexes = {
-        @Index(name = "idx_reqver_req", columnList = "requirement_id"),
-        @Index(name = "idx_reqver_hash", columnList = "requirement_id,content_hash")
+        @Index(name = "idx_reqver_req", columnList = "scope_key,requirement_id"),
+        @Index(name = "idx_reqver_hash", columnList = "scope_key,requirement_id,content_hash"),
+        @Index(name = "idx_reqver_scope", columnList = "scope_key")
 }, uniqueConstraints = {
-        @UniqueConstraint(name = "uq_reqver_number", columnNames = {"requirement_id", "version_number"}),
-        @UniqueConstraint(name = "uq_reqver_hash", columnNames = {"requirement_id", "content_hash"})
+        @UniqueConstraint(name = "uq_reqver_number",
+                columnNames = {"scope_key", "requirement_id", "version_number"}),
+        @UniqueConstraint(name = "uq_reqver_hash",
+                columnNames = {"scope_key", "requirement_id", "content_hash"}),
+        @UniqueConstraint(name = "uq_reqver_id_scope", columnNames = {"id", "scope_key"})
 })
 public class ProjectRequirementVersion {
 
@@ -30,8 +37,16 @@ public class ProjectRequirementVersion {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "scope_key", nullable = false,
+            length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
+    private String scopeKey;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "requirement_id", nullable = false)
+    @JoinColumns({
+            @JoinColumn(name = "requirement_id", referencedColumnName = "id", nullable = false),
+            @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
+                    nullable = false, insertable = false, updatable = false)
+    })
     private ProjectRequirement requirement;
 
     @Column(name = "version_number", nullable = false)
@@ -103,9 +118,28 @@ public class ProjectRequirementVersion {
         this.sectionReference = sectionReference;
         this.pageNumber = pageNumber;
         this.originalText = originalText;
+        synchronizeTenantAuthority();
+    }
+
+    @PrePersist
+    @PreUpdate
+    private void synchronizeTenantAuthority() {
+        if (requirement == null || requirement.getScopeKey() == null
+                || requirement.getScopeKey().isBlank()) {
+            throw new IllegalArgumentException(
+                    "Requirement version must reference an exact requirement tenant");
+        }
+        String requirementScope = requirement.getScopeKey().strip();
+        if (scopeKey != null && !scopeKey.isBlank()
+                && !requirementScope.equals(scopeKey.strip())) {
+            throw new IllegalArgumentException(
+                    "Requirement version tenant scope does not match its requirement");
+        }
+        scopeKey = requirementScope;
     }
 
     public Long getId() { return id; }
+    public String getScopeKey() { return scopeKey; }
     public ProjectRequirement getRequirement() { return requirement; }
     public int getVersionNumber() { return versionNumber; }
     public String getText() { return text; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinColumns;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
@@ -44,17 +43,12 @@ public class ProjectRequirementVersion {
             length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
 
-    /** Writable parent identity; the composite association below is deliberately read-only. */
-    @Column(name = "requirement_id", nullable = false)
+    /** Read-only scalar parent identity for scoped queries without initializing the association. */
+    @Column(name = "requirement_id", nullable = false, insertable = false, updatable = false)
     private Long requirementId;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumns({
-            @JoinColumn(name = "requirement_id", referencedColumnName = "id",
-                    nullable = false, insertable = false, updatable = false),
-            @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
-                    nullable = false, insertable = false, updatable = false)
-    })
+    @JoinColumn(name = "requirement_id", nullable = false)
     private ProjectRequirement requirement;
 
     @Column(name = "version_number", nullable = false)

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 @Entity
 @Table(name = "project_req_version", indexes = {
         @Index(name = "idx_reqver_req", columnList = "scope_key,requirement_id"),
-        @Index(name = "idx_reqver_hash", columnList = "scope_key,requirement_id,content_hash"),
         @Index(name = "idx_reqver_scope", columnList = "scope_key")
 }, uniqueConstraints = {
         @UniqueConstraint(name = "uq_reqver_number",

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
@@ -29,7 +29,9 @@ import java.time.Instant;
                 columnNames = {"scope_key", "requirement_id", "version_number"}),
         @UniqueConstraint(name = "uq_reqver_hash",
                 columnNames = {"scope_key", "requirement_id", "content_hash"}),
-        @UniqueConstraint(name = "uq_reqver_id_scope", columnNames = {"id", "scope_key"})
+        @UniqueConstraint(name = "uq_reqver_id_scope", columnNames = {"id", "scope_key"}),
+        @UniqueConstraint(name = "uq_reqver_id_req_scope",
+                columnNames = {"id", "requirement_id", "scope_key"})
 })
 public class ProjectRequirementVersion {
 

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/model/ProjectRequirementVersion.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import java.time.Instant;
+import java.util.Objects;
 
 /** Immutable text/provenance version of a project requirement in one exact tenant. */
 @Entity
@@ -43,9 +44,14 @@ public class ProjectRequirementVersion {
             length = PortfolioTenantIdentity.MAX_SCOPE_KEY_LENGTH)
     private String scopeKey;
 
+    /** Writable parent identity; the composite association below is deliberately read-only. */
+    @Column(name = "requirement_id", nullable = false)
+    private Long requirementId;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumns({
-            @JoinColumn(name = "requirement_id", referencedColumnName = "id", nullable = false),
+            @JoinColumn(name = "requirement_id", referencedColumnName = "id",
+                    nullable = false, insertable = false, updatable = false),
             @JoinColumn(name = "scope_key", referencedColumnName = "scope_key",
                     nullable = false, insertable = false, updatable = false)
     })
@@ -120,12 +126,16 @@ public class ProjectRequirementVersion {
         this.sectionReference = sectionReference;
         this.pageNumber = pageNumber;
         this.originalText = originalText;
-        synchronizeTenantAuthority();
+        synchronizeTenantAuthority(false);
     }
 
     @PrePersist
     @PreUpdate
     private void synchronizeTenantAuthority() {
+        synchronizeTenantAuthority(true);
+    }
+
+    private void synchronizeTenantAuthority(boolean requirePersistentParent) {
         if (requirement == null || requirement.getScopeKey() == null
                 || requirement.getScopeKey().isBlank()) {
             throw new IllegalArgumentException(
@@ -138,10 +148,25 @@ public class ProjectRequirementVersion {
                     "Requirement version tenant scope does not match its requirement");
         }
         scopeKey = requirementScope;
+
+        Long persistentRequirementId = requirement.getId();
+        if (persistentRequirementId == null) {
+            if (requirePersistentParent) {
+                throw new IllegalArgumentException(
+                        "Requirement must be persisted before its version");
+            }
+            return;
+        }
+        if (requirementId != null && !Objects.equals(requirementId, persistentRequirementId)) {
+            throw new IllegalArgumentException(
+                    "Requirement version parent ID does not match its association");
+        }
+        requirementId = persistentRequirementId;
     }
 
     public Long getId() { return id; }
     public String getScopeKey() { return scopeKey; }
+    public Long getRequirementId() { return requirementId; }
     public ProjectRequirement getRequirement() { return requirement; }
     public int getVersionNumber() { return versionNumber; }
     public String getText() { return text; }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
@@ -14,17 +14,50 @@ import java.util.Optional;
 public interface ProjectRequirementRepository extends JpaRepository<ProjectRequirement, Long> {
 
     @EntityGraph(attributePaths = "currentVersion")
-    List<ProjectRequirement> findByProjectIdOrderByRequirementKeyAsc(Long projectId);
+    List<ProjectRequirement> findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+            Long projectId, String scopeKey);
 
-    Optional<ProjectRequirement> findByIdAndProjectId(Long id, Long projectId);
+    Optional<ProjectRequirement> findByIdAndProjectIdAndScopeKey(
+            Long id, Long projectId, String scopeKey);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select requirement from ProjectRequirement requirement "
+            + "where requirement.id = :id and requirement.project.id = :projectId "
+            + "and requirement.scopeKey = :scopeKey")
+    Optional<ProjectRequirement> findByIdAndProjectIdAndScopeKeyForUpdate(
+            @Param("id") Long id,
+            @Param("projectId") Long projectId,
+            @Param("scopeKey") String scopeKey);
+
+    Optional<ProjectRequirement> findByProjectIdAndScopeKeyAndRequirementKeyIgnoreCase(
+            Long projectId, String scopeKey, String requirementKey);
+
+    long countByProjectIdAndScopeKey(Long projectId, String scopeKey);
+
+    /**
+     * Compatibility methods for callers that have not yet migrated to the exact
+     * tenant boundary. Productive repository-sensitive code must use the
+     * scope-aware variants above.
+     */
+    @Deprecated(forRemoval = false)
+    @EntityGraph(attributePaths = "currentVersion")
+    List<ProjectRequirement> findByProjectIdOrderByRequirementKeyAsc(Long projectId);
+
+    @Deprecated(forRemoval = false)
+    Optional<ProjectRequirement> findByIdAndProjectId(Long id, Long projectId);
+
+    @Deprecated(forRemoval = false)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select requirement from ProjectRequirement requirement "
             + "where requirement.id = :id and requirement.project.id = :projectId")
-    Optional<ProjectRequirement> findByIdAndProjectIdForUpdate(@Param("id") Long id,
-                                                               @Param("projectId") Long projectId);
+    Optional<ProjectRequirement> findByIdAndProjectIdForUpdate(
+            @Param("id") Long id,
+            @Param("projectId") Long projectId);
 
-    Optional<ProjectRequirement> findByProjectIdAndRequirementKeyIgnoreCase(Long projectId, String requirementKey);
+    @Deprecated(forRemoval = false)
+    Optional<ProjectRequirement> findByProjectIdAndRequirementKeyIgnoreCase(
+            Long projectId, String requirementKey);
 
+    @Deprecated(forRemoval = false)
     long countByProjectId(Long projectId);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementRepository.java
@@ -22,7 +22,7 @@ public interface ProjectRequirementRepository extends JpaRepository<ProjectRequi
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select requirement from ProjectRequirement requirement "
-            + "where requirement.id = :id and requirement.project.id = :projectId "
+            + "where requirement.id = :id and requirement.projectId = :projectId "
             + "and requirement.scopeKey = :scopeKey")
     Optional<ProjectRequirement> findByIdAndProjectIdAndScopeKeyForUpdate(
             @Param("id") Long id,
@@ -49,7 +49,7 @@ public interface ProjectRequirementRepository extends JpaRepository<ProjectRequi
     @Deprecated(forRemoval = false)
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select requirement from ProjectRequirement requirement "
-            + "where requirement.id = :id and requirement.project.id = :projectId")
+            + "where requirement.id = :id and requirement.projectId = :projectId")
     Optional<ProjectRequirement> findByIdAndProjectIdForUpdate(
             @Param("id") Long id,
             @Param("projectId") Long projectId);

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
@@ -22,8 +22,21 @@ public interface ProjectRequirementVersionRepository
     Optional<ProjectRequirementVersion> findByRequirementIdAndScopeKeyAndContentHash(
             Long requirementId, String scopeKey, String contentHash);
 
-    Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
-            Long id, Long requirementId, String scopeKey);
+    /**
+     * Uses the persistence-context identity lookup first. Portfolio list queries
+     * already join-fetch the exact current version, so this remains constant-work
+     * while still rejecting a version from another requirement or tenant.
+     */
+    default Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
+            Long id, Long requirementId, String scopeKey) {
+        if (id == null || requirementId == null
+                || scopeKey == null || scopeKey.isBlank()) {
+            return Optional.empty();
+        }
+        return findById(id)
+                .filter(version -> requirementId.equals(version.getRequirementId()))
+                .filter(version -> scopeKey.equals(version.getScopeKey()));
+    }
 
     /** Compatibility methods retained while all callers migrate to exact scope. */
     @Deprecated(forRemoval = false)
@@ -49,6 +62,6 @@ public interface ProjectRequirementVersionRepository
             return Optional.empty();
         }
         return findById(id)
-                .filter(version -> requirementId.equals(version.getRequirement().getId()));
+                .filter(version -> requirementId.equals(version.getRequirementId()));
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
@@ -22,21 +22,8 @@ public interface ProjectRequirementVersionRepository
     Optional<ProjectRequirementVersion> findByRequirementIdAndScopeKeyAndContentHash(
             Long requirementId, String scopeKey, String contentHash);
 
-    /**
-     * Uses the persistence-context identity lookup first. Portfolio list queries
-     * already join-fetch the exact current version, so this remains constant-work
-     * while still rejecting a version from another requirement or tenant.
-     */
-    default Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
-            Long id, Long requirementId, String scopeKey) {
-        if (id == null || requirementId == null
-                || scopeKey == null || scopeKey.isBlank()) {
-            return Optional.empty();
-        }
-        return findById(id)
-                .filter(version -> requirementId.equals(version.getRequirementId()))
-                .filter(version -> scopeKey.equals(version.getScopeKey()));
-    }
+    Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
+            Long id, Long requirementId, String scopeKey);
 
     /** Compatibility methods retained while all callers migrate to exact scope. */
     @Deprecated(forRemoval = false)
@@ -56,12 +43,6 @@ public interface ProjectRequirementVersionRepository
             Long requirementId, String contentHash);
 
     @Deprecated(forRemoval = false)
-    default Optional<ProjectRequirementVersion> findByIdAndRequirementId(
-            Long id, Long requirementId) {
-        if (id == null || requirementId == null) {
-            return Optional.empty();
-        }
-        return findById(id)
-                .filter(version -> requirementId.equals(version.getRequirementId()));
-    }
+    Optional<ProjectRequirementVersion> findByIdAndRequirementId(
+            Long id, Long requirementId);
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
@@ -6,22 +6,45 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface ProjectRequirementVersionRepository extends JpaRepository<ProjectRequirementVersion, Long> {
+public interface ProjectRequirementVersionRepository
+        extends JpaRepository<ProjectRequirementVersion, Long> {
 
-    List<ProjectRequirementVersion> findByRequirementIdOrderByVersionNumberDesc(Long requirementId);
+    List<ProjectRequirementVersion> findByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+            Long requirementId, String scopeKey);
 
-    Optional<ProjectRequirementVersion> findFirstByRequirementIdOrderByVersionNumberDesc(Long requirementId);
+    Optional<ProjectRequirementVersion>
+            findFirstByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+                    Long requirementId, String scopeKey);
 
+    Optional<ProjectRequirementVersion> findByRequirementIdAndScopeKeyAndVersionNumber(
+            Long requirementId, String scopeKey, int versionNumber);
+
+    Optional<ProjectRequirementVersion> findByRequirementIdAndScopeKeyAndContentHash(
+            Long requirementId, String scopeKey, String contentHash);
+
+    Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
+            Long id, Long requirementId, String scopeKey);
+
+    /** Compatibility methods retained while all callers migrate to exact scope. */
+    @Deprecated(forRemoval = false)
+    List<ProjectRequirementVersion> findByRequirementIdOrderByVersionNumberDesc(
+            Long requirementId);
+
+    @Deprecated(forRemoval = false)
+    Optional<ProjectRequirementVersion> findFirstByRequirementIdOrderByVersionNumberDesc(
+            Long requirementId);
+
+    @Deprecated(forRemoval = false)
     Optional<ProjectRequirementVersion> findByRequirementIdAndVersionNumber(
             Long requirementId, int versionNumber);
 
-    Optional<ProjectRequirementVersion> findByRequirementIdAndContentHash(Long requirementId, String contentHash);
+    @Deprecated(forRemoval = false)
+    Optional<ProjectRequirementVersion> findByRequirementIdAndContentHash(
+            Long requirementId, String contentHash);
 
-    /**
-     * Uses the first-level persistence cache when the version was fetched with
-     * its requirement list, while retaining the requirement ownership check.
-     */
-    default Optional<ProjectRequirementVersion> findByIdAndRequirementId(Long id, Long requirementId) {
+    @Deprecated(forRemoval = false)
+    default Optional<ProjectRequirementVersion> findByIdAndRequirementId(
+            Long id, Long requirementId) {
         if (id == null || requirementId == null) {
             return Optional.empty();
         }

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/repository/ProjectRequirementVersionRepository.java
@@ -1,7 +1,10 @@
 package com.taxonomy.portfolio.repository;
 
 import com.taxonomy.portfolio.model.ProjectRequirementVersion;
+import jakarta.persistence.Persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,8 +25,34 @@ public interface ProjectRequirementVersionRepository
     Optional<ProjectRequirementVersion> findByRequirementIdAndScopeKeyAndContentHash(
             Long requirementId, String scopeKey, String contentHash);
 
-    Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
-            Long id, Long requirementId, String scopeKey);
+    /**
+     * Resolve from the already populated persistence context when a requirement
+     * list join-fetched its current version. Otherwise execute a query containing
+     * the complete requirement and tenant key; never initialize an ID-only proxy.
+     */
+    default Optional<ProjectRequirementVersion> findByIdAndRequirementIdAndScopeKey(
+            Long id, Long requirementId, String scopeKey) {
+        if (id == null || requirementId == null
+                || scopeKey == null || scopeKey.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedScope = scopeKey.strip();
+        ProjectRequirementVersion candidate = getReferenceById(id);
+        if (Persistence.getPersistenceUtil().isLoaded(candidate)) {
+            return Optional.of(candidate)
+                    .filter(version -> requirementId.equals(version.getRequirementId()))
+                    .filter(version -> normalizedScope.equals(version.getScopeKey()));
+        }
+        return findExactTenantVersion(id, requirementId, normalizedScope);
+    }
+
+    @Query("select version from ProjectRequirementVersion version "
+            + "where version.id = :id and version.requirementId = :requirementId "
+            + "and version.scopeKey = :scopeKey")
+    Optional<ProjectRequirementVersion> findExactTenantVersion(
+            @Param("id") Long id,
+            @Param("requirementId") Long requirementId,
+            @Param("scopeKey") String scopeKey);
 
     /** Compatibility methods retained while all callers migrate to exact scope. */
     @Deprecated(forRemoval = false)

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortablePortfolioGitService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortablePortfolioGitService.java
@@ -147,11 +147,14 @@ public class PortablePortfolioGitService extends PortfolioGitService {
         String scopeKey = PortfolioScope.key(username, context);
         for (ArchitectureProject project :
                 projectRepository.findByScopeKeyOrderByUpdatedAtDesc(scopeKey)) {
-            for (ProjectRequirement requirement :
-                    requirementRepository.findByProjectIdOrderByRequirementKeyAsc(project.getId())) {
+            for (ProjectRequirement requirement : requirementRepository
+                    .findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+                            project.getId(), scopeKey)) {
                 if (requirement.getCurrentVersionId() == null) continue;
-                versionRepository.findByIdAndRequirementId(
-                                requirement.getCurrentVersionId(), requirement.getId())
+                versionRepository.findByIdAndRequirementIdAndScopeKey(
+                                requirement.getCurrentVersionId(),
+                                requirement.getId(),
+                                scopeKey)
                         .ifPresent(version -> result.put(
                                 composite(project.getProjectKey(), requirement.getRequirementKey()),
                                 version.getVersionNumber()));
@@ -177,11 +180,13 @@ public class PortablePortfolioGitService extends PortfolioGitService {
                     .orElse(null);
             if (project == null) continue;
             ProjectRequirement requirement = requirementRepository
-                    .findByProjectIdAndRequirementKeyIgnoreCase(project.getId(), requirementKey)
+                    .findByProjectIdAndScopeKeyAndRequirementKeyIgnoreCase(
+                            project.getId(), scopeKey, requirementKey)
                     .orElse(null);
             if (requirement == null) continue;
             ProjectRequirementVersion version = versionRepository
-                    .findByRequirementIdAndVersionNumber(requirement.getId(), versionNumber)
+                    .findByRequirementIdAndScopeKeyAndVersionNumber(
+                            requirement.getId(), scopeKey, versionNumber)
                     .orElse(null);
             if (version != null
                     && !Objects.equals(requirement.getCurrentVersionId(), version.getId())) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioGitService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/PortfolioGitService.java
@@ -229,7 +229,8 @@ public class PortfolioGitService {
             }
 
             ProjectRequirement existingRequirement = requirementRepository
-                    .findByProjectIdAndRequirementKeyIgnoreCase(project.id(), requirementKey)
+                    .findByProjectIdAndScopeKeyAndRequirementKeyIgnoreCase(
+                            project.id(), scopeKey, requirementKey)
                     .orElse(null);
             RequirementView requirementView;
             BlockAst firstVersion = versionsForRequirement.getFirst();
@@ -306,7 +307,8 @@ public class PortfolioGitService {
                     MANAGED_PROPERTY, "true")));
 
             List<ProjectRequirement> requirements = requirementRepository
-                    .findByProjectIdOrderByRequirementKeyAsc(project.getId());
+                    .findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+                            project.getId(), scopeKey);
             Map<Long, List<RequirementElementMapping>> mappingsByRequirement =
                     mappingsByRequirement(project.getId());
             for (ProjectRequirement requirement : requirements) {
@@ -324,7 +326,8 @@ public class PortfolioGitService {
                                 MANAGED_PROPERTY, "true")));
 
                 List<ProjectRequirementVersion> versions = versionRepository
-                        .findByRequirementIdOrderByVersionNumberDesc(requirement.getId()).stream()
+                        .findByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+                                requirement.getId(), scopeKey).stream()
                         .sorted(Comparator.comparingInt(ProjectRequirementVersion::getVersionNumber))
                         .toList();
                 for (ProjectRequirementVersion version : versions) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectConflictService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectConflictService.java
@@ -80,8 +80,9 @@ public class ProjectConflictService {
                                      String username,
                                      WorkspaceContext context) {
         ArchitectureProject project = projectService.requireProject(projectId, username, context);
-        List<ProjectRequirement> requirements =
-                requirementRepository.findByProjectIdOrderByRequirementKeyAsc(projectId);
+        List<ProjectRequirement> requirements = requirementRepository
+                .findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+                        projectId, project.getScopeKey());
         Instant now = Instant.now();
 
         for (int leftIndex = 0; leftIndex < requirements.size(); leftIndex++) {

--- a/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/portfolio/service/ProjectPortfolioService.java
@@ -35,7 +35,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-/** Application service for workspace-isolated projects and immutable requirement versions. */
+/** Application service for exact-tenant projects and immutable requirement versions. */
 @Service
 public class ProjectPortfolioService {
 
@@ -155,8 +155,12 @@ public class ProjectPortfolioService {
                                              WorkspaceContext context) {
         requireNonNull(request, "requirement request");
         ArchitectureProject project = requireProject(projectId, username, context);
+        String scopeKey = project.getScopeKey();
         String requirementKey = normalizeBusinessKey(request.requirementKey(), "requirementKey");
-        if (requirementRepository.findByProjectIdAndRequirementKeyIgnoreCase(projectId, requirementKey).isPresent()) {
+        if (requirementRepository
+                .findByProjectIdAndScopeKeyAndRequirementKeyIgnoreCase(
+                        projectId, scopeKey, requirementKey)
+                .isPresent()) {
             throw PortfolioException.conflict(
                     "Requirement key already exists in project " + project.getProjectKey() + ": " + requirementKey);
         }
@@ -224,8 +228,11 @@ public class ProjectPortfolioService {
     public List<RequirementView> listRequirements(Long projectId,
                                                   String username,
                                                   WorkspaceContext context) {
-        requireProject(projectId, username, context);
-        return requirementRepository.findByProjectIdOrderByRequirementKeyAsc(projectId).stream()
+        ArchitectureProject project = requireProject(projectId, username, context);
+        return requirementRepository
+                .findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+                        projectId, project.getScopeKey())
+                .stream()
                 .map(requirement -> toRequirementView(requirement, currentVersion(requirement)))
                 .toList();
     }
@@ -269,17 +276,21 @@ public class ProjectPortfolioService {
         requireNonNull(request, "requirement version request");
         ProjectRequirement requirement = requireRequirementForUpdate(
                 projectId, requirementId, username, context);
+        String scopeKey = requirement.getScopeKey();
         String text = requireText(request.text(), "text", 100_000);
         String contentHash = fingerprintService.contentFingerprint(text);
         ProjectRequirementVersion existing = versionRepository
-                .findByRequirementIdAndContentHash(requirementId, contentHash)
+                .findByRequirementIdAndScopeKeyAndContentHash(
+                        requirementId, scopeKey, contentHash)
                 .orElse(null);
         if (existing != null) {
             requirement.pointToVersion(existing.getId(), Instant.now());
             return toVersionView(existing);
         }
 
-        int nextVersion = versionRepository.findFirstByRequirementIdOrderByVersionNumberDesc(requirementId)
+        int nextVersion = versionRepository
+                .findFirstByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+                        requirementId, scopeKey)
                 .map(last -> last.getVersionNumber() + 1)
                 .orElse(1);
         Instant now = Instant.now();
@@ -301,8 +312,11 @@ public class ProjectPortfolioService {
                                                                Long requirementId,
                                                                String username,
                                                                WorkspaceContext context) {
-        requireRequirement(projectId, requirementId, username, context);
-        return versionRepository.findByRequirementIdOrderByVersionNumberDesc(requirementId)
+        ProjectRequirement requirement = requireRequirement(
+                projectId, requirementId, username, context);
+        return versionRepository
+                .findByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+                        requirementId, requirement.getScopeKey())
                 .stream().map(this::toVersionView).toList();
     }
 
@@ -320,9 +334,11 @@ public class ProjectPortfolioService {
                                                  Long requirementId,
                                                  String username,
                                                  WorkspaceContext context) {
-        requireProject(projectId, username, context);
+        ArchitectureProject project = requireProject(projectId, username, context);
         if (requirementId == null) throw PortfolioException.validation("requirementId is required");
-        return requirementRepository.findByIdAndProjectId(requirementId, projectId)
+        return requirementRepository
+                .findByIdAndProjectIdAndScopeKey(
+                        requirementId, projectId, project.getScopeKey())
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Requirement " + requirementId + " was not found in project " + projectId));
     }
@@ -331,9 +347,11 @@ public class ProjectPortfolioService {
                                                            Long requirementId,
                                                            String username,
                                                            WorkspaceContext context) {
-        requireProject(projectId, username, context);
+        ArchitectureProject project = requireProject(projectId, username, context);
         if (requirementId == null) throw PortfolioException.validation("requirementId is required");
-        return requirementRepository.findByIdAndProjectIdForUpdate(requirementId, projectId)
+        return requirementRepository
+                .findByIdAndProjectIdAndScopeKeyForUpdate(
+                        requirementId, projectId, project.getScopeKey())
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Requirement " + requirementId + " was not found in project " + projectId));
     }
@@ -341,20 +359,25 @@ public class ProjectPortfolioService {
     @Transactional(readOnly = true)
     public ProjectRequirementVersion currentVersion(ProjectRequirement requirement) {
         Objects.requireNonNull(requirement, "requirement");
+        String scopeKey = requirement.getScopeKey();
         if (requirement.getCurrentVersionId() != null) {
-            return versionRepository.findByIdAndRequirementId(
-                            requirement.getCurrentVersionId(), requirement.getId())
+            return versionRepository.findByIdAndRequirementIdAndScopeKey(
+                            requirement.getCurrentVersionId(), requirement.getId(), scopeKey)
                     .orElseThrow(() -> PortfolioException.notFound(
                             "Current requirement version not found: " + requirement.getCurrentVersionId()));
         }
-        return versionRepository.findFirstByRequirementIdOrderByVersionNumberDesc(requirement.getId())
+        return versionRepository
+                .findFirstByRequirementIdAndScopeKeyOrderByVersionNumberDesc(
+                        requirement.getId(), scopeKey)
                 .orElseThrow(() -> PortfolioException.notFound(
                         "Requirement has no text version: " + requirement.getRequirementKey()));
     }
 
     @Transactional(readOnly = true)
     public ProjectView toProjectView(ArchitectureProject project) {
-        int requirementCount = Math.toIntExact(requirementRepository.countByProjectId(project.getId()));
+        int requirementCount = Math.toIntExact(
+                requirementRepository.countByProjectIdAndScopeKey(
+                        project.getId(), project.getScopeKey()));
         int solutionCount = Math.toIntExact(projectSolutionRepository.countByProjectId(project.getId()));
         int openConflicts = Math.toIntExact(conflictRepository.countByProjectIdAndStatusNotIn(
                 project.getId(), CLOSED_CONFLICT_STATUSES));

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
@@ -1,0 +1,111 @@
+-- Bind requirements and immutable requirement versions to the exact project tenant.
+-- The migration derives authority only from already-scoped parent rows and fails
+-- closed if pre-existing columns disagree with that authority.
+
+alter table project_requirement
+    add column if not exists scope_key varchar(1024);
+alter table project_req_version
+    add column if not exists scope_key varchar(1024);
+
+do $$
+begin
+    if exists (
+        select 1
+        from project_requirement requirement
+        left join arch_project project on project.id = requirement.project_id
+        where project.id is null or nullif(btrim(project.scope_key), '') is null
+    ) then
+        raise exception 'Requirement tenancy migration found a requirement without an exact project tenant';
+    end if;
+
+    if exists (
+        select 1
+        from project_requirement requirement
+        join arch_project project on project.id = requirement.project_id
+        where requirement.scope_key is not null
+          and btrim(requirement.scope_key) <> btrim(project.scope_key)
+    ) then
+        raise exception 'Requirement tenancy migration found a requirement/project scope mismatch';
+    end if;
+
+    if exists (
+        select 1
+        from project_req_version version
+        left join project_requirement requirement on requirement.id = version.requirement_id
+        where requirement.id is null or nullif(btrim(requirement.scope_key), '') is null
+    ) then
+        raise exception 'Requirement tenancy migration found a version without an exact requirement tenant';
+    end if;
+
+    if exists (
+        select 1
+        from project_req_version version
+        join project_requirement requirement on requirement.id = version.requirement_id
+        where version.scope_key is not null
+          and btrim(version.scope_key) <> btrim(requirement.scope_key)
+    ) then
+        raise exception 'Requirement tenancy migration found a version/requirement scope mismatch';
+    end if;
+end $$;
+
+update project_requirement requirement
+set scope_key = project.scope_key
+from arch_project project
+where project.id = requirement.project_id;
+
+update project_req_version version
+set scope_key = requirement.scope_key
+from project_requirement requirement
+where requirement.id = version.requirement_id;
+
+alter table arch_project
+    drop constraint if exists uq_proj_id_scope;
+alter table arch_project
+    add constraint uq_proj_id_scope unique (id, scope_key);
+
+alter table project_requirement
+    drop constraint if exists uq_req_project_key,
+    drop constraint if exists uq_req_id_scope,
+    drop constraint if exists fk_req_project_scope,
+    drop constraint if exists fk_req_current_version_scope;
+alter table project_requirement
+    alter column scope_key set not null,
+    add constraint uq_req_project_key
+        unique (scope_key, project_id, requirement_key),
+    add constraint uq_req_id_scope unique (id, scope_key),
+    add constraint fk_req_project_scope
+        foreign key (project_id, scope_key)
+        references arch_project (id, scope_key);
+
+alter table project_req_version
+    drop constraint if exists uq_reqver_number,
+    drop constraint if exists uq_reqver_hash,
+    drop constraint if exists uq_reqver_id_scope,
+    drop constraint if exists fk_reqver_requirement_scope;
+alter table project_req_version
+    alter column scope_key set not null,
+    add constraint uq_reqver_number
+        unique (scope_key, requirement_id, version_number),
+    add constraint uq_reqver_hash
+        unique (scope_key, requirement_id, content_hash),
+    add constraint uq_reqver_id_scope unique (id, scope_key),
+    add constraint fk_reqver_requirement_scope
+        foreign key (requirement_id, scope_key)
+        references project_requirement (id, scope_key);
+
+-- The pointer is nullable while a requirement is first created. Once populated,
+-- it may only address a version in the same exact repository/workspace/branch.
+alter table project_requirement
+    add constraint fk_req_current_version_scope
+        foreign key (current_version_id, scope_key)
+        references project_req_version (id, scope_key)
+        deferrable initially deferred;
+
+create index if not exists idx_req_scope
+    on project_requirement (scope_key);
+create index if not exists idx_req_status_scope
+    on project_requirement (scope_key, project_id, status);
+create index if not exists idx_reqver_scope
+    on project_req_version (scope_key);
+create index if not exists idx_reqver_hash_scope
+    on project_req_version (scope_key, requirement_id, content_hash);

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
@@ -119,5 +119,3 @@ create index if not exists idx_req_status_scope
     on project_requirement (scope_key, project_id, status);
 create index if not exists idx_reqver_scope
     on project_req_version (scope_key);
-create index if not exists idx_reqver_hash_scope
-    on project_req_version (scope_key, requirement_id, content_hash);

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
@@ -81,6 +81,7 @@ alter table project_req_version
     drop constraint if exists uq_reqver_number,
     drop constraint if exists uq_reqver_hash,
     drop constraint if exists uq_reqver_id_scope,
+    drop constraint if exists uq_reqver_id_req_scope,
     drop constraint if exists fk_reqver_requirement_scope;
 alter table project_req_version
     alter column scope_key set not null,
@@ -89,16 +90,18 @@ alter table project_req_version
     add constraint uq_reqver_hash
         unique (scope_key, requirement_id, content_hash),
     add constraint uq_reqver_id_scope unique (id, scope_key),
+    add constraint uq_reqver_id_req_scope
+        unique (id, requirement_id, scope_key),
     add constraint fk_reqver_requirement_scope
         foreign key (requirement_id, scope_key)
         references project_requirement (id, scope_key);
 
 -- The pointer is nullable while a requirement is first created. Once populated,
--- it may only address a version in the same exact repository/workspace/branch.
+-- it may only address a version belonging to that same requirement and tenant.
 alter table project_requirement
     add constraint fk_req_current_version_scope
-        foreign key (current_version_id, scope_key)
-        references project_req_version (id, scope_key)
+        foreign key (current_version_id, id, scope_key)
+        references project_req_version (id, requirement_id, scope_key)
         deferrable initially deferred;
 
 create index if not exists idx_req_scope

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V13__scope_requirements_and_versions_by_tenant.sql
@@ -28,11 +28,18 @@ begin
         raise exception 'Requirement tenancy migration found a requirement/project scope mismatch';
     end if;
 
+    -- project_requirement.scope_key was introduced immediately above and has not
+    -- been backfilled yet. Existing versions therefore derive their pre-migration
+    -- authority through requirement -> project, not through the new child column.
     if exists (
         select 1
         from project_req_version version
-        left join project_requirement requirement on requirement.id = version.requirement_id
-        where requirement.id is null or nullif(btrim(requirement.scope_key), '') is null
+        left join project_requirement requirement
+            on requirement.id = version.requirement_id
+        left join arch_project project on project.id = requirement.project_id
+        where requirement.id is null
+           or project.id is null
+           or nullif(btrim(project.scope_key), '') is null
     ) then
         raise exception 'Requirement tenancy migration found a version without an exact requirement tenant';
     end if;
@@ -40,9 +47,11 @@ begin
     if exists (
         select 1
         from project_req_version version
-        join project_requirement requirement on requirement.id = version.requirement_id
+        join project_requirement requirement
+            on requirement.id = version.requirement_id
+        join arch_project project on project.id = requirement.project_id
         where version.scope_key is not null
-          and btrim(version.scope_key) <> btrim(requirement.scope_key)
+          and btrim(version.scope_key) <> btrim(project.scope_key)
     ) then
         raise exception 'Requirement tenancy migration found a version/requirement scope mismatch';
     end if;

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/RequirementTenantPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/RequirementTenantPostgresMigrationIT.java
@@ -1,0 +1,350 @@
+package com.taxonomy.dsl.storage;
+
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Upgrade evidence for PostgreSQL V13 with real pre-existing requirement history. */
+@Testcontainers
+@Tag("db-postgres")
+class RequirementTenantPostgresMigrationIT {
+
+    private static final String REPOSITORY_ID = "primary-repository";
+    private static final String SCOPE_KEY =
+            "v2|r18:primary-repository|s7:CENTRAL|b4:main";
+
+    @Container
+    @SuppressWarnings("rawtypes")
+    static PostgreSQLContainer database = new PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("taxonomy")
+            .withUsername("taxonomy")
+            .withPassword("taxonomy");
+
+    @Test
+    void scopesExistingRequirementsAndVersionsFromTheirAuthoritativeProject()
+            throws Exception {
+        DataSource dataSource = isolatedDataSource("requirement_tenant_upgrade");
+        migrateJgit(dataSource);
+        installApplicationAtVersion(dataSource, "12");
+        insertRepositoryAndLegacyRequirementHistory(dataSource);
+
+        TaxonomySchemaMigrationConfig.migrateApplicationSchema(
+                Flyway.configure().dataSource(dataSource).load().getConfiguration());
+
+        assertThat(singleString(dataSource, """
+                select scope_key from project_requirement where id = 4201
+                """)).isEqualTo(SCOPE_KEY);
+        assertThat(singleString(dataSource, """
+                select scope_key from project_req_version where id = 4301
+                """)).isEqualTo(SCOPE_KEY);
+        assertThat(singleLong(dataSource, """
+                select current_version_id from project_requirement where id = 4201
+                """)).isEqualTo(4301L);
+        assertThat(singleString(dataSource, """
+                select convert_from(lo_get(requirement_text), 'UTF8')
+                from project_req_version
+                where id = 4301
+                """)).isEqualTo("Legacy requirement text");
+
+        insertSecondScopedRequirementVersion(dataSource);
+        assertThatThrownBy(() -> execute(dataSource, """
+                update project_requirement
+                set current_version_id = 4302
+                where id = 4201
+                """))
+                .isInstanceOf(SQLException.class);
+        assertThatThrownBy(() -> execute(dataSource, """
+                update project_req_version
+                set scope_key = 'v2|r5:other|s7:CENTRAL|b4:main'
+                where id = 4301
+                """))
+                .isInstanceOf(SQLException.class);
+    }
+
+    private static void insertRepositoryAndLegacyRequirementHistory(
+            DataSource dataSource) throws SQLException {
+        execute(dataSource, """
+                insert into system_repository (
+                    repository_id,
+                    display_name,
+                    topology_mode,
+                    default_branch,
+                    primary_repo,
+                    created_at,
+                    storage_repository_name,
+                    slug,
+                    visibility,
+                    lifecycle_state,
+                    owner_type,
+                    owner_id,
+                    created_by,
+                    updated_at)
+                values (
+                    'primary-repository',
+                    'Primary',
+                    'INTERNAL_SHARED',
+                    'main',
+                    true,
+                    current_timestamp,
+                    'taxonomy-dsl',
+                    'shared-architecture',
+                    'ORGANIZATION',
+                    'ACTIVE',
+                    'SYSTEM',
+                    'system',
+                    'system',
+                    current_timestamp)
+                """);
+        execute(dataSource, """
+                insert into arch_project (
+                    id,
+                    scope_key,
+                    workspace_id,
+                    owner_username,
+                    project_key,
+                    title,
+                    description,
+                    status,
+                    target_architecture,
+                    target_date,
+                    budget_amount,
+                    budget_currency,
+                    created_at,
+                    updated_at,
+                    row_version,
+                    repository_id,
+                    workspace_scope,
+                    branch_name)
+                values (
+                    4101,
+                    'v2|r18:primary-repository|s7:CENTRAL|b4:main',
+                    null,
+                    'architect',
+                    'LEGACY-PROJECT',
+                    'Legacy project',
+                    'V13 backfill fixture',
+                    'ACTIVE',
+                    null,
+                    null,
+                    null,
+                    null,
+                    current_timestamp,
+                    current_timestamp,
+                    0,
+                    'primary-repository',
+                    'CENTRAL',
+                    'main')
+                """);
+        execute(dataSource, """
+                insert into project_requirement (
+                    id,
+                    project_id,
+                    requirement_key,
+                    title,
+                    status,
+                    priority,
+                    criticality,
+                    requirement_type,
+                    review_status,
+                    owner_username,
+                    current_version_id,
+                    current_snapshot_id,
+                    created_at,
+                    updated_at,
+                    row_version)
+                values (
+                    4201,
+                    4101,
+                    'LEGACY-REQ',
+                    'Legacy requirement',
+                    'APPROVED',
+                    50,
+                    'HIGH',
+                    'FUNCTIONAL',
+                    'CONFIRMED',
+                    'architect',
+                    null,
+                    null,
+                    current_timestamp,
+                    current_timestamp,
+                    0)
+                """);
+        execute(dataSource, """
+                insert into project_req_version (
+                    id,
+                    requirement_id,
+                    version_number,
+                    requirement_text,
+                    content_hash,
+                    change_reason,
+                    created_by,
+                    created_at)
+                values (
+                    4301,
+                    4201,
+                    1,
+                    lo_from_bytea(0, convert_to('Legacy requirement text', 'UTF8')),
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                    'legacy import',
+                    'architect',
+                    current_timestamp)
+                """);
+        execute(dataSource, """
+                update project_requirement
+                set current_version_id = 4301
+                where id = 4201
+                """);
+    }
+
+    private static void insertSecondScopedRequirementVersion(DataSource dataSource)
+            throws SQLException {
+        execute(dataSource, """
+                insert into project_requirement (
+                    id,
+                    scope_key,
+                    project_id,
+                    requirement_key,
+                    title,
+                    status,
+                    priority,
+                    criticality,
+                    requirement_type,
+                    review_status,
+                    owner_username,
+                    current_version_id,
+                    current_snapshot_id,
+                    created_at,
+                    updated_at,
+                    row_version)
+                values (
+                    4202,
+                    'v2|r18:primary-repository|s7:CENTRAL|b4:main',
+                    4101,
+                    'SECOND-REQ',
+                    'Second requirement',
+                    'APPROVED',
+                    50,
+                    'HIGH',
+                    'FUNCTIONAL',
+                    'CONFIRMED',
+                    'architect',
+                    null,
+                    null,
+                    current_timestamp,
+                    current_timestamp,
+                    0)
+                """);
+        execute(dataSource, """
+                insert into project_req_version (
+                    id,
+                    scope_key,
+                    requirement_id,
+                    version_number,
+                    requirement_text,
+                    content_hash,
+                    change_reason,
+                    created_by,
+                    created_at)
+                values (
+                    4302,
+                    'v2|r18:primary-repository|s7:CENTRAL|b4:main',
+                    4202,
+                    1,
+                    lo_from_bytea(0, convert_to('Second requirement text', 'UTF8')),
+                    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                    'tenant pointer fixture',
+                    'architect',
+                    current_timestamp)
+                """);
+    }
+
+    private static void migrateJgit(DataSource dataSource) {
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.POSTGRESQL_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false);
+    }
+
+    private static void installApplicationAtVersion(
+            DataSource dataSource, String version) {
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(TaxonomySchemaMigrationConfig.POSTGRES_LOCATION)
+                .table(TaxonomySchemaMigrationConfig.HISTORY_TABLE)
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .baselineDescription("before Taxonomy application schema")
+                .target(version)
+                .load()
+                .migrate();
+    }
+
+    private static DataSource isolatedDataSource(String schema) throws SQLException {
+        DataSource admin = baseDataSource();
+        execute(admin, "drop schema if exists " + schema + " cascade");
+        execute(admin, "create schema " + schema);
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(withCurrentSchema(database.getJdbcUrl(), schema));
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static String withCurrentSchema(String jdbcUrl, String schema) {
+        return jdbcUrl + (jdbcUrl.contains("?") ? "&" : "?")
+                + "currentSchema=" + schema;
+    }
+
+    private static DataSource baseDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(database.getJdbcUrl());
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static void execute(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static String singleString(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getString(1);
+        }
+    }
+
+    private static long singleLong(DataSource dataSource, String sql)
+            throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getLong(1);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -47,6 +47,8 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(tableExists(dataSource, "product_taxonomy")).isTrue();
         assertThat(tableExists(dataSource, "project_conflict")).isTrue();
         assertThat(tableExists(dataSource, "repository_membership")).isTrue();
+        assertThat(columnExists(dataSource, "project_requirement", "scope_key")).isTrue();
+        assertThat(columnExists(dataSource, "project_req_version", "scope_key")).isTrue();
         assertThat(columnExists(dataSource, "system_repository", "storage_repository_name"))
                 .isTrue();
         assertThat(columnExists(dataSource, "system_repository", "slug")).isTrue();
@@ -138,7 +140,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "0", "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11", "12");
+                        "6", "7", "8", "9", "10", "11", "12", "13");
     }
 
     @Test
@@ -160,6 +162,8 @@ class TaxonomySchemaPostgresMigrationIT {
                 "select count(*) from app_user where username = 'existing-user'"))
                 .isEqualTo(1L);
         assertThat(tableExists(dataSource, "project_requirement")).isTrue();
+        assertThat(columnExists(dataSource, "project_requirement", "scope_key")).isTrue();
+        assertThat(columnExists(dataSource, "project_req_version", "scope_key")).isTrue();
         assertThat(tableExists(dataSource, "repository_membership")).isTrue();
         assertThat(columnExists(dataSource, "relation_hypothesis", "analysis_snapshot_id"))
                 .isTrue();
@@ -209,7 +213,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11", "12");
+                        "6", "7", "8", "9", "10", "11", "12", "13");
     }
 
     @Test

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectConflictNaturalLanguageTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectConflictNaturalLanguageTest.java
@@ -57,7 +57,8 @@ class ProjectConflictNaturalLanguageTest {
                 "local-hash", now);
 
         when(projects.requireProject(1L, "architect", context)).thenReturn(project);
-        when(requirements.findByProjectIdOrderByRequirementKeyAsc(1L))
+        when(requirements.findByProjectIdAndScopeKeyOrderByRequirementKeyAsc(
+                1L, project.getScopeKey()))
                 .thenReturn(List.of(cloud, local));
         when(projects.currentVersion(cloud)).thenReturn(cloudVersion);
         when(projects.currentVersion(local)).thenReturn(localVersion);

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioViewCountTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/ProjectPortfolioViewCountTest.java
@@ -62,13 +62,15 @@ class ProjectPortfolioViewCountTest {
     void createsProjectSummaryFromAggregateCountsWithoutLoadingChildEntities() {
         ArchitectureProject project = org.mockito.Mockito.mock(ArchitectureProject.class);
         when(project.getId()).thenReturn(42L);
+        when(project.getScopeKey()).thenReturn("scope-load-test");
         when(project.getProjectKey()).thenReturn("LOAD-TEST");
         when(project.getTitle()).thenReturn("Large portfolio");
         when(project.getStatus()).thenReturn(ProjectStatus.ACTIVE);
         when(project.getOwnerUsername()).thenReturn("load-user");
         when(project.getCreatedAt()).thenReturn(Instant.EPOCH);
         when(project.getUpdatedAt()).thenReturn(Instant.EPOCH);
-        when(requirementRepository.countByProjectId(42L)).thenReturn(10_000L);
+        when(requirementRepository.countByProjectIdAndScopeKey(
+                42L, "scope-load-test")).thenReturn(10_000L);
         when(solutionRepository.countByProjectId(42L)).thenReturn(1_000L);
         when(conflictRepository.countByProjectIdAndStatusNotIn(eq(42L), argThat(statuses ->
                 statuses.size() == 2
@@ -81,6 +83,8 @@ class ProjectPortfolioViewCountTest {
         assertThat(view.requirementCount()).isEqualTo(10_000);
         assertThat(view.solutionCount()).isEqualTo(1_000);
         assertThat(view.openConflictCount()).isEqualTo(250);
+        verify(requirementRepository).countByProjectIdAndScopeKey(
+                42L, "scope-load-test");
         verify(solutionRepository).countByProjectId(42L);
         verify(conflictRepository).countByProjectIdAndStatusNotIn(eq(42L), argThat(statuses ->
                 statuses.contains(ConflictStatus.REJECTED)

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantCoverageTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantCoverageTest.java
@@ -1,0 +1,93 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.model.ArchitectureProject;
+import com.taxonomy.portfolio.model.PortfolioTenantIdentity;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.model.ProjectRequirement;
+import com.taxonomy.portfolio.repository.ProjectRequirementVersionRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/** Focused negative/default-path evidence for the exact requirement tenant boundary. */
+class RequirementTenantCoverageTest {
+
+    @Test
+    void transientRequirementDerivesScopeAndAppliesStableDefaults() {
+        Instant createdAt = Instant.parse("2026-08-16T00:00:00Z");
+        String scopeKey = new PortfolioTenantIdentity(
+                "repository-coverage",
+                PortfolioTenantIdentity.CENTRAL_SCOPE,
+                "main").scopeKey();
+        ArchitectureProject project = new ArchitectureProject(
+                scopeKey,
+                null,
+                "architect",
+                "COVERAGE-PROJECT",
+                "Coverage project",
+                null,
+                ProjectStatus.ACTIVE,
+                createdAt);
+
+        ProjectRequirement requirement = new ProjectRequirement(
+                project,
+                "REQ-COVERAGE",
+                "Coverage requirement",
+                null,
+                50,
+                null,
+                null,
+                null,
+                "architect",
+                createdAt);
+
+        assertThat(requirement.getScopeKey()).isEqualTo(scopeKey);
+        assertThat(requirement.getProjectId()).isNull();
+        assertThat(requirement.getStatus()).isEqualTo(RequirementStatus.DRAFT);
+        assertThat(requirement.getCriticality()).isEqualTo(Criticality.MEDIUM);
+        assertThat(requirement.getRequirementType()).isEqualTo(RequirementType.FUNCTIONAL);
+        assertThat(requirement.getReviewStatus()).isEqualTo(ReviewStatus.PROPOSED);
+        assertThat(requirement.getCurrentVersion()).isNull();
+        assertThat(requirement.getRowVersion()).isZero();
+
+        Instant updatedAt = createdAt.plusSeconds(1);
+        requirement.updateMetadata(
+                null, null, null, null, null, null, null, updatedAt);
+
+        assertThat(requirement.getTitle()).isEqualTo("Coverage requirement");
+        assertThat(requirement.getStatus()).isEqualTo(RequirementStatus.DRAFT);
+        assertThat(requirement.getUpdatedAt()).isEqualTo(updatedAt);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void repositoryIdentityGuardsRejectIncompleteKeysBeforeDatabaseLookup() {
+        ProjectRequirementVersionRepository repository = mock(
+                ProjectRequirementVersionRepository.class,
+                Answers.CALLS_REAL_METHODS);
+
+        assertThat(repository.findByIdAndRequirementIdAndScopeKey(
+                null, 1L, "scope")).isEmpty();
+        assertThat(repository.findByIdAndRequirementIdAndScopeKey(
+                1L, null, "scope")).isEmpty();
+        assertThat(repository.findByIdAndRequirementIdAndScopeKey(
+                1L, 2L, null)).isEmpty();
+        assertThat(repository.findByIdAndRequirementIdAndScopeKey(
+                1L, 2L, "  ")).isEmpty();
+        assertThat(repository.findByIdAndRequirementId(null, 1L)).isEmpty();
+        assertThat(repository.findByIdAndRequirementId(1L, null)).isEmpty();
+
+        verify(repository, never()).findById(anyLong());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantCoverageTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantCoverageTest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,8 +72,7 @@ class RequirementTenantCoverageTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
-    void repositoryIdentityGuardsRejectIncompleteKeysBeforeDatabaseLookup() {
+    void repositoryIdentityGuardsRejectIncompleteKeysBeforePersistenceAccess() {
         ProjectRequirementVersionRepository repository = mock(
                 ProjectRequirementVersionRepository.class,
                 Answers.CALLS_REAL_METHODS);
@@ -85,9 +85,9 @@ class RequirementTenantCoverageTest {
                 1L, 2L, null)).isEmpty();
         assertThat(repository.findByIdAndRequirementIdAndScopeKey(
                 1L, 2L, "  ")).isEmpty();
-        assertThat(repository.findByIdAndRequirementId(null, 1L)).isEmpty();
-        assertThat(repository.findByIdAndRequirementId(1L, null)).isEmpty();
 
-        verify(repository, never()).findById(anyLong());
+        verify(repository, never()).getReferenceById(anyLong());
+        verify(repository, never()).findExactTenantVersion(
+                anyLong(), anyLong(), anyString());
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
@@ -18,6 +18,8 @@ import com.taxonomy.portfolio.service.ProjectPortfolioService;
 import com.taxonomy.workspace.model.RepositoryVisibility;
 import com.taxonomy.workspace.service.SystemRepositoryService;
 import com.taxonomy.workspace.service.WorkspaceContext;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +47,9 @@ class RequirementTenantIsolationTest {
     @Autowired
     private SystemRepositoryService systemRepositoryService;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @Test
     void identicalRequirementKeysAndContentRemainRepositoryAndBranchLocal() {
         String repositoryA = repository("Requirement tenant A");
@@ -71,6 +76,11 @@ class RequirementTenantIsolationTest {
         String scopeAMain = PortfolioScope.key("architect", aMain);
         String scopeADraft = PortfolioScope.key("architect", aDraft);
         String scopeBMain = PortfolioScope.key("architect", bMain);
+
+        // Force the first scoped version lookup down the exact-query path. The
+        // following wrong-scope lookup then exercises the already-loaded fast path.
+        entityManager.flush();
+        entityManager.clear();
 
         assertThat(requirementRepository.findByIdAndProjectIdAndScopeKey(
                 requirementAMain.id(), projectAMain.id(), scopeAMain)).isPresent();

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
@@ -77,8 +77,8 @@ class RequirementTenantIsolationTest {
         String scopeADraft = PortfolioScope.key("architect", aDraft);
         String scopeBMain = PortfolioScope.key("architect", bMain);
 
-        // Force the first scoped version lookup down the exact-query path. The
-        // following wrong-scope lookup then exercises the already-loaded fast path.
+        // Force scoped version resolution through exact SQL before exercising
+        // the already-loaded constant-work path used by list projections.
         entityManager.flush();
         entityManager.clear();
 
@@ -88,6 +88,13 @@ class RequirementTenantIsolationTest {
                 requirementAMain.id(), projectAMain.id(), scopeADraft)).isEmpty();
         assertThat(requirementRepository.findByIdAndProjectIdAndScopeKey(
                 requirementAMain.id(), projectAMain.id(), scopeBMain)).isEmpty();
+
+        assertThat(versionRepository.findByIdAndRequirementIdAndScopeKey(
+                requirementAMain.currentVersion().id(), requirementAMain.id(), scopeADraft))
+                .isEmpty();
+        assertThat(versionRepository.findByIdAndRequirementIdAndScopeKey(
+                requirementAMain.currentVersion().id(), requirementADraft.id(), scopeAMain))
+                .isEmpty();
         assertThat(versionRepository.findByIdAndRequirementIdAndScopeKey(
                 requirementAMain.currentVersion().id(), requirementAMain.id(), scopeAMain))
                 .isPresent();

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantIsolationTest.java
@@ -1,0 +1,169 @@
+package com.taxonomy.portfolio;
+
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateProjectRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.CreateRequirementVersionRequest;
+import com.taxonomy.portfolio.dto.PortfolioDtos.ProjectView;
+import com.taxonomy.portfolio.dto.PortfolioDtos.RequirementView;
+import com.taxonomy.portfolio.model.PortfolioTypes.Criticality;
+import com.taxonomy.portfolio.model.PortfolioTypes.ProjectStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementStatus;
+import com.taxonomy.portfolio.model.PortfolioTypes.RequirementType;
+import com.taxonomy.portfolio.model.PortfolioTypes.ReviewStatus;
+import com.taxonomy.portfolio.repository.ProjectRequirementRepository;
+import com.taxonomy.portfolio.repository.ProjectRequirementVersionRepository;
+import com.taxonomy.portfolio.service.PortfolioException;
+import com.taxonomy.portfolio.service.PortfolioScope;
+import com.taxonomy.portfolio.service.ProjectPortfolioService;
+import com.taxonomy.workspace.model.RepositoryVisibility;
+import com.taxonomy.workspace.service.SystemRepositoryService;
+import com.taxonomy.workspace.service.WorkspaceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** End-to-end evidence that requirement identities and versions cannot cross exact tenants. */
+@SpringBootTest
+@Transactional
+class RequirementTenantIsolationTest {
+
+    @Autowired
+    private ProjectPortfolioService projectService;
+
+    @Autowired
+    private ProjectRequirementRepository requirementRepository;
+
+    @Autowired
+    private ProjectRequirementVersionRepository versionRepository;
+
+    @Autowired
+    private SystemRepositoryService systemRepositoryService;
+
+    @Test
+    void identicalRequirementKeysAndContentRemainRepositoryAndBranchLocal() {
+        String repositoryA = repository("Requirement tenant A");
+        String repositoryB = repository("Requirement tenant B");
+        WorkspaceContext aMain = context(repositoryA, null, "main");
+        WorkspaceContext aDraft = context(repositoryA, null, "draft");
+        WorkspaceContext bMain = context(repositoryB, null, "main");
+
+        ProjectView projectAMain = createProject(aMain);
+        ProjectView projectADraft = createProject(aDraft);
+        ProjectView projectBMain = createProject(bMain);
+
+        RequirementView requirementAMain = createRequirement(projectAMain.id(), aMain);
+        RequirementView requirementADraft = createRequirement(projectADraft.id(), aDraft);
+        RequirementView requirementBMain = createRequirement(projectBMain.id(), bMain);
+
+        assertThat(requirementAMain.id())
+                .isNotEqualTo(requirementADraft.id())
+                .isNotEqualTo(requirementBMain.id());
+        assertThat(requirementAMain.currentVersion().id())
+                .isNotEqualTo(requirementADraft.currentVersion().id())
+                .isNotEqualTo(requirementBMain.currentVersion().id());
+
+        String scopeAMain = PortfolioScope.key("architect", aMain);
+        String scopeADraft = PortfolioScope.key("architect", aDraft);
+        String scopeBMain = PortfolioScope.key("architect", bMain);
+
+        assertThat(requirementRepository.findByIdAndProjectIdAndScopeKey(
+                requirementAMain.id(), projectAMain.id(), scopeAMain)).isPresent();
+        assertThat(requirementRepository.findByIdAndProjectIdAndScopeKey(
+                requirementAMain.id(), projectAMain.id(), scopeADraft)).isEmpty();
+        assertThat(requirementRepository.findByIdAndProjectIdAndScopeKey(
+                requirementAMain.id(), projectAMain.id(), scopeBMain)).isEmpty();
+        assertThat(versionRepository.findByIdAndRequirementIdAndScopeKey(
+                requirementAMain.currentVersion().id(), requirementAMain.id(), scopeAMain))
+                .isPresent();
+        assertThat(versionRepository.findByIdAndRequirementIdAndScopeKey(
+                requirementAMain.currentVersion().id(), requirementAMain.id(), scopeADraft))
+                .isEmpty();
+
+        assertThatThrownBy(() -> projectService.getRequirement(
+                projectADraft.id(), requirementAMain.id(), "architect", aDraft))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("was not found in project");
+        assertThatThrownBy(() -> projectService.addRequirementVersion(
+                projectBMain.id(),
+                requirementAMain.id(),
+                new CreateRequirementVersionRequest(
+                        "Foreign update must fail", "guessed identifier", null),
+                "architect",
+                bMain))
+                .isInstanceOf(PortfolioException.class)
+                .hasMessageContaining("was not found in project");
+
+        var secondVersion = projectService.addRequirementVersion(
+                projectAMain.id(),
+                requirementAMain.id(),
+                new CreateRequirementVersionRequest(
+                        "Shared requirement text, revision two", "tenant-local revision", null),
+                "architect",
+                aMain);
+        assertThat(secondVersion.versionNumber()).isEqualTo(2);
+        assertThat(projectService.listRequirementVersions(
+                projectAMain.id(), requirementAMain.id(), "architect", aMain))
+                .hasSize(2);
+        assertThat(projectService.listRequirementVersions(
+                projectADraft.id(), requirementADraft.id(), "architect", aDraft))
+                .hasSize(1);
+    }
+
+    private ProjectView createProject(WorkspaceContext context) {
+        return projectService.createProject(
+                new CreateProjectRequest(
+                        "SAME-PROJECT",
+                        "Exact tenant project",
+                        "Repository/branch isolation fixture",
+                        ProjectStatus.ACTIVE,
+                        null,
+                        null,
+                        null,
+                        null),
+                "architect",
+                context);
+    }
+
+    private RequirementView createRequirement(Long projectId, WorkspaceContext context) {
+        return projectService.createRequirement(
+                projectId,
+                new CreateRequirementRequest(
+                        "SAME-REQUIREMENT",
+                        "Exact tenant requirement",
+                        "Shared requirement text",
+                        RequirementStatus.APPROVED,
+                        50,
+                        Criticality.HIGH,
+                        RequirementType.FUNCTIONAL,
+                        ReviewStatus.CONFIRMED,
+                        "architect",
+                        "initial tenant-local version",
+                        null),
+                "architect",
+                context);
+    }
+
+    private String repository(String displayName) {
+        String discriminator = UUID.randomUUID().toString();
+        return systemRepositoryService.createCentralRepository(
+                displayName,
+                "requirement-tenant-" + discriminator,
+                "Requirement isolation fixture",
+                RepositoryVisibility.PRIVATE,
+                "architect",
+                "main").getRepositoryId();
+    }
+
+    private static WorkspaceContext context(
+            String repositoryId,
+            String workspaceId,
+            String branch) {
+        return new WorkspaceContext("architect", workspaceId, branch, repositoryId);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantRepositoryBoundaryTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantRepositoryBoundaryTest.java
@@ -25,6 +25,7 @@ class RequirementTenantRepositoryBoundaryTest {
             "requirementRepository.findByIdAndProjectIdForUpdate(",
             "requirementRepository.findByProjectIdAndRequirementKeyIgnoreCase(",
             "requirementRepository.countByProjectId(",
+            "versionRepository.findById(",
             "versionRepository.findByRequirementIdOrderByVersionNumberDesc(",
             "versionRepository.findFirstByRequirementIdOrderByVersionNumberDesc(",
             "versionRepository.findByRequirementIdAndVersionNumber(",

--- a/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantRepositoryBoundaryTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/portfolio/RequirementTenantRepositoryBoundaryTest.java
@@ -1,0 +1,61 @@
+package com.taxonomy.portfolio;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Prevents migrated productive requirement paths from returning to ID-only lookups. */
+class RequirementTenantRepositoryBoundaryTest {
+
+    private static final List<String> MIGRATED_SERVICES = List.of(
+            "ProjectPortfolioService.java",
+            "ProjectConflictService.java",
+            "PortfolioGitService.java",
+            "PortablePortfolioGitService.java");
+
+    private static final List<String> FORBIDDEN_CALLS = List.of(
+            "requirementRepository.findByProjectIdOrderByRequirementKeyAsc(",
+            "requirementRepository.findByIdAndProjectId(",
+            "requirementRepository.findByIdAndProjectIdForUpdate(",
+            "requirementRepository.findByProjectIdAndRequirementKeyIgnoreCase(",
+            "requirementRepository.countByProjectId(",
+            "versionRepository.findByRequirementIdOrderByVersionNumberDesc(",
+            "versionRepository.findFirstByRequirementIdOrderByVersionNumberDesc(",
+            "versionRepository.findByRequirementIdAndVersionNumber(",
+            "versionRepository.findByRequirementIdAndContentHash(",
+            "versionRepository.findByIdAndRequirementId(");
+
+    @Test
+    void migratedServicesUseOnlyExactTenantRequirementRepositories() throws IOException {
+        Path serviceDirectory = repositoryRoot().resolve(
+                "taxonomy-app/src/main/java/com/taxonomy/portfolio/service");
+        for (String service : MIGRATED_SERVICES) {
+            String source = Files.readString(
+                    serviceDirectory.resolve(service), StandardCharsets.UTF_8);
+            for (String forbidden : FORBIDDEN_CALLS) {
+                assertThat(source)
+                        .as("%s must not use %s", service, forbidden)
+                        .doesNotContain(forbidden);
+            }
+        }
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isDirectory(current.resolve("taxonomy-app"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Purpose

Continue #743 after the merged repository/workspace/branch portfolio foundation in #784. Requirements and immutable requirement versions must no longer rely on globally meaningful database IDs or project-only lookups.

## Exact persistence authority

- add mandatory `scope_key` to `project_requirement` and `project_req_version`;
- bind requirements to their exact project tenant and versions to their exact requirement tenant;
- bind `current_version_id` to the same requirement and exact tenant, not merely to a version ID;
- scope requirement/version uniqueness, indexes and current-version associations by the reversible repository/workspace/branch identity;
- derive and validate child scope from the already authoritative parent before every write.

## PostgreSQL V13 and existing-data upgrade

`V13__scope_requirements_and_versions_by_tenant.sql` handles both fresh databases and real installations with requirement history:

- pre-existing requirements derive their tenant from the already-scoped project;
- pre-existing versions derive authority through `version -> requirement -> project` before the new child columns are backfilled;
- non-null pre-existing child scopes are checked against that authoritative chain and mismatches fail closed;
- backfill precedes `NOT NULL`, scoped uniqueness and composite foreign-key enforcement;
- the current-version pointer is constrained to a version of the same requirement and exact tenant.

`RequirementTenantPostgresMigrationIT` installs the schema at V12, inserts an unscoped requirement and immutable version with an active current-version pointer, upgrades to V13 and proves:

- requirement and version scopes are preserved and backfilled;
- existing large-object text and current-version identity survive the upgrade;
- a current-version pointer cannot cross to another requirement;
- a version cannot be moved to another tenant scope.

## Productive runtime enforcement

- `ProjectPortfolioService` uses exact scope for create, list, get, update, locking, version history, content idempotency and current-version resolution;
- `ProjectConflictService` detects conflicts from the exact tenant requirement set;
- `PortfolioGitService` exports and materializes only exact-tenant requirements and versions;
- `PortablePortfolioGitService` restores portable current-version numbers only inside the same exact tenant;
- a source contract prevents these migrated services from returning to ID-only repository methods, including direct `versionRepository.findById(...)` calls.

## Safe and scalable current-version resolution

Requirement list queries entity-graph-fetch the tenant-bound current version. `findByIdAndRequirementIdAndScopeKey(...)` uses two explicit paths:

1. an already loaded version is validated in memory against both requirement ID and normalized scope, preserving constant-work list rendering;
2. an unloaded proxy is never initialized by ID alone; the repository executes `findExactTenantVersion(...)`, whose SQL predicate contains version ID, requirement ID and scope key.

The isolation test flushes and clears the persistence context to exercise the exact-query path with wrong scope, wrong requirement and correct scope, then exercises the already-loaded rejection path. Null or blank identity parts fail before any persistence access.

## Hibernate, concurrency and scale corrections

- project/requirement parent associations load by primary key, while scalar parent IDs support scoped queries without association initialization;
- `scope_key` remains mandatory and lifecycle-validated against the authoritative parent;
- the current-version association remains bound to `(version id, requirement id, scope)`;
- the pessimistic writer lock targets scalar `projectId`, preserving concurrent monotonic version allocation;
- tenant-bound entity-graph loading keeps large requirement-list reads constant-work.

## Review follow-up

The review correctly identified that `uq_reqver_hash` already creates the required index over `(scope_key, requirement_id, content_hash)`. The redundant JPA index and the duplicate PostgreSQL migration index have been removed. The uniqueness and tenant constraints remain unchanged while requirement-version writes avoid unnecessary index maintenance.

## Evidence

`RequirementTenantIsolationTest` creates identical project keys, requirement keys and text in repository A/main, repository A/draft and repository B/main. It proves distinct identities, exact stored scopes, tenant-local histories, exact-query and persistence-context lookup behavior, and not-found responses for guessed foreign IDs.

Focused repository-boundary and coverage tests protect the fail-closed identity guards, default metadata behavior and the prohibition on global ID-only productive lookups. No coverage threshold or product behavior is weakened.

## Current exact state

- base: protected `main` at `a365232f5c229558b0c6318baa3adb0cbf48df24` after merged delivery hotfix #791;
- exact head: `e0795289ac2ad6aa26d74f3bb5f31f81076dbd28`;
- 17 intended changed files; 32 commits;
- JGit Storage Consumer Contract: green;
- Security Scan: green;
- CodeQL Source Analysis: green;
- PostgreSQL, Oracle and Microsoft SQL Server compatibility matrix: green;
- canonical CI/CD Maven verification: still active for this exact head;
- no release request, tag, publication, image or deployment change.

## Scope boundary

This PR advances but does not close #743 or #609. Analysis jobs/items/snapshots, mappings, decisions, provenance, audit and deletion/copy lifecycle authority remain subsequent tenant slices. Integration remains subject to the protected branch gates.