### PR TITLE
Restore Docker reactor build and guard module drift

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,6 +89,62 @@ jobs:
       - name: Verify Docker availability
         run: docker info
 
+      - name: Detect production-image changes
+        id: production-image-scope
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet "${PR_BASE_SHA}...${PR_HEAD_SHA}" -- \
+            Dockerfile \
+            .dockerignore \
+            pom.xml \
+            mvnw \
+            .mvn/wrapper \
+            'taxonomy-*/pom.xml' \
+            docs \
+            LICENSE \
+            NOTICE \
+            THIRD-PARTY-NOTICES.md \
+            observability/javaagent.properties; then
+            echo 'run=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'run=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify production Docker image build
+        if: steps.production-image-scope.outputs.run == 'true'
+        env:
+          IMAGE_TAG: taxonomy-ci:${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build \
+            --progress=plain \
+            --build-arg BUILD_DATE=1970-01-01T00:00:00Z \
+            --build-arg VCS_REF="$GITHUB_SHA" \
+            --build-arg VERSION="ci-${GITHUB_SHA}" \
+            --tag "$IMAGE_TAG" \
+            .
+
+          revision=$(docker image inspect \
+            --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+            "$IMAGE_TAG")
+          image_user=$(docker image inspect \
+            --format '{{ .Config.User }}' \
+            "$IMAGE_TAG")
+          if [[ "$revision" != "$GITHUB_SHA" ]]; then
+            echo "::error::Production image revision label does not match the tested commit"
+            exit 1
+          fi
+          if [[ "$image_user" != "10001:10001" ]]; then
+            echo "::error::Production image must retain the non-root 10001:10001 identity"
+            exit 1
+          fi
+
       - name: Validate production and Rancher Helm profiles
         shell: bash
         run: bash deploy/helm/taxonomy/verify.sh target/taxonomy-helm-rendered.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN chmod +x mvnw
 
 # Copy the reactor descriptors first so dependency downloads remain cacheable.
 COPY pom.xml .
+COPY taxonomy-tooling/pom.xml taxonomy-tooling/pom.xml
 COPY taxonomy-domain/pom.xml taxonomy-domain/pom.xml
 COPY taxonomy-dsl/pom.xml taxonomy-dsl/pom.xml
 COPY taxonomy-export/pom.xml taxonomy-export/pom.xml
@@ -32,6 +33,7 @@ COPY taxonomy-build/pom.xml taxonomy-build/pom.xml
 
 # Copy all inputs required by the packaged application. In particular, the app
 # Maven module embeds Markdown help, screenshots and legal notices in the JAR.
+COPY taxonomy-tooling/src taxonomy-tooling/src
 COPY taxonomy-domain/src taxonomy-domain/src
 COPY taxonomy-dsl/src taxonomy-dsl/src
 COPY taxonomy-export/src taxonomy-export/src

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
@@ -38,6 +38,34 @@ class DockerfileReactorContractTest {
         }
     }
 
+    @Test
+    void pullRequestCiBuildsChangedProductionImagesBeforeCanonicalVerification()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String workflow = Files.readString(
+                root.resolve(".github/workflows/ci-cd.yml"),
+                StandardCharsets.UTF_8);
+
+        assertThat(workflow)
+                .contains("- name: Detect production-image changes")
+                .contains("id: production-image-scope")
+                .contains("Dockerfile \\")
+                .contains("'taxonomy-*/pom.xml' \\")
+                .contains("- name: Verify production Docker image build")
+                .contains("if: steps.production-image-scope.outputs.run == 'true'")
+                .contains("docker build \\")
+                .contains("--build-arg VCS_REF=\"$GITHUB_SHA\" \\")
+                .contains("org.opencontainers.image.revision")
+                .contains("10001:10001");
+
+        int imageBuild = workflow.indexOf(
+                "- name: Verify production Docker image build");
+        int canonicalVerification = workflow.indexOf(
+                "- name: Run the canonical Maven verification suite");
+        assertThat(imageBuild).isGreaterThanOrEqualTo(0);
+        assertThat(canonicalVerification).isGreaterThan(imageBuild);
+    }
+
     private static List<String> readReactorModules(Path pom) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setFeature(

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,16 +27,42 @@ class DockerfileReactorContractTest {
 
         assertThat(modules).isNotEmpty();
         for (String module : modules) {
-            assertThat(dockerfile)
+            assertThat(containsCopyInstruction(
+                    dockerfile,
+                    module + "/pom.xml",
+                    module + "/pom.xml"))
                     .as("Dockerfile must copy the Maven descriptor for reactor module %s", module)
-                    .contains("COPY " + module + "/pom.xml " + module + "/pom.xml");
+                    .isTrue();
 
             if (Files.isDirectory(root.resolve(module).resolve("src/main"))) {
-                assertThat(dockerfile)
+                assertThat(containsCopyInstruction(
+                        dockerfile,
+                        module + "/src",
+                        module + "/src"))
                         .as("Dockerfile must copy productive sources for reactor module %s", module)
-                        .contains("COPY " + module + "/src " + module + "/src");
+                        .isTrue();
             }
         }
+    }
+
+    @Test
+    void copyInstructionMatchingAcceptsFlagsFlexibleWhitespaceAndJsonForm() {
+        String dockerfile = """
+                # A commented instruction must not satisfy the contract.
+                # COPY missing/pom.xml missing/pom.xml
+                COPY --link --chown=10001:0   module/pom.xml\tmodule/pom.xml
+                copy --chmod=0644 ["module/src", "module/src"]
+                """;
+
+        assertThat(containsCopyInstruction(
+                dockerfile, "module/pom.xml", "module/pom.xml"))
+                .isTrue();
+        assertThat(containsCopyInstruction(
+                dockerfile, "module/src", "module/src"))
+                .isTrue();
+        assertThat(containsCopyInstruction(
+                dockerfile, "missing/pom.xml", "missing/pom.xml"))
+                .isFalse();
     }
 
     @Test
@@ -64,6 +91,22 @@ class DockerfileReactorContractTest {
                 "- name: Run the canonical Maven verification suite");
         assertThat(imageBuild).isGreaterThanOrEqualTo(0);
         assertThat(canonicalVerification).isGreaterThan(imageBuild);
+    }
+
+    private static boolean containsCopyInstruction(
+            String dockerfile, String source, String destination) {
+        String optionalFlags = "(?:\\s+--\\S+)*";
+        String shellForm = "\\s+" + Pattern.quote(source)
+                + "\\s+" + Pattern.quote(destination);
+        String jsonForm = "\\s*\\[\\s*\"" + Pattern.quote(source)
+                + "\"\\s*,\\s*\"" + Pattern.quote(destination)
+                + "\"\\s*\\]";
+        Pattern copyInstruction = Pattern.compile(
+                "^\\s*COPY" + optionalFlags
+                        + "(?:" + shellForm + "|" + jsonForm + ")"
+                        + "\\s*(?:#.*)?$",
+                Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+        return copyInstruction.matcher(dockerfile).find();
     }
 
     private static List<String> readReactorModules(Path pom) throws Exception {

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/DockerfileReactorContractTest.java
@@ -1,0 +1,80 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DockerfileReactorContractTest {
+
+    @Test
+    void dockerBuildContextContainsEveryReactorDescriptorAndProductiveSourceTree()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String dockerfile = Files.readString(
+                root.resolve("Dockerfile"), StandardCharsets.UTF_8);
+        List<String> modules = readReactorModules(root.resolve("pom.xml"));
+
+        assertThat(modules).isNotEmpty();
+        for (String module : modules) {
+            assertThat(dockerfile)
+                    .as("Dockerfile must copy the Maven descriptor for reactor module %s", module)
+                    .contains("COPY " + module + "/pom.xml " + module + "/pom.xml");
+
+            if (Files.isDirectory(root.resolve(module).resolve("src/main"))) {
+                assertThat(dockerfile)
+                        .as("Dockerfile must copy productive sources for reactor module %s", module)
+                        .contains("COPY " + module + "/src " + module + "/src");
+            }
+        }
+    }
+
+    private static List<String> readReactorModules(Path pom) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(
+                "http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature(
+                "http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+
+        Document document = factory.newDocumentBuilder().parse(pom.toFile());
+        NodeList moduleNodes = document.getElementsByTagName("module");
+        List<String> modules = new ArrayList<>(moduleNodes.getLength());
+        for (int index = 0; index < moduleNodes.getLength(); index++) {
+            String module = moduleNodes.item(index).getTextContent().strip();
+            if (!module.isEmpty()) {
+                modules.add(module);
+            }
+        }
+        return List.copyOf(modules);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve("Dockerfile"))
+                    && Files.isRegularFile(current.resolve(
+                            "taxonomy-tooling/pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Root cause

`main` added `taxonomy-tooling` to the root Maven reactor, but the Docker build context still copied only the older module descriptors and source trees. The delivery workflow therefore failed before Maven could build the image with:

```text
Child module /workspace/taxonomy-tooling ... does not exist
```

## Fix

- copy `taxonomy-tooling/pom.xml` before the cached reactor build;
- copy `taxonomy-tooling/src` with the productive module inputs;
- add `DockerfileReactorContractTest`, which reads the root Maven reactor and requires the Dockerfile to copy every module POM and every module that has `src/main`;
- detect Docker-context and reactor-descriptor changes in pull requests and build the complete production image before the canonical Maven suite;
- inspect the built image to prove that the tested commit is present in the OCI revision label and the non-root `10001:10001` runtime identity is retained.

The repository contract also protects the PR image-build gate itself. A future module addition or accidental removal of the pre-merge image build therefore fails in Maven/JUnit before post-merge delivery.

## Scope

This is a focused delivery repair. It does not change application behavior, release metadata, deployment configuration, tags, or published images. After merge, the successful `main` CI handoff should rebuild and publish the exact commit through the existing delivery workflow.