### PR TITLE
Fix PostgreSQL migration contract for JGit schema 0.9.2

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/JgitStoragePostgresMigrationIT.java
@@ -69,6 +69,9 @@ class JgitStoragePostgresMigrationIT {
         if (columnExists(dataSource, "git_reflog", "ref_name_key")) {
             expectedCoreVersions.add("0.9.1");
         }
+        if (columnExists(dataSource, "git_reflog", "delivery_id")) {
+            expectedCoreVersions.add("0.9.2");
+        }
         assertEquals(expectedCoreVersions, coreVersions);
 
         SQLException duplicate = assertThrows(


### PR DESCRIPTION
## Summary

Updates the real PostgreSQL adoption test so its expected Flyway history follows the schema that was actually installed:

- retain `0.9.1` when `ref_name_key` exists;
- additionally expect `0.9.2` when `delivery_id` exists.

This keeps the same Taxonomy revision compatible with both the released `jgit-storage-hibernate` baseline (ending at `0.9.1`) and the PR #301 candidate (ending at `0.9.2`).

## Why

The real-consumer candidate build completed the `0.9.2` migration successfully and preserved the legacy PostgreSQL data, but `JgitStoragePostgresMigrationIT` still asserted that the migration history must end at `0.9.1`.

Observed mismatch:

```text
expected: [..., 0.9.1]
actual:   [..., 0.9.1, 0.9.2]
```

The application-context/schema-shape failure addressed by #822 is already resolved; this PR fixes the remaining stale integration-test expectation.