### PR TITLE
Remove redundant relation projection checkpoint index

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationDecisionProjectionCheckpoint.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/relations/model/RelationDecisionProjectionCheckpoint.java
@@ -24,14 +24,9 @@ import java.time.Instant;
  */
 @Entity
 @Table(name = "relation_decision_projection_checkpoint",
-        indexes = {
-                @Index(
-                        name = "idx_rel_projection_checkpoint_repository",
-                        columnList = "repository_id"),
-                @Index(
-                        name = "idx_rel_projection_checkpoint_scope",
-                        columnList = "repository_id, workspace_scope_key, branch")
-        },
+        indexes = @Index(
+                name = "idx_rel_projection_checkpoint_repository",
+                columnList = "repository_id"),
         uniqueConstraints = @UniqueConstraint(
                 name = "uq_rel_projection_checkpoint_scope",
                 columnNames = {

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/R__drop_redundant_relation_projection_checkpoint_scope_index.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/R__drop_redundant_relation_projection_checkpoint_scope_index.sql
@@ -1,6 +1,0 @@
--- The unique constraint uq_rel_projection_checkpoint_scope already owns an
--- index over the exact same repository/workspace/branch columns. Retain the
--- constraint as the lookup and uniqueness authority and remove only the
--- duplicate non-unique index introduced by V10.
-
-drop index if exists idx_rel_projection_checkpoint_scope;

--- a/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V18__drop_redundant_relation_projection_checkpoint_scope_index.sql
+++ b/taxonomy-app/src/main/resources/db/migration/taxonomy/postgresql/V18__drop_redundant_relation_projection_checkpoint_scope_index.sql
@@ -1,0 +1,7 @@
+-- The unique constraint uq_rel_projection_checkpoint_scope already owns an
+-- equivalent unique index on (repository_id, workspace_scope_key, branch).
+-- Drop the additional non-unique index introduced by V10 through one immutable
+-- versioned migration. Existing installations that already ran the former
+-- repeatable cleanup remain safe because the statement is idempotent.
+
+drop index if exists idx_rel_projection_checkpoint_scope;

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomyRelationProjectionIndexMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomyRelationProjectionIndexMigrationIT.java
@@ -1,0 +1,118 @@
+package com.taxonomy.dsl.storage;
+
+import com.taxonomy.relations.model.RelationDecisionProjectionCheckpoint;
+import io.github.carstenartur.jgit.storage.hibernate.schema.CoreSchemaMigrations;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@Tag("db-postgres")
+class TaxonomyRelationProjectionIndexMigrationIT {
+
+    @Container
+    static final PostgreSQLContainer database =
+            new PostgreSQLContainer("postgres:16-alpine")
+                    .withDatabaseName("taxonomy")
+                    .withUsername("taxonomy")
+                    .withPassword("taxonomy");
+
+    @Test
+    void freshMigrationKeepsOnlyTheConstraintOwnedScopeIndex() throws Exception {
+        DataSource dataSource = isolatedDataSource("projection_index_cleanup");
+        migrateJgit(dataSource);
+
+        TaxonomySchemaMigrationConfig.migrateApplicationSchema(
+                Flyway.configure().dataSource(dataSource).load().getConfiguration());
+
+        assertThat(indexExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "idx_rel_projection_checkpoint_scope"))
+                .isFalse();
+        assertThat(indexExists(
+                dataSource,
+                "relation_decision_projection_checkpoint",
+                "uq_rel_projection_checkpoint_scope"))
+                .isTrue();
+    }
+
+    @Test
+    void entityMappingCannotRecreateTheRedundantScopeIndex() {
+        Table table = RelationDecisionProjectionCheckpoint.class.getAnnotation(Table.class);
+
+        assertThat(table).isNotNull();
+        assertThat(table.indexes())
+                .extracting(Index::name)
+                .containsExactly("idx_rel_projection_checkpoint_repository")
+                .doesNotContain("idx_rel_projection_checkpoint_scope");
+    }
+
+    private static void migrateJgit(DataSource dataSource) {
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations(CoreSchemaMigrations.POSTGRESQL_LOCATION)
+                .table(CoreSchemaMigrations.SCHEMA_HISTORY_TABLE)
+                .load();
+        JgitStorageSchemaMigrationConfig.migrateCoreSchema(flyway, false);
+    }
+
+    private static DataSource isolatedDataSource(String schema) throws SQLException {
+        DataSource admin = baseDataSource();
+        execute(admin, "drop schema if exists " + schema + " cascade");
+        execute(admin, "create schema " + schema);
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(database.getJdbcUrl() + "?currentSchema=" + schema);
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static DataSource baseDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(database.getJdbcUrl());
+        dataSource.setUsername(database.getUsername());
+        dataSource.setPassword(database.getPassword());
+        return dataSource;
+    }
+
+    private static boolean indexExists(
+            DataSource dataSource,
+            String table,
+            String index) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery("""
+                     select 1
+                     from pg_indexes
+                     where schemaname = current_schema()
+                       and tablename = '%s'
+                       and indexname = '%s'
+                     """.formatted(table, index))) {
+            return resultSet.next();
+        }
+    }
+
+    private static void execute(DataSource dataSource, String sql) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/dsl/storage/TaxonomySchemaPostgresMigrationIT.java
@@ -141,7 +141,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "0", "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17");
+                        "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18");
     }
 
     @Test
@@ -215,7 +215,7 @@ class TaxonomySchemaPostgresMigrationIT {
         assertThat(successfulVersions(dataSource))
                 .containsExactly(
                         "1", "2", "3", "4", "5",
-                        "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17");
+                        "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18");
     }
 
     @Test


### PR DESCRIPTION
## What it does

Resolves the remaining genuine review finding from merged PR #701 without rewriting an already-applied Flyway migration:

- adds application migration V18 to drop the non-unique `idx_rel_projection_checkpoint_scope` index;
- preserves the equivalent constraint-owned unique index from `uq_rel_projection_checkpoint_scope`;
- removes the former repeatable cleanup so V18 is the single immutable migration authority;
- removes the redundant JPA `@Index`, preventing Hibernate `ddl-auto=update` from recreating it;
- advances fresh-install and adopted-schema migration expectations to V18;
- adds a real PostgreSQL/Testcontainers integration test proving that the redundant index is absent while the constraint-owned unique index remains present.

All historical review threads are resolved.

## Exact integration state

After PR #846 merged as `4434df45d1520c331956d017ba2b4171677f3acf`, this branch was reconstructed directly on that current `main`. Head `a2d744e258e02b496c58a96a4494bed0d6c707ab` is exactly one commit ahead and contains only the reviewed five-path delta. A fresh exact-head matrix is required before merge.

No release request, product version or publication state is changed.

Follow-up to #701 and release preparation for #711.