### PR TITLE
Guard analysis draft startup resolution

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -13,9 +13,10 @@
     "test:analysis-operation-controller": "node --test scripts/analysis-operation-controller.test.mjs",
     "test:analysis-session-api-routing": "node scripts/analysis-session-api-routing.test.mjs",
     "test:analysis-session-draft": "node --test scripts/analysis-session-draft.test.mjs",
+    "test:analysis-session-startup": "node --test scripts/analysis-session-startup.test.mjs",
     "test:ui-role-state-isolation": "node --test scripts/ui-role-state-isolation.test.mjs",
     "test:ui-suite-plan": "node --test scripts/ui-suite-plan.test.mjs",
-    "verify:ui": "npm run test:ui-evidence-policy && npm run test:ui-evidence-targets && npm run test:state-render-consistency && npm run test:analysis-operation-controller && npm run test:analysis-session-api-routing && npm run test:analysis-session-draft && npm run test:ui-role-state-isolation && npm run test:ui-suite-plan && node scripts/run-ui-suite.mjs",
+    "verify:ui": "npm run test:ui-evidence-policy && npm run test:ui-evidence-targets && npm run test:state-render-consistency && npm run test:analysis-operation-controller && npm run test:analysis-session-api-routing && npm run test:analysis-session-draft && npm run test:analysis-session-startup && npm run test:ui-role-state-isolation && npm run test:ui-suite-plan && node scripts/run-ui-suite.mjs",
     "test:api-transport": "node scripts/test-taxonomy-api-client.mjs"
   },
   "devDependencies": {

--- a/.github/scripts/analysis-session-startup.test.mjs
+++ b/.github/scripts/analysis-session-startup.test.mjs
@@ -1,0 +1,217 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+
+const sourceRoot = '../../taxonomy-app/src/main/resources/static/js/core/';
+const draftSource = await readFile(
+  new URL(`${sourceRoot}taxonomy-analysis-session-draft.js`, import.meta.url),
+  'utf8'
+);
+const projectsSource = await readFile(
+  new URL(`${sourceRoot}taxonomy-analysis-session-projects.js`, import.meta.url),
+  'utf8'
+);
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createProbeHarness(request) {
+  const runtime = {
+    workspaceId: 'ws-1',
+    version: null,
+    restoring: false,
+    invalidating: false,
+    conflict: false,
+    saveTimer: null
+  };
+  const context = {
+    S: { taxonomyData: [] },
+    runtime,
+    AUTOSAVE_DELAY_MS: 900,
+    MAX_RESTORE_ATTEMPTS: 1,
+    text: key => key,
+    businessTextElement: () => ({ value: '', classList: { add() {} } }),
+    currentPayload: () => ({ businessText: '' }),
+    comparable: value => JSON.stringify(value),
+    meaningful: () => false,
+    draftEndpoint: () => '/api/analysis-drafts/ws-1',
+    jsonRequest: request,
+    hasDerivedAnalysis: () => false,
+    isStale: () => false,
+    showActionAlert() {},
+    showStaleActions() {},
+    openRequirementDialog() {}
+  };
+  const window = {
+    __TaxonomyAnalysisSessionContext: context,
+    TaxonomyBrowse: null,
+    TaxonomyScoring: null,
+    _taxonomyCurrentScores: null,
+    _currentProvisionalRelations: [],
+    console,
+    clearTimeout() {},
+    setTimeout() {
+      return 1;
+    }
+  };
+  const document = {
+    addEventListener() {},
+    dispatchEvent() {},
+    getElementById() {
+      return null;
+    },
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    }
+  };
+
+  vm.runInNewContext(draftSource, {
+    window,
+    document,
+    console,
+    Array,
+    Boolean,
+    CustomEvent: class CustomEvent {},
+    JSON,
+    Object,
+    Promise,
+    Set,
+    String,
+    encodeURIComponent
+  }, { filename: 'taxonomy-analysis-session-draft.js' });
+
+  return { context, runtime };
+}
+
+function createStartupHarness(workspaceResponse) {
+  const pendingStates = [];
+  const runtime = {
+    initialized: false,
+    workspaceId: null,
+    version: null,
+    restoring: false,
+    invalidating: false,
+    conflict: false,
+    draftDecisionPending: false,
+    lastObservedComparable: null
+  };
+  const context = {
+    S: {},
+    runtime,
+    CHANGE_POLL_MS: 1500,
+    language: () => 'en',
+    text: key => key,
+    businessTextElement: () => null,
+    jsonRequest(url, options) {
+      assert.equal(url, '/api/workspace/current');
+      assert.equal(options.method, 'GET');
+      return workspaceResponse;
+    },
+    rememberedWorkspaceId: () => null,
+    rememberWorkspaceId() {},
+    installWorkspaceFetchRouting() {},
+    installWorkspaceEventSourceRouting() {},
+    currentPayload: () => ({ businessText: '' }),
+    comparable: value => JSON.stringify(value),
+    isStale: () => false,
+    statusArea: () => null,
+    showActionAlert() {},
+    invalidate() {},
+    queueStaleActions() {},
+    queueSave() {},
+    deleteDraft: async () => undefined,
+    saveDraft: async () => undefined,
+    loadDraft: async () => null,
+    setDraftDecisionPending(pending) {
+      runtime.draftDecisionPending = pending;
+      pendingStates.push(pending);
+    }
+  };
+  const document = {
+    readyState: 'complete',
+    visibilityState: 'visible',
+    addEventListener() {},
+    getElementById() {
+      return null;
+    }
+  };
+  const window = {
+    __TaxonomyAnalysisSessionContext: context,
+    TaxonomyI18n: null,
+    console,
+    location: { assign() {} },
+    setInterval() {
+      return 1;
+    },
+    addEventListener() {}
+  };
+  class MutationObserver {
+    observe() {}
+  }
+
+  vm.runInNewContext(projectsSource, {
+    window,
+    document,
+    console,
+    Array,
+    Boolean,
+    Date,
+    JSON,
+    Math,
+    MutationObserver,
+    Object,
+    Promise,
+    Set,
+    String,
+    encodeURIComponent
+  }, { filename: 'taxonomy-analysis-session-projects.js' });
+
+  return { runtime, pendingStates };
+}
+
+test('remembered-workspace probe failure keeps the restoration barrier active', async () => {
+  const failure = Object.assign(new Error('Remembered workspace unavailable'), {
+    status: 403
+  });
+  const harness = createProbeHarness(async () => {
+    throw failure;
+  });
+
+  await assert.rejects(
+    harness.context.loadDraft({ probe: true }),
+    /Remembered workspace unavailable/
+  );
+
+  assert.equal(harness.runtime.restoring, true);
+  assert.equal(harness.runtime.draftDecisionPending, true);
+});
+
+test('workspace discovery is guarded before analysis or initial autosave can start', async () => {
+  const workspace = deferred();
+  const harness = createStartupHarness(workspace.promise);
+
+  assert.equal(harness.runtime.initialized, true);
+  assert.equal(harness.runtime.restoring, true);
+  assert.equal(harness.runtime.draftDecisionPending, true);
+
+  workspace.resolve(null);
+  await workspace.promise;
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(harness.runtime.restoring, false);
+  assert.equal(harness.runtime.draftDecisionPending, false);
+  assert.equal(harness.pendingStates.at(0), true);
+  assert.equal(harness.pendingStates.at(-1), false);
+});

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-draft.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-draft.js
@@ -251,9 +251,9 @@
             }
             return view;
         }).catch(function (error) {
+            if (options.probe) throw error;
             runtime.restoring = false;
             setDraftDecisionPending(false);
-            if (options.probe) throw error;
             if (window.console) window.console.warn('[Taxonomy] Draft load failed', error);
             return null;
         });

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-projects.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-projects.js
@@ -25,6 +25,7 @@
     var deleteDraft = C.deleteDraft;
     var saveDraft = C.saveDraft;
     var loadDraft = C.loadDraft;
+    var setDraftDecisionPending = C.setDraftDecisionPending;
 
     function generateProjectKey() {
         var now = new Date();
@@ -327,7 +328,18 @@
         });
     }
 
+    function beginDraftResolution() {
+        runtime.restoring = true;
+        setDraftDecisionPending(true);
+    }
+
+    function finishDraftResolution() {
+        runtime.restoring = false;
+        setDraftDecisionPending(false);
+    }
+
     function resolveWorkspaceAndLoad() {
+        beginDraftResolution();
         var remembered = rememberedWorkspaceId();
         installWorkspaceFetchRouting();
         installWorkspaceEventSourceRouting();
@@ -351,14 +363,19 @@
     }
 
     function resolveActiveWorkspaceAndLoad() {
+        beginDraftResolution();
         return jsonRequest('/api/workspace/current', { method: 'GET' })
             .then(function (workspace) {
-                if (!workspace || !workspace.workspaceId) return null;
+                if (!workspace || !workspace.workspaceId) {
+                    finishDraftResolution();
+                    return null;
+                }
                 runtime.workspaceId = workspace.workspaceId;
                 rememberWorkspaceId(runtime.workspaceId);
                 return loadDraft();
             })
             .catch(function (error) {
+                finishDraftResolution();
                 if (window.console) window.console.warn('[Taxonomy] Workspace draft unavailable', error);
                 return null;
             });


### PR DESCRIPTION
## Summary

Closes the single-session analysis-draft race recorded in #817. The UI now establishes the draft-restoration barrier synchronously before resolving either the remembered workspace or the active workspace, so analysis actions and autosave cannot start while the authoritative draft revision is still unknown.

## Root cause

The draft mutation queue already serialized `PUT` and `DELETE` requests. The remaining race occurred earlier:

1. the analysis-session module installed observers;
2. asynchronous workspace discovery started while `runtime.restoring` was still `false`;
3. the UI acceptance flow could begin analysis and create revision `0`;
4. a late startup/probe path could still behave as if no authoritative revision had been established;
5. a subsequent save was sent with `expectedVersion = null`, producing `expected none, current 0`.

A remembered-workspace probe failure also cleared the restoration barrier before active-workspace fallback began.

## Changes

- establish `restoring` and the decision-control guard synchronously at workspace-resolution startup;
- retain that barrier across remembered-workspace probe failure and active-workspace fallback;
- release it only when workspace discovery conclusively returns no workspace, fails, or normal draft restoration establishes the authoritative state;
- add a deterministic VM-based regression test for both startup windows;
- include the regression test in the canonical UI verification script.

## Validation

Targeted validation performed against the published source content:

- JavaScript syntax checks for both modified lifecycle modules;
- existing analysis-session draft tests;
- new `analysis-session-startup.test.mjs` tests (2/2 passing);
- the same assertions fail against the pre-fix startup behavior, proving the regression test reproduces the race rather than merely exercising the new implementation.

The full protected CI suite remains authoritative.

Fixes #817
