### PR TITLE
Temporary: inspect failing main CI run

### DIFF
--- a/.github/workflows/temp-inspect-main-ci.yml
+++ b/.github/workflows/temp-inspect-main-ci.yml
@@ -1,0 +1,27 @@
+name: Temporary inspect main CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/temp-inspect-main-ci.yml'
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  inspect:
+    name: Inspect latest main CI/CD push runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Print recent main CI/CD push runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-cd.yml/runs?branch=main&event=push&per_page=10" \
+            --jq '.workflow_runs[] | [.id, .run_number, .status, (.conclusion // ""), .head_sha, .created_at, .html_url] | @tsv'

--- a/.github/workflows/temp-inspect-main-ci.yml
+++ b/.github/workflows/temp-inspect-main-ci.yml
@@ -13,24 +13,34 @@ permissions:
 
 jobs:
   inspect:
-    name: Inspect exact main workflow and check state
+    name: Inspect failing exact-main CodeQL logs
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Print exact main workflow runs and checks
+      - name: Print failed CodeQL logs from exact main
         env:
           GH_TOKEN: ${{ github.token }}
+          FAILED_RUN_ID: '32692941814'
+          JAVA_JOB_ID: '97329087511'
+          JAVASCRIPT_JOB_ID: '97329087687'
         shell: bash
         run: |
           set -euo pipefail
           main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')
           printf 'MAIN_SHA\t%s\n' "$main_sha"
-          printf '%s\n' '--- ACTION RUNS ---'
-          gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${main_sha}&per_page=100" \
-            --jq '.workflow_runs[] | [.id, .name, .run_number, .event, .status, (.conclusion // ""), .head_branch, .head_sha, .created_at, .html_url] | @tsv'
-          printf '%s\n' '--- CHECK RUNS ---'
-          gh api \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/${GITHUB_REPOSITORY}/commits/${main_sha}/check-runs?per_page=100" \
-            --jq '.check_runs[] | [.id, .name, .status, (.conclusion // ""), .started_at, (.completed_at // ""), .html_url] | @tsv'
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FAILED_RUN_ID}" \
+            --jq '[.id, .name, .run_number, .event, .status, .conclusion, .head_branch, .head_sha, .html_url] | @tsv'
+
+          for entry in "java:${JAVA_JOB_ID}" "javascript:${JAVASCRIPT_JOB_ID}"; do
+            language=${entry%%:*}
+            job_id=${entry##*:}
+            log_file="$RUNNER_TEMP/${language}.log"
+            printf '\n===== %s JOB %s =====\n' "$language" "$job_id"
+            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" > "$log_file"
+            printf '%s\n' '--- ERROR-FOCUSED EXCERPTS ---'
+            grep -n -E -i -C 8 \
+              '::error::|(^|[^a-z])(error|exception|failed|failure|fatal)([^a-z]|$)|codeql gate|sarif|security-severity|unsupported|unknown rule|no .*file' \
+              "$log_file" | tail -n 500 || true
+            printf '%s\n' '--- FINAL 250 LOG LINES ---'
+            tail -n 250 "$log_file"
+          done

--- a/.github/workflows/temp-inspect-main-ci.yml
+++ b/.github/workflows/temp-inspect-main-ci.yml
@@ -8,20 +8,29 @@ on:
 
 permissions:
   actions: read
+  checks: read
   contents: read
 
 jobs:
   inspect:
-    name: Inspect latest main CI/CD push runs
+    name: Inspect exact main workflow and check state
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Print recent main CI/CD push runs
+      - name: Print exact main workflow runs and checks
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
+          main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')
+          printf 'MAIN_SHA\t%s\n' "$main_sha"
+          printf '%s\n' '--- ACTION RUNS ---'
           gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-cd.yml/runs?branch=main&event=push&per_page=10" \
-            --jq '.workflow_runs[] | [.id, .run_number, .status, (.conclusion // ""), .head_sha, .created_at, .html_url] | @tsv'
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${main_sha}&per_page=100" \
+            --jq '.workflow_runs[] | [.id, .name, .run_number, .event, .status, (.conclusion // ""), .head_branch, .head_sha, .created_at, .html_url] | @tsv'
+          printf '%s\n' '--- CHECK RUNS ---'
+          gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${GITHUB_REPOSITORY}/commits/${main_sha}/check-runs?per_page=100" \
+            --jq '.check_runs[] | [.id, .name, .status, (.conclusion // ""), .started_at, (.completed_at // ""), .html_url] | @tsv'

--- a/.github/workflows/temp-inspect-main-ci.yml
+++ b/.github/workflows/temp-inspect-main-ci.yml
@@ -13,34 +13,89 @@ permissions:
 
 jobs:
   inspect:
-    name: Inspect failing exact-main CodeQL logs
+    name: Inspect current exact-main workflow state
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - name: Print failed CodeQL logs from exact main
+      - name: Print current main runs, jobs and failed log excerpts
         env:
           GH_TOKEN: ${{ github.token }}
-          FAILED_RUN_ID: '32692941814'
-          JAVA_JOB_ID: '97329087511'
-          JAVASCRIPT_JOB_ID: '97329087687'
         shell: bash
         run: |
-          set -euo pipefail
+          set -Eeuo pipefail
+
           main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')
           printf 'MAIN_SHA\t%s\n' "$main_sha"
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FAILED_RUN_ID}" \
-            --jq '[.id, .name, .run_number, .event, .status, .conclusion, .head_branch, .head_sha, .html_url] | @tsv'
 
-          for entry in "java:${JAVA_JOB_ID}" "javascript:${JAVASCRIPT_JOB_ID}"; do
-            language=${entry%%:*}
-            job_id=${entry##*:}
-            log_file="$RUNNER_TEMP/${language}.log"
-            printf '\n===== %s JOB %s =====\n' "$language" "$job_id"
-            gh api "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" > "$log_file"
-            printf '%s\n' '--- ERROR-FOCUSED EXCERPTS ---'
-            grep -n -E -i -C 8 \
-              '::error::|(^|[^a-z])(error|exception|failed|failure|fatal)([^a-z]|$)|codeql gate|sarif|security-severity|unsupported|unknown rule|no .*file' \
-              "$log_file" | tail -n 500 || true
-            printf '%s\n' '--- FINAL 250 LOG LINES ---'
-            tail -n 250 "$log_file"
+          runs_file="$RUNNER_TEMP/main-runs.json"
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?branch=main&event=push&per_page=100" \
+            > "$runs_file"
+
+          mapfile -t run_ids < <(
+            jq -r --arg sha "$main_sha" \
+              '.workflow_runs[] | select(.head_sha == $sha) | .id' \
+              "$runs_file"
+          )
+
+          if (( ${#run_ids[@]} == 0 )); then
+            printf 'NO_PUSH_RUNS_FOR_MAIN_SHA\t%s\n' "$main_sha"
+            exit 0
+          fi
+
+          printf '%s\n' '===== WORKFLOW RUNS FOR EXACT MAIN ====='
+          jq -r --arg sha "$main_sha" '
+            .workflow_runs[]
+            | select(.head_sha == $sha)
+            | [.id, .name, .run_number, .event, .status,
+               (.conclusion // ""), .head_branch, .head_sha, .html_url]
+            | @tsv
+          ' "$runs_file"
+
+          for run_id in "${run_ids[@]}"; do
+            jobs_file="$RUNNER_TEMP/jobs-${run_id}.json"
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?filter=latest&per_page=100" \
+              > "$jobs_file"
+
+            printf '\n===== JOBS FOR RUN %s =====\n' "$run_id"
+            jq -r '
+              .jobs[]
+              | [.id, .name, .status, (.conclusion // ""), .html_url]
+              | @tsv
+            ' "$jobs_file"
+
+            while IFS=$'\t' read -r job_id job_name job_status job_conclusion; do
+              case "$job_conclusion" in
+                failure|cancelled|timed_out|action_required|startup_failure)
+                  ;;
+                *)
+                  continue
+                  ;;
+              esac
+
+              safe_name=$(printf '%s' "$job_name" | tr -cs 'A-Za-z0-9._-' '_')
+              log_file="$RUNNER_TEMP/${run_id}-${job_id}-${safe_name}.log"
+              printf '\n===== FAILED JOB %s: %s (%s/%s) =====\n' \
+                "$job_id" "$job_name" "$job_status" "$job_conclusion"
+
+              if gh api \
+                  "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" \
+                  > "$log_file"; then
+                printf '%s\n' '--- ERROR-FOCUSED EXCERPTS ---'
+                grep -n -E -i -C 10 \
+                  '::error::|(^|[^a-z])(error|exception|failed|failure|fatal)([^a-z]|$)|codeql gate|sarif|security-severity|unsupported|unknown rule|no .*file|BUILD FAILURE|Tests run:.*Failures: [1-9]|Tests run:.*Errors: [1-9]' \
+                  "$log_file" | tail -n 700 || true
+                printf '%s\n' '--- FINAL 300 LOG LINES ---'
+                tail -n 300 "$log_file"
+              else
+                printf 'LOG_UNAVAILABLE\t%s\n' "$job_id"
+              fi
+            done < <(
+              jq -r '
+                .jobs[]
+                | [.id, .name, .status, (.conclusion // "")]
+                | @tsv
+              ' "$jobs_file"
+            )
           done

--- a/.github/workflows/temp-inspect-main-ci.yml
+++ b/.github/workflows/temp-inspect-main-ci.yml
@@ -1,4 +1,4 @@
-name: Temporary inspect main CI
+name: Temporary inspect failed PR workflows
 
 on:
   pull_request:
@@ -13,38 +13,37 @@ permissions:
 
 jobs:
   inspect:
-    name: Inspect current exact-main workflow state
+    name: Inspect exact failed configuration-reference head
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Print current main runs, jobs and failed log excerpts
+      - name: Print runs, jobs and failed log excerpts
         env:
           GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: 20593ce41633ae3351ec1f41571721e7f83fe500
         shell: bash
         run: |
           set -Eeuo pipefail
 
-          main_sha=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq '.commit.sha')
-          printf 'MAIN_SHA\t%s\n' "$main_sha"
-
-          runs_file="$RUNNER_TEMP/main-runs.json"
+          printf 'TARGET_SHA\t%s\n' "$TARGET_SHA"
+          runs_file="$RUNNER_TEMP/target-runs.json"
           gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/runs?branch=main&event=push&per_page=100" \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${TARGET_SHA}&per_page=100" \
             > "$runs_file"
 
           mapfile -t run_ids < <(
-            jq -r --arg sha "$main_sha" \
+            jq -r --arg sha "$TARGET_SHA" \
               '.workflow_runs[] | select(.head_sha == $sha) | .id' \
               "$runs_file"
           )
 
           if (( ${#run_ids[@]} == 0 )); then
-            printf 'NO_PUSH_RUNS_FOR_MAIN_SHA\t%s\n' "$main_sha"
-            exit 0
+            printf 'NO_RUNS_FOR_TARGET_SHA\t%s\n' "$TARGET_SHA"
+            exit 1
           fi
 
-          printf '%s\n' '===== WORKFLOW RUNS FOR EXACT MAIN ====='
-          jq -r --arg sha "$main_sha" '
+          printf '%s\n' '===== WORKFLOW RUNS FOR EXACT TARGET ====='
+          jq -r --arg sha "$TARGET_SHA" '
             .workflow_runs[]
             | select(.head_sha == $sha)
             | [.id, .name, .run_number, .event, .status,
@@ -83,11 +82,11 @@ jobs:
                   "repos/${GITHUB_REPOSITORY}/actions/jobs/${job_id}/logs" \
                   > "$log_file"; then
                 printf '%s\n' '--- ERROR-FOCUSED EXCERPTS ---'
-                grep -n -E -i -C 10 \
-                  '::error::|(^|[^a-z])(error|exception|failed|failure|fatal)([^a-z]|$)|codeql gate|sarif|security-severity|unsupported|unknown rule|no .*file|BUILD FAILURE|Tests run:.*Failures: [1-9]|Tests run:.*Errors: [1-9]' \
-                  "$log_file" | tail -n 700 || true
-                printf '%s\n' '--- FINAL 300 LOG LINES ---'
-                tail -n 300 "$log_file"
+                grep -n -E -i -C 14 \
+                  '::error::|(^|[^a-z])(error|exception|failed|failure|fatal)([^a-z]|$)|BUILD FAILURE|Tests run:.*Failures: [1-9]|Tests run:.*Errors: [1-9]|expected:|but was:|Compilation failure|Could not resolve|npm ERR|playwright|chromium|ConfigurationReferenceContractTest|TaxonomyMultiRepositoryConfigurationTest|ProposalProductServiceTest' \
+                  "$log_file" | tail -n 1200 || true
+                printf '%s\n' '--- FINAL 450 LOG LINES ---'
+                tail -n 450 "$log_file"
               else
                 printf 'LOG_UNAVAILABLE\t%s\n' "$job_id"
               fi


### PR DESCRIPTION
Short-lived diagnostics only. The workflow has read-only `actions`/`contents` permissions and prints the latest `main` CI/CD push-run IDs so the failed job log can be inspected through the connected GitHub interface. This PR will be closed and the branch removed after diagnosis; it must not be merged.