### PR TITLE
Add operation identity to analysis transport envelopes

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/analysis/controller/AnalysisApiController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/analysis/controller/AnalysisApiController.java
@@ -42,9 +42,12 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * HTTP/SSE transport adapter for requirement analysis. Business orchestration is
@@ -54,6 +57,8 @@ import java.util.concurrent.ExecutorService;
 @RequestMapping("/api")
 @Tag(name = "Analysis")
 public class AnalysisApiController {
+
+    static final String ANALYSIS_OPERATION_ID_HEADER = "X-Analysis-Operation-Id";
 
     private static final Logger log = LoggerFactory.getLogger(AnalysisApiController.class);
 
@@ -106,6 +111,8 @@ public class AnalysisApiController {
                 || request.getBusinessText().isBlank()) {
             return ResponseEntity.badRequest().build();
         }
+
+        String operationId = newOperationId();
         try {
             String username = workspaceResolver.resolveCurrentUsername();
             AnalyzeRequirementResult result = analyzeRequirementUseCase.analyze(
@@ -116,11 +123,15 @@ public class AnalysisApiController {
                             request.getProvider(),
                             username,
                             resolveWorkspaceContext(username)));
-            return ResponseEntity.ok(result.analysisResult());
+            return ResponseEntity.ok()
+                    .header(ANALYSIS_OPERATION_ID_HEADER, operationId)
+                    .body(result.analysisResult());
         } catch (UnknownAnalysisProviderException e) {
             @SuppressWarnings("unchecked")
             ResponseEntity<AnalysisResult> badProvider = (ResponseEntity<AnalysisResult>)
-                    (ResponseEntity<?>) ResponseEntity.badRequest().body(Map.of(
+                    (ResponseEntity<?>) ResponseEntity.badRequest()
+                    .header(ANALYSIS_OPERATION_ID_HEADER, operationId)
+                    .body(Map.of(
                             "error", "Unknown provider: " + e.getProvider(),
                             "validProviders", e.getValidProviders()));
             return badProvider;
@@ -128,7 +139,7 @@ public class AnalysisApiController {
     }
 
     @Operation(summary = "Streaming analysis (SSE)",
-            description = "Emits phase, scores, expanding, complete, and error events as the taxonomy is processed.",
+            description = "Emits phase, scores, expanding, complete, and error events as the taxonomy is processed. Every event carries one operation ID and a monotonic sequence.",
             tags = {"Analysis"})
     @GetMapping(value = "/analyze-stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter analyzeStream(
@@ -137,9 +148,11 @@ public class AnalysisApiController {
             @Parameter(description = "LLM provider override")
             @RequestParam(required = false) String provider) {
         SseEmitter emitter = new SseEmitter(120_000L);
+        String operationId = newOperationId();
+        AtomicLong eventSequence = new AtomicLong();
 
         if (!taxonomyService.isInitialized()) {
-            sendEvent(emitter, "error", Map.of(
+            sendEvent(emitter, operationId, eventSequence.incrementAndGet(), "error", Map.of(
                     "status", "ERROR",
                     "errorMessage", messageSource.getMessage(
                             "error.loading", null,
@@ -150,7 +163,7 @@ public class AnalysisApiController {
             return emitter;
         }
         if (businessText == null || businessText.isBlank()) {
-            sendEvent(emitter, "error", Map.of(
+            sendEvent(emitter, operationId, eventSequence.incrementAndGet(), "error", Map.of(
                     "status", "ERROR",
                     "errorMessage", "businessText must not be blank"));
             emitter.complete();
@@ -163,20 +176,24 @@ public class AnalysisApiController {
             try {
                 streamRequirementAnalysisUseCase.stream(command, event -> {
                     AnalysisSseEventMapper.MappedEvent mapped = analysisSseEventMapper.map(event);
-                    sendEvent(emitter, mapped.name(), mapped.payload());
+                    sendEvent(emitter, operationId, eventSequence.incrementAndGet(),
+                            mapped.name(), mapped.payload());
                     if (event instanceof AnalysisStreamEvent.Complete
                             || event instanceof AnalysisStreamEvent.Error) {
                         emitter.complete();
                     }
                 });
             } catch (UnknownAnalysisProviderException e) {
-                sendEvent(emitter, "error", Map.of(
+                sendEvent(emitter, operationId, eventSequence.incrementAndGet(), "error", Map.of(
                         "status", "ERROR",
                         "errorMessage", "Unknown provider: " + e.getProvider()));
                 emitter.complete();
             } catch (Exception e) {
                 log.error("Streaming analysis failed", e);
-                emitter.completeWithError(e);
+                sendEvent(emitter, operationId, eventSequence.incrementAndGet(), "error", Map.of(
+                        "status", "ERROR",
+                        "errorMessage", "Analysis failed. Retry the operation or inspect administrator diagnostics."));
+                emitter.complete();
             }
         });
         return emitter;
@@ -239,16 +256,34 @@ public class AnalysisApiController {
         }
     }
 
-    private void sendEvent(SseEmitter emitter, String eventName, Object data) {
+    private void sendEvent(SseEmitter emitter,
+                           String operationId,
+                           long sequence,
+                           String eventName,
+                           Object data) {
         try {
+            Map<String, Object> envelope = new LinkedHashMap<>();
+            envelope.put("operationId", operationId);
+            envelope.put("sequence", sequence);
+            envelope.put("emittedAt", Instant.now().toString());
+            if (data instanceof Map<?, ?> dataMap) {
+                dataMap.forEach((key, value) -> envelope.put(String.valueOf(key), value));
+            } else {
+                envelope.put("data", data);
+            }
             emitter.send(SseEmitter.event()
+                    .id(operationId + ":" + sequence)
                     .name(eventName)
-                    .data(objectMapper.writeValueAsString(data)));
+                    .data(objectMapper.writeValueAsString(envelope)));
         } catch (IOException e) {
             emitter.complete();
         } catch (Exception e) {
             emitter.completeWithError(e);
         }
+    }
+
+    private String newOperationId() {
+        return UUID.randomUUID().toString();
     }
 
     private WorkspaceContext resolveWorkspaceContext(String username) {

--- a/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
@@ -314,6 +314,25 @@ class AnalysisApiControllerTest {
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("Unknown provider: nope")));
     }
 
+    @Test
+    void analyzeStreamMapsUnexpectedFailureToBoundedErrorEvent() throws Exception {
+        doAnswer(invocation -> {
+            throw new IllegalStateException("sensitive provider diagnostics");
+        }).when(streamRequirementAnalysisUseCase).stream(any(), any());
+
+        mockMvc.perform(get("/api/analyze-stream")
+                        .param("businessText", "Need secure voice comms")
+                        .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("event:error")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"operationId\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"sequence\":1")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "Analysis failed. Retry the operation or inspect administrator diagnostics.")))
+                .andExpect(content().string(org.hamcrest.Matchers.not(
+                        org.hamcrest.Matchers.containsString("sensitive provider diagnostics"))));
+    }
+
     private void assertValidOperationId(ResponseEntity<?> response) {
         String operationId = response.getHeaders()
                 .getFirst(AnalysisApiController.ANALYSIS_OPERATION_ID_HEADER);

--- a/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
@@ -1,6 +1,7 @@
 package com.taxonomy.analysis.controller;
 
 import com.taxonomy.analysis.usecase.AnalysisStreamEvent;
+import com.taxonomy.analysis.usecase.AnalysisStreamEventHandler;
 import com.taxonomy.analysis.usecase.AnalyzeNodeChildrenResult;
 import com.taxonomy.analysis.usecase.AnalyzeNodeChildrenUseCase;
 import com.taxonomy.analysis.usecase.AnalyzeRequirementResult;
@@ -38,7 +39,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
-import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -240,13 +240,12 @@ class AnalysisApiControllerTest {
         detail.setDurationMs(42L);
 
         doAnswer(invocation -> {
-            @SuppressWarnings("unchecked")
-            Consumer<AnalysisStreamEvent> handler = invocation.getArgument(1);
-            handler.accept(new AnalysisStreamEvent.Phase("Working", 12));
-            handler.accept(new AnalysisStreamEvent.Scores(
+            AnalysisStreamEventHandler handler = invocation.getArgument(1);
+            handler.handle(new AnalysisStreamEvent.Phase("Working", 12));
+            handler.handle(new AnalysisStreamEvent.Scores(
                     Map.of("CP", 80), Map.of("CP", "reason"),
                     "Capabilities scored 80/100", detail));
-            handler.accept(new AnalysisStreamEvent.Complete(
+            handler.handle(new AnalysisStreamEvent.Complete(
                     "SUCCESS", Map.of("CP", 80), List.of(), List.of()));
             return null;
         }).when(streamRequirementAnalysisUseCase).stream(any(), any());
@@ -270,10 +269,9 @@ class AnalysisApiControllerTest {
     @Test
     void analyzeStreamEmitsOneOperationAndMonotonicSequences() throws Exception {
         doAnswer(invocation -> {
-            @SuppressWarnings("unchecked")
-            Consumer<AnalysisStreamEvent> handler = invocation.getArgument(1);
-            handler.accept(new AnalysisStreamEvent.Phase("Working", 12));
-            handler.accept(new AnalysisStreamEvent.Complete(
+            AnalysisStreamEventHandler handler = invocation.getArgument(1);
+            handler.handle(new AnalysisStreamEvent.Phase("Working", 12));
+            handler.handle(new AnalysisStreamEvent.Complete(
                     "SUCCESS", Map.of("CP", 80), List.of(), List.of()));
             return null;
         }).when(streamRequirementAnalysisUseCase).stream(any(), any());

--- a/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/analysis/controller/AnalysisApiControllerTest.java
@@ -35,11 +35,13 @@ import tools.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
@@ -121,6 +123,7 @@ class AnalysisApiControllerTest {
         ResponseEntity<AnalysisResult> response = controller.analyze(request);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isSameAs(analysisResult);
+        assertValidOperationId(response);
 
         ArgumentCaptor<com.taxonomy.analysis.usecase.AnalyzeRequirementCommand> captor =
                 ArgumentCaptor.forClass(com.taxonomy.analysis.usecase.AnalyzeRequirementCommand.class);
@@ -140,6 +143,7 @@ class AnalysisApiControllerTest {
 
         ResponseEntity<AnalysisResult> response = controller.analyze(request);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertValidOperationId(response);
         Map<?, ?> body = (Map<?, ?>) (Object) response.getBody();
         assertThat(body.get("error")).isEqualTo("Unknown provider: nope");
     }
@@ -219,6 +223,9 @@ class AnalysisApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM_VALUE))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("event:error")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("id:")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"operationId\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"sequence\":1")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
                         "businessText must not be blank")));
         verifyNoInteractions(streamRequirementAnalysisUseCase);
@@ -261,6 +268,38 @@ class AnalysisApiControllerTest {
     }
 
     @Test
+    void analyzeStreamEmitsOneOperationAndMonotonicSequences() throws Exception {
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Consumer<AnalysisStreamEvent> handler = invocation.getArgument(1);
+            handler.accept(new AnalysisStreamEvent.Phase("Working", 12));
+            handler.accept(new AnalysisStreamEvent.Complete(
+                    "SUCCESS", Map.of("CP", 80), List.of(), List.of()));
+            return null;
+        }).when(streamRequirementAnalysisUseCase).stream(any(), any());
+
+        String response = mockMvc.perform(get("/api/analyze-stream")
+                        .param("businessText", "Need secure voice comms")
+                        .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"sequence\":1")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"sequence\":2")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"emittedAt\"")))
+                .andReturn().getResponse().getContentAsString();
+
+        java.util.regex.Matcher matcher = java.util.regex.Pattern
+                .compile("\\\"operationId\\\":\\\"([0-9a-f-]{36})\\\"")
+                .matcher(response);
+        assertThat(matcher.find()).isTrue();
+        String operationId = matcher.group(1);
+        assertThatCode(() -> UUID.fromString(operationId)).doesNotThrowAnyException();
+        assertThat(response).contains("id:" + operationId + ":1");
+        assertThat(response).contains("id:" + operationId + ":2");
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo(operationId);
+    }
+
+    @Test
     void analyzeStreamMapsUnknownProviderToErrorEvent() throws Exception {
         doAnswer(invocation -> {
             throw new UnknownAnalysisProviderException("nope");
@@ -272,6 +311,15 @@ class AnalysisApiControllerTest {
                         .accept(MediaType.TEXT_EVENT_STREAM_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("event:error")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"operationId\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"sequence\":1")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString("Unknown provider: nope")));
+    }
+
+    private void assertValidOperationId(ResponseEntity<?> response) {
+        String operationId = response.getHeaders()
+                .getFirst(AnalysisApiController.ANALYSIS_OPERATION_ID_HEADER);
+        assertThat(operationId).isNotBlank();
+        assertThatCode(() -> UUID.fromString(operationId)).doesNotThrowAnyException();
     }
 }


### PR DESCRIPTION
## Parent

First implementation slice of #805, itself a concrete child of #621.

## Delivered in this slice

- every successful synchronous `POST /api/analyze` response exposes a server-generated UUID in `X-Analysis-Operation-Id`;
- backward-compatible unknown-provider responses expose the same correlation header;
- every `/api/analyze-stream` event carries one shared `operationId`, a strictly increasing `sequence`, and `emittedAt`;
- each SSE frame also uses `operationId:sequence` as its SSE event ID;
- initialization, validation, provider and unexpected terminal errors use the same envelope;
- unexpected server failures return a bounded terminal error event instead of exposing internal exception text;
- controller tests prove valid UUID headers, one operation identity across a stream and monotonic event sequences.

## CI and review corrections

The first exact-head database matrix exposed a test-only `ClassCastException`: two Mockito answers cast the typed `AnalysisStreamEventHandler` argument to `Consumer<AnalysisStreamEvent>`. Commit `21f7eb5b758ebac300b87521923cefa11c2c341a` invokes the actual handler contract directly in both tests. Productive code and the transport envelope were unchanged.

That corrected head passed CI/CD, PostgreSQL, Oracle, SQL Server, Security and CodeQL. Commit `c45de5a04a5b7644bc59fa7ea5f0782d8751b7c0` then merged protected `main` without rewriting the reviewed commits.

Review identified that the catch-all streaming failure contract still lacked a direct negative test. Commit `d05853555973a616ea6a4e7322c5b5446c9fc25e` now forces a sensitive internal exception and proves that the SSE response contains only the generic bounded error together with `operationId` and `sequence`, never the internal detail. The review thread is resolved.

## Exact scope

- current protected base: `6afa246a7f6c861519fbaa78d607b0f2d529e5b7`;
- exact candidate head: `d05853555973a616ea6a4e7322c5b5446c9fc25e`;
- four commits including one ordinary merge from protected `main`;
- two changed files relative to `main`.

## Deliberate boundary

This is transport identity only. It does **not** yet claim the complete #805 contract:

- no durable status registry or lifecycle endpoint;
- no reconnect/replay storage;
- no cancel/recovery implementation;
- no exact repository/workspace/branch/source-commit status record;
- the browser does not yet reject stale or out-of-order events by these fields.

Those remain subsequent #805 slices after this envelope and #803 acceptance restoration are integrated.

No release request, version, tag, package, image or deployment is changed. Auto-merge remains subject to the exact-head protected checks.