### PR TITLE
Restore special-modes browser acceptance after #799

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -6,6 +6,7 @@
     "node": "24.x"
   },
   "scripts": {
+    "install:playwright:github": "playwright install --with-deps webkit && playwright install chromium firefox",
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
     "test:ui-evidence-targets": "node --test scripts/ui-primary-evidence.test.mjs",
     "test:state-render-consistency": "node --test scripts/taxonomy-state.test.mjs",

--- a/.github/package.json
+++ b/.github/package.json
@@ -6,7 +6,7 @@
     "node": "24.x"
   },
   "scripts": {
-    "install:playwright:github": "playwright install --with-deps webkit && playwright install chromium firefox",
+    "install:playwright:github": "bash scripts/install-playwright-github.sh",
     "test:ui-evidence-policy": "node --test scripts/ui-evidence-policy.test.mjs",
     "test:ui-evidence-targets": "node --test scripts/ui-primary-evidence.test.mjs",
     "test:state-render-consistency": "node --test scripts/taxonomy-state.test.mjs",

--- a/.github/scripts/install-playwright-github.sh
+++ b/.github/scripts/install-playwright-github.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Playwright delegates Linux runtime setup to apt. Keep that operation retryable
+# but bounded so a mutable package mirror cannot consume the complete CI job.
+sudo tee /etc/apt/apt.conf.d/99taxonomy-playwright >/dev/null <<'EOF'
+Acquire::Retries "4";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+DPkg::Lock::Timeout "120";
+EOF
+
+playwright_bin="./node_modules/.bin/playwright"
+if [[ ! -x "${playwright_bin}" ]]; then
+    echo "Pinned Playwright executable is missing; npm ci must run first." >&2
+    exit 1
+fi
+
+# The hosted runner already launches Chromium and Firefox, while the acceptance
+# evidence proves that WebKit still needs GTK/GStreamer and related libraries.
+timeout --foreground 20m "${playwright_bin}" install --with-deps webkit
+
+# Browser binaries remain pinned by package-lock.json. Avoid repeating OS package
+# setup for Chromium and Firefox after the targeted WebKit dependency install.
+timeout --foreground 20m "${playwright_bin}" install chromium firefox

--- a/.github/scripts/ui-special-modes-acceptance.mjs
+++ b/.github/scripts/ui-special-modes-acceptance.mjs
@@ -1,34 +1,283 @@
+import AxeBuilder from '@axe-core/playwright';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { navigateToPage, openRoleSession, ROLE_ACCOUNTS } from './ui-role-fixtures.mjs';
 
-const outputDir = path.resolve(
-  process.env.TAXONOMY_UI_OUTPUT_DIR || 'target/ui-special-modes');
+const baseUrl = process.env.TAXONOMY_BASE_URL || 'http://127.0.0.1:8080';
+const outputDir = path.resolve(process.env.TAXONOMY_UI_OUTPUT_DIR || 'target/ui-special-modes');
+const checks = [];
+const findings = [];
+let auditError = null;
+let browser;
+let context;
+let page;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isAnalyzeResponseForText(response, expectedText) {
+  try {
+    const url = new URL(response.url());
+    if (response.request().method() !== 'POST' || url.pathname !== '/api/analyze') {
+      return false;
+    }
+    return response.request().postDataJSON()?.businessText === expectedText;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForTaxonomyReady() {
+  await page.waitForFunction(() => {
+    const state = window.TaxonomyState;
+    return Array.isArray(state?.taxonomyData) && state.taxonomyData.length > 0;
+  }, null, { timeout: 60_000 });
+}
+
+async function selectSynchronousAnalysisView() {
+  const sunburst = page.locator('#viewSunburst');
+  await sunburst.scrollIntoViewIfNeeded();
+  await sunburst.click();
+  await page.waitForFunction(() => window.TaxonomyState?.currentView === 'sunburst', null,
+    { timeout: 10_000 });
+}
+
+async function submitAnalysisAndWaitForPublishedState(
+  businessText,
+  expectedStatus,
+  timeout = 120_000
+) {
+  const responsePromise = page.waitForResponse(
+    response => isAnalyzeResponseForText(response, businessText),
+    { timeout }
+  );
+  await page.locator('#analyzeBtn').click();
+  const response = await responsePromise;
+  assert(response.ok(), `Analysis request failed with HTTP ${response.status()}`);
+
+  const payload = await response.json();
+  const actualStatus = String(payload.status || '').toUpperCase();
+  assert(actualStatus === expectedStatus,
+    `Expected ${expectedStatus} analysis response but received ${actualStatus || '(missing)'}`);
+  assert(Array.isArray(payload.tree) && payload.tree.length > 0,
+    `${expectedStatus} analysis response produced no reusable tree`);
+  assert(payload.scores && Object.values(payload.scores).some(value => Number(value) > 0),
+    `${expectedStatus} analysis response produced no reusable positive scores`);
+
+  await page.waitForFunction(({ treeCount, scores, businessText }) => {
+    const state = window.TaxonomyState;
+    const button = document.querySelector('#analyzeBtn');
+    const spinner = document.querySelector('#analyzeSpinner');
+    return Boolean(button)
+      && button.disabled === false
+      && (!spinner || spinner.classList.contains('d-none'))
+      && state?.lastAnalyzedText === businessText
+      && Array.isArray(state.taxonomyData)
+      && state.taxonomyData.length === treeCount
+      && Object.entries(scores).every(([code, score]) =>
+        Number(state.currentScores?.[code]) === Number(score));
+  }, {
+    treeCount: payload.tree.length,
+    scores: payload.scores,
+    businessText
+  }, { timeout });
+
+  return payload;
+}
+
+async function openDetails(selector) {
+  const details = page.locator(selector);
+  await details.waitFor({ state: 'attached', timeout: 20_000 });
+  if (!(await details.getAttribute('open'))) {
+    const summary = details.locator(':scope > summary');
+    await summary.scrollIntoViewIfNeeded();
+    await summary.click();
+    await page.waitForFunction(candidate =>
+      document.querySelector(candidate)?.hasAttribute('open'), selector,
+    { timeout: 10_000 });
+  }
+}
+
+async function runAxe(state, include) {
+  const result = await new AxeBuilder({ page })
+    .include(include)
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+  const blocking = result.violations.filter(item =>
+    ['critical', 'serious', 'moderate'].includes(item.impact));
+  findings.push({ state, violations: result.violations, blocking });
+  if (blocking.length) {
+    throw new Error(`Blocking axe findings in ${state}: ${blocking.map(item => `${item.impact}:${item.id}`).join(', ')}`);
+  }
+  checks.push(`axe ${state}`);
+}
+
+async function screenshot(state, selector) {
+  const target = page.locator(selector);
+  await target.waitFor({ state: 'visible', timeout: 20_000 });
+  await target.screenshot({ path: path.join(outputDir, `${state}.png`), animations: 'disabled' });
+  await writeFile(path.join(outputDir, `${state}.html`), await target.evaluate(node => node.outerHTML), 'utf8');
+}
+
+async function testPartialAnalysis() {
+  await navigateToPage(page, 'analyze');
+  await waitForTaxonomyReady();
+  const interactive = page.locator('#interactiveMode');
+  if (await interactive.isChecked()) await interactive.uncheck();
+
+  // List and tabs intentionally use SSE. This scenario validates the synchronous
+  // POST response and then replaces exactly one POST with a PARTIAL response, so
+  // select a non-streaming view explicitly rather than relying on UI timing.
+  await selectSynchronousAnalysisView();
+
+  const successfulText = 'Provide traceable and resilient hospital communication services.';
+  await page.locator('#businessText').fill(successfulText);
+  const fixture = await submitAnalysisAndWaitForPublishedState(successfulText, 'SUCCESS');
+
+  await page.route('**/api/analyze', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'PARTIAL',
+        errorMessage: 'One provider branch was unavailable',
+        warnings: ['Some architecture branches were not evaluated.'],
+        tree: fixture.tree,
+        scores: fixture.scores,
+        discrepancies: [],
+        provisionalRelations: []
+      })
+    });
+  }, { times: 1 });
+
+  const partialText = 'Provide traceable hospital communication services with a partial provider result.';
+  await page.locator('#businessText').fill(partialText);
+  await submitAnalysisAndWaitForPublishedState(partialText, 'PARTIAL', 30_000);
+
+  const statusHandle = await page.waitForFunction(() => {
+    const text = (document.querySelector('#statusArea')?.textContent || '').trim();
+    const normalized = text.toLowerCase();
+    return text && (normalized.includes('unavailable')
+      || normalized.includes('incomplete')
+      || normalized.includes('partial')) ? text : false;
+  }, null, { timeout: 30_000 });
+  const statusText = await statusHandle.jsonValue();
+  assert(typeof statusText === 'string' && statusText.length > 0, 'Partial analysis status is empty');
+  await page.waitForFunction(() => {
+    const text = (document.querySelector('#a11yStatus')?.textContent || '').trim().toLowerCase();
+    return text.includes('unavailable') || text.includes('incomplete') || text.includes('partial');
+  }, null, { timeout: 10_000 });
+  checks.push('partial analysis status, warning detail, and live announcement');
+  await runAxe('analysis-partial', '#tab-analyze');
+  await screenshot('analysis-partial', '#tab-analyze');
+}
+
+async function testTextSpacing() {
+  // WCAG 1.4.12 models an external user stylesheet. Keep the product CSP strict
+  // and append the test-only override to an already allowed, same-origin CSS
+  // response before reloading the authenticated page.
+  await page.route('**/css/taxonomy-ergonomics.css', async route => {
+    const response = await route.fetch();
+    const original = await response.text();
+    const override = [
+      '',
+      '/* WCAG 1.4.12 test-only external user stylesheet */',
+      '#tab-analyze, #tab-analyze * {',
+      '  line-height: 1.5 !important;',
+      '  letter-spacing: 0.12em !important;',
+      '  word-spacing: 0.16em !important;',
+      '}',
+      '#tab-analyze p { margin-bottom: 2em !important; }'
+    ].join('\n');
+    await route.fulfill({ response, body: original + override });
+  });
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.locator('#mainContent').waitFor({ state: 'visible', timeout: 60_000 });
+  await page.evaluate(() => window.TaxonomyI18n?.ready?.());
+  await page.locator('#analysisTaskProgress').waitFor({ state: 'visible', timeout: 20_000 });
+  const onboardingDismiss = page.locator('#onboardingDismiss');
+  if (await onboardingDismiss.isVisible().catch(() => false)) {
+    await onboardingDismiss.click();
+    await page.locator('#onboardingOverlay').waitFor({ state: 'detached', timeout: 5_000 });
+  }
+  await page.waitForFunction(() => Boolean(window.TaxonomyRoleSurface?.ready), null, { timeout: 20_000 });
+  await page.evaluate(() => window.TaxonomyRoleSurface.ready);
+  await navigateToPage(page, 'analyze');
+  await openDetails('#analysisSecondaryTools');
+  await openDetails('#documentImportPanel');
+  await page.locator('#documentImportPanel p').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const spacing = await page.evaluate(() => {
+    const sample = document.querySelector('#documentImportPanel p');
+    if (!sample) throw new Error('Text-spacing sample paragraph is unavailable');
+    const style = getComputedStyle(sample);
+    const fontSize = Number.parseFloat(style.fontSize);
+    return {
+      fontSize,
+      lineHeight: Number.parseFloat(style.lineHeight),
+      letterSpacing: Number.parseFloat(style.letterSpacing),
+      wordSpacing: Number.parseFloat(style.wordSpacing),
+      marginBottom: Number.parseFloat(style.marginBottom),
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth
+    };
+  });
+  assert(spacing.lineHeight / spacing.fontSize >= 1.49,
+    `Line spacing is below 1.5: ${JSON.stringify(spacing)}`);
+  assert(spacing.letterSpacing / spacing.fontSize >= 0.119,
+    `Letter spacing is below 0.12em: ${JSON.stringify(spacing)}`);
+  assert(spacing.wordSpacing / spacing.fontSize >= 0.159,
+    `Word spacing is below 0.16em: ${JSON.stringify(spacing)}`);
+  assert(spacing.marginBottom / spacing.fontSize >= 1.99,
+    `Paragraph spacing is below 2em: ${JSON.stringify(spacing)}`);
+  assert(spacing.scrollWidth <= spacing.clientWidth + 2,
+    `Text spacing introduced horizontal scrolling: ${JSON.stringify(spacing)}`);
+  checks.push('WCAG text spacing and reflow');
+  await runAxe('text-spacing', '#tab-analyze');
+  await screenshot('text-spacing', '#documentImportPanel');
+}
+
+async function testWorkspaceOffline() {
+  await page.route('**/api/workspace/sync-state', route => route.abort('internetdisconnected'));
+  await navigateToPage(page, 'versions');
+  await page.locator('#versionsSubTabs [data-versions-tab="sync"]').click();
+  await page.locator('#versions-sync').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.evaluate(() => window.TaxonomySyncOfflineGuard.refresh().catch(() => undefined));
+  const offlineStatus = page.locator('#syncStatePanel [role="status"]');
+  await offlineStatus.waitFor({ state: 'visible', timeout: 15_000 });
+  const offlineText = (await offlineStatus.textContent()).trim();
+  assert(offlineText.length > 0, 'Offline sync status has no accessible text');
+  checks.push('workspace offline status and retry guidance');
+  await runAxe('workspace-offline', '#versions-sync');
+  await screenshot('workspace-offline', '#versions-sync');
+}
 
 await mkdir(outputDir, { recursive: true });
 
-const reason = [
-  'Temporarily quarantined to integrate PR #792.',
-  'The scenario currently relies on shared DOM status text and transport-specific',
-  'timing instead of an operation-scoped server state and client event contract.',
-  'Restore and repair immediately on main; do not treat this as passing evidence.'
-].join(' ');
+try {
+  ({ browser, context, page } = await openRoleSession({
+    baseUrl,
+    role: 'ADMIN',
+    browserName: 'chromium',
+    viewport: { width: 1024, height: 768 },
+    adminUsername: 'admin',
+    adminPassword: ROLE_ACCOUNTS.ADMIN.password
+  }));
 
-const report = {
-  checks: [],
-  findings: [],
-  auditError: null,
-  quarantined: true,
-  reason,
-  skippedChecks: [
-    'partial analysis status, warning detail, and live announcement',
-    'WCAG text spacing and reflow',
-    'workspace offline status and retry guidance'
-  ]
-};
+  await testPartialAnalysis();
+  await testTextSpacing();
+  await testWorkspaceOffline();
+} catch (error) {
+  auditError = error?.stack || String(error);
+  process.exitCode = 1;
+} finally {
+  const report = { checks, findings, auditError };
+  await writeFile(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  if (auditError) console.error(auditError);
+  if (context) await context.close().catch(() => undefined);
+  if (browser) await browser.close().catch(() => undefined);
+}
 
-await writeFile(
-  path.join(outputDir, 'report.json'),
-  `${JSON.stringify(report, null, 2)}\n`,
-  'utf8');
-
-console.warn(`Special modes acceptance quarantined: ${reason}`);
+if (auditError) throw new Error(auditError);
+console.log(`Special modes acceptance passed: ${checks.join(', ')}`);

--- a/.github/scripts/ui-special-modes-acceptance.mjs
+++ b/.github/scripts/ui-special-modes-acceptance.mjs
@@ -28,11 +28,36 @@ function isAnalyzeResponseForText(response, expectedText) {
   }
 }
 
-async function waitForTaxonomyReady() {
+async function waitForTaxonomyReady(timeout = 180_000) {
+  try {
+    await page.waitForFunction(async () => {
+      try {
+        const response = await fetch('/api/status/startup', {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' }
+        });
+        if (!response.ok) return false;
+        const status = await response.json();
+        window.__taxonomyStartupStatus = status;
+        return status?.initialized === true;
+      } catch (error) {
+        window.__taxonomyStartupStatus = { error: String(error) };
+        return false;
+      }
+    }, null, { timeout, polling: 1_000 });
+  } catch (error) {
+    const status = await page.evaluate(() => window.__taxonomyStartupStatus || null);
+    throw new Error(
+      `Taxonomy server did not become ready: ${JSON.stringify(status)}`,
+      { cause: error }
+    );
+  }
+
+  await page.locator('#analyzeBtn').waitFor({ state: 'visible', timeout: 30_000 });
   await page.waitForFunction(() => {
-    const state = window.TaxonomyState;
-    return Array.isArray(state?.taxonomyData) && state.taxonomyData.length > 0;
-  }, null, { timeout: 60_000 });
+    const button = document.querySelector('#analyzeBtn');
+    return Boolean(button) && button.disabled === false;
+  }, null, { timeout: 30_000 });
 }
 
 async function selectSynchronousAnalysisView() {

--- a/.github/scripts/ui-special-modes-acceptance.mjs
+++ b/.github/scripts/ui-special-modes-acceptance.mjs
@@ -89,7 +89,7 @@ async function submitAnalysisAndWaitForPublishedState(
 async function openDetails(selector) {
   const details = page.locator(selector);
   await details.waitFor({ state: 'attached', timeout: 20_000 });
-  if (!(await details.getAttribute('open'))) {
+  if ((await details.getAttribute('open')) === null) {
     const summary = details.locator(':scope > summary');
     await summary.scrollIntoViewIfNeeded();
     await summary.click();

--- a/.github/scripts/ui-special-modes-acceptance.mjs
+++ b/.github/scripts/ui-special-modes-acceptance.mjs
@@ -146,56 +146,86 @@ async function screenshot(state, selector) {
 }
 
 async function testPartialAnalysis() {
-  await navigateToPage(page, 'analyze');
-  await waitForTaxonomyReady();
-  const interactive = page.locator('#interactiveMode');
-  if (await interactive.isChecked()) await interactive.uncheck();
-
-  // List and tabs intentionally use SSE. This scenario validates the synchronous
-  // POST response and then replaces exactly one POST with a PARTIAL response, so
-  // select a non-streaming view explicitly rather than relying on UI timing.
-  await selectSynchronousAnalysisView();
-
-  const successfulText = 'Provide traceable and resilient hospital communication services.';
-  await page.locator('#businessText').fill(successfulText);
-  const fixture = await submitAnalysisAndWaitForPublishedState(successfulText, 'SUCCESS');
-
-  await page.route('**/api/analyze', async route => {
+  const partialMarker = 'PARTIAL_FIXTURE_803';
+  const stableAiStatus = async route => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        status: 'PARTIAL',
-        errorMessage: 'One provider branch was unavailable',
-        warnings: ['Some architecture branches were not evaluated.'],
-        tree: fixture.tree,
-        scores: fixture.scores,
-        discrepancies: [],
-        provisionalRelations: []
+        level: 'FULL',
+        available: true,
+        limited: false,
+        provider: 'TEST',
+        availableProviders: ['TEST']
       })
     });
-  }, { times: 1 });
+  };
+  await page.route('**/api/ai-status', stableAiStatus);
 
-  const partialText = 'Provide traceable hospital communication services with a partial provider result.';
-  await page.locator('#businessText').fill(partialText);
-  await submitAnalysisAndWaitForPublishedState(partialText, 'PARTIAL', 30_000);
+  try {
+    await navigateToPage(page, 'analyze');
+    await waitForTaxonomyReady();
+    const interactive = page.locator('#interactiveMode');
+    if (await interactive.isChecked()) await interactive.uncheck();
 
-  const statusHandle = await page.waitForFunction(() => {
-    const text = (document.querySelector('#statusArea')?.textContent || '').trim();
-    const normalized = text.toLowerCase();
-    return text && (normalized.includes('unavailable')
-      || normalized.includes('incomplete')
-      || normalized.includes('partial')) ? text : false;
-  }, null, { timeout: 30_000 });
-  const statusText = await statusHandle.jsonValue();
-  assert(typeof statusText === 'string' && statusText.length > 0, 'Partial analysis status is empty');
-  await page.waitForFunction(() => {
-    const text = (document.querySelector('#a11yStatus')?.textContent || '').trim().toLowerCase();
-    return text.includes('unavailable') || text.includes('incomplete') || text.includes('partial');
-  }, null, { timeout: 10_000 });
-  checks.push('partial analysis status, warning detail, and live announcement');
-  await runAxe('analysis-partial', '#tab-analyze');
-  await screenshot('analysis-partial', '#tab-analyze');
+    // List and tabs intentionally use SSE. This scenario validates the synchronous
+    // POST response and then replaces exactly one POST with a PARTIAL response, so
+    // select a non-streaming view explicitly rather than relying on UI timing.
+    await selectSynchronousAnalysisView();
+
+    const successfulText = 'Provide traceable and resilient hospital communication services.';
+    await page.locator('#businessText').fill(successfulText);
+    const fixture = await submitAnalysisAndWaitForPublishedState(successfulText, 'SUCCESS');
+
+    await page.route('**/api/analyze', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'PARTIAL',
+          errorMessage: partialMarker,
+          warnings: [`${partialMarker}: Some architecture branches were not evaluated.`],
+          tree: fixture.tree,
+          scores: fixture.scores,
+          discrepancies: [],
+          provisionalRelations: []
+        })
+      });
+    }, { times: 1 });
+
+    const partialText = 'Provide traceable hospital communication services with a partial provider result.';
+    await page.locator('#businessText').fill(partialText);
+
+    // The editor deliberately debounces its stale-result warning. Let that
+    // input-owned status settle before starting the new analysis, otherwise its
+    // pending callback can clear a correctly published PARTIAL result afterward.
+    await page.waitForFunction(() =>
+      document.querySelector('#businessText')?.classList.contains('stale-results'),
+    null, { timeout: 5_000 });
+
+    const [statusHandle] = await Promise.all([
+      page.waitForFunction(marker => {
+        const warningText = (
+          document.querySelector('#statusArea .alert-warning')?.textContent || ''
+        ).trim();
+        const liveText = (document.querySelector('#a11yStatus')?.textContent || '').trim();
+        return warningText.includes(marker) && liveText.includes(marker)
+          ? { warningText, liveText }
+          : false;
+      }, partialMarker, { timeout: 30_000 }),
+      submitAnalysisAndWaitForPublishedState(partialText, 'PARTIAL', 30_000)
+    ]);
+    const partialUi = await statusHandle.jsonValue();
+    assert(partialUi?.warningText?.includes(partialMarker),
+      'Partial analysis warning was not published in the visible status area');
+    assert(partialUi?.liveText?.includes(partialMarker),
+      'Partial analysis warning was not announced in the accessibility live region');
+    checks.push('partial analysis status, warning detail, and live announcement');
+    await runAxe('analysis-partial', '#tab-analyze');
+    await screenshot('analysis-partial', '#tab-analyze');
+  } finally {
+    await page.unroute('**/api/ai-status', stableAiStatus).catch(() => undefined);
+  }
 }
 
 async function testTextSpacing() {

--- a/taxonomy-app/src/main/resources/static/js/versioning/taxonomy-viewcontext.js
+++ b/taxonomy-app/src/main/resources/static/js/versioning/taxonomy-viewcontext.js
@@ -34,15 +34,18 @@ window.TaxonomyViewContext = (function () {
 
         parts.push(
             '<span class="vc-commit">' + escapeHtml(t('context.based.on')) + ' <strong>' + branch +
-            '</strong> @ <code>' + sha + '</code>' +
+            '</strong> @ <code class="text-danger-emphasis">' + sha + '</code>' +
             (ts ? ' <small class="text-muted">(' + ts + ')</small>' : '') +
             '</span>'
         );
 
-        // Provisional relations warning
+        // Provisional relations warning. Bootstrap's emphasis utility adapts to
+        // light and dark themes and meets normal-text contrast requirements;
+        // the base warning yellow is intended for filled surfaces, not text.
         if (viewContext.includesProvisionalRelations) {
             parts.push(
-                '<span class="vc-warning">' + escapeHtml(t('context.provisional.warning')) + '</span>'
+                '<span class="vc-warning text-warning-emphasis">' +
+                escapeHtml(t('context.provisional.warning')) + '</span>'
             );
         }
 

--- a/taxonomy-build/pom.xml
+++ b/taxonomy-build/pom.xml
@@ -163,6 +163,23 @@
 
     <profiles>
         <profile>
+            <id>github-actions-playwright-runtime</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <!-- GitHub's Ubuntu runner image already provides browser runtime
+                     libraries and Xvfb. Re-running Playwright's apt installation
+                     makes the canonical build depend on mutable package mirrors
+                     and previously exhausted the two-hour job limit. Browser
+                     binaries remain installed and pinned by package-lock.json. -->
+                <taxonomy.playwright.install.arguments>exec -- playwright install chromium firefox webkit</taxonomy.playwright.install.arguments>
+            </properties>
+        </profile>
+        <profile>
             <id>supply-chain-policy</id>
             <build>
                 <plugins>

--- a/taxonomy-build/pom.xml
+++ b/taxonomy-build/pom.xml
@@ -171,12 +171,13 @@
                 </property>
             </activation>
             <properties>
-                <!-- GitHub's Ubuntu runner image already provides browser runtime
-                     libraries and Xvfb. Re-running Playwright's apt installation
-                     makes the canonical build depend on mutable package mirrors
-                     and previously exhausted the two-hour job limit. Browser
-                     binaries remain installed and pinned by package-lock.json. -->
-                <taxonomy.playwright.install.arguments>exec -- playwright install chromium firefox webkit</taxonomy.playwright.install.arguments>
+                <!-- GitHub's runner contains the Chromium and Firefox runtime,
+                     but the verified WebKit launch proves that its GTK/GStreamer
+                     libraries are incomplete. Install only WebKit's required OS
+                     packages, then fetch all browser binaries from the pinned
+                     package-lock dependency instead of reinstalling every browser's
+                     OS dependency set. -->
+                <taxonomy.playwright.install.arguments>run install:playwright:github</taxonomy.playwright.install.arguments>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## Purpose

Restore the `special-modes` browser acceptance scenario that was narrowly quarantined for the #792/#799 integration, while making the browser-runtime setup deterministic enough for the complete Chromium, Firefox, and WebKit matrix.

## Restored browser contract

- selects the non-streaming Sunburst view so Analyze deliberately uses `POST /api/analyze` rather than the list/tabs SSE path;
- correlates each response with the exact submitted `businessText` instead of shared status text;
- validates HTTP success, the expected `SUCCESS`/`PARTIAL` state, a reusable tree and positive scores directly from that response;
- waits for the real browser publication contract: enabled Analyze button, hidden spinner, matching `lastAnalyzedText`, tree and scores;
- restores the PARTIAL warning, accessible live-region, Axe, text-spacing and offline assertions.

## Browser-race corrections

- `openDetails()` tests the boolean `open` attribute explicitly; an already-open `<details>` element is not clicked closed;
- startup waits on the authenticated `/api/status/startup` authority rather than a not-yet-populated browser array;
- the PARTIAL fixture uses a unique marker and starts its visible-status and live-region waits before the response is submitted;
- the stale-input debounce is allowed to settle before analysis, and the unrelated periodic `/api/ai-status` writer is isolated for this scenario only.

## CI runtime correction

The first attempt to avoid Playwright's broad `--with-deps` installation removed too much: the GitHub runner could launch Chromium and Firefox, but WebKit proved that GTK 4, GStreamer, Graphene, Flite, Opus and related runtime libraries were still absent.

GitHub CI now uses the pinned Playwright package to install **only WebKit's required OS dependencies and WebKit binary**, then installs the Chromium and Firefox binaries without repeating their OS dependency setup:

```text
playwright install --with-deps webkit
playwright install chromium firefox
```

The installer configures bounded apt retries, HTTP timeouts, a dpkg lock timeout, and a 20-minute process boundary. This preserves all three browser profiles without allowing a mutable Ubuntu mirror to consume the complete job.

## Accessibility correction from restored evidence

Once the browser matrix completed, the restored PARTIAL-state audit exposed two real WCAG 2.1 AA contrast defects in the view-context bar:

- the abbreviated commit hash inherited Bootstrap's low-contrast inline-code colour;
- the provisional-relations warning used warning yellow as text on a light surface.

The renderer now uses Bootstrap's theme-aware `text-danger-emphasis` and `text-warning-emphasis` utilities. These retain the semantic distinction while adapting to light and dark themes and meeting normal-text contrast requirements. The Axe assertion remains strict; no rule or severity was suppressed.

## Scope

Changed files:

- `.github/scripts/ui-special-modes-acceptance.mjs`;
- `.github/scripts/install-playwright-github.sh`;
- `.github/package.json`;
- `taxonomy-app/src/main/resources/static/js/versioning/taxonomy-viewcontext.js`;
- `taxonomy-build/pom.xml`.

The branch is merged with the current protected `main` and is not behind it. No release request, version, tag, package, image or deployment is changed. Merge remains subject to the exact-head checks.