### PR TITLE
Restore Hibernate Search version normalization on current main

### DIFF
--- a/taxonomy-build/src/test/java/com/taxonomy/build/HibernateSearchAlignmentPolicy.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/HibernateSearchAlignmentPolicy.java
@@ -28,9 +28,11 @@ final class HibernateSearchAlignmentPolicy {
             String expectedSearchVersion,
             String expectedOrmPrefix,
             String expectedLuceneVersion) {
-        requireText(expectedSearchVersion, "expectedSearchVersion");
-        requireText(expectedOrmPrefix, "expectedOrmPrefix");
-        requireText(expectedLuceneVersion, "expectedLuceneVersion");
+        expectedSearchVersion = requireText(
+                expectedSearchVersion, "expectedSearchVersion");
+        expectedOrmPrefix = requireText(expectedOrmPrefix, "expectedOrmPrefix");
+        expectedLuceneVersion = requireText(
+                expectedLuceneVersion, "expectedLuceneVersion");
 
         final String text;
         try {
@@ -59,10 +61,11 @@ final class HibernateSearchAlignmentPolicy {
         if (searchEntries.isEmpty()) {
             failures.add("No org.hibernate.search artifacts were found in the dependency tree");
         }
+        String normalizedSearchVersion = expectedSearchVersion;
         searchEntries.forEach((artifact, versions) -> {
-            if (!versions.equals(Set.of(expectedSearchVersion))) {
+            if (!versions.equals(Set.of(normalizedSearchVersion))) {
                 failures.add(artifact + " resolved to " + sorted(versions)
-                        + ", expected only " + expectedSearchVersion);
+                        + ", expected only " + normalizedSearchVersion);
             }
         });
         if (ormVersions.size() != 1

--- a/taxonomy-build/src/test/java/com/taxonomy/build/HibernateSearchAlignmentWhitespaceTest.java
+++ b/taxonomy-build/src/test/java/com/taxonomy/build/HibernateSearchAlignmentWhitespaceTest.java
@@ -1,0 +1,34 @@
+package com.taxonomy.build;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HibernateSearchAlignmentWhitespaceTest {
+
+    @Test
+    void policyUsesTheValidatedNormalizedVersionParameters(@TempDir Path root)
+            throws Exception {
+        Path tree = root.resolve("dependencies.txt");
+        Files.writeString(tree, """
+                +- org.hibernate.search:hibernate-search-mapper-orm:jar:8.4.0.Final:compile
+                +- org.hibernate.orm:hibernate-core:jar:7.4.2.Final:compile
+                \\- org.apache.lucene:lucene-core:jar:9.12.3:compile
+                """, StandardCharsets.UTF_8);
+
+        var evaluation = new HibernateSearchAlignmentPolicy().evaluate(
+                tree,
+                " 8.4.0.Final ",
+                " 7.4. ",
+                " 9.12.3 ");
+
+        assertThat(evaluation.passed()).isTrue();
+        assertThat(evaluation.failures()).isEmpty();
+        assertThat(evaluation.report()).contains("Result: PASS");
+    }
+}


### PR DESCRIPTION
## What it does

Reconstructs the exact two-file correction from #849 directly on the current protected `main` after #847:

- retains and uses the stripped values returned by `requireText(...)` for Hibernate Search, ORM-prefix and Lucene expectations;
- prevents harmless leading/trailing whitespace in Maven/system-property inputs from causing false dependency-alignment failures;
- adds an explicit UTF-8 regression fixture covering whitespace on all three expected values.

This avoids rewriting the already-reviewed #849 branch while satisfying the required up-to-date Maven verification rule. No release request, version or publication state changes.

Supersedes #849 after protected merge. Follow-up to #685 and #681.