### PR TITLE
Prepare truthful Taxonomy 1.4.0 release documentation

### DIFF
--- a/docs/dev/PYTHON_TOOLING_POLICY.md
+++ b/docs/dev/PYTHON_TOOLING_POLICY.md
@@ -1,31 +1,34 @@
-# No-Python build tooling policy
+# Python tooling migration policy
 
-Taxonomy uses Maven as the canonical verification entry point and JUnit/Failsafe
-as the authority for executable tests and repository pass/fail policies. The
-repository owner decided on 14 August 2026 that the final Taxonomy source and
-release toolchain must contain **no Python files and no Python invocation**.
+Taxonomy uses Maven as the canonical verification entry point and JUnit/Failsafe as the authority for executable tests and repository pass/fail policies. Dependency-free Java tooling owns structured release transformations where a real program is required. Shell and GitHub Actions orchestrate external tools but must not duplicate policy logic.
 
-This document records the migration boundary until the remaining files are
-removed. It is not an allow-list for permanent exceptions.
+The long-term goal remains a repository with no tracked Python files and no executable Python setup or invocation. On 24 August 2026, complete removal was deliberately moved from the Taxonomy 1.4.0 release scope to issue #673 on the 1.4.1 development line. The bounded adapters retained in 1.4.0 are not product runtime dependencies and remain protected by Maven/JUnit-owned positive and negative contracts.
 
-## Permanent rules
+## Taxonomy 1.4.0 boundary
 
-1. A deterministic repository policy belongs in JUnit, Maven Enforcer, another
-   Maven-native plugin, or the frontend toolchain that owns the source format.
-2. Structured artifact generation belongs in Java/Maven-native tooling when a
-   real program is required.
-3. Shell and GitHub Actions may orchestrate external command-line tools, Git,
-   Helm, containers and publication, but must not become a second test or policy
-   implementation.
-4. No `.py` file, versioned or unversioned `python`/`pip`, `pytest`, `unittest`
-   or `actions/setup-python` invocation may remain in the final release candidate.
-5. A productive adapter is removed only after its positive, negative, failure,
-   retry and output contracts are preserved at the real boundary.
-6. New Python is prohibited while the migration is in progress.
-7. Every protected integration must remain green; adapter deletion and the
-   relocation of tests that execute it are one atomic transition.
+Taxonomy 1.4.0 may retain only the Python files already listed by the removal-only source ratchet. This is a temporary migration boundary, not an invitation to add new Python tooling and not a permanent exception list.
 
-## Policies already owned by Maven/JUnit or dependency-free Java tooling
+The release remains acceptable only while all of the following hold:
+
+1. Maven remains the canonical verification command.
+2. JUnit/Failsafe or dependency-free Java owns deterministic pass/fail policy.
+3. No new `.py` file, `python`, `python3`, `pytest`, `pip`, `unittest`, or `actions/setup-python` reference is introduced.
+4. Every retained adapter continues to pass its existing process, output, failure, retry, provenance, and security contracts.
+5. Release notes disclose the retained bounded adapters and the post-1.4.0 migration plan truthfully.
+6. Any retained adapter shown to cause a concrete correctness or security defect becomes a release issue in its own right.
+
+Complete removal is therefore not a 1.4.0 publication gate. It remains required before #673 can close.
+
+## Permanent architecture rules
+
+- Deterministic repository policy belongs in JUnit, Maven Enforcer, another Maven-native plugin, or the frontend toolchain that owns the source format.
+- Structured artifact generation belongs in Java/Maven-native tooling when a real program is required.
+- Shell and GitHub Actions may invoke Git, Helm, containers, scanners, and publication clients, but must not become a second implementation of repository policy.
+- A productive adapter is removed only after its positive, negative, malformed-input, retry, and output contracts are preserved at the real boundary.
+- Adapter deletion and relocation of tests that execute it form one atomic transition.
+- Every migration slice must pass the exact-head CI, database, CodeQL, Security, and relevant consumer matrix required by its scope.
+
+## Policies already owned by Maven/JUnit or dependency-free Java
 
 | Concern | Integration |
 |---|---|
@@ -37,190 +40,91 @@ removed. It is not an allow-list for permanent exceptions.
 | Packaged CycloneDX dependency hygiene | #685 |
 | Frontend API transport boundaries | #687 |
 | Release request ancestry and revision | #716 / #757 |
-| Exact release-gate behavior | #737 |
+| Exact release-gate behaviour | #737 |
 | Version-state implementation | #756 |
 | Release parameters and request anchoring | #757 |
 | Declared-reactor release-plan validation | #767 |
 | Productive release/version workflow routing | #769 |
 | Release metadata transformation and routing | #771 / #774 |
-| CycloneDX SBOM/VEX companion generation and legacy-helper removal | #804 / #673 bounded cleanup slice |
-| CodeQL SARIF high-severity enforcement | #673 bounded Java slice |
+| CycloneDX SBOM/VEX companion generation | #804 / #846 |
+| CodeQL SARIF high-severity enforcement | #846 |
 
 ## Completed Java release-core migration
 
-The `taxonomy-tooling` reactor module is a dependency-free executable Java JAR.
-It owns the release boundary before and after immutable checkout changes and is
-preserved in `$RUNNER_TEMP` by workflows that change checkout state.
+The dependency-free `taxonomy-tooling` executable JAR owns the release boundary before and after immutable checkout changes. It replaced the former Python release-parameter, release-plan, version-state, release-metadata, CodeQL SARIF, and SBOM/VEX companion implementations.
 
-The release-core migration replaces and removes:
+Its Java and JUnit contracts cover:
 
-- `resolve-release-parameters.py` and its Python test suite;
-- `check-release-plan.py` and its Python test suite;
-- `check-version-state.py`;
-- `update-release-metadata.py`.
+- workflow-dispatch derivation and explicit major, minor, patch, or exact next-version choices;
+- exact-first-parent release-request anchoring, one-file request commits, and sequential request revisions;
+- staged-release ancestry and resume behaviour;
+- declared Maven reactor traversal, inherited properties, duplicate coordinates, and internal versus external snapshots;
+- worktree cleanliness and transactional release metadata updates;
+- release, development, and advanced version-state agreement;
+- deterministic JSON output and actionable failure diagnostics;
+- CodeQL SARIF rules stored in drivers or extensions, unknown-rule and malformed-input rejection, high-severity thresholds, and stale-evidence cleanup;
+- SBOM/VEX companion generation without an obsolete Python fallback.
 
-The Java implementation and JUnit contracts cover:
-
-- workflow-dispatch derivation and freely selected major/minor/patch advances;
-- reviewed push requests, exact-first-parent anchoring, one-file request commits
-  and exact `request_revision` increments;
-- staged-release tag ancestry and repaired history;
-- declared Maven reactor traversal, inherited properties, duplicate coordinates,
-  internal versus external snapshots and nested modules;
-- ordinary and linked-worktree cleanliness;
-- Maven, citation, CodeMeta, Zenodo and Helm version-state agreement;
-- release, development and advanced lifecycle states;
-- clean immutable release/tag validation, staged resume and protected-main handoff;
-- stable GitHub output ordering and user-facing failure diagnostics;
-- deterministic JSON output with Unicode, arbitrary-precision integer and
-  exponent-preserving decimal semantics;
-- transactional CFF, citation, Zenodo, CodeMeta and Helm metadata updates with
-  validation-before-write, rollback, idempotency and release-date handling.
-
-Release, protected-main and manual development-version workflows call the same
-Java JAR rather than reconstructing these rules in YAML or shell. Historical
-`taxonomy-build` fixtures that executed the removed scripts have been deleted;
-their behavior remains covered beside the Java implementation in
-`taxonomy-tooling`.
-
-## CodeQL SARIF gate
-
-The Java and JavaScript CodeQL jobs build the same dependency-free
-`taxonomy-tooling` JAR and invoke its `check-codeql-sarif` command. The command
-preserves the reviewed threshold contract: a result blocks when its referenced
-rule has `security-severity >= 7.0` or when the result itself explicitly carries
-SARIF level `error`.
-
-Retained CodeQL artifacts prove that GitHub's reports keep query rules under
-`runs[].tool.extensions[].rules` while `tool.driver.rules` is empty. The former
-Python adapter inspected only the driver and therefore resolved those real rule
-severities as zero. The Java gate resolves rule metadata from both the driver and
-every extension and requires every result to reference exactly one known rule.
-Duplicate rule IDs, unsupported SARIF versions, missing/non-regular inputs,
-unknown rule references, malformed messages, invalid levels and non-numeric,
-non-finite or out-of-range severities fail closed.
-
-Missing result levels remain `warning`; the gate deliberately does not reinterpret
-a rule's `defaultConfiguration.level` as an explicit result override. This keeps
-the historical error-level policy stable while correcting high-severity lookup.
-A deterministic JSON evidence file records all supplied reports, result count,
-threshold, blocking findings and PASS/FAIL state. Any controlled failure removes
-stale evidence rather than leaving an earlier PASS file behind.
-
-The workflow contains orchestration only: it discovers SARIF paths in stable,
-NUL-safe order and invokes the immutable Java JAR. Missing-input policy and all
-positive, blocking and malformed-input behavior belong to Java/JUnit. A
-repository contract prevents the deleted Python adapter, a shell duplicate or a
-Python fallback from returning.
-
-This slice reduces the tracked Python inventory from twelve to **eleven** files.
-That count is encoded by the removal-only source ratchet and may only decrease in
-subsequent protected integrations.
-
-## Legacy VEX helper removal
-
-The Maven build and productive release script already use the reviewed
-`taxonomy-tooling generate-sbom-companion` command for `target/taxonomy-vex.json`.
-The old `generate-vex.py` program therefore had no remaining productive call;
-only the release workflow still copied it to `$RUNNER_TEMP` and exposed an unused
-`VEX_HELPER` variable.
-
-The bounded cleanup removes the file, the copy/chmod operations and the unused
-environment variable together. The existing productive-routing JUnit contract is
-extended to inspect the release workflow as well as Maven and `release.sh`, so a
-legacy helper, Python fallback or competing VEX authority cannot return. The
-source inventory then decreases from eleven to **ten** Python files without
-changing SBOM/VEX output semantics.
+Workflows call the same immutable JAR rather than recreating those rules in YAML or shell.
 
 ## Removal-only source ratchet
 
-The remaining Python inventory is an upper bound. Later slices may delete an
-allowed path but cannot introduce another `.py` file. Productive XML, workflow
-YAML, shell, Java main source, JavaScript build scripts, properties, Dockerfiles,
-Makefiles and package metadata are diffed against the immutable green
-release-core-removal baseline. New executable versioned or unversioned
-`python`/`pip`, `pytest`, `unittest` or `actions/setup-python` references fail the
-Maven/JUnit build. Token boundaries prevent ordinary shell terms such as
-`pipefail` or application identifiers containing `python` from becoming false
-positives.
+The current Python inventory is an upper bound. Later slices may delete an allowed path but cannot introduce another Python source file. Productive XML, workflow YAML, shell, Java main source, JavaScript build scripts, properties, Dockerfiles, Makefiles, and package metadata are diffed against the immutable release-core-removal baseline. New executable Python or setup references fail the Maven/JUnit build.
 
-The exact file-inventory check runs in every checkout, including source archives
-and intentionally shallow specialized jobs. The ancestry and productive-diff
-checks require the immutable baseline object and therefore run in complete-history
-checkouts. Canonical CI uses `fetch-depth: 0` and is the merge authority for those
-history-sensitive assertions. A missing baseline in any non-shallow Git checkout
-remains a hard failure; shallow database or security jobs do not pretend to own a
-history they were deliberately not given.
+The exact file inventory runs in every checkout. Complete-history checkouts also enforce ancestry and productive-diff rules. Shallow specialised jobs do not pretend to own history they were deliberately not given; canonical CI remains the authority for those assertions.
 
-## Remaining migration inventory
+## Remaining post-1.4.0 inventory
 
-The following programs are still present only until their Java/Maven-native or
-bounded shell replacements have equivalent JUnit contracts:
+The following files remain temporarily and may only be removed in contract-preserving slices:
 
 ### Artifact generation
 
-- `generate-quality-site.py`
+- `.github/scripts/generate-quality-site.py`
 
-### Release, delivery and external-format verification
+### Release, delivery, and external-boundary verification
 
-- `check-release-delivery-contract.py`
-- `check-release-image-gate.py`
-- `check-delivery-hardening.py`
-- `verify-deployment.py`
-- `verify-quality-publication.py`
-- `check-observability-performance-scope.py`
+- `.github/scripts/check-release-delivery-contract.py`
+- `.github/scripts/check-release-image-gate.py`
+- `.github/scripts/check-delivery-hardening.py`
+- `.github/scripts/check-observability-performance-scope.py`
+- `.github/scripts/verify-deployment.py`
+- `.github/scripts/verify-quality-publication.py`
 
-### Duplicate Python test programs to remove with their productive boundary
+### Duplicate Python test programs
 
-- `test-generate-quality-site.py`
-- `test-verify-deployment.py`
-- `test-verify-quality-publication.py`
+- `.github/scripts/test-generate-quality-site.py`
+- `.github/scripts/test-verify-deployment.py`
+- `.github/scripts/test-verify-quality-publication.py`
 
-No remaining item is an accepted permanent exception.
+No item is accepted as a permanent exception.
 
-## Migration order
+## Post-release migration order
 
-1. Release parameter, plan and version-state core in `taxonomy-tooling` — complete.
-2. Release metadata transformation, productive routing and helper removal — complete.
-3. CycloneDX SBOM companion generation, productive routing and obsolete helper removal — complete.
-4. CodeQL SARIF policy gate in dependency-free Java with JUnit contracts — complete.
-5. Remaining release/delivery and observability policy checks under Java/JUnit authority.
-6. Quality-site generation and publication verification in Java/Maven-native code.
-7. Deployment verification at its real HTTP/Helm boundary.
-8. Repository-wide absolute source contract rejecting every Python path and
-   invocation.
+1. Move release-delivery and immutable-image policy to Java/JUnit authority.
+2. Move delivery-hardening and observability-scope policy to Java/JUnit authority.
+3. Replace quality-site generation and publication verification with Java/Maven-native tooling and deterministic output tests.
+4. Replace deployment verification at its real HTTP/Helm boundary.
+5. Delete the final Python file and executable/setup reference.
+6. Replace the shrinking allow-list with an absolute zero-Python source contract.
 
-Each slice must remain bounded, preserve the real behavior before deleting the
-old implementation, and pass the exact-head CI, database, CodeQL and security
-matrix required by its scope.
-
-## Shell and JavaScript boundaries
-
-Shell remains appropriate for invoking external command-line tools, rendering
-Helm, installing pinned binaries and orchestrating release state transitions.
-JavaScript remains appropriate for browser/accessibility verification and the
-frontend build. Neither is a fallback location for policy logic migrated out of
-Python.
+Draft PRs #851 and #852 were closed unmerged when 1.4.0 publication was prioritised. Their ideas may be reconstructed on the post-release `main`; stale stacked branches are not release evidence.
 
 ## Prohibited patterns
 
 - any new `.py` file or Python setup/install step;
 - translating Python unit tests into shell tests;
 - duplicating a Java/JUnit rule in workflow YAML;
-- silent JSON/YAML allow-lists without owner, rationale and expiry semantics;
-- deleting a productive adapter before its exact behavior is covered;
-- merging a deletion before tests that execute the deleted adapter are relocated;
-- keeping Java and Python implementations of the same policy as fallback.
+- silent JSON/YAML allow-lists without owner, rationale, and expiry semantics;
+- deleting a productive adapter before its exact behaviour is covered;
+- keeping Java and Python implementations of the same policy as fallbacks.
 
-## Completion criteria
+## Completion criteria for #673
 
 Issue #673 can close only when:
 
-- GitHub code search for `extension:py repo:carstenartur/Taxonomy` returns zero;
-- repository-wide search finds no executable Python reference;
+- repository search returns zero tracked Python files;
+- repository-wide search finds no executable Python or setup reference;
 - `./mvnw -B verify -Pci` remains the canonical verification command;
 - every migrated generator and adapter has positive and negative JUnit coverage;
-- the final non-publishing 1.4.0 release dry run succeeds without Python;
 - an absolute source contract prevents Python from returning; and
-- CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan and relevant
-  consumer contracts are green on one unchanged exact head.
+- CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, and relevant consumer contracts are green on one unchanged exact head.

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,145 +1,146 @@
 # Taxonomy 1.4.0
 
-Taxonomy 1.4.0 is the first published release after 1.3.0. It introduces versioned Word-template administration and template-backed decision reports, and combines the stabilization work that had been prepared for 1.3.1 with a substantially stronger project-portfolio workbench, deterministic architecture exports, local semantic-search readiness, deployment profiles, and a fail-closed release and quality pipeline.
+Taxonomy 1.4.0 is the first published release after 1.3.0. It combines the stabilization work prepared for the unpublished 1.3.1 line with a substantially stronger requirements and architecture workbench, versioned Word-template administration, deterministic architecture exports, local semantic-search readiness, constrained-cluster deployment profiles, and a fail-closed release pipeline.
 
 ## Important release-line note
 
-The immutable `v1.3.1` Git tag exists only to preserve release ancestry. **No GitHub Release was published for 1.3.1, and 1.3.1 is not a supported deployment target.** Taxonomy 1.4.0 supersedes that incomplete publication attempt. Users of the latest published release should upgrade from 1.3.0 directly to 1.4.0.
-
-The 1.3.1 release commit remains reachable from the 1.4.0 history and from the maintenance line; no tag or published history was rewritten.
+The immutable `v1.3.1` Git tag remains only as release-ancestry evidence. No GitHub Release was published for 1.3.1, and 1.3.1 is not a supported deployment target. Existing installations should upgrade directly from the published 1.3.0 assets to 1.4.0. No tag or published history was rewritten.
 
 ## Product highlights
 
 ### Versioned Word templates and template-backed decision reports
 
-Administrators can now maintain DOTX templates through the browser or through a virtual WebDAV collection while retaining precise Git history for the package contents. Taxonomy stores every template canonically as an unpacked OOXML tree in a dedicated Hibernate-backed JGit repository and materialises a valid `.dotx` package on demand. The WebDAV view intentionally exposes only complete Office documents, never the unpacked internal tree.
+Administrators can maintain DOTX templates through the browser or a virtual WebDAV collection while retaining precise Git history for the unpacked OOXML package contents. Taxonomy stores each template canonically as an unpacked tree in a dedicated Hibernate-backed JGit repository and materialises a valid `.dotx` package on demand. WebDAV exposes complete Office documents only; the unpacked representation remains an internal Git and inspection concern.
 
-The template workspace includes:
+The template workspace provides:
 
-- upload, download, version history, per-part OOXML inspection and diff, and conflict-protected restore;
-- direct Microsoft Word actions for editing a template or creating a new document from it, restricted to public HTTPS or loopback development;
+- upload, download, history, per-part OOXML inspection and diff, conflict-protected restore, and test export;
 - revocable, user-bound WebDAV application credentials with read/write scopes, expiry, hashed storage, and one-time secret display;
-- per-template commits and ETags, lock-token handling, conditional writes, stale-write rejection, and concurrent-create protection;
+- ETags, lock tokens, conditional writes, stale-write rejection, and concurrent-create protection;
 - fail-closed validation of XML parts, OPC relationships, ZIP paths, manifests, external links, dangerous field instructions, macros, ActiveX, OLE objects, signatures, comments, and tracked changes;
-- deterministic package materialisation and semantic-validation caching by immutable template revision.
+- deterministic package materialisation and semantic-validation caching by immutable template revision;
+- direct Microsoft Word actions where a public HTTPS origin, or loopback development origin, makes those links safe to expose.
 
-A valid macro-free decision-rationale template is bundled and seeded idempotently on first start without overwriting organisation-specific changes. Generated decision reports inherit the selected template's branding, page setup, styles, headers, footers, and static metadata while retaining the existing generated executive summary, decision chapters, diagrams, and appendix. The returned package is converted to a genuine DOCX and records the template ID, Git commit, and package checksum as provenance properties.
+A valid macro-free decision-rationale template is bundled and seeded idempotently without overwriting organisation-specific changes. Generated reports inherit the chosen template's branding, page setup, styles, headers, footers, and static metadata while retaining the generated executive summary, decision chapters, diagrams, and appendix. The produced DOCX records the template identity, Git revision, and package checksum as provenance.
 
-The browser/container acceptance path starts the packaged application with Testcontainers, signs in through Playwright, verifies first-start seeding and WebDAV discoverability, downloads the generated DOCX, validates the package, and renders that exact document through LibreOffice for screenshot evidence. See the [English document-template guide](docs/en/DOCUMENT_TEMPLATES.md) and [German document-template guide](docs/de/DOCUMENT_TEMPLATES.md).
+The browser/container acceptance path starts the packaged application with Testcontainers, signs in through Playwright, verifies first-start seeding and WebDAV discovery, downloads the generated DOCX, validates the package, and renders that exact document through LibreOffice. See the [English document-template guide](docs/en/DOCUMENT_TEMPLATES.md) and [German document-template guide](docs/de/DOCUMENT_TEMPLATES.md).
 
 ### Complete project and requirement portfolio workflow
 
-The project portfolio now supports a complete traceable workflow rather than a collection of isolated screens:
+The portfolio workbench supports a traceable end-to-end process rather than isolated screens:
 
 - project creation, selection, and independent requirements;
 - reviewed PDF and DOCX import with an atomic apply step;
 - immutable requirement versions, snapshots, history, and diffs;
-- persisted asynchronous analysis jobs, reload recovery, retry, and job status;
+- persisted asynchronous analysis jobs with reload recovery and retry;
 - evidence-backed taxonomy mapping review;
-- solution and product catalogues with requirement links and comparisons;
+- solution and product catalogues with comparisons and requirement links;
 - conflict detection with guided decisions;
-- interactive coverage and decision matrices with drill-down plus filtered CSV and JSON export;
+- interactive coverage and decision matrices with drill-down and filtered CSV/JSON export;
 - portfolio Git preview, commit, materialisation preview/apply, ordinary merge, and semantic merge;
 - project and requirement reports in HTML, DOCX, Markdown, JSON, and CSV.
 
-The browser acceptance suite exercises this as one vertical process and treats serious accessibility findings as release failures. See the [Project Portfolio Guide](docs/en/PROJECT_REQUIREMENT_PORTFOLIO.md) and [feature matrix](docs/en/PROJECT_PORTFOLIO_FEATURE_MATRIX.md).
+The browser acceptance suite exercises this as a vertical workflow and treats serious accessibility findings as release failures. See the [Project Portfolio Guide](docs/en/PROJECT_REQUIREMENT_PORTFOLIO.md) and [feature matrix](docs/en/PROJECT_PORTFOLIO_FEATURE_MATRIX.md).
 
 ### Server-authoritative architecture workbench
 
-Requirement architecture is now rendered from the persisted analysis snapshot through one neutral server-side diagram scene. The browser view, standalone SVG, and vector PDF therefore use the same semantic nodes, relationships, layout, and source snapshot.
-
-Exports no longer print the current browser page or silently fall back to an unrelated taxonomy graph. Viewing or exporting an existing snapshot does not invoke the LLM and does not rebuild historical content from current preferences. See [ADR 0003](docs/adr/0003-server-authoritative-architecture-workbench.md).
+Requirement architecture is rendered from the persisted analysis snapshot through one neutral server-side diagram scene. The browser view, standalone SVG, and vector PDF use the same semantic nodes, relationships, layout, and source snapshot. Viewing or exporting an existing snapshot does not invoke the LLM and does not rebuild historical content from current preferences. See [ADR 0003](docs/adr/0003-server-authoritative-architecture-workbench.md).
 
 ### Deterministic local semantic-search readiness
 
-The local ONNX path now has an explicit, fail-closed lifecycle:
+The local ONNX path has an explicit, fail-closed lifecycle:
 
 - the pinned embedding model is restored or downloaded deterministically;
 - catalogue nodes are available before the semantic index is rebuilt;
-- the application reports whether semantic search is ready instead of exposing a partially initialized index;
+- the application reports readiness instead of exposing a partially initialized index;
 - stale or missing indexes are rebuilt through the controlled initializer;
-- real-model and browser integration tests cover startup, readiness, rebuild, and interaction behavior.
+- real-model and browser tests cover startup, readiness, rebuild, and interaction behaviour.
 
 Custom OpenAI-compatible provider configuration and diagnostics also provide clearer validation and failure reporting.
 
 ### Responsive and accessible task interaction
 
-The interface has stronger keyboard, zoom, mobile, and disclosure behavior. Navigation and task controls remain discoverable at narrow widths and 200–400% zoom, overlays cannot silently hide the required action surface, native disclosures use collision-safe identities, and shared semantic helpers keep role and accessibility state consistent.
+Navigation and task controls remain discoverable at narrow widths and 200–400% zoom. Overlays cannot silently hide the required action surface, disclosures use collision-safe identities, keyboard order follows visual order, and shared semantic helpers keep role and accessibility state consistent.
 
 ### Rancher, RKE2, and constrained-cluster deployment
 
-The Helm chart now includes:
+The Helm chart includes:
 
 - a Rancher/RKE2 profile for ingress-nginx under `/taxonomy/`;
 - a generic small evaluation profile with a 500-mCPU ceiling;
 - forwarded-prefix and browser base-path handling that prevents sub-path 404 responses;
-- explicit immutable-image requirements, readiness checks, resource-quota diagnostics, and NetworkPolicy guidance.
+- explicit immutable-image requirements, readiness checks, ResourceQuota and LimitRange validation, restricted-egress coverage, secret-safe diagnostics, and NetworkPolicy guidance.
 
-See the [Rancher/RKE2 deployment guide](deploy/helm/taxonomy/RANCHER.md). The small profile is intended for evaluation and functional validation; it is not a capacity claim for bulk imports, local model download, or high-concurrency analysis.
+See the [Rancher/RKE2 deployment guide](deploy/helm/taxonomy/RANCHER.md). The small profile is an evaluation and functional-validation floor, not a measured capacity claim for bulk imports, local model download, or high-concurrency analysis.
+
+### Reliability and data integrity
+
+Analysis-draft autosaves are serialized. Multiple browser changes that arrive during an active save are coalesced and persisted with the server-returned optimistic revision, preventing two local PUT requests from racing with the same version. Genuine cross-tab or cross-device conflicts remain visible and require an explicit user decision.
+
+The PostgreSQL schema removes the redundant non-unique relation-projection checkpoint index through immutable migration V18 while preserving the equivalent constraint-owned unique index. The JPA mapping no longer recreates the removed index when schema update is enabled, and Testcontainers coverage proves the resulting index state.
+
+### Integrated multi-repository technical foundation
+
+Taxonomy 1.4.0 includes the repository-scoped storage, context, and service foundation needed for future multi-repository operation. This is not yet a generally supported public multi-repository product surface. The `/api/repositories/**` API remains disabled by default, and the broader tenancy, recovery, authority, cache, UX, and end-to-end isolation programme remains tracked separately. The established primary-repository/workspace behaviour is the supported default for 1.4.0.
 
 ## Release, security, and reproducibility
 
 ### One exact release candidate
 
-A publishing request is now bound to one exact reviewed `main` parent and may change only `.github/release-request.json`. The request revision must advance exactly once, preventing a stale or fabricated release request from borrowing evidence from another commit.
-
-Before immutable artifacts are built, the release workflow requires the same unchanged final `main` SHA to pass:
+Every release request is bound to one exact reviewed parent commit and may change only `.github/release-request.json`. Its revision must advance exactly once. Before immutable artifacts are published, the unchanged candidate must pass:
 
 - canonical CI/CD and browser verification;
 - PostgreSQL compatibility;
 - Oracle compatibility;
 - Microsoft SQL Server compatibility;
 - CodeQL source analysis;
-- Security Scan.
+- Security Scan;
+- relevant constrained-Kubernetes, document-template, and consumer contracts.
 
-Missing exact-SHA evidence is dispatched explicitly on `main`; failed, cancelled, skipped, timed-out, mismatched, or unreliable workflow results stop publication. The already completed non-publishing `1.4.0 -> 1.4.1-SNAPSHOT` dry run proved the version transition without creating a tag, public release, image, or deployment side effect.
+Missing, failed, cancelled, skipped, timed-out, mismatched, or unreliable exact-SHA evidence stops publication.
 
 ### Immutable, digest-bound delivery
 
-The publishing transaction keeps source and deployment evidence aligned:
+The release transaction aligns source and deployment evidence:
 
 - the release tag and packaged source are verified before use;
-- Maven module JARs, checksums, SBOM, VEX, Helm assets, and Kubernetes manifests are archived as release evidence;
-- the OCI image is referenced by digest rather than only by a mutable tag;
+- Maven module JARs, checksums, SBOM/VEX companion, Helm assets, and Kubernetes manifests are archived;
+- the OCI image carries source/version labels and is referenced by immutable digest;
 - provenance and SBOM attestations are enabled;
-- the exact digest is vulnerability-scanned before the draft release becomes public;
-- Helm deployment evidence records that same image digest.
+- the immutable digest is vulnerability-scanned before the draft release becomes public;
+- Helm deployment evidence records the same image digest and source commit.
 
 ### Maven/JUnit-owned quality contracts
 
-Deterministic repository policy is now owned by the normal Maven/JUnit lifecycle instead of parallel Python pass/fail implementations. Executable contracts cover:
+Maven remains the canonical verification entry point. Deterministic repository policy is owned by JUnit/Failsafe or dependency-free Java tooling, including workflow test authority, documentation links, aggregate reactor coverage, dependency alignment, immutable supply-chain references, packaged dependency hygiene, frontend API boundaries, release version state, request ancestry, CodeQL SARIF enforcement, and SBOM/VEX companion generation.
 
-- workflow test authority;
-- repository documentation links;
-- aggregate reactor JaCoCo coverage, including branch coverage;
-- Hibernate Search, Hibernate ORM, and Lucene dependency alignment;
-- immutable GitHub Action and production-image pins;
-- packaged dependency hygiene and reviewed exceptions;
-- frontend API-boundary debt and direct-transport ratchets;
-- release version-state and request ancestry.
-
-Standalone Python remains only where it is useful as a bounded release adapter or evidence generator; JUnit owns the positive and negative contracts around those retained boundaries.
+A bounded set of existing Python release adapters and evidence generators remains in 1.4.0 under Maven/JUnit-owned positive and negative contracts. Complete removal is explicitly deferred to issue #673 on the 1.4.1 development line. This release introduces no new Python tooling and does not represent retained adapters as product runtime dependencies.
 
 ## Compatibility and deliberate exclusions
 
-- The unfinished multi-repository and federated-authority implementation tracked by #609/#610 is **not included** in Taxonomy 1.4.0. It remains on its isolated integration line until its tenancy, recovery, authority, cache, UX, and end-to-end isolation boundaries are complete.
-- The federated authority and collaborative editing document included in this release is a planning baseline, not a claim that those future capabilities are already delivered.
-- The existing published primary-repository/workspace behavior remains the supported product boundary for 1.4.0.
-- WebDAV exposes valid packaged DOTX resources only. The unpacked OOXML representation remains an internal Git and inspection-API concern.
-- Direct Word links require public HTTPS, except for loopback development. Deployments should use scoped application credentials rather than ordinary account passwords for desktop WebDAV clients.
-- No deployment should use the unpublished `v1.3.1` tag as a substitute for the 1.4.0 release assets.
+- The public multi-repository API is disabled by default and is not a production-supported 1.4.0 capability.
+- Federated authority and collaborative-editing documents are planning baselines, not claims that those future capabilities are delivered.
+- WebDAV exposes valid packaged DOTX resources only; unpacked OOXML remains an internal Git and inspection concern.
+- Direct Word links require public HTTPS except for loopback development. Deployments should use scoped application credentials rather than ordinary account passwords for desktop WebDAV clients.
+- Direct desktop-Word editing is not certified as generally compatible across Microsoft 365 versions, operating systems, reverse proxies, credential managers, and recovery/autosave flows. Ordinary HTTPS download and upload remain the supported fallback.
+- WebDAV lock coordination is currently process-local. Multi-replica direct editing requires shared lock coordination and remains follow-up work; Git/ETag preconditions still prevent silent lost updates.
+- DOCX and FOP/PDF decision reports use separate rendering paths. Their end-to-end semantic parity is tracked separately and is not claimed by this release.
+- Autosave-session grouping and long-history/template-count performance work remain follow-up items.
+- Complete Python removal is deferred to #673 after 1.4.0.
+- The small Kubernetes profile is not a measured production capacity envelope.
+- The unpublished `v1.3.1` tag must not be used as a substitute for 1.4.0 release assets.
 
 ## Upgrade notes
 
 1. Back up the application database and persistent storage using the normal operational procedure.
-2. Upgrade directly from the published 1.3.0 assets to the 1.4.0 release.
+2. Upgrade directly from the published 1.3.0 assets to 1.4.0.
 3. After the first 1.4.0 start, verify that `decision-rationale-report.dotx` is present in `/admin/document-templates`. Seeding is idempotent and does not replace an organisation-specific revision.
-4. Configure a trusted external HTTPS origin before offering direct Word/WebDAV actions, and create scoped WebDAV application credentials for the users who require them.
-5. Use the immutable 1.4.0 image digest or verified release tag; do not deploy `latest` or `v1.3.1`.
+4. Configure a trusted external HTTPS origin before enabling direct Word/WebDAV actions, and create scoped WebDAV application credentials for users who require them.
+5. Deploy the immutable 1.4.0 image digest or verified release tag; do not deploy `latest` or `v1.3.1`.
 6. For Rancher/RKE2 sub-path deployments, start with `values-rancher-rke2.yaml` and verify `/taxonomy/actuator/health/readiness`.
-7. Local semantic search can remain unavailable until its controlled model/index initialization completes; use the reported readiness state rather than assuming an empty result means a ready index.
-8. Contributors and downstream verifiers should use the repository-owned Maven wrapper and canonical verification lifecycle rather than invoking internal test selectors directly.
+7. Treat the reported semantic-search readiness state as authoritative while model/index initialization is in progress.
+8. Contributors and downstream verifiers should use the repository-owned Maven wrapper and canonical verification lifecycle.
 
 ## Verification boundary
 
-Taxonomy 1.4.0 is published only after the release request, final source commit, Git tag, GitHub Release, Maven artifacts, SBOM/VEX evidence, OCI digest, image scan, Helm package, Kubernetes manifests, and post-release `1.4.1-SNAPSHOT` state agree with the release transaction.
+Taxonomy 1.4.0 is published only after the release request, final source commit, Git tag, GitHub Release, Maven artifacts, checksums, SBOM/VEX evidence, OCI digest, image scan, attestations, Helm package, Kubernetes manifests, deployment evidence, and post-release `1.4.1-SNAPSHOT` state agree with the same release transaction.


### PR DESCRIPTION
## What it does

Aligns the published 1.4.0 description and the developer tooling policy with the prospective release source instead of carrying forward stale assumptions.

### `release_notes.md`

The notes now:

- state that 1.3.1 was never published and upgrades proceed from 1.3.0;
- describe versioned DOTX/WebDAV administration and template-backed decision reports;
- cover the portfolio workflow, server-authoritative architecture exports, local semantic-search readiness, accessibility work, and constrained Rancher/RKE2 deployment floor;
- document serialized analysis-draft autosaves and the durable V18 relation-projection index cleanup;
- describe the integrated multi-repository technical foundation while making clear that the public API remains disabled by default and is not production-supported in 1.4.0;
- disclose that bounded existing Python release/evidence adapters remain under Maven/JUnit contracts and full removal is deferred to #673 after 1.4.0;
- preserve exact-candidate, digest-bound artifact, scan, SBOM/VEX, Helm, and post-release version boundaries.

### `docs/dev/PYTHON_TOOLING_POLICY.md`

The policy distinguishes the long-term zero-Python goal from the explicit 1.4.0 scope decision while keeping the removal ratchet and post-release migration plan.

## Exact integration state

The branch was reconstructed directly on the exact green `main` commit `ef3a405b334659c46eb5115ebb7832cd8701c693` after #858. Head `3565869de57ceb64a437e5d6d5cd331403012529` is exactly one documentation-only commit ahead and changes only:

- `docs/dev/PYTHON_TOOLING_POLICY.md`;
- `release_notes.md`.

Both resulting blobs are byte-identical to the previously reviewed documentation content. No application, migration, test, workflow, release request, product version, or publication state is changed. Fresh exact-head CI/CD run `32737716064` and Database Compatibility run `32737716066` have been started for this unchanged head.

Release preparation for #711; post-release migration remains tracked by #673.