### PR TITLE
Route productive SBOM companion generation through Java

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 : "${RELEASE_VERSION:?RELEASE_VERSION is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${TOOLING_JAR:?TOOLING_JAR is required}"
-: "${VEX_HELPER:?VEX_HELPER is required}"
 : "${RELEASE_NOTES_VALIDATOR:?RELEASE_NOTES_VALIDATOR is required}"
 
 NEXT_VERSION_INPUT=${NEXT_VERSION_INPUT:-}
@@ -312,7 +311,9 @@ if [[ "$SKIP_TESTS" == "true" ]]; then
 else
   run_maven_release_check release release-check,ci clean verify
 fi
-python3 "$VEX_HELPER"
+java -jar "$TOOLING_JAR" generate-sbom-companion \
+  --sbom target/taxonomy-sbom.json \
+  --output target/taxonomy-vex.json
 collect_release_artifacts
 
 PUBLISHED_THIS_RUN=false

--- a/taxonomy-build/pom.xml
+++ b/taxonomy-build/pom.xml
@@ -146,9 +146,11 @@
                         <configuration>
                             <skip>${taxonomy.quality.skip}</skip>
                             <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-                            <executable>python3</executable>
+                            <executable>java</executable>
                             <arguments>
-                                <argument>.github/scripts/generate-vex.py</argument>
+                                <argument>-jar</argument>
+                                <argument>${maven.multiModuleProjectDirectory}/taxonomy-tooling/target/taxonomy-tooling-${project.version}.jar</argument>
+                                <argument>generate-sbom-companion</argument>
                                 <argument>--sbom</argument><argument>target/taxonomy-sbom.json</argument>
                                 <argument>--output</argument><argument>target/taxonomy-vex.json</argument>
                             </arguments>

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionArtifactOrderRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionArtifactOrderRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SbomCompanionArtifactOrderRepositoryTest {
+
+    @Test
+    void generationRunsInMavenVerifyAndBeforeReleaseArtifactCollection()
+            throws Exception {
+        Path root = findRepositoryRoot();
+        String buildPom = Files.readString(
+                root.resolve("taxonomy-build/pom.xml"),
+                StandardCharsets.UTF_8);
+        String releaseScript = Files.readString(
+                root.resolve(".github/scripts/release.sh"),
+                StandardCharsets.UTF_8);
+
+        int execution = buildPom.indexOf("<id>generate-sbom-companion</id>");
+        int verifyPhase = buildPom.indexOf("<phase>verify</phase>", execution);
+        int javaCommand = buildPom.indexOf(
+                "<argument>generate-sbom-companion</argument>", execution);
+        assertThat(execution).isGreaterThanOrEqualTo(0);
+        assertThat(verifyPhase).isGreaterThan(execution);
+        assertThat(javaCommand).isGreaterThan(verifyPhase);
+
+        int releaseGeneration = releaseScript.indexOf(
+                "java -jar \"$TOOLING_JAR\" generate-sbom-companion");
+        int artifactCollection = releaseScript.indexOf(
+                "collect_release_artifacts", releaseGeneration);
+        assertThat(releaseGeneration).isGreaterThanOrEqualTo(0);
+        assertThat(artifactCollection).isGreaterThan(releaseGeneration);
+        assertThat(releaseScript)
+                .contains("--sbom target/taxonomy-sbom.json")
+                .contains("--output target/taxonomy-vex.json");
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            "taxonomy-tooling/pom.xml"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionProductiveRoutingRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionProductiveRoutingRepositoryTest.java
@@ -33,7 +33,9 @@ class SbomCompanionProductiveRoutingRepositoryTest {
                 .contains("java -jar \"$TOOLING_JAR\" generate-sbom-companion")
                 .contains("--sbom target/taxonomy-sbom.json")
                 .contains("--output target/taxonomy-vex.json")
-                .doesNotContain("python3 \"$VEX_HELPER\"");
+                .doesNotContain("generate-vex.py")
+                .doesNotContain("VEX_HELPER")
+                .doesNotContain("python3");
     }
 
     private static Path findRepositoryRoot() {

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionProductiveRoutingRepositoryTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/SbomCompanionProductiveRoutingRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SbomCompanionProductiveRoutingRepositoryTest {
+
+    @Test
+    void productiveMavenAndReleasePathsUseJavaInsteadOfPython() throws Exception {
+        Path root = findRepositoryRoot();
+        String buildPom = Files.readString(
+                root.resolve("taxonomy-build/pom.xml"),
+                StandardCharsets.UTF_8);
+        String releaseScript = Files.readString(
+                root.resolve(".github/scripts/release.sh"),
+                StandardCharsets.UTF_8);
+
+        assertThat(buildPom)
+                .contains("<id>generate-sbom-companion</id>")
+                .contains("<executable>java</executable>")
+                .contains("taxonomy-tooling-${project.version}.jar")
+                .contains("<argument>generate-sbom-companion</argument>")
+                .contains("target/taxonomy-sbom.json")
+                .contains("target/taxonomy-vex.json")
+                .doesNotContain("generate-vex.py")
+                .doesNotContain("<executable>python3</executable>");
+        assertThat(releaseScript)
+                .contains("java -jar \"$TOOLING_JAR\" generate-sbom-companion")
+                .contains("--sbom target/taxonomy-sbom.json")
+                .contains("--output target/taxonomy-vex.json")
+                .doesNotContain("python3 \"$VEX_HELPER\"");
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isRegularFile(current.resolve(
+                            "taxonomy-tooling/pom.xml"))
+                    && Files.isRegularFile(current.resolve("CITATION.cff"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}


### PR DESCRIPTION
## Purpose

Reconstruct the real four-file delta from the former stacked PR #800 directly on the merged #799 `main`, without carrying obsolete integration history.

## Productive routing

- `taxonomy-build` invokes `taxonomy-tooling.jar generate-sbom-companion` during Maven `verify`;
- `.github/scripts/release.sh` invokes the same immutable Java tooling JAR after canonical verification and before artifact collection;
- both retain `target/taxonomy-sbom.json` as input and `target/taxonomy-vex.json` as output;
- the productive release path no longer requires or executes `VEX_HELPER`/Python.

## Regression protection

- `SbomCompanionArtifactOrderRepositoryTest` proves Maven phase placement and generation-before-collection ordering;
- `SbomCompanionProductiveRoutingRepositoryTest` proves both productive callers use Java and cannot regress to Python.

## Review correction

Commit `5a5dffd2e0c22eae3732d3b1da6c3e22f0f44953` strengthens the release-path contract: `.github/scripts/release.sh` may contain neither `generate-vex.py`, `VEX_HELPER`, nor `python3`, regardless of invocation spelling. The review thread is resolved.

## Exact scope

- base: `77509c2de7862dd224a1171117ae6899e7113f5e`;
- head: `5a5dffd2e0c22eae3732d3b1da6c3e22f0f44953`;
- two commits;
- exactly four files changed.

The `main` blobs of `.github/scripts/release.sh` and `taxonomy-build/pom.xml` were byte-identical to the original #800 parent for these files when reconstructed, so this preserves the reviewed delta rather than overwriting later work.

## Boundary

This does not yet delete the now-unused Python helper or remove every non-productive workflow reference; those remain subsequent #673 cleanup. No release request, version, tag, package, image or deployment is created. Auto-merge remains subject to the exact-head protected checks.