### PR TITLE
Document and enforce the complete runtime configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,77 +1,91 @@
-# .env — Configuration for docker-compose.prod.yml
+# .env — configuration for docker-compose.prod.yml
 # Copy this file:  cp .env.example .env
-# Then edit .env with your actual values before starting the production stack.
+# Then edit .env before starting the production stack. Do not commit .env.
+# The complete variable inventory is in docs/en/CONFIGURATION_REFERENCE.md and
+# docs/de/CONFIGURATION_REFERENCE.md.
 
-# Source builds resolve all dependencies anonymously. No GitHub account or token is required.
-# Do not commit the populated .env file.
-
-# ─── Required at runtime ─────────────────────────────────────
-# Your domain name (DNS A/AAAA record must point to this server)
+# ─── Required by the production Compose stack ───────────────────────────────
+# DNS A/AAAA records must point to this server.
 DOMAIN=taxonomy.example.com
 
-# Initial form-login administrator password.
-# docker-compose.prod.yml refuses to start when this value is missing.
-# Use a unique, long password and rotate it after first login.
-TAXONOMY_ADMIN_PASSWORD=replace-with-a-long-random-password
+# Initial local form-login administrator password. The production profile rejects
+# empty values, known placeholders and values shorter than 16 characters.
+TAXONOMY_ADMIN_PASSWORD=replace-with-a-unique-random-password
 
-# Existing pre-library installations only: leave false during normal operation.
-# After a restorable backup and successful adoption preflight, set true for one
-# startup, verify repository history and BLOB checksums, then set it back to false.
+# Optional, separate Actuator/admin token for X-Admin-Token and Bearer checks.
+# Never reuse the interactive login password above as this machine credential.
+# ADMIN_PASSWORD=replace-with-a-distinct-random-machine-token
+
+# Existing pre-library installations only: after a restorable backup and successful
+# adoption preflight, set true for one startup, verify the result, then restore false.
 TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION=false
 
-# ─── LLM Provider (choose one) ───────────────────────────────
-# Option 1: Google Gemini (cloud, needs API key)
-# GEMINI_API_KEY=your-gemini-api-key
-# LLM_PROVIDER=GEMINI
+# ─── Generative LLM provider (choose and configure one) ─────────────────────
+# Empty is fail-closed unless one complete provider configuration below is present;
+# Taxonomy then auto-detects the first complete provider.
+LLM_PROVIDER=
 
-# Option 2: Generative LLM through an OpenAI-compatible server.
-# URL and model are mandatory; the Bearer token is optional for a trusted local server.
-# From the Taxonomy container, use a reachable hostname or Docker service name —
-# not localhost unless the model server runs inside the same container.
+# Option 1: Google Gemini
+# LLM_PROVIDER=GEMINI
+# GEMINI_API_KEY=your-gemini-api-key
+
+# Option 2: OpenAI
+# LLM_PROVIDER=OPENAI
+# OPENAI_API_KEY=your-openai-api-key
+
+# Option 3: OpenAI-compatible local or private server. From the Taxonomy container,
+# use a reachable Docker service/host name, not localhost unless both run together.
 # LLM_PROVIDER=CUSTOM_OPENAI
 # CUSTOM_LLM_URL=http://llm-server:8000/v1/chat/completions
 # CUSTOM_LLM_MODEL=architecture-model
 # CUSTOM_LLM_API_KEY=
 
-# Option 3: Local embedding-based semantic scoring (not a generative chat LLM).
-# For a network-isolated deployment, pre-download the model and set
-# TAXONOMY_EMBEDDING_MODEL_DIR to the mounted directory. Runtime downloads are
-# disabled by default in docker-compose.prod.yml.
-LLM_PROVIDER=LOCAL_ONNX
+# Other supported cloud providers are documented in docs/en/AI_PROVIDERS.md.
+# DEEPSEEK_API_KEY=
+# DASHSCOPE_API_KEY=
+# LLAMA_API_KEY=
+# MISTRAL_API_KEY=
+
+# ─── Local semantic embeddings (not a generative chat LLM) ─────────────────
+# Safe production default: disabled and no runtime network download. To enable,
+# mount a pre-downloaded model directory and set TAXONOMY_EMBEDDING_ENABLED=true.
+TAXONOMY_EMBEDDING_ENABLED=false
 TAXONOMY_EMBEDDING_MODEL_DIR=
 TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD=false
 
-# Option 4: Other cloud providers (see docs/en/AI_PROVIDERS.md)
-# OPENAI_API_KEY=your-openai-key
-# LLM_PROVIDER=OPENAI
-
-# ─── Copilot and explicitly enabled Autopilot ────────────────
-# Safe default: every Copilot run is user-triggered and no unattended work starts.
+# ─── Manual Copilot and explicitly enabled Autopilot ────────────────────────
+# Manual Copilot remains user-triggered. These defaults never start unattended work.
 TAXONOMY_AI_COST_POLICY=METERED
+TAXONOMY_AI_COPILOT_PROFILE=FULL
+TAXONOMY_AI_AUTOPILOT_PROFILE=EXHAUSTIVE
+TAXONOMY_AI_COPILOT_VERIFICATION_PASSES=1
+TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES=2
+
+# Historic name retained: this is the operator ceiling for BOTH manual Copilot and
+# Autopilot architecture views. The general portfolio ceiling must not be lower.
+TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES=50
+
 TAXONOMY_AI_AUTOPILOT_ENABLED=false
 TAXONOMY_AI_AUTOPILOT_PROVIDER=
 TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE=true
-TAXONOMY_AI_COPILOT_VERIFICATION_PASSES=1
-TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES=2
-TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS=true
+TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS=true
 TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS=50
+TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE=25
+TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE=0.25
 TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS=4
 TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY=100
 TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS=1800
 
 # Unattended Autopilot requires all three deliberate settings below plus a fully
-# configured provider. CUSTOM_OPENAI is never assumed to be free automatically.
+# configured provider. CUSTOM_OPENAI is never assumed to be unmetered automatically.
 # TAXONOMY_AI_COST_POLICY=UNMETERED
 # TAXONOMY_AI_AUTOPILOT_ENABLED=true
 # TAXONOMY_AI_AUTOPILOT_PROVIDER=CUSTOM_OPENAI
 
-# ─── Optional external canonical Git repository ──────────────
-# Configure the repository URL through the administrator UI/API. Credentials are
-# write-only deployment secrets and are never persisted in the Taxonomy database.
-# The username value depends on the Git provider; oauth2 is a common token user.
+# ─── Optional external canonical Git repository ─────────────────────────────
+# Configure its URL through the administrator UI/API. Credentials stay in the
+# process environment and are never persisted in the Taxonomy database.
 # TAXONOMY_EXTERNAL_GIT_USERNAME=oauth2
 # TAXONOMY_EXTERNAL_GIT_TOKEN=replace-with-provider-token
-
-# ─── Optional ────────────────────────────────────────────────
-# Semantic/KNN search (requires ~80-140 MB extra memory)
-TAXONOMY_EMBEDDING_ENABLED=true

--- a/deploy/helm/taxonomy/RANCHER.md
+++ b/deploy/helm/taxonomy/RANCHER.md
@@ -100,9 +100,26 @@ SPRING_DATASOURCE_PASSWORD
 ADMIN_PASSWORD
 ```
 
-LLM API keys remain optional. Create the Secret in the same namespace in which Rancher installs the chart. Do not place credentials in ordinary chart values.
+`ADMIN_PASSWORD` is the interactive local administrator credential and is injected into the application as `TAXONOMY_ADMIN_PASSWORD`. When the protected Prometheus ServiceMonitor is enabled, add a separate machine credential:
 
-For a new installation, point `SPRING_DATASOURCE_URL` at the empty new database. For an upgrade, retain the existing database URL and backup that database before installing the new chart version.
+```text
+ADMIN_TOKEN
+```
+
+The chart injects `ADMIN_TOKEN` into the application as its historic `ADMIN_PASSWORD` environment variable and configures the ServiceMonitor to read the same Secret key. Never reuse the interactive `ADMIN_PASSWORD` value as `ADMIN_TOKEN`. The chart rejects a configuration that maps both purposes to the same key. LLM API keys remain optional. Create the Secret in the same namespace in which Rancher installs the chart, and do not place credentials in ordinary chart values.
+
+Example:
+
+```bash
+kubectl -n taxonomy create secret generic taxonomy-secrets \
+  --from-literal=SPRING_DATASOURCE_URL='jdbc:postgresql://postgres.example:5432/taxonomy' \
+  --from-literal=SPRING_DATASOURCE_USERNAME='taxonomy' \
+  --from-literal=SPRING_DATASOURCE_PASSWORD='replace-me' \
+  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-login-password' \
+  --from-literal=ADMIN_TOKEN='replace-with-a-different-long-random-machine-token'
+```
+
+For a new installation, point `SPRING_DATASOURCE_URL` at the empty new database. For an upgrade, retain the existing database URL and backup that database before installing the new chart version. Existing installations that leave `serviceMonitor.enabled=false` may omit the optional `ADMIN_TOKEN` key until another admin-token consumer requires it.
 
 ## 3. Render before installing
 

--- a/deploy/helm/taxonomy/README.md
+++ b/deploy/helm/taxonomy/README.md
@@ -21,10 +21,11 @@ kubectl -n taxonomy create secret generic taxonomy-secrets \
   --from-literal=SPRING_DATASOURCE_URL='jdbc:postgresql://postgres.example:5432/taxonomy' \
   --from-literal=SPRING_DATASOURCE_USERNAME='taxonomy' \
   --from-literal=SPRING_DATASOURCE_PASSWORD='replace-me' \
-  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-value'
+  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-login-password' \
+  --from-literal=ADMIN_TOKEN='replace-with-a-different-long-random-machine-token'
 ```
 
-Optional LLM keys may be added to the same Secret. Their mappings are marked optional; database and admin credentials are not.
+The Secret key `ADMIN_PASSWORD` is mapped to the application variable `TAXONOMY_ADMIN_PASSWORD` and bootstraps the interactive local administrator account. The distinct `ADMIN_TOKEN` key is mapped to the application variable `ADMIN_PASSWORD` and is used for Actuator/admin-token checks and the optional ServiceMonitor. Never reuse the interactive login credential as the machine token. Existing installations that do not enable the ServiceMonitor may omit the optional `ADMIN_TOKEN` key. Optional LLM keys may be added to the same Secret; database and login credentials remain mandatory.
 
 Install or upgrade a source-tree chart with an immutable image reference:
 
@@ -87,7 +88,8 @@ kubectl -n taxonomy-fresh create secret generic taxonomy-secrets \
   --from-literal=SPRING_DATASOURCE_URL='jdbc:postgresql://postgres.example:5432/taxonomy_fresh' \
   --from-literal=SPRING_DATASOURCE_USERNAME='taxonomy_fresh' \
   --from-literal=SPRING_DATASOURCE_PASSWORD='replace-me' \
-  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-value'
+  --from-literal=ADMIN_PASSWORD='replace-with-a-long-random-login-password' \
+  --from-literal=ADMIN_TOKEN='replace-with-a-different-long-random-machine-token'
 
 helm upgrade --install taxonomy-fresh deploy/helm/taxonomy \
   --namespace taxonomy-fresh \
@@ -261,7 +263,7 @@ Runtime model download is disabled by default in the chart, and embedding is ini
 
 ## Prometheus metrics
 
-The application protects `/actuator/prometheus` with the admin token. Enable the optional ServiceMonitor as follows:
+The application protects `/actuator/prometheus` with the separate admin token. Enable the optional ServiceMonitor as follows:
 
 ```yaml
 serviceMonitor:
@@ -270,10 +272,10 @@ serviceMonitor:
     release: kube-prometheus-stack
   authorization:
     enabled: true
-    secretKey: ADMIN_PASSWORD
+    secretKey: ADMIN_TOKEN
 ```
 
-The ServiceMonitor reads the Bearer credential from `existingSecret` by default. `serviceMonitor.authorization.secretName` can point to a different Secret. Prometheus must be permitted to read that Secret in the release namespace, and its ServiceMonitor selector must match `additionalLabels`.
+The application and ServiceMonitor read `ADMIN_TOKEN` from `existingSecret` by default. The chart maps that key to the application's historic `ADMIN_PASSWORD` environment variable while keeping the interactive login password under the distinct `ADMIN_PASSWORD` Secret key and `TAXONOMY_ADMIN_PASSWORD` environment variable. `serviceMonitor.authorization.secretName` can point to a different Secret; in that case the operator must ensure that its selected token value exactly matches the application token. Prometheus must be permitted to read the Secret in the release namespace, and its ServiceMonitor selector must match `additionalLabels`.
 
 ## Network policy
 
@@ -339,7 +341,7 @@ For a protected metrics check:
 
 ```bash
 TOKEN=$(kubectl -n taxonomy get secret taxonomy-secrets \
-  -o jsonpath='{.data.ADMIN_PASSWORD}' | base64 --decode)
+  -o jsonpath='{.data.ADMIN_TOKEN}' | base64 --decode)
 curl --fail -H "Authorization: Bearer ${TOKEN}" \
   http://127.0.0.1:8080/actuator/prometheus
 ```

--- a/deploy/helm/taxonomy/questions.yaml
+++ b/deploy/helm/taxonomy/questions.yaml
@@ -4,6 +4,8 @@ questions:
     description: >-
       Select a Secret in the target namespace containing SPRING_DATASOURCE_URL,
       SPRING_DATASOURCE_USERNAME, SPRING_DATASOURCE_PASSWORD and ADMIN_PASSWORD.
+      When the Prometheus ServiceMonitor is enabled, add a distinct ADMIN_TOKEN
+      key; never reuse the interactive ADMIN_PASSWORD value as the machine token.
     type: secret
     required: true
     group: Required configuration
@@ -55,7 +57,9 @@ questions:
 
   - variable: serviceMonitor.enabled
     label: Create Prometheus ServiceMonitor
-    description: Requires Prometheus Operator CRDs in the cluster.
+    description: >-
+      Requires Prometheus Operator CRDs and a distinct ADMIN_TOKEN key in the
+      selected credential Secret.
     type: boolean
     default: false
     group: Observability

--- a/deploy/helm/taxonomy/templates/validation.yaml
+++ b/deploy/helm/taxonomy/templates/validation.yaml
@@ -26,6 +26,13 @@
 {{- if and (gt (len .Values.secretEnv) 0) (empty .Values.existingSecret) -}}
 {{- fail "existingSecret is required while secretEnv contains credential mappings" -}}
 {{- end -}}
+{{- if and (hasKey .Values.secretEnv "TAXONOMY_ADMIN_PASSWORD") (hasKey .Values.secretEnv "ADMIN_PASSWORD") -}}
+{{- $loginCredential := index .Values.secretEnv "TAXONOMY_ADMIN_PASSWORD" -}}
+{{- $adminTokenCredential := index .Values.secretEnv "ADMIN_PASSWORD" -}}
+{{- if eq (index $loginCredential "key") (index $adminTokenCredential "key") -}}
+{{- fail "TAXONOMY_ADMIN_PASSWORD and ADMIN_PASSWORD must use different Secret keys; do not reuse the interactive login password as an Actuator/admin token" -}}
+{{- end -}}
+{{- end -}}
 {{- if ge (int .Values.preStopDelaySeconds) (int .Values.terminationGracePeriodSeconds) -}}
 {{- fail "preStopDelaySeconds must be lower than terminationGracePeriodSeconds" -}}
 {{- end -}}
@@ -75,5 +82,11 @@
 {{- end -}}
 {{- if empty .Values.serviceMonitor.authorization.secretKey -}}
 {{- fail "serviceMonitor.authorization.secretKey is required when authorization is enabled" -}}
+{{- end -}}
+{{- if and (eq $metricsSecret (.Values.existingSecret | trim)) (hasKey .Values.secretEnv "ADMIN_PASSWORD") -}}
+{{- $adminTokenCredential := index .Values.secretEnv "ADMIN_PASSWORD" -}}
+{{- if ne .Values.serviceMonitor.authorization.secretKey (index $adminTokenCredential "key") -}}
+{{- fail "ServiceMonitor and the application must read the Actuator/admin token from the same key when they share existingSecret" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/taxonomy/values.yaml
+++ b/deploy/helm/taxonomy/values.yaml
@@ -158,11 +158,18 @@ secretEnv:
   SPRING_DATASOURCE_PASSWORD:
     key: SPRING_DATASOURCE_PASSWORD
     optional: false
-  # Spring maps TAXONOMY_ADMIN_PASSWORD to taxonomy.admin-password. The Secret
-  # key remains ADMIN_PASSWORD for compatibility with existing deployments.
+  # Local form-login bootstrap credential. The Secret key remains ADMIN_PASSWORD
+  # for compatibility with existing chart installations.
   TAXONOMY_ADMIN_PASSWORD:
     key: ADMIN_PASSWORD
     optional: false
+  # Separate Actuator/admin-token credential. It deliberately uses a different
+  # Secret key so the interactive login password is not reused as a machine token.
+  # Existing installations remain compatible while this optional token and the
+  # optional ServiceMonitor are disabled.
+  ADMIN_PASSWORD:
+    key: ADMIN_TOKEN
+    optional: true
   GEMINI_API_KEY:
     key: GEMINI_API_KEY
     optional: true
@@ -194,26 +201,45 @@ config:
   TAXONOMY_SEARCH_SYNC_STRATEGY: write-sync
   TAXONOMY_SPRINGDOC_ENABLED: "false"
   TAXONOMY_FORWARD_HEADERS_STRATEGY: framework
+
+  # Generative providers are fail-closed until a complete configuration is supplied.
+  LLM_PROVIDER: ""
+  CUSTOM_LLM_URL: ""
+  CUSTOM_LLM_MODEL: ""
+
+  # Local semantic embeddings are independent of the chat provider and opt-in.
   TAXONOMY_EMBEDDING_ENABLED: "false"
   TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD: "false"
-  # Autopilot is opt-in twice: the operator must enable it and explicitly classify
-  # the selected provider as UNMETERED. These defaults never start unattended work.
+  TAXONOMY_EMBEDDING_MODEL_DIR: ""
+
+  # Copilot can be invoked manually with a configured provider. Autopilot is opt-in
+  # twice: the operator must enable it and classify its explicit provider UNMETERED.
   TAXONOMY_AI_COST_POLICY: METERED
+  TAXONOMY_AI_COPILOT_PROFILE: FULL
+  TAXONOMY_AI_AUTOPILOT_PROFILE: EXHAUSTIVE
   TAXONOMY_AI_AUTOPILOT_ENABLED: "false"
   TAXONOMY_AI_AUTOPILOT_PROVIDER: ""
   TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE: "true"
   TAXONOMY_AI_COPILOT_VERIFICATION_PASSES: "1"
   TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES: "2"
+  # Historic name retained: this ceiling applies to both manual Copilot and Autopilot.
   TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES: "50"
+  # The general portfolio ceiling must be at least as high as the AI-specific ceiling.
+  TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES: "50"
+  TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS: "true"
+  TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS: "true"
   TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS: "50"
+  TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE: "25"
+  TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE: "0.25"
   TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS: "4"
   TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY: "100"
   TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS: "1800"
+
   JAVA_OPTS: -XX:MaxRAMPercentage=65.0 -XX:InitialRAMPercentage=20.0 -Xss512k -XX:+ExitOnOutOfMemoryError -Djava.io.tmpdir=/tmp
 
-# Prometheus Operator integration. The application accepts the configured local
-# administrator password as a Bearer token for /actuator/prometheus; the
-# ServiceMonitor reads that value from the existing Secret.
+# Prometheus Operator integration. The application receives its ADMIN_PASSWORD
+# Bearer token from the distinct ADMIN_TOKEN Secret key. Do not reuse the local
+# form-login password stored under ADMIN_PASSWORD.
 serviceMonitor:
   enabled: false
   additionalLabels: {}
@@ -222,7 +248,7 @@ serviceMonitor:
   authorization:
     enabled: true
     secretName: ""
-    secretKey: ADMIN_PASSWORD
+    secretKey: ADMIN_TOKEN
   relabelings: []
   metricRelabelings: []
 

--- a/deploy/helm/taxonomy/verify.sh
+++ b/deploy/helm/taxonomy/verify.sh
@@ -51,7 +51,7 @@ for required in \
   'type: Recreate' \
   'path: /actuator/health/readiness' \
   'type: Bearer' \
-  'key: "ADMIN_PASSWORD"'; do
+  'key: "ADMIN_TOKEN"'; do
   if ! grep -Fq "${required}" "${OUTPUT_FILE}"; then
     echo "Rendered chart is missing required contract: ${required}" >&2
     exit 1
@@ -222,6 +222,15 @@ expect_failure 'simultaneous image tag and digest' \
     --set image.digest=sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 expect_failure 'missing credentials Secret' \
   helm template taxonomy "${CHART_DIR}" --set "image.tag=${VALID_TAG}"
+expect_failure 'interactive login credential reused as Actuator/admin token' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" \
+    --set secretEnv.ADMIN_PASSWORD.key=ADMIN_PASSWORD
+expect_failure 'ServiceMonitor token key diverges from the application token key' \
+  helm template taxonomy "${CHART_DIR}" \
+    "${COMMON_VALUES[@]}" \
+    --set serviceMonitor.enabled=true \
+    --set serviceMonitor.authorization.secretKey=OTHER_TOKEN
 expect_failure 'invalid upgrade strategy' \
   helm template taxonomy "${CHART_DIR}" \
     "${COMMON_VALUES[@]}" --set upgrade.strategy=BlueGreen
@@ -273,5 +282,6 @@ done
 
 grep -Fq 'publish-helm-oci.yml' "${ROOT_DIR}/.mvn/verification-suites.json"
 grep -Fq 'upgrade.strategy' "${CHART_DIR}/questions.yaml"
+grep -Fq 'ADMIN_TOKEN' "${CHART_DIR}/questions.yaml"
 
 printf 'Helm chart verification passed. Rendered evidence: %s\n' "${OUTPUT_FILE}"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,10 @@ services:
       context: .
     # Or use the published image instead of building locally. Production image
     # references must be digest-pinned before enabling this alternative.
+    # Forward the complete operator-edited file. Explicit values below remain the
+    # production floor and override matching entries from .env where intentional.
+    env_file:
+      - .env
     environment:
       - SPRING_PROFILES_ACTIVE=production,hsqldb
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
@@ -53,7 +57,9 @@ services:
       - TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION=${TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION:-false}
       - TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem
       - TAXONOMY_SEARCH_DIRECTORY_ROOT=/app/data/lucene-index
-      - TAXONOMY_EMBEDDING_ENABLED=${TAXONOMY_EMBEDDING_ENABLED:-true}
+      # Local semantic embeddings are opt-in because they increase memory use and
+      # may otherwise trigger an unexpected model download/network dependency.
+      - TAXONOMY_EMBEDDING_ENABLED=${TAXONOMY_EMBEDDING_ENABLED:-false}
       - TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD=${TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD:-false}
       - TAXONOMY_EMBEDDING_MODEL_DIR=${TAXONOMY_EMBEDDING_MODEL_DIR:-}
       - TAXONOMY_THYMELEAF_CACHE=true

--- a/docs/de/CONFIGURATION_REFERENCE.md
+++ b/docs/de/CONFIGURATION_REFERENCE.md
@@ -1,511 +1,232 @@
 # Taxonomy Architecture Analyzer — Konfigurationsreferenz
 
-Dieses Dokument ist die **kanonische, vollständige Liste** aller Umgebungsvariablen und
-Anwendungseigenschaften, die vom Taxonomy Architecture Analyzer erkannt werden.  
-Werte werden über Umgebungsvariablen (empfohlen für Produktion) oder in
-`src/main/resources/application.properties` für die lokale Entwicklung gesetzt.
+Dies ist das kanonische Verzeichnis der betriebsrelevanten Umgebungsvariablen der Taxonomy-Anwendung. Ein Vertragstest gleicht die Tabellen mit Spring-Property-Dateien, direkten `@Value`-Bindings, Feature-Flags und `@ConfigurationProperties` ab.
 
----
+Umgebungsvariablen haben Vorrang vor `application*.properties`. `SPRING_DATASOURCE_URL` und `TAXONOMY_DATASOURCE_URL` setzen dieselbe Spring-Eigenschaft; pro Installation nur eine davon verwenden.
 
-## Start und Kataloginitialisierung
+Profilabhängige Standards:
 
-| Umgebungsvariable | Property | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | Boolean | `false` | Lädt die Taxonomie erst, nachdem der HTTP-Server seinen Port geöffnet hat. |
-| `TAXONOMY_INIT_RELOAD_EXISTING` | `taxonomy.init.reload-existing` | Boolean | `false` | Verwendet einen persistierten Katalog bei normalen Neustarts weiter. Nur für einen bewusst destruktiven Neuimport aus der mitgelieferten Excel-Datei auf `true` setzen. |
-
-Produktivinstallationen sollten `TAXONOMY_INIT_RELOAD_EXISTING=false` beibehalten. Vor einem erzwungenen Neuimport müssen Datenbank und Suchindex gesichert werden.
-
-## LLM-Anbieter-Konfiguration
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `LLM_PROVIDER` | `llm.provider` | Enum | *(Auto-Erkennung)* | Erzwingt einen bestimmten LLM-Anbieter. Werte: `GEMINI`, `OPENAI`, `DEEPSEEK`, `QWEN`, `LLAMA`, `MISTRAL`, `CUSTOM_OPENAI`, `LOCAL_ONNX`. Wenn nicht gesetzt, wird die erste vollständige Providerkonfiguration automatisch erkannt. |
-| `LLM_MOCK` | `llm.mock` | Boolean | `false` | Wenn `true`, gibt der LLM-Service fest kodierte realistische Bewertungen zurück, anstatt einen echten LLM-Anbieter aufzurufen. Gedacht für CI-Pipelines, Screenshot-Generierung und Offline-Tests. Kein API-Schlüssel erforderlich, wenn der Mock-Modus aktiv ist. |
-| `GEMINI_API_KEY` | `gemini.api.key` | String | *(leer)* | Google Gemini API-Schlüssel. Erhältlich unter [aistudio.google.com](https://aistudio.google.com). |
-| `OPENAI_API_KEY` | `openai.api.key` | String | *(leer)* | OpenAI API-Schlüssel. |
-| `DEEPSEEK_API_KEY` | `deepseek.api.key` | String | *(leer)* | DeepSeek API-Schlüssel. |
-| `DASHSCOPE_API_KEY` | `qwen.api.key` | String | *(leer)* | Alibaba Cloud DashScope API-Schlüssel (Qwen-Modell). |
-| `LLAMA_API_KEY` | `llama.api.key` | String | *(leer)* | Llama API-Schlüssel. |
-| `MISTRAL_API_KEY` | `mistral.api.key` | String | *(leer)* | Mistral API-Schlüssel. |
-| `CUSTOM_LLM_URL` | `custom.llm.url` | URI | *(leer)* | Vollständiger HTTP- oder HTTPS-Endpunkt einer OpenAI-kompatiblen Chat-Completions-Schnittstelle. Er muss mit `/chat/completions` enden; eingebettete Benutzerinformationen werden abgelehnt. |
-| `CUSTOM_LLM_MODEL` | `custom.llm.model` | String | *(leer)* | Modellkennung, die unverändert in das Feld `model` der Anfrage übernommen wird. Für `CUSTOM_OPENAI` erforderlich. |
-| `CUSTOM_LLM_API_KEY` | `custom.llm.api.key` | String | *(leer)* | Optionaler Bearer-Token für `CUSTOM_OPENAI`. Bei leerem Wert sendet Taxonomy keinen `Authorization`-Header. |
-
-### Prioritätsreihenfolge der automatischen LLM-Anbieter-Erkennung
-
-Wenn `LLM_PROVIDER` **nicht gesetzt** ist, prüft die Anwendung vollständige Providerkonfigurationen in dieser Reihenfolge:
-
-1. **Gemini** — wenn `GEMINI_API_KEY` gesetzt ist
-2. **OpenAI** — wenn `OPENAI_API_KEY` gesetzt ist
-3. **DeepSeek** — wenn `DEEPSEEK_API_KEY` gesetzt ist
-4. **Qwen** — wenn `DASHSCOPE_API_KEY` gesetzt ist
-5. **Llama** — wenn `LLAMA_API_KEY` gesetzt ist
-6. **Mistral** — wenn `MISTRAL_API_KEY` gesetzt ist
-7. **Eigener OpenAI-kompatibler Endpunkt** — wenn `CUSTOM_LLM_URL` und `CUSTOM_LLM_MODEL` gültig sind; `CUSTOM_LLM_API_KEY` ist optional
-
-Der erste Treffer gewinnt. Wird keine vollständige HTTP-Providerkonfiguration gefunden und
-ist `LLM_PROVIDER` nicht `LOCAL_ONNX`, steht keine generative LLM-Analyse zur Verfügung.
-Ein geladenes lokales Embedding-Modell kann weiterhin eine eingeschränkte semantische
-Bewertung liefern.
-
-Die explizite Einstellung `LLM_PROVIDER=LOCAL_ONNX` aktiviert die Offline-Semantikbewertung — kein API-Schlüssel oder Internetzugang ist erforderlich, sobald das Modell lokal verfügbar ist.
-
-Mit `LLM_PROVIDER=CUSTOM_OPENAI` wird der vom Betreiber definierte Endpunkt verwendet. Der
-[Leitfaden für ein eigenes OpenAI-kompatibles LLM](../dev/custom-llm-de.md) beschreibt
-Schnittstellenvertrag, Docker-Netzwerk, Sicherheit und Fehlerbehebung.
-
-### Neuen LLM-Anbieter hinzufügen
-
-Für jeden Dienst, der den OpenAI-Chat-Completions-Vertrag erfüllt, sollte zunächst
-`CUSTOM_OPENAI` verwendet werden. Neuer Java-Code ist nur erforderlich, wenn Protokoll,
-Authentifizierung oder providerspezifische Fähigkeiten abweichen. Anbieter werden über die
-`LlmProviderExtension`-SPI beschrieben (siehe `docs/dev/07-extension-points.md`).
-
-1. Neue Konstante zur `LlmProvider`-Enum hinzufügen.
-2. Spring-`@Component` erstellen, das `LlmProviderExtension` mit passendem `descriptor().providerId()` implementiert.
-3. Gateway in `LlmGatewayRegistry` registrieren.
-4. Pflichtkonfiguration und Verfügbarkeitslogik in `LlmProviderConfig` ergänzen.
-5. Neuen `LLM_PROVIDER`-Enum-Wert und die Konfigurationsvariablen in dieser Tabelle ergänzen.
-
----
-
-## Lokales Embedding-Modell
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_EMBEDDING_ENABLED` | `embedding.enabled` | Boolean | `true` | Auf `false` setzen, um Embedding und alle semantische Suche global zu deaktivieren. |
-| `TAXONOMY_EMBEDDING_MODEL_DIR` | `embedding.model.dir` | Pfad | *(leer)* | Absoluter Pfad zu einem vorab heruntergeladenen Modellverzeichnis. Wenn leer, lädt DJL das Modell automatisch bei der ersten Verwendung herunter. |
-| `TAXONOMY_EMBEDDING_MODEL_NAME` | `embedding.model.name` | String | `djl://ai.djl.huggingface/BAAI/bge-small-en-v1.5` | DJL-Modell-URL oder HuggingFace-Modellname. Nur ändern, wenn Sie ein anderes Embedding-Modell verwenden möchten. |
-| `TAXONOMY_EMBEDDING_QUERY_PREFIX` | `embedding.query.prefix` | String | `Represent this sentence for searching relevant passages: ` | Präfix, das Abfragetexten für asymmetrisches Retrieval vorangestellt wird. Auf leeren String setzen, um es zu deaktivieren (z. B. bei Verwendung eines symmetrischen Modells). |
-| `TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD` | `embedding.allow-download` | Boolean | `true` | Auf `false` setzen, um den Download von Modellen zur Laufzeit zu verhindern. Wenn deaktiviert, muss ein lokales Modell über `TAXONOMY_EMBEDDING_MODEL_DIR` bereitgestellt werden. Empfohlen für CI-Umgebungen. |
-
-### Vorab-Download des Embedding-Modells (Deployments ohne Internetzugang)
-
-Für Umgebungen ohne Internetzugang laden Sie das Modell `bge-small-en-v1.5` vorab herunter:
-
-```bash
-# 1. Auf einem Rechner mit Internetzugang die Anwendung einmal starten, um den Download auszulösen:
-LLM_PROVIDER=LOCAL_ONNX ./mvnw -pl taxonomy-app spring-boot:run
-# Das Modell wird unter ~/.djl.ai/cache/ zwischengespeichert (ca. 33 MB)
-
-# 2. Das zwischengespeicherte Modellverzeichnis auf den Zielrechner kopieren:
-scp -r ~/.djl.ai/cache/repo/model/ai/djl/huggingface/BAAI/bge-small-en-v1.5/ \
-    target-machine:/opt/models/bge-small-en-v1.5/
-
-# 3. Die Umgebungsvariable auf dem Zielrechner setzen:
-export TAXONOMY_EMBEDDING_MODEL_DIR=/opt/models/bge-small-en-v1.5
-```
-
-Alternativ können Sie das Modell direkt von HuggingFace herunterladen:
-
-```bash
-# Modelldateien herunterladen
-pip install huggingface-hub
-huggingface-cli download BAAI/bge-small-en-v1.5 --local-dir /opt/models/bge-small-en-v1.5
-```
-
----
-
-## Authentifizierung & Sicherheit
-
-Die Anwendung verwendet **Spring Security** mit formularbasierter Anmeldung (Browser) und HTTP-Basic-Authentifizierung (REST-Clients). Beim ersten Start wird ein Standard-`admin`-Benutzer erstellt.
-
-### Standardbenutzer
-
-| Benutzername | Passwort | Rollen |
-|---|---|---|
-| `admin` | Wert von `TAXONOMY_ADMIN_PASSWORD` (Standard: `admin`) | USER, ARCHITECT, ADMIN |
-
-### Rollen und Berechtigungen
-
-| Rolle | Berechtigungen |
+| Profil | Wesentliche Standards |
 |---|---|
-| **ROLE_USER** | Alle API-Endpunkte lesen (`GET /api/**`), Analysen durchführen (`POST /api/analyze`, `POST /api/justify-leaf`), Exportieren (`POST /api/export/**`), GUI-Zugriff |
-| **ROLE_ARCHITECT** | Alles aus ROLE_USER, plus Schreibzugriff auf Beziehungen (`POST/PUT/DELETE /api/relations/**`), DSL (`POST/PUT/DELETE /api/dsl/**`) und Git-Operationen (`POST/PUT/DELETE /api/git/**`) |
-| **ROLE_ADMIN** | Alles aus ROLE_ARCHITECT, plus Admin-Endpunkte (`/admin/**`, `/api/admin/**`) |
+| Standard / `hsqldb` | HSQLDB im Speicher, `ddl-auto=create`, Lucene `local-heap`, Indexstrategie `sync`, SpringDoc aktiv |
+| `production` | `ddl-auto=update`, Lucene `local-filesystem`, `write-sync`, Audit und Passwortwechsel aktiv, SpringDoc aus |
+| `kubernetes` | `ddl-auto=validate`, standardmäßig `local-heap`, `write-sync`, Audit aktiv, SpringDoc aus |
+| `keycloak` | lokale Benutzer-/Passwortverwaltung und direkte Word-Links aus |
 
-### CSRF-Schutz
+Git-gestützte Einstellungen (`taxonomy.llm.*`, `taxonomy.analysis.min-score`, `taxonomy.dsl.*`, `taxonomy.limits.max-*`, `taxonomy.diagram.policy` und das Request-Limit) übernehmen die Umgebung bei ihrer ersten Initialisierung. Später gespeicherte Admin-Werte haben Vorrang, bis sie erneut geändert werden.
 
-CSRF-Schutz ist für Browser-Sitzungen **aktiviert**, aber für `/api/**`-Pfade **deaktiviert**. Das bedeutet, dass REST-Clients, die über HTTP Basic authentifiziert sind, kein CSRF-Token einschließen müssen.
+`DOMAIN`, `JAVA_OPTS` und OpenTelemetry-Agentvariablen gehören zu Deployment-Hüllen und stehen in deren Anleitungen. Zugangsdaten gehören in den Secret Store.
 
-### REST-API-Authentifizierung
+## Start, Profile und Lebenszyklus
 
-REST-Clients müssen sich über **HTTP Basic** authentifizieren:
-
-```bash
-curl -u admin:admin http://localhost:8080/api/taxonomy
-```
-
-### Öffentliche Endpunkte (keine Authentifizierung erforderlich)
-
-- `/login`, `/error`
-- `/actuator/health`, `/actuator/health/**`, `/actuator/info`
-- `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`
-- Statische Assets: `/css/**`, `/js/**`, `/images/**`, `/webjars/**`
-
----
-
-## Administration
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `ADMIN_PASSWORD` | `admin.token` | String | *(muss für nicht-lokale Deployments gesetzt werden)* | Passwort zum Schutz von Admin-Panels (LLM-Diagnose, Prompt-Vorlagen, Kommunikationsprotokoll). **Für jedes Deployment, das über einen vollständig vertrauenswürdigen lokalen Rechner hinausgeht, MUSS dies auf einen starken, nicht-leeren Wert gesetzt werden.** Wenn leer gelassen, sind alle Admin-Panels für jeden zugänglich — dieses Verhalten ist nur für isolierte Entwicklungsumgebungen vorgesehen. Wenn gesetzt, müssen Benutzer auf die 🔒-Schaltfläche klicken und das Passwort eingeben. |
-| `TAXONOMY_ADMIN_PASSWORD` | `taxonomy.admin-password` | String | `admin` | Passwort für den integrierten `admin`-Benutzer (Spring Security-Anmeldung). Wird für die Formularanmeldung (Browser) und HTTP-Basic-Authentifizierung (REST-Clients) verwendet. Ändern Sie dies vom Standard für jedes nicht-lokale Deployment. |
-
-### Admin-Passwort konfigurieren
-
-> **Sicherheitswarnung:** Das Ausführen der Anwendung mit einem leeren `ADMIN_PASSWORD` lässt alle Admin-Panels unauthentifiziert. **Verwenden Sie kein leeres Admin-Passwort auf einem internetexponierten, gemeinsam genutzten oder Produktionssystem.** Konfigurieren Sie in solchen Umgebungen immer einen starken, nicht-leeren Wert für `ADMIN_PASSWORD`.
-
-**Lokale Entwicklung:**
-```bash
-ADMIN_PASSWORD=my-secret ./mvnw -pl taxonomy-app spring-boot:run
-```
-
-**Docker:**
-```bash
-docker run -p 8080:8080 \
-  -e ADMIN_PASSWORD=my-secret \
-  -e GEMINI_API_KEY=your-key \
-  ghcr.io/carstenartur/taxonomy:latest
-```
-
-**Render.com:**
-Setzen Sie `ADMIN_PASSWORD` als geheime Umgebungsvariable im Render-Dashboard
-(Dashboard → Service → Environment → Add Secret).
-
----
-
-## Server-Konfiguration
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `PORT` | `server.port` | Integer | `8080` | HTTP-Port, auf dem die Anwendung lauscht. Wird von Render und ähnlichen Plattformen gesetzt; fällt lokal auf `8080` zurück. |
-| — | `spring.application.name` | String | `taxonomy-analyzer` | Anwendungsname (wird in Logs verwendet). |
-| `TAXONOMY_THYMELEAF_CACHE` | `spring.thymeleaf.cache` | Boolean | `true` | Kompilierte Thymeleaf-Templates zwischenspeichern. Standard ist `true` (Produktion). Setzen Sie `TAXONOMY_THYMELEAF_CACHE=false` für lokale Entwicklung, um Template-Änderungen ohne Neustart zu übernehmen. |
-| `TAXONOMY_LAZY_INIT` | `spring.main.lazy-initialization` | Boolean | `true` | Lazy-Bean-Initialisierung — Beans werden erst beim ersten Zugriff erstellt. Reduziert die Spring-Context-Startzeit erheblich (typische Einsparung: 30–50 s). `TaxonomyService` ist mit `@Lazy(false)` annotiert und wird unabhängig von dieser Einstellung immer sofort initialisiert. |
-| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | Boolean | `false` | Wenn `true`, werden Taxonomiedaten in einem Hintergrund-Thread **nach** dem Start der Verbindungsannahme geladen. Empfohlen für Render und ähnliche PaaS-Plattformen, um „No open ports detected“-Deploy-Timeouts zu vermeiden. Standard ist `false` für Abwärtskompatibilität (synchrones Laden). |
-
----
-
-## Datenbank-Konfiguration
-
-Die Anwendung verwendet **Spring-Profile**, um zwischen Datenbank-Backends zu wechseln.
-Setzen Sie `SPRING_PROFILES_ACTIVE`, um die Datenbank auszuwählen; der Standard ist `hsqldb`.
-
-| Profil | Datenbank | Konfigurationsdatei |
-|---|---|---|
-| `hsqldb` (Standard) | HSQLDB (In-Memory oder Datei) | `application-hsqldb.properties` |
-| `mssql` | Microsoft SQL Server | `application-mssql.properties` |
-| `postgres` | PostgreSQL | `application-postgres.properties` |
-| `oracle` | Oracle Database | `application-oracle.properties` |
-
-### Allgemeine Datenbank-Eigenschaften
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `SPRING_PROFILES_ACTIVE` | `spring.profiles.active` | String | `hsqldb` | Datenbankprofil. Setzen Sie auf `mssql` für SQL Server, `postgres` für PostgreSQL oder `oracle` für Oracle Database. |
-| `TAXONOMY_DATASOURCE_URL` | `spring.datasource.url` | String | *(profilabhängig)* | JDBC-URL. Jedes Profil bietet einen sinnvollen Standard; überschreiben Sie diesen für benutzerdefinierte Hosts. |
-| `SPRING_DATASOURCE_USERNAME` | `spring.datasource.username` | String | *(profilabhängig)* | Datenbank-Benutzername. Standard: `sa` (MSSQL), `taxonomy` (PostgreSQL, Oracle), `sa` (HSQLDB). |
-| `SPRING_DATASOURCE_PASSWORD` | `spring.datasource.password` | String | *(profilabhängig)* | Datenbank-Passwort. Standard: *(leer)* (HSQLDB), `taxonomy` (PostgreSQL, Oracle). **Erforderlich** für MSSQL (muss Komplexitätsregeln erfüllen). |
-| `TAXONOMY_DDL_AUTO` | `spring.jpa.hibernate.ddl-auto` | String | `create` | Schema-Generierungsstrategie. `create` erstellt bei jedem Start neu (sicher für In-Memory-Standard). Setzen Sie auf `update` für dateibasierte Deployments, damit Daten bei Neustarts nicht gelöscht werden. |
-| — | `spring.jpa.show-sql` | Boolean | `false` | Ob SQL-Anweisungen protokolliert werden sollen. |
-
-### HSQLDB-Profil (Standard)
-
-| Eigenschaft | Standard | Beschreibung |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:hsqldb:mem:taxonomydb;DB_CLOSE_DELAY=-1` | In-Memory-HSQLDB. Überschreiben Sie für Festplatten-basierte Speicherung. |
-| `spring.datasource.driver-class-name` | `org.hsqldb.jdbc.JDBCDriver` | HSQLDB-JDBC-Treiber. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | Begrenzter Pool für In-Memory- und dateibasierte HSQLDB. |
-| `spring.datasource.hikari.minimum-idle` | `${TAXONOMY_DB_MIN_IDLE:1}` | Hält eine Verbindung offen; erforderlich für Datei-URLs mit `shutdown=true`. |
-| `spring.datasource.hikari.maximum-pool-size` | `${TAXONOMY_DB_MAX_POOL_SIZE:4}` | Begrenztes Maximum für eingebettete HSQLDB. |
-| `spring.datasource.hikari.connection-timeout` | `${TAXONOMY_DB_CONNECTION_TIMEOUT_MS:30000}` | Maximale Wartezeit auf eine Verbindung in Millisekunden. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.HSQLDialect` | Expliziter Dialekt für deterministischen Start. |
-
-### MSSQL-Profil
-
-Aktivieren mit `SPRING_PROFILES_ACTIVE=mssql`. Siehe [DATABASE_SETUP.md](DATABASE_SETUP.md#microsoft-sql-server-mssql) für Details.
-
-| Eigenschaft | Standard | Beschreibung |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:sqlserver://localhost:1433;databaseName=taxonomy;encrypt=false;trustServerCertificate=true` | SQL Server-JDBC-URL. |
-| `spring.datasource.driver-class-name` | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | MSSQL-JDBC-Treiber. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP-Verbindungspool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.SQLServerDialect` | SQL Server-Dialekt. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | Maximale HikariCP-Verbindungen. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Verbindungs-Timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Start-Wiederholungs-Timeout (ms). |
-
-### PostgreSQL-Profil
-
-Aktivieren mit `SPRING_PROFILES_ACTIVE=postgres`. Siehe [DATABASE_SETUP.md](DATABASE_SETUP.md#postgresql) für Details.
-
-| Eigenschaft | Standard | Beschreibung |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:postgresql://localhost:5432/taxonomy` | PostgreSQL JDBC-URL. |
-| `spring.datasource.driver-class-name` | `org.postgresql.Driver` | PostgreSQL-JDBC-Treiber. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP-Verbindungspool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.PostgreSQLDialect` | PostgreSQL-Dialekt. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | Maximale HikariCP-Verbindungen. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Verbindungs-Timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Start-Wiederholungs-Timeout (ms). |
-
-### Oracle-Profil
-
-Aktivieren mit `SPRING_PROFILES_ACTIVE=oracle`. Siehe [DATABASE_SETUP.md](DATABASE_SETUP.md#oracle-database) für Details.
-
-| Eigenschaft | Standard | Beschreibung |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:oracle:thin:@localhost:1521/taxonomy` | Oracle JDBC-URL (Thin-Treiber). |
-| `spring.datasource.driver-class-name` | `oracle.jdbc.OracleDriver` | Oracle-JDBC-Treiber. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP-Verbindungspool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.OracleDialect` | Oracle-Dialekt. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | Maximale HikariCP-Verbindungen. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Verbindungs-Timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Start-Wiederholungs-Timeout (ms). |
-
----
-
-## Auswahl von Build- und Integrationstests
-
-Dies sind Maven-Eigenschaften beziehungsweise Tags, keine Laufzeitvariablen:
-
-| Eigenschaft/Tag | Standard | Wirkung |
-|---|---|---|
-| `skipITs` | `true` | Hält den Standard-Lebenszyklus begrenzt; `-DskipITs=false` aktiviert Failsafe-/Testcontainers-Tests. |
-| `excludedGroups` | `real-llm,db-postgres,db-mssql,db-oracle` | Schließt Live-Provider und schwere Datenbankfamilien standardmäßig aus. |
-| `db-postgres` | ausgeschlossen | PostgreSQL-Kompatibilitätstests. |
-| `db-mssql` | ausgeschlossen | Microsoft-SQL-Server-Kompatibilitätstests. |
-| `db-oracle` | ausgeschlossen | Oracle-Kompatibilitätstests. |
-| `real-llm` | ausgeschlossen | Live-Aufrufe externer LLMs. |
-
-`-DexcludedGroups=real-llm` schließt nur Live-LLMs aus und aktiviert damit
-bewusst die Datenbank-Tags. Siehe
-[`docs/dev/06-testing-by-change-type.md`](../dev/06-testing-by-change-type.md).
-
----
-
-## Hibernate Search / Lucene
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| — | `spring.jpa.properties.hibernate.search.enabled` | Boolean | `true` | Hibernate-Search-Integration aktivieren. |
-| — | `spring.jpa.properties.hibernate.search.backend.type` | String | `lucene` | Such-Backend-Typ. |
-| `TAXONOMY_SEARCH_DIRECTORY_TYPE` | `spring.jpa.properties.hibernate.search.backend.directory.type` | String | `local-heap` | Index-Speicher. `local-heap` = In-Memory (lokale Entwicklung / Tests). Setzen Sie auf `local-filesystem` für Produktions-Deployments mit Festplatten-basierter Speicherung. |
-| `TAXONOMY_SEARCH_DIRECTORY_ROOT` | `spring.jpa.properties.hibernate.search.backend.directory.root` | String | `/app/data/lucene-index` | Stammverzeichnis für die Lucene-Indexdateien (wird nur verwendet, wenn `TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem`). |
-| — | `spring.jpa.properties.hibernate.search.configuration_property_checking.strategy` | String | `ignore` | Unterdrückt die `HSEARCH000568`-Warnung über ein ungenutztes `directory.root`, wenn `directory.type=local-heap`. |
-
----
-
-## Ratenbegrenzung
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_RATE_LIMIT_PER_MINUTE` | `taxonomy.rate-limit.per-minute` | Integer | `10` | Maximale LLM-gestützte API-Anfragen pro IP pro Minute. Schützt vor einer Erschöpfung des Provider-Kontingents. Auf `0` setzen, um die Ratenbegrenzung zu deaktivieren. |
-
-Geschützte Endpunkte: `POST /api/analyze`, `GET /api/analyze-stream`, `GET /api/analyze-node`, `POST /api/justify-leaf`.
-
-Wenn das Limit überschritten wird, gibt der Server HTTP `429 Too Many Requests` zurück. Die Client-IP wird aus dem `X-Forwarded-For`-Header extrahiert (mit `X-Real-IP`-Fallback).
-
----
-
-## Brute-Force-Schutz bei der Anmeldung
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_LOGIN_RATE_LIMIT` | `taxonomy.security.login-rate-limit.enabled` | Boolean | `true` | Brute-Force-Schutz bei der Anmeldung aktivieren/deaktivieren. |
-| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `taxonomy.security.login-rate-limit.max-attempts` | Integer | `5` | Maximale fehlgeschlagene Anmeldeversuche vor Sperrung. |
-| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `taxonomy.security.login-rate-limit.lockout-seconds` | Integer | `300` | Sperrdauer in Sekunden nach Überschreitung der maximalen Versuche. |
-
-Bei Sperrung gibt der Server HTTP `423 Locked` mit einem JSON-Body zurück, der die Wartezeit enthält. Deaktivieren Sie mit `TAXONOMY_LOGIN_RATE_LIMIT=false` für die Entwicklung.
-
----
-
-## Passwort-Richtlinie
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_REQUIRE_PASSWORD_CHANGE` | `taxonomy.security.require-password-change` | Boolean | `false` | Wenn `true`, werden Benutzer mit dem Standardpasswort zu `/change-password` weitergeleitet. |
-
----
-
-## Swagger-Zugriffskontrolle
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_SWAGGER_PUBLIC` | `taxonomy.security.swagger-public` | Boolean | `true` | Wenn `true`, ist die Swagger-UI ohne Authentifizierung zugänglich. In Produktion auf `false` setzen, um Authentifizierung zu erfordern. |
-
----
-
-## Sicherheits-Audit-Protokollierung
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_AUDIT_LOGGING` | `taxonomy.security.audit-logging` | Boolean | `false` | Wenn `true`, werden Authentifizierungsereignisse protokolliert (Anmeldeerfolge/-fehler, Benutzerverwaltungsaktionen). |
-
----
-
-## Keycloak-/OIDC-Konfiguration
-
-Die Keycloak-Authentifizierung wird über das `keycloak`-Spring-Profil aktiviert (`SPRING_PROFILES_ACTIVE=keycloak`). Wenn aktiv, werden Form-Login und HTTP Basic durch OAuth2-Login (Browser) und JWT-Bearer-Tokens (REST-API) ersetzt.
-
-| Variable | Eigenschaft | Standard | Beschreibung |
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
 |---|---|---|---|
-| `KEYCLOAK_ISSUER_URI` | `spring.security.oauth2.client.provider.keycloak.issuer-uri` | `http://localhost:8180/realms/taxonomy` | Keycloak-Realm-Issuer-URI. Wird für OIDC-Discovery und JWT-Validierung verwendet. |
-| `KEYCLOAK_CLIENT_ID` | `spring.security.oauth2.client.registration.keycloak.client-id` | `taxonomy-app` | OAuth2-Client-ID, die in Keycloak registriert ist. |
-| `KEYCLOAK_CLIENT_SECRET` | `spring.security.oauth2.client.registration.keycloak.client-secret` | *(leer)* | OAuth2-Client-Secret. **Muss für Produktion gesetzt werden.** |
-| `KEYCLOAK_JWK_SET_URI` | `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` | `http://localhost:8180/realms/taxonomy/protocol/openid-connect/certs` | JWKS-Endpunkt für JWT-Signaturvalidierung. |
-| `KEYCLOAK_ADMIN_URL` | `taxonomy.keycloak.admin-console-url` | `http://localhost:8180` | Basis-URL der Keycloak Admin Console (wird für Passwortänderungs-Weiterleitungen verwendet). |
-| `KEYCLOAK_REALM` | `taxonomy.keycloak.realm` | `taxonomy` | Keycloak-Realm-Name. Wird für Account-Console-Weiterleitungs-URLs verwendet. |
+| `PORT` | `server.port` | `8080` | HTTP-Port. |
+| `SPRING_PROFILES_ACTIVE` | Spring-Profile | `hsqldb` | Kommagetrennte Profile, etwa `production,postgres`. |
+| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | `false` | Öffnet den Port vor dem Katalogladen; Readiness wartet weiter. |
+| `TAXONOMY_INIT_RELOAD_EXISTING` | `taxonomy.init.reload-existing` | `false` | Erzwingt einen destruktiven Katalogneuimport; nur nach Sicherung. |
+| `TAXONOMY_LAZY_INIT` | `spring.main.lazy-initialization` | `true` | Initialisiert die meisten Beans erst bei Bedarf. |
+| `TAXONOMY_THYMELEAF_CACHE` | `spring.thymeleaf.cache` | `true` | Template-Cache. |
+| `TAXONOMY_SPRINGDOC_ENABLED` | SpringDoc API/UI | Basis `true`; Produktion/Kubernetes `false` | Schaltet OpenAPI und Swagger UI technisch ein oder aus. |
+| `TAXONOMY_FORWARD_HEADERS_STRATEGY` | Kubernetes: `server.forward-headers-strategy` | `framework` | Verarbeitung vertrauenswürdiger Ingress-Header. |
+| `TAXONOMY_SHUTDOWN_TIMEOUT` | Kubernetes: Shutdown-Phase | `30s` | Graceful-Shutdown-Frist. |
+| `TAXONOMY_LOG_FILE` | Kubernetes: `logging.file.name` | leer | Optionale Logdatei; bei read-only Containern leer lassen. |
+| `TAXONOMY_CATALOGUE_RESOURCE` | `taxonomy.catalogue.resource` | mitgelieferter C3-Katalog | Katalogquelle und Report-Provenienz. |
+| `TAXONOMY_REPORT_TIME_ZONE` | `taxonomy.report.time-zone` | `Europe/Berlin` | Zeitzone der Berichte. |
+| `GIT_COMMIT` | `git.commit.id` | leer | Bevorzugter Quell-Commit der Report-Provenienz. |
+| `GITHUB_SHA` | Fallback für `git.commit.id` | `unknown` | CI-Fallback, wenn `GIT_COMMIT` fehlt. |
+| `TAXONOMY_SCHEMA_MIGRATION_ENABLED` | `taxonomy.schema-migration.enabled` | `true` | Portable idempotente Schema-Vertragsmigrationen. |
+| `TAXONOMY_COMMIT_INDEX_SEARCH_REBUILD_EMPTY` | `taxonomy.commit-index.search-rebuild-empty` | `true` | Bereinigt/baut den Commit-Suchindex bei leerer Projektion neu. |
+| `TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION` | `taxonomy.jgit-storage.legacy-adoption` | `false` | Einmalige, fail-closed Altschema-Adoption nach Backup und Preflight. |
+| `TAXONOMY_GIT_BOOTSTRAP` | `taxonomy.git.bootstrap` | `true` | Erzeugt bei leerem Systemrepository den ersten `draft`-Commit. |
+| `TAXONOMY_FEATURES_MULTI_REPOSITORY_API_ENABLED` | `taxonomy.features.multi-repository-api.enabled` | `false` | Aktiviert die opt-in `/api/repositories`-Oberfläche. |
 
-**Eigenschaften, die automatisch im `keycloak`-Profil gesetzt werden:**
+## Datenbank und Suche
 
-| Eigenschaft | Wert | Auswirkung |
-|---|---|---|
-| `taxonomy.security.local-users-enabled` | `false` | Deaktiviert `UserManagementController` (Benutzer-CRUD über REST-API) |
-| `taxonomy.security.change-password-enabled` | `false` | Deaktiviert lokalen `ChangePasswordController` (Weiterleitung zu Keycloak) |
+Die HSQLDB-Poolvariablen gelten nur im HSQLDB-Profil; PostgreSQL, MSSQL und Oracle haben derzeit feste Profilwerte.
 
-Siehe [Keycloak- & SSO-Einrichtung](KEYCLOAK_SETUP.md) für vollständige Einrichtungsanweisungen und [Keycloak-Migrationsanleitung](KEYCLOAK_MIGRATION.md) für die Migration von Form-Login.
-
----
-
-## OpenAPI / Swagger UI
-
-Die Anwendung stellt interaktive API-Dokumentation über [springdoc-openapi](https://springdoc.org/) bereit.
-
-| Variable | Eigenschaft | Typ | Standard | Beschreibung |
-|---|---|---|---|---|
-| `TAXONOMY_SPRINGDOC_ENABLED` | `springdoc.api-docs.enabled` / `springdoc.swagger-ui.enabled` | Boolean | `true` | Aktivieren oder Deaktivieren der `/swagger-ui.html`- und `/v3/api-docs`-Endpunkte. In Produktion auf `false` setzen, um Speicher zu sparen und die Angriffsfläche zu reduzieren. |
-
-| URL | Beschreibung |
-|---|---|
-| `/swagger-ui.html` | Interaktive Swagger-UI |
-| `/v3/api-docs` | OpenAPI 3.0 JSON-Spezifikation |
-
----
-
-## Spring Boot Actuator (Überwachung)
-
-Die Anwendung enthält Spring Boot Actuator mit Micrometer Prometheus für HTTP-basierte Überwachung.
-Dies ist der moderne Ersatz für JMX (das auf dem Render Free Tier nicht verfügbar ist).
-
-### Verfügbare Endpunkte
-
-| Endpunkt | Authentifizierung erforderlich | Beschreibung |
-|---|---|---|
-| `GET /actuator/health` | Nein | Gesundheitsstatus der Anwendung (immer öffentlich — wird von Render-Gesundheitsprüfungen verwendet) |
-| `GET /actuator/health/liveness` | Nein | Liveness-Probe (Kubernetes-kompatibel) |
-| `GET /actuator/health/readiness` | Nein | Readiness-Probe (Kubernetes-kompatibel) |
-| `GET /actuator/info` | Nein | Anwendungsinformationen (Name, Version, Java, Betriebssystem) |
-| `GET /actuator/metrics` | Ja (X-Admin-Token) | Liste aller verfügbaren Metriknamen |
-| `GET /actuator/metrics/{name}` | Ja (X-Admin-Token) | Wert einer bestimmten Metrik (z. B. `jvm.memory.used`) |
-| `GET /actuator/prometheus` | Ja (X-Admin-Token) | Alle Metriken im Prometheus-Textformat (zum Scraping) |
-
-### Zugriff auf geschützte Endpunkte
-
-Endpunkte mit „Ja“ erfordern den `X-Admin-Token`-Header, wenn `ADMIN_PASSWORD` konfiguriert ist:
-
-```bash
-# Gesundheit (öffentlich)
-curl https://your-app.onrender.com/actuator/health
-
-# Metriken (erfordert Admin-Token)
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/metrics
-
-# Prometheus-Scrape
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/prometheus
-
-# Bestimmte Metrik
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/metrics/jvm.memory.used
-```
-
-Wenn `ADMIN_PASSWORD` nicht gesetzt ist, sind alle Actuator-Endpunkte ohne Authentifizierung zugänglich
-(abwärtskompatibel mit lokaler Entwicklung).
-
-### JMX-Äquivalente
-
-| JMX MBean | Actuator-Äquivalent |
-|---|---|
-| `java.lang:type=Memory` | `/actuator/metrics/jvm.memory.used`, `/actuator/metrics/jvm.memory.max` |
-| `java.lang:type=GarbageCollector` | `/actuator/metrics/jvm.gc.pause`, `/actuator/metrics/jvm.gc.memory.promoted` |
-| `java.lang:type=Threading` | `/actuator/metrics/jvm.threads.live`, `/actuator/metrics/jvm.threads.peak` |
-| `java.lang:type=OperatingSystem` | `/actuator/metrics/process.cpu.usage`, `/actuator/metrics/system.cpu.usage` |
-| `java.lang:type=Runtime` | `/actuator/info`, `/actuator/metrics/process.uptime` |
-| Benutzerdefinierte MBeans | `/actuator/prometheus` (alle Metriken in einem Scrape) |
-
-### Taxonomy-Gesundheitsindikator
-
-Der `/actuator/health`-Endpunkt enthält eine benutzerdefinierte `taxonomy`-Komponente, die Folgendes meldet:
-
-```json
-{
-  "status": "UP",
-  "components": {
-    "taxonomy": {
-      "status": "UP",
-      "details": {
-        "initStatus": "Async taxonomy initialization complete.",
-        "initialized": true,
-        "heapUsedMB": 256,
-        "heapMaxMB": 512,
-        "heapUsagePercent": 50
-      }
-    }
-  }
-}
-```
-
-Gesundheitskomponentendetails werden nur angezeigt, wenn `management.endpoint.health.show-components=when-authorized`
-und die Anfrage einen gültigen `X-Admin-Token`-Header enthält.
-
----
-
-## Laufzeit-Einstellungen
-
-Zusätzlich zu Umgebungsvariablen können mehrere Einstellungen zur Laufzeit über die Einstellungen-API geändert werden, ohne die Anwendung neu zu starten:
-
-| Einstellungsschlüssel | Typ | Standard | Beschreibung |
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
 |---|---|---|---|
-| `llm.rpm` | int | `5` | Ausgehende Gemini-Anfragen pro Minute |
-| `llm.rpm.custom_openai` | int | `0` | Ausgehende Anfragen an den eigenen Provider pro Minute; `0` deaktiviert die Drosselung |
-| `llm.timeout.seconds` | int | `30` | HTTP-Lese-Timeout für LLM-Aufrufe |
-| `llm.retry.max` | int | `2` | Wiederholungsversuche bei geeigneten LLM-Serverfehlern und Timeouts |
-| `rate-limit.per-minute` | int | `10` | Eingehende Ratenbegrenzung für Analyse-Endpunkte |
-| `analysis.min-relevance-score` | int | `70` | Mindestbewertungsschwelle für Analyseergebnisse |
-| `dsl.default-branch` | string | `draft` | Aktiver DSL-Branch für die Materialisierung |
-| `dsl.project-name` | string | `Taxonomy Architecture` | Projekt-Anzeigename |
-| `dsl.auto-save.interval-seconds` | int | `0` | Auto-Speicher-Häufigkeit (0 = deaktiviert) |
-| `dsl.remote.url` | string | *(leer)* | Remote-Git-URL für Push/Pull |
-| `dsl.remote.token` | string | *(leer)* | Remote-Git-Authentifizierungstoken |
-| `dsl.remote.push-on-commit` | boolean | `false` | Automatisches Pushen nach lokalen Commits |
-| `limits.max-business-text` | int | `5000` | Maximale Zeichen im Anforderungstext |
-| `limits.max-architecture-nodes` | int | `50` | Maximale Knoten in der Architekturansicht |
-| `limits.max-export-nodes` | int | `200` | Maximale Knoten beim Export |
-| `diagram.policy` | string | `defaultImpact` | Diagramm-Auswahlrichtlinie: `defaultImpact`, `leafOnly`, `clustering` oder `trace` |
+| `TAXONOMY_DATASOURCE_URL` | `spring.datasource.url` über DB-Profile | profilabhängig | Taxonomy-Alias der JDBC-URL. |
+| `SPRING_DATASOURCE_URL` | direkte Spring-Bindung | leer | JDBC-URL, unter anderem im Helm-Chart; überschreibt den Alias. |
+| `SPRING_DATASOURCE_USERNAME` | `spring.datasource.username` | profilabhängig | Datenbankkonto. |
+| `SPRING_DATASOURCE_PASSWORD` | `spring.datasource.password` | Entwicklungswert des Profils | Produktiv aus einem Secret setzen. |
+| `TAXONOMY_DB_MIN_IDLE` | HSQLDB Hikari | `1` | Minimale Idle-Verbindungen. |
+| `TAXONOMY_DB_MAX_POOL_SIZE` | HSQLDB Hikari | `4` | Maximale Poolgröße. |
+| `TAXONOMY_DB_CONNECTION_TIMEOUT_MS` | HSQLDB Hikari | `30000` | Connection-Timeout in Millisekunden. |
+| `TAXONOMY_DDL_AUTO` | `spring.jpa.hibernate.ddl-auto` | Basis `create`; Produktion `update`; Kubernetes `validate` | Schemaaktion; `create` nie mit persistenten Daten. |
+| `TAXONOMY_SEARCH_DIRECTORY_TYPE` | Hibernate Search | Basis/Kubernetes `local-heap`; Produktion `local-filesystem` | In-Memory- oder Dateispeicher; keine Mehrreplikat-Koordination. |
+| `TAXONOMY_SEARCH_DIRECTORY_ROOT` | Hibernate Search | `/app/data/lucene-index` | Wurzel für `local-filesystem`. |
+| `TAXONOMY_SEARCH_SYNC_STRATEGY` | Hibernate Search | Basis `sync`; Produktion/Kubernetes `write-sync` | Sichtbarkeits-/Durchsatzstrategie nach Transaktionen. |
 
-Siehe [Einstellungen](PREFERENCES.md) für die REST-API und den Audit-Trail.
+## Generative LLMs und Analyse
 
----
+`LOCAL_ONNX` ist nur lokale Semantik, kein generatives Chatmodell. Ohne expliziten Anbieter erfolgt Autoerkennung in der Reihenfolge Gemini, OpenAI, DeepSeek, Qwen, Llama, Mistral, `CUSTOM_OPENAI`.
 
-## Framework-Import-Konfiguration
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `LLM_PROVIDER` | `llm.provider` | leer | Anbieter oder Autoerkennung. |
+| `LLM_MOCK` | `llm.mock` | `false` | Deterministische CI-/Screenshot-Daten, nicht für echte Entscheidungen. |
+| `GEMINI_API_KEY` | `gemini.api.key` | leer | Gemini-Zugang. |
+| `OPENAI_API_KEY` | `openai.api.key` | leer | OpenAI-Zugang. |
+| `DEEPSEEK_API_KEY` | `deepseek.api.key` | leer | DeepSeek-Zugang. |
+| `DASHSCOPE_API_KEY` | `qwen.api.key` | leer | Qwen/DashScope-Zugang. |
+| `LLAMA_API_KEY` | `llama.api.key` | leer | Llama-Zugang. |
+| `MISTRAL_API_KEY` | `mistral.api.key` | leer | Mistral-Zugang. |
+| `CUSTOM_LLM_URL` | `custom.llm.url` | leer | HTTP(S)-Chat-Completions-URL mit Host, ohne Userinfo, endend auf `/chat/completions`. |
+| `CUSTOM_LLM_MODEL` | `custom.llm.model` | leer | Erforderliche Modellkennung für `CUSTOM_OPENAI`. |
+| `CUSTOM_LLM_API_KEY` | `custom.llm.api.key` | leer | Optionaler Bearer-Token; leer sendet keinen Authorization-Header. |
+| `TAXONOMY_LLM_RPM` | Git-Einstellung `taxonomy.llm.rpm` | `5` | Ausgehende Requests je Anbieter und Minute. |
+| `TAXONOMY_LLM_TIMEOUT_SECONDS` | Git-Einstellung `taxonomy.llm.timeout-seconds` | `30` | Timeout eines LLM-Aufrufs. |
+| `TAXONOMY_ANALYSIS_MIN_SCORE` | Git-Einstellung `taxonomy.analysis.min-score` | `70` | Mindestwert 0–100 für gewöhnliche Architektursichten. |
+| `TAXONOMY_RATE_LIMIT_PER_MINUTE` | Git-Einstellung `taxonomy.rate-limit.per-minute` | `10` | Clientlimit LLM-gestützter API-Aufrufe; `0` deaktiviert. |
 
-Die Framework-Import-Pipeline wird über Zuordnungsprofile konfiguriert. Verfügbare Profile können zur Laufzeit aufgelistet werden:
+## LLM Record/Replay
+
+Produktiv normalerweise vollständig deaktiviert lassen.
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `LLM_RECORD` | `llm.record` | `false` | Zeichnet Live-Antworten auf. |
+| `LLM_REPLAY` | `llm.replay` | `false` | Spielt anhand des Prompt-Hashes auf. |
+| `LLM_REPLAY_FALLBACK` | `llm.replay.fallback` | `error` | Nur `live` erlaubt bei fehlender Aufnahme einen echten Aufruf. |
+| `LLM_PRUNE` | `llm.prune` | `false` | Markiert nicht benutzte Manifest-Einträge als veraltet. |
+| `LLM_PRUNE_DELETE` | `llm.prune.delete` | `false` | Löscht veraltete Aufzeichnungen. |
+| `LLM_RECORDINGS_DIR` | `llm.recordings.dir` | automatisch erkannt | Explizites Aufnahmeverzeichnis; Manifest ist veränderlich. |
+
+## Lokale Embeddings
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `TAXONOMY_EMBEDDING_ENABLED` | `embedding.enabled` | `false` | Aktiviert lokale Vektoren und semantische Suche. |
+| `TAXONOMY_EMBEDDING_MODEL_DIR` | `embedding.model.dir` | leer | Eingehängtes vorab geladenes Modell. |
+| `TAXONOMY_EMBEDDING_MODEL_NAME` | `embedding.model.name` | BAAI `bge-small-en-v1.5` | Entfernte Referenz oder lokaler Modellpfad. |
+| `TAXONOMY_EMBEDDING_QUERY_PREFIX` | `embedding.query.prefix` | BGE-Präfix | Präfix asymmetrischer Suchanfragen. |
+| `TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD` | `embedding.allow-download` | `false` | Erlaubt Laufzeitdownload; Egress muss ebenfalls passen. |
+| `TAXONOMY_EMBEDDING_INDEX_LOADER_THREADS` | `embedding.index.loader-threads` | `2`, mindestens `1` | Ladethreads der Mass-Indexing-Phasen. |
+| `TAXONOMY_EMBEDDING_INDEX_BATCH_SIZE` | `embedding.index.batch-size` | `16`, mindestens `1` | Entitäten je Indexierungsbatch. |
+
+## Copilot und Autopilot
+
+Der historische Variablenname `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` bleibt unverändert. Die Property `taxonomy.ai.max-architecture-nodes` gilt sowohl für den manuellen Copilot als auch für den Autopiloten. Zusätzlich begrenzt `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES` jede Portfolioanalyse; wirksam ist der kleinere Wert.
+
+Profile: `STANDARD`, `FULL`, `EXHAUSTIVE`. Prüfdurchläufe: 1–3, bei `EXHAUSTIVE` mindestens 2. Durchläufe einer Operation laufen nacheinander; Koordinatorparallelität betrifft verschiedene Operationen.
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `TAXONOMY_AI_COST_POLICY` | `taxonomy.ai.cost-policy` | `METERED` | Autopilot verlangt ausdrücklich `UNMETERED`; manueller Copilot nicht. |
+| `TAXONOMY_AI_COPILOT_PROFILE` | `taxonomy.ai.copilot.profile` | `FULL` | Standard des manuellen Copiloten. |
+| `TAXONOMY_AI_AUTOPILOT_PROFILE` | `taxonomy.ai.autopilot.profile` | `EXHAUSTIVE` | Standard des Autopiloten. |
+| `TAXONOMY_AI_COPILOT_VERIFICATION_PASSES` | `taxonomy.ai.copilot.verification-passes` | `1` | Manueller Standard, gültig 1–3. |
+| `TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES` | `taxonomy.ai.autopilot.verification-passes` | `2` | Autopilot-Standard, gültig 1–3. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` | `taxonomy.ai.max-architecture-nodes` | `50`, mindestens `1` | Betreiberobergrenze für Architekturknoten des manuellen Copiloten und Autopiloten; höhere Werte vergrößern Lauf, Snapshot und Diagramm, nicht die Projekt-Batchgröße. |
+| `TAXONOMY_AI_AUTOPILOT_ENABLED` | `taxonomy.ai.autopilot.enabled` | `false` | Ausdrückliche Freigabe unbeaufsichtigter Läufe. |
+| `TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE` | `taxonomy.ai.autopilot.on-requirement-save` | `true` | Start nach neuer Anforderungsversion, sofern Autopilot vollständig bereit ist. |
+| `TAXONOMY_AI_AUTOPILOT_PROVIDER` | `taxonomy.ai.autopilot.provider` | leer | Expliziter, vollständig konfigurierter Anbieter unbeaufsichtigter Arbeit. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS` | `taxonomy.ai.autopilot.propose-solutions` | `true` | Erzeugt bei Nicht-`STANDARD` `PROPOSED`-Lösungen. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS` | `taxonomy.ai.autopilot.propose-products` | `true` | Erzeugt bei Nicht-`STANDARD` `CANDIDATE`-Produkte. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS` | `taxonomy.ai.autopilot.max-project-requirements` | `50`, gültig 1–500 | Projektweite Batchgrenze; Überschreitungen werden abgewiesen. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE` | `taxonomy.ai.product-proposals.minimum-coverage` | `25`, 0–100 | Mindestabdeckung für deterministische Produktvorschläge. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE` | `taxonomy.ai.product-proposals.minimum-confidence` | `0.25`, 0–1 | Mindestanteil abgedeckter bestätigter Lösungsknoten. |
+| `TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS` | `taxonomy.ai.maximum-runtime-seconds` | `1800`, mindestens wirksam `60` | Koordinator-Wartezeit; persistierte Jobs bleiben wiederaufnehmbar. |
+| `TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS` | `taxonomy.ai.coordinator.max-concurrent-operations` | `4`, gültig 1–64 | Parallel koordinierte Operationen, nicht Durchläufe einer Operation. |
+| `TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY` | `taxonomy.ai.coordinator.queue-capacity` | `100`, gültig 1–10000 | In-Memory-Koordinatorqueue. |
+
+Wirksame Richtlinie: `GET /api/ai-automation`. Verbindliche Zuordnungen, Zuständigkeiten, Produkte, Beschaffung und Branch-Merge bleiben menschliche Entscheidungen.
+
+## Portfolio und Arbeitszustand
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `TAXONOMY_ANALYSIS_DRAFT_MAX_CHARACTERS` | `taxonomy.analysis-draft.max-characters` | `2000000`, mindestens `10000` | Maximale serialisierte JSON-Zeichen eines branchgebundenen Analyseentwurfs. |
+| `TAXONOMY_CONTEXT_MAX_HISTORY` | `taxonomy.context.max-history` | `50` | Navigationseinträge je aktivem Arbeitsbereich. |
+| `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `taxonomy.portfolio.max-import-requirements` | `100`, mindestens `1` | Anforderungen je geprüftem Import. |
+| `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `taxonomy.portfolio.max-import-characters` | `500000`, mindestens `1` | Gesamttext je geprüftem Import. |
+| `TAXONOMY_PORTFOLIO_MAX_ANALYSIS_BATCH` | `taxonomy.portfolio.max-analysis-batch` | `100`, mindestens `1` | Anforderungen je persistiertem Analysejob. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `900`, mindestens `60` | Frist bis zur Claim-Wiederherstellung. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY` | `taxonomy.portfolio.analysis-worker-concurrency` | `1`, mindestens `1` | Parallele Portfolio-Worker. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `taxonomy.portfolio.analysis-worker-queue-capacity` | `100`, mindestens `0` | In-Memory-Dispatch-Queue; Jobs bleiben persistiert. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `30`, mindestens `0` | Worker-Auslaufzeit. |
+| `TAXONOMY_PORTFOLIO_SNAPSHOT_STALE_AFTER_DAYS` | `taxonomy.portfolio.snapshot-stale-after-days` | `30`, mindestens `1` | Altersgrenze der Stale-Snapshot-Metrik. |
+
+## Sicherheit und Keycloak
+
+`ADMIN_PASSWORD` schützt zusätzliche Actuator-/Legacy-Token-Prüfungen. `TAXONOMY_ADMIN_PASSWORD` initialisiert das lokale Konto `admin`. Ohne diesen Wert erzeugt ein Nicht-Produktionsstart ein einmaliges zufälliges Startpasswort; Produktion verlangt mindestens 16 nicht triviale Zeichen.
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `ADMIN_PASSWORD` | `admin.token` | leer | Optionaler `X-Admin-Token`/Bearer für sensible Zusatzprüfungen; ersetzt keine rollenbasierte Anmeldung. |
+| `TAXONOMY_ADMIN_PASSWORD` | `taxonomy.admin-password` | leer außerhalb Produktion; dort erforderlich | Initiales lokales Administratorpasswort. |
+| `TAXONOMY_LOGIN_RATE_LIMIT` | `taxonomy.security.login-rate-limit.enabled` | `true` | Login-Fehlversuchsbegrenzung. |
+| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `taxonomy.security.login-rate-limit.max-attempts` | `5` | Fehlversuche bis zur Sperre. |
+| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `taxonomy.security.login-rate-limit.lockout-seconds` | `300` | Sperrdauer. |
+| `TAXONOMY_REQUIRE_PASSWORD_CHANGE` | `taxonomy.security.require-password-change` | Basis `false`; Produktion `true` | Erzwingt Änderung temporärer lokaler Passwörter. |
+| `TAXONOMY_SWAGGER_PUBLIC` | `taxonomy.security.swagger-public` | Basis `true`; Produktion/Kubernetes `false` | Öffentliche oder authentifizierte Swagger-Nutzung, falls SpringDoc aktiv ist. |
+| `TAXONOMY_AUDIT_LOGGING` | `taxonomy.security.audit-logging` | Basis `false`; Produktion/Kubernetes `true` | Authentifizierungs-Audit. |
+| `TAXONOMY_SECURITY_LOCAL_USERS_ENABLED` | `taxonomy.security.local-users-enabled` | Basis `true`; Keycloak `false` | Lokale Benutzer-/Rollendienste. |
+| `TAXONOMY_SECURITY_CHANGE_PASSWORD_ENABLED` | `taxonomy.security.change-password-enabled` | Basis `true`; Keycloak `false` | Lokale Passwortänderung. |
+| `TAXONOMY_DIRECT_WORD_ENABLED` | `taxonomy.document-templates.direct-word-enabled` | Basis `true`; Keycloak `false` | `ms-word:`-Links nur mit passender WebDAV-Authentifizierung. |
+| `KEYCLOAK_CLIENT_ID` | OAuth2-Client | `taxonomy-app` | OIDC-Client-ID. |
+| `KEYCLOAK_CLIENT_SECRET` | OAuth2-Client | leer | Vertrauliches Client-Secret. |
+| `KEYCLOAK_ISSUER_URI` | Client und Resource Server | lokale Realm-URL | Issuer für Discovery und Tokenprüfung. |
+| `KEYCLOAK_JWK_SET_URI` | Resource Server | lokale Zertifikats-URL | Expliziter JWK-Endpunkt. |
+| `KEYCLOAK_ADMIN_URL` | `taxonomy.keycloak.admin-console-url` | `http://localhost:8180` | Basis der Kontoverwaltungsweiterleitung. |
+| `KEYCLOAK_REALM` | `taxonomy.keycloak.realm` | `taxonomy` | Realm der Kontoverwaltung. |
+| `TAXONOMY_KEYCLOAK_ROLE_CLAIM_PATH` | `taxonomy.keycloak.role-claim-path` | `realm_access.roles` | JWT-Pfad für die festen Rollen `ROLE_USER`, `ROLE_ARCHITECT`, `ROLE_ADMIN`; kein konfigurierbares Präfix. |
+
+## DSL und externe Repositories
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `TAXONOMY_DSL_DEFAULT_BRANCH` | Git-Einstellung `taxonomy.dsl.default-branch` | `draft` | Initialer DSL-Branch. |
+| `TAXONOMY_DSL_PROJECT_NAME` | Git-Einstellung `taxonomy.dsl.project-name` | `Taxonomy Architecture` | Name in DSL-/Exportmetadaten. |
+| `TAXONOMY_DSL_AUTO_SAVE_INTERVAL` | Git-Einstellung `taxonomy.dsl.auto-save-interval` | `0` | Auto-Commit-Sekunden; `0` aus. |
+| `TAXONOMY_DSL_REMOTE_URL` | Git-Einstellung `taxonomy.dsl.remote-url` | leer | Historisches DSL-Remote. |
+| `TAXONOMY_DSL_REMOTE_TOKEN` | Git-Einstellung `taxonomy.dsl.remote-token` | leer | Token dieses Remotes. |
+| `TAXONOMY_DSL_REMOTE_PUSH_ON_COMMIT` | Git-Einstellung `taxonomy.dsl.remote-push-on-commit` | `false` | Push nach jedem DSL-Commit. |
+| `TAXONOMY_EXTERNAL_GIT_USERNAME` | direkte Deployment-Zugangsdaten | `oauth2` | Benutzername des administrativ konfigurierten kanonischen Remotes. |
+| `TAXONOMY_EXTERNAL_GIT_TOKEN` | direkte Deployment-Zugangsdaten | leer | Write-only Fetch-/Push-Token, nicht persistiert. |
+
+## Eingabe-, Architektur- und Dokumentgrenzen
+
+Die AI-Knotengrenze kann die allgemeine Portfolio-Grenze wirksam nicht überschreiten. Bytewerte sind binär.
+
+| Variable | Property / Gültigkeit | Standard | Bedeutung |
+|---|---|---|---|
+| `TAXONOMY_LIMITS_MAX_BUSINESS_TEXT` | Git-Einstellung `taxonomy.limits.max-business-text` | `5000` | Zeichen einer gewöhnlichen Anforderung. |
+| `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES` | Git-Einstellung/Portfolio-Limit `taxonomy.limits.max-architecture-nodes` | `50` | Allgemeine Architekturknoten-Obergrenze. |
+| `TAXONOMY_LIMITS_MAX_EXPORT_NODES` | Git-Einstellung `taxonomy.limits.max-export-nodes` | `200` | Knoten je begrenztem Export. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_UPLOAD_BYTES` | `taxonomy.limits.document.max-upload-bytes` | `52428800` (50 MiB) | Uploadgröße. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_PDF_PAGES` | `taxonomy.limits.document.max-pdf-pages` | `500` | Verarbeitete PDF-Seiten. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_EXTRACTED_CHARACTERS` | `taxonomy.limits.document.max-extracted-characters` | `1000000` | Behaltene extrahierte Zeichen. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_CANDIDATES` | `taxonomy.limits.document.max-candidates` | `2000` | Kandidaten-/Provenienzobjekte. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_LLM_CHARACTERS` | `taxonomy.limits.document.max-llm-characters` | `200000` | Zeichen für die LLM-Stufe. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_ENTRY_BYTES` | `taxonomy.limits.document.max-docx-entry-bytes` | `67108864` (64 MiB) | Entpackte Größe eines DOCX-Eintrags. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_TEXT_BYTES` | `taxonomy.limits.document.max-docx-text-bytes` | `134217728` (128 MiB) | Gesamte entpackte DOCX-Text-/XML-Größe. |
+| `TAXONOMY_LIMITS_DOCUMENT_MIN_DOCX_INFLATE_RATIO` | `taxonomy.limits.document.min-docx-inflate-ratio` | `0.01` | Mindestkompressionsverhältnis des Zip-Bomb-Schutzes. |
+| `TAXONOMY_DIAGRAM_POLICY` | Git-Einstellung `taxonomy.diagram.policy` | `defaultImpact` | `defaultImpact`, `leafOnly`, `clustering` oder `trace`. |
+
+## Beispiele
+
+Manueller Copilot:
 
 ```bash
-curl -u admin:password http://localhost:8080/api/import/profiles
+LLM_PROVIDER=GEMINI
+GEMINI_API_KEY=secret
+TAXONOMY_AI_COPILOT_PROFILE=FULL
+TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES=50
 ```
 
-| Profil-ID | Framework | Dateiformat |
-|---|---|---|
-| `uaf` | UAF / DoDAF | XMI / XML |
-| `apqc` | APQC PCF | CSV |
-| `apqc-excel` | APQC PCF | XLSX (Excel) |
-| `c4` | C4 / Structurizr | DSL |
+Ausdrücklich ungemessener eigener Autopilot-Endpunkt:
 
-Für den Framework-Import werden keine zusätzlichen Umgebungsvariablen benötigt — Profile werden beim Start automatisch registriert.
+```bash
+LLM_PROVIDER=CUSTOM_OPENAI
+CUSTOM_LLM_URL=http://llm-server:8000/v1/chat/completions
+CUSTOM_LLM_MODEL=architecture-model
+TAXONOMY_AI_COST_POLICY=UNMETERED
+TAXONOMY_AI_AUTOPILOT_ENABLED=true
+TAXONOMY_AI_AUTOPILOT_PROVIDER=CUSTOM_OPENAI
+```
 
-Siehe [Framework-Import](FRAMEWORK_IMPORT.md) für detaillierte Zuordnungstabellen und Verwendung.
+Docker Compose reicht `.env` an den Anwendungscontainer weiter. Bei Helm gehören Nicht-Geheimnisse nach `config`, Zugangsdaten ins referenzierte Secret und zusätzliche Werte nach `extraEnv`.

--- a/docs/de/COPILOT_AUTOPILOT.md
+++ b/docs/de/COPILOT_AUTOPILOT.md
@@ -1,22 +1,46 @@
 # Copilot und Autopilot
 
-Taxonomy unterscheidet zwischen einer ausdrücklich gestarteten **Copilot-Vollanalyse** und dem unbeaufsichtigten **Autopilot**.
+Taxonomy unterscheidet zwischen einer ausdrücklich gestarteten **Copilot-Vollanalyse** und dem unbeaufsichtigten **Autopiloten**. Beide verwenden persistente, mandanten-, repository- und branchgebundene Portfolio-Analysejobs. Navigation oder Neuladen verliert eine Operation nicht.
 
-## Copilot-Vollanalyse
+Das kanonische Verzeichnis aller Anwendungseinstellungen steht in [CONFIGURATION_REFERENCE.md](CONFIGURATION_REFERENCE.md). Diese Seite erklärt die AI-Automatisierung im Nutzungskontext.
 
-Eine gespeicherte Anforderung wird über persistente, mandanten- und branchgebundene Analysejobs verarbeitet. Ein vollständiger Durchlauf erzeugt Taxonomiebewertungen, Architekturelemente und -relationen, Lücken- und Musteranalyse, eine Architekturempfehlung sowie einen unveränderlichen Snapshot. Navigation oder Neuladen der Seite verliert den Vorgang nicht.
+## Manuelle Copilot-Vollanalyse
 
-Der manuelle Start erfolgt über:
+Eine gespeicherte unveränderliche Anforderungsversion durchläuft einen oder mehrere begrenzte Prüfdurchläufe. Eine abgeschlossene Operation erzeugt Taxonomiebewertungen mit Begründungen, eine relationsbezogene Architektursicht, Lücken- und Musteranalyse, eine Architekturempfehlung, unveränderliche Snapshots und—wenn aktiviert—deterministische Lösungs- und Produktvorschläge.
 
 ```text
 POST /api/projects/{projectId}/requirements/{requirementId}/copilot
+GET  /api/projects/{projectId}/requirements/{requirementId}/copilot/latest
+GET  /api/projects/{projectId}/copilot-operations/{operationId}
+POST /api/projects/{projectId}/copilot-operations/{operationId}/cancel
 ```
 
-Vorhandene Vorgänge können über die Operations-Endpunkte fortgesetzt oder abgebrochen werden. Die Profile `STANDARD`, `FULL` und `EXHAUSTIVE` führen ein bis drei begrenzte Prüfdurchläufe aus. Identische Eingaben verwenden ihre persistierten Jobs erneut, sofern nicht bewusst `force=true` gesetzt wird.
+| Profil | Mindestdurchläufe | Lösungs-/Produktvorschläge |
+|---|---:|---|
+| `STANDARD` | 1 | deaktiviert |
+| `FULL` | konfigurierter Copilot-Standard, mindestens 1 | aktiv, sofern die Anfrage sie nicht abschaltet |
+| `EXHAUSTIVE` | mindestens 2 | aktiv, sofern die Anfrage sie nicht abschaltet |
+
+Konfigurierte oder angeforderte Durchlaufzahlen müssen zwischen 1 und 3 liegen. Die Durchläufe einer Operation laufen nacheinander. Identischer Eingabestand und identische Einstellungen verwenden die persistierte Operation erneut, sofern nicht bewusst `force=true` angefordert wird.
+
+Der manuelle Copilot benötigt einen bereiten Anbieter, aber **kein** `TAXONOMY_AI_COST_POLICY=UNMETERED`, weil jeder Lauf ausdrücklich durch einen Benutzer gestartet wird.
+
+## Grenzen der Architekturknoten
+
+`TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` behält aus Kompatibilitätsgründen seinen historischen Namen. Die zugehörige Spring-Property heißt `taxonomy.ai.max-architecture-nodes` und gilt **sowohl für den manuellen Copilot als auch für den Autopiloten**. Sie ist die Betreiberobergrenze der Architektursicht jedes AI-Automatisierungsdurchlaufs. Eine manuelle API-Anfrage darf einen kleineren Wert wählen, aber keinen größeren.
+
+Zusätzlich ist `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES` die allgemeine Portfolio-Analyseobergrenze. Wirksam ist daher der kleinere Wert. Sofern keine bewusst kleinere AI-Sicht gewünscht ist, sollten beide Werte übereinstimmen:
+
+```text
+TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES=50
+```
+
+Ein höherer Wert kann mehr relevante Knoten bewahren, vergrößert aber Pipeline-Arbeit, Snapshots, Relationserzeugung und Diagramme. Er verändert nicht die Anzahl der in einem projektweiten Autopilot-Batch verarbeiteten Anforderungen.
 
 ## Ausdrückliche Autopilot-Freigabe
 
-Taxonomy nimmt niemals automatisch an, dass ein eigener OpenAI-kompatibler Endpunkt kostenlos ist. Unbeaufsichtigte Ausführung benötigt alle drei Einstellungen:
+Taxonomy nimmt niemals automatisch an, dass ein eigener OpenAI-kompatibler Endpunkt kostenlos oder ungemessen ist. Unbeaufsichtigte Ausführung benötigt alle drei bewussten Einstellungen:
 
 ```text
 TAXONOMY_AI_COST_POLICY=UNMETERED
@@ -24,9 +48,9 @@ TAXONOMY_AI_AUTOPILOT_ENABLED=true
 TAXONOMY_AI_AUTOPILOT_PROVIDER=CUSTOM_OPENAI
 ```
 
-Der ausgewählte Provider muss außerdem vollständig konfiguriert sein. Für `CUSTOM_OPENAI` sind `CUSTOM_LLM_URL` und `CUSTOM_LLM_MODEL` erforderlich; bei einem vertrauenswürdigen lokalen Server kann der Schlüssel leer bleiben.
+Der gewählte Anbieter muss vollständig konfiguriert sein. Für `CUSTOM_OPENAI` sind `CUSTOM_LLM_URL` und `CUSTOM_LLM_MODEL` erforderlich; der API-Schlüssel darf bei einem vertrauenswürdigen unauthentifizierten lokalen Server leer bleiben.
 
-Mit `TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE=false` lässt sich der automatische Start nach dem Speichern abschalten, ohne ausdrücklich ausgelöste projektweite Autopilot-Läufe zu deaktivieren.
+`TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE=false` deaktiviert den automatischen Start nach dem Speichern, ohne ausdrücklich gestartete projektweite Läufe abzuschalten.
 
 ## Projektweite Ausführung
 
@@ -35,16 +59,36 @@ GET  /api/projects/{projectId}/autopilot
 POST /api/projects/{projectId}/autopilot/run
 ```
 
-Der POST-Body kann `requirementIds` und `maxRequirements` enthalten. Der Server kürzt ein Projekt niemals stillschweigend: Überschreitet die Auswahl die konfigurierte Batch-Grenze, wird der Aufruf abgewiesen und verlangt eine kleinere explizite Auswahl oder eine bewusste Anpassung des Betreiberlimits.
+Der POST-Body kann `requirementIds` und `maxRequirements` enthalten. Der Server kürzt ein Projekt niemals still. Überschreitet die Auswahl die wirksame Anfrage-/Betreibergrenze, wird sie abgewiesen und verlangt eine kleinere explizite Auswahl oder eine bewusste Änderung des Betreiberlimits.
 
-Wichtige Grenzen sind:
+## Konfigurationstabelle
+
+| Umgebungsvariable | Standard / Prüfung | Wirkung |
+|---|---|---|
+| `TAXONOMY_AI_COST_POLICY` | `METERED`; Enum | Kostenerklärung des Betreibers. Autopilot verlangt `UNMETERED`, manueller Copilot nicht. |
+| `TAXONOMY_AI_COPILOT_PROFILE` | `FULL` | Standardprofil manuell gestarteter Operationen. |
+| `TAXONOMY_AI_AUTOPILOT_PROFILE` | `EXHAUSTIVE` | Profil unbeaufsichtigter Operationen. |
+| `TAXONOMY_AI_COPILOT_VERIFICATION_PASSES` | `1`; gültig 1–3 | Manueller Standard vor Anwendung des Profilminimums. |
+| `TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES` | `2`; gültig 1–3 | Unbeaufsichtigter Standard; `EXHAUSTIVE` verlangt weiterhin mindestens 2. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` | `50`; mindestens 1 | Knotengrenze der Architektursichten des manuellen Copiloten und Autopiloten; zusätzlich durch `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES` begrenzt. |
+| `TAXONOMY_AI_AUTOPILOT_ENABLED` | `false` | Erste ausdrückliche Freigabe unbeaufsichtigter Ausführung. |
+| `TAXONOMY_AI_AUTOPILOT_PROVIDER` | leer | Expliziter, vollständig konfigurierter Autopilot-Anbieter passend zur `UNMETERED`-Erklärung. |
+| `TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE` | `true` | Startet bei vollständiger Bereitschaft eine unbeaufsichtigte Operation für eine neu gespeicherte unveränderliche Anforderungsversion. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS` | `true` | Erzeugt bei Nicht-`STANDARD`-Autopilot-Läufen deterministische Lösungsverknüpfungen im Zustand `PROPOSED`. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS` | `true` | Erzeugt bei Nicht-`STANDARD`-Autopilot-Läufen deterministische Produktvorschläge im Zustand `CANDIDATE`. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS` | `50`; gültig 1–500 | Maximale projektweite Auswahl; Überschreitungen werden abgewiesen und nie still gekürzt. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE` | `25`; auf 0–100 begrenzt | Minimale überlappende bestätigte Taxonomieabdeckung eines deterministischen Produktvorschlags. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE` | `0.25`; auf 0–1 begrenzt | Minimaler Anteil bestätigter Lösungsknoten, die das Produkt abdeckt. |
+| `TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS` | `1800`; mindestens wirksam 60 | Maximale Koordinator-Wartezeit je Durchlauf. Der persistierte Job bleibt anschließend wiederaufnehmbar. |
+| `TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS` | `4`; gültig 1–64 | Zahl verschiedener parallel koordinierter Copilot-/Autopilot-Operationen. Parallelisiert keine Durchläufe derselben Operation. |
+| `TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY` | `100`; gültig 1–10000 | In-Memory-Koordinatorwarteschlange. Nach Kapazitätsabweisung bleiben persistierte Operationen wiederaufnehmbar. |
+
+Der Portfolio-Analyse-Worker ist ein getrennter Ausführungspool. Seine Einstellungen sind `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY`, `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` und `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS`. Eine höhere Koordinatorgrenze beschleunigt keinen einzelnen Anbieteraufruf und kann den Rate-Limit-Druck erhöhen.
+
+Wirksame Bereitschaft und Begründung sind hier sichtbar:
 
 ```text
-TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS=50
-TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
-TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS=4
-TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY=100
-TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS=1800
+GET /api/ai-automation
 ```
 
 ## Menschliche Freigabegrenze

--- a/docs/en/CONFIGURATION_REFERENCE.md
+++ b/docs/en/CONFIGURATION_REFERENCE.md
@@ -1,515 +1,235 @@
 # Taxonomy Architecture Analyzer — Configuration Reference
 
-This document is the **canonical, complete list** of every environment variable and
-application property recognised by the Taxonomy Architecture Analyzer.  
-Values are set via environment variables (recommended for production) or in
-`src/main/resources/application.properties` for local development.
+This document is the canonical inventory of deployment-facing environment variables recognised by the Taxonomy application. It is generated conceptually from the effective Spring property files, direct `@Value` bindings, feature flags and `@ConfigurationProperties` classes; a contract test keeps this table aligned with those sources.
 
----
+Environment variables have higher precedence than `application*.properties`. Standard Spring variables such as `SPRING_DATASOURCE_URL` therefore override the same property populated through a Taxonomy-specific placeholder such as `TAXONOMY_DATASOURCE_URL`. Do not set both aliases for one deployment.
 
-## Startup and Catalogue Initialization
+The values shown below are application defaults. Profile-specific files may deliberately override them. In particular:
 
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | Boolean | `false` | Load the taxonomy after the HTTP server has opened its port. Useful on constrained PaaS platforms. |
-| `TAXONOMY_INIT_RELOAD_EXISTING` | `taxonomy.init.reload-existing` | Boolean | `false` | Reuse a persisted catalogue on normal restarts. Set to `true` only for an intentional destructive refresh from the bundled Excel catalogue. Relations are removed before nodes and deletes are flushed before inserts. |
-
-Persistent production deployments should leave `TAXONOMY_INIT_RELOAD_EXISTING=false`. Catalogue replacement is an explicit maintenance operation and should be preceded by a database and index backup.
-
----
-
-## LLM Provider Configuration
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `LLM_PROVIDER` | `llm.provider` | Enum | *(auto-detect)* | Force a specific LLM provider. Values: `GEMINI`, `OPENAI`, `DEEPSEEK`, `QWEN`, `LLAMA`, `MISTRAL`, `CUSTOM_OPENAI`, `LOCAL_ONNX`. When not set, the provider is auto-detected from the first complete provider configuration (see priority order below). |
-| `LLM_MOCK` | `llm.mock` | Boolean | `false` | When `true`, the LLM service returns hardcoded realistic scores instead of calling a real LLM provider. Intended for CI pipelines, screenshot generation, and offline testing. No API key is required when mock mode is active. |
-| `GEMINI_API_KEY` | `gemini.api.key` | String | *(empty)* | Google Gemini API key. Obtain from [aistudio.google.com](https://aistudio.google.com). |
-| `OPENAI_API_KEY` | `openai.api.key` | String | *(empty)* | OpenAI API key. |
-| `DEEPSEEK_API_KEY` | `deepseek.api.key` | String | *(empty)* | DeepSeek API key. |
-| `DASHSCOPE_API_KEY` | `qwen.api.key` | String | *(empty)* | Alibaba Cloud DashScope API key (Qwen model). |
-| `LLAMA_API_KEY` | `llama.api.key` | String | *(empty)* | Llama API key. |
-| `MISTRAL_API_KEY` | `mistral.api.key` | String | *(empty)* | Mistral API key. |
-| `CUSTOM_LLM_URL` | `custom.llm.url` | URI | *(empty)* | Complete HTTP or HTTPS OpenAI-compatible Chat Completions endpoint. It must end with `/chat/completions`; embedded user-info credentials are rejected. |
-| `CUSTOM_LLM_MODEL` | `custom.llm.model` | String | *(empty)* | Model identifier copied into the `model` field of requests to `CUSTOM_LLM_URL`. Required with `CUSTOM_OPENAI`. |
-| `CUSTOM_LLM_API_KEY` | `custom.llm.api.key` | String | *(empty)* | Optional Bearer token for `CUSTOM_OPENAI`. When empty, Taxonomy sends no `Authorization` header. |
-
-### LLM Provider Auto-Detection Priority Order
-
-When `LLM_PROVIDER` is **not set**, the application checks for complete provider configurations in this order:
-
-1. **Gemini** — if `GEMINI_API_KEY` is set
-2. **OpenAI** — if `OPENAI_API_KEY` is set
-3. **DeepSeek** — if `DEEPSEEK_API_KEY` is set
-4. **Qwen** — if `DASHSCOPE_API_KEY` is set
-5. **Llama** — if `LLAMA_API_KEY` is set
-6. **Mistral** — if `MISTRAL_API_KEY` is set
-7. **Custom OpenAI-compatible** — if both `CUSTOM_LLM_URL` and `CUSTOM_LLM_MODEL` are valid; `CUSTOM_LLM_API_KEY` is optional
-
-The first match wins. If no complete HTTP provider configuration is found and
-`LLM_PROVIDER` is not `LOCAL_ONNX`, the application starts without generative LLM
-analysis. A loaded local embedding model may still provide limited semantic scoring.
-
-Setting `LLM_PROVIDER=LOCAL_ONNX` explicitly activates offline semantic scoring — no API
-key or internet connection is required after the model is available locally.
-
-Setting `LLM_PROVIDER=CUSTOM_OPENAI` selects the operator-defined endpoint. See
-[Custom OpenAI-Compatible LLM](../dev/custom-llm.md) for the request/response contract,
-Docker networking, security guidance, and troubleshooting.
-
-### Adding a New LLM Provider
-
-Before adding Java code, use `CUSTOM_OPENAI` for any service that implements the OpenAI
-Chat Completions request and response contract. A new provider implementation is needed
-only for a different protocol, authentication model, or provider-specific capability.
-Providers are described via the `LlmProviderExtension` SPI (see
-`docs/dev/07-extension-points.md` for the full extension-point documentation). To add one:
-
-1. Add a new constant to the `LlmProvider` enum.
-2. Create a Spring `@Component` implementing `LlmProviderExtension` with a matching
-   `descriptor().providerId()`.
-3. Register a gateway in `LlmGatewayRegistry`.
-4. Add mandatory configuration and availability handling in `LlmProviderConfig`.
-5. Add the new `LLM_PROVIDER` enum value and configuration variables to this table.
-
----
-
-## Local Embedding Model
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_EMBEDDING_ENABLED` | `embedding.enabled` | Boolean | `true` | Set to `false` to disable embedding and all semantic search globally. |
-| `TAXONOMY_EMBEDDING_MODEL_DIR` | `embedding.model.dir` | Path | *(empty)* | Absolute path to a pre-downloaded model directory. When empty, DJL downloads the model automatically on first use. |
-| `TAXONOMY_EMBEDDING_MODEL_NAME` | `embedding.model.name` | String | `djl://ai.djl.huggingface/BAAI/bge-small-en-v1.5` | DJL model URL or HuggingFace model name. Change only if you want a different embedding model. |
-| `TAXONOMY_EMBEDDING_QUERY_PREFIX` | `embedding.query.prefix` | String | `Represent this sentence for searching relevant passages: ` | Prefix prepended to query texts for asymmetric retrieval. Set to empty string to disable (e.g. when using a symmetric model). |
-| `TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD` | `embedding.allow-download` | Boolean | `true` | Set to `false` to prevent runtime model downloads. When disabled, a local model must be provided via `TAXONOMY_EMBEDDING_MODEL_DIR`. Recommended for CI environments. |
-
-### Pre-Downloading the Embedding Model (Air-Gapped Deployments)
-
-For environments without internet access, pre-download the `bge-small-en-v1.5` model:
-
-```bash
-# 1. On a machine with internet access, run the app once to trigger the download:
-LLM_PROVIDER=LOCAL_ONNX ./mvnw -pl taxonomy-app spring-boot:run
-# The model is cached under ~/.djl.ai/cache/ (approximately 33 MB)
-
-# 2. Copy the cached model directory to the target machine:
-scp -r ~/.djl.ai/cache/repo/model/ai/djl/huggingface/BAAI/bge-small-en-v1.5/ \
-    target-machine:/opt/models/bge-small-en-v1.5/
-
-# 3. Set the environment variable on the target machine:
-export TAXONOMY_EMBEDDING_MODEL_DIR=/opt/models/bge-small-en-v1.5
-```
-
-Alternatively, download the model directly from HuggingFace:
-
-```bash
-# Download model files
-pip install huggingface-hub
-huggingface-cli download BAAI/bge-small-en-v1.5 --local-dir /opt/models/bge-small-en-v1.5
-```
-
----
-
-## Authentication & Security
-
-The application uses **Spring Security** with form-based login (browser) and HTTP Basic authentication (REST clients). A default `admin` user is created on first startup.
-
-### Default User
-
-| Username | Password | Roles |
-|---|---|---|
-| `admin` | Value of `TAXONOMY_ADMIN_PASSWORD` (default: `admin`) | USER, ARCHITECT, ADMIN |
-
-### Roles and Permissions
-
-| Role | Permissions |
+| Active profile | Important effective defaults |
 |---|---|
-| **ROLE_USER** | Read all API endpoints (`GET /api/**`), run analysis (`POST /api/analyze`, `POST /api/justify-leaf`), export (`POST /api/export/**`), access GUI |
-| **ROLE_ARCHITECT** | Everything in ROLE_USER, plus write access to relations (`POST/PUT/DELETE /api/relations/**`), DSL (`POST/PUT/DELETE /api/dsl/**`), and Git operations (`POST/PUT/DELETE /api/git/**`) |
-| **ROLE_ADMIN** | Everything in ROLE_ARCHITECT, plus admin endpoints (`/admin/**`, `/api/admin/**`) |
+| default / `hsqldb` | in-memory HSQLDB, `ddl-auto=create`, heap Lucene, synchronous indexing, SpringDoc enabled |
+| `production` | `ddl-auto=update`, filesystem Lucene, `write-sync`, audit logging and first-login password change enabled, SpringDoc disabled |
+| `kubernetes` | `ddl-auto=validate`, heap Lucene by default, `write-sync`, audit logging enabled, SpringDoc disabled |
+| `keycloak` | local account management and local password changes disabled; direct Word links disabled |
 
-### CSRF Protection
+Several preferences (`taxonomy.llm.*`, `taxonomy.analysis.min-score`, `taxonomy.dsl.*`, `taxonomy.limits.max-*`, `taxonomy.diagram.policy` and the request-rate limit) are committed into the repository-backed preferences store when it is first initialised. After that point, a value changed through the administration UI/API can supersede a changed process environment until the stored preference is changed again.
 
-CSRF protection is **enabled** for browser sessions but **disabled** for `/api/**` paths. This means REST clients authenticated via HTTP Basic do not need to include a CSRF token.
+`DOMAIN`, `JAVA_OPTS`, OpenTelemetry agent variables and other Docker/Helm wrapper settings are not Taxonomy application variables. They remain documented in the corresponding deployment guide. Secrets must be supplied through the platform secret store and must never be committed.
 
-### REST API Authentication
+## Startup, profiles, catalogue and lifecycle
 
-REST clients must authenticate using **HTTP Basic**:
-
-```bash
-curl -u admin:admin http://localhost:8080/api/taxonomy
-```
-
-### Public Endpoints (No Authentication Required)
-
-- `/login`, `/error`
-- `/actuator/health`, `/actuator/health/**`, `/actuator/info`
-- `/v3/api-docs/**`, `/swagger-ui/**`, `/swagger-ui.html`
-- Static assets: `/css/**`, `/js/**`, `/images/**`, `/webjars/**`
-
----
-
-## Administration
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `ADMIN_PASSWORD` | `admin.token` | String | *(must be set for non-local deployments)* | Password to protect admin-only panels (LLM Diagnostics, Prompt Templates, Communication Log). **For any deployment exposed beyond a fully trusted local machine, this MUST be set to a strong, non-empty value.** When left empty, all admin panels are accessible to everyone and this behaviour is intended for isolated development environments only. When set, users must click the 🔒 button and enter the password. |
-| `TAXONOMY_ADMIN_PASSWORD` | `taxonomy.admin-password` | String | `admin` | Password for the built-in `admin` user (Spring Security login). Used for form login (browser) and HTTP Basic authentication (REST clients). Change this from the default for any non-local deployment. |
-
-### Configuring the Admin Password
-
-> **Security warning:** Running the application with an empty `ADMIN_PASSWORD` leaves all admin panels unauthenticated. **Do not use an empty admin password on any internet-exposed, shared, or production system.** Always configure a strong, non-empty value for `ADMIN_PASSWORD` in such environments.
-
-**Local development:**
-```bash
-ADMIN_PASSWORD=my-secret ./mvnw -pl taxonomy-app spring-boot:run
-```
-
-**Docker:**
-```bash
-docker run -p 8080:8080 \
-  -e ADMIN_PASSWORD=my-secret \
-  -e GEMINI_API_KEY=your-key \
-  ghcr.io/carstenartur/taxonomy:latest
-```
-
-**Render.com:**
-Set `ADMIN_PASSWORD` as a secret environment variable in the Render dashboard
-(Dashboard → Service → Environment → Add Secret).
-
----
-
-## Server Configuration
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `PORT` | `server.port` | Integer | `8080` | HTTP port the application listens on. Set by Render and similar platforms; falls back to `8080` locally. |
-| — | `spring.application.name` | String | `taxonomy-analyzer` | Application name (used in logs). |
-| `TAXONOMY_THYMELEAF_CACHE` | `spring.thymeleaf.cache` | Boolean | `true` | Cache compiled Thymeleaf templates. Defaults to `true` (production). Set `TAXONOMY_THYMELEAF_CACHE=false` for local development to pick up template changes without restart. |
-| `TAXONOMY_LAZY_INIT` | `spring.main.lazy-initialization` | Boolean | `true` | Lazy bean initialization — beans are created only on first access. Reduces Spring context startup time significantly (typical saving: 30–50 s). `TaxonomyService` is annotated `@Lazy(false)` and is always eagerly initialized regardless of this setting. |
-| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | Boolean | `false` | When `true`, taxonomy data is loaded in a background thread **after** the server starts accepting connections. Recommended for Render and similar PaaS platforms to avoid "No open ports detected" deploy timeouts. Defaults to `false` for backward compatibility (synchronous loading). |
-
----
-
-## Database Configuration
-
-The application uses **Spring profiles** to switch between database backends.
-Set `SPRING_PROFILES_ACTIVE` to select the database; the default is `hsqldb`.
-
-| Profile | Database | Config File |
-|---|---|---|
-| `hsqldb` (default) | HSQLDB (in-memory or file) | `application-hsqldb.properties` |
-| `mssql` | Microsoft SQL Server | `application-mssql.properties` |
-| `postgres` | PostgreSQL | `application-postgres.properties` |
-| `oracle` | Oracle Database | `application-oracle.properties` |
-
-### Common Database Properties
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `SPRING_PROFILES_ACTIVE` | `spring.profiles.active` | String | `hsqldb` | Database profile. Set to `mssql` for SQL Server, `postgres` for PostgreSQL, or `oracle` for Oracle Database. |
-| `TAXONOMY_DATASOURCE_URL` | `spring.datasource.url` | String | *(profile-dependent)* | JDBC URL. Each profile provides a sensible default; override for custom hosts. |
-| `SPRING_DATASOURCE_USERNAME` | `spring.datasource.username` | String | *(profile-dependent)* | Database username. Default: `sa` (MSSQL), `taxonomy` (PostgreSQL, Oracle), `sa` (HSQLDB). |
-| `SPRING_DATASOURCE_PASSWORD` | `spring.datasource.password` | String | *(profile-dependent)* | Database password. Default: *(empty)* (HSQLDB), `taxonomy` (PostgreSQL, Oracle). **Required** for MSSQL (must meet complexity rules). |
-| `TAXONOMY_DDL_AUTO` | `spring.jpa.hibernate.ddl-auto` | String | `create` | Schema generation strategy. `create` rebuilds on each start (safe for in-memory default). Set to `update` for file-based deployments so data is not wiped on restart. |
-| — | `spring.jpa.show-sql` | Boolean | `false` | Whether to log SQL statements. |
-
-### HSQLDB Profile (Default)
-
-| Property | Default | Description |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:hsqldb:mem:taxonomydb;DB_CLOSE_DELAY=-1` | In-memory HSQLDB. Override for disk-backed storage. |
-| `spring.datasource.driver-class-name` | `org.hsqldb.jdbc.JDBCDriver` | HSQLDB JDBC driver. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | Bounded pool used for both in-memory and file HSQLDB. |
-| `spring.datasource.hikari.minimum-idle` | `${TAXONOMY_DB_MIN_IDLE:1}` | Keeps one connection alive; required for file URLs using `shutdown=true`. |
-| `spring.datasource.hikari.maximum-pool-size` | `${TAXONOMY_DB_MAX_POOL_SIZE:4}` | Bounded maximum for embedded HSQLDB. |
-| `spring.datasource.hikari.connection-timeout` | `${TAXONOMY_DB_CONNECTION_TIMEOUT_MS:30000}` | Maximum connection wait in milliseconds. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.HSQLDialect` | Explicit dialect for deterministic startup. |
-
-### MSSQL Profile
-
-Activate with `SPRING_PROFILES_ACTIVE=mssql`. See [DATABASE_SETUP.md](DATABASE_SETUP.md#microsoft-sql-server-mssql) for details.
-
-| Property | Default | Description |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:sqlserver://localhost:1433;databaseName=taxonomy;encrypt=false;trustServerCertificate=true` | SQL Server JDBC URL. |
-| `spring.datasource.driver-class-name` | `com.microsoft.sqlserver.jdbc.SQLServerDriver` | MSSQL JDBC driver. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP connection pool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.SQLServerDialect` | SQL Server dialect. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | HikariCP max connections. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Connection timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Startup retry timeout (ms). |
-
-### PostgreSQL Profile
-
-Activate with `SPRING_PROFILES_ACTIVE=postgres`. See [DATABASE_SETUP.md](DATABASE_SETUP.md#postgresql) for details.
-
-| Property | Default | Description |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:postgresql://localhost:5432/taxonomy` | PostgreSQL JDBC URL. |
-| `spring.datasource.driver-class-name` | `org.postgresql.Driver` | PostgreSQL JDBC driver. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP connection pool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.PostgreSQLDialect` | PostgreSQL dialect. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | HikariCP max connections. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Connection timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Startup retry timeout (ms). |
-
-### Oracle Profile
-
-Activate with `SPRING_PROFILES_ACTIVE=oracle`. See [DATABASE_SETUP.md](DATABASE_SETUP.md#oracle-database) for details.
-
-| Property | Default | Description |
-|---|---|---|
-| `spring.datasource.url` | `jdbc:oracle:thin:@localhost:1521/taxonomy` | Oracle JDBC URL (thin driver). |
-| `spring.datasource.driver-class-name` | `oracle.jdbc.OracleDriver` | Oracle JDBC driver. |
-| `spring.datasource.type` | `com.zaxxer.hikari.HikariDataSource` | HikariCP connection pool. |
-| `spring.jpa.database-platform` | `org.hibernate.dialect.OracleDialect` | Oracle dialect. |
-| `spring.datasource.hikari.maximum-pool-size` | `10` | HikariCP max connections. |
-| `spring.datasource.hikari.connection-timeout` | `30000` | Connection timeout (ms). |
-| `spring.datasource.hikari.initialization-fail-timeout` | `60000` | Startup retry timeout (ms). |
-
----
-
-## Build and integration-test selection
-
-These are Maven properties/tags, not runtime environment variables:
-
-| Property/tag | Default | Effect |
-|---|---|---|
-| `skipITs` | `true` | Keeps the standard lifecycle bounded; set `-DskipITs=false` for Failsafe/Testcontainers tests. |
-| `excludedGroups` | `real-llm,db-postgres,db-mssql,db-oracle` | Excludes live providers and heavyweight database families by default. |
-| `db-postgres` | excluded | PostgreSQL compatibility tests. |
-| `db-mssql` | excluded | Microsoft SQL Server compatibility tests. |
-| `db-oracle` | excluded | Oracle compatibility tests. |
-| `real-llm` | excluded | Live external LLM calls. |
-
-Passing `-DexcludedGroups=real-llm` deliberately includes all database tags
-while still excluding live LLM calls. See
-[`docs/dev/06-testing-by-change-type.md`](../dev/06-testing-by-change-type.md).
-
----
-
-## Hibernate Search / Lucene
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| — | `spring.jpa.properties.hibernate.search.enabled` | Boolean | `true` | Enable Hibernate Search integration. |
-| — | `spring.jpa.properties.hibernate.search.backend.type` | String | `lucene` | Search backend type. |
-| `TAXONOMY_SEARCH_DIRECTORY_TYPE` | `spring.jpa.properties.hibernate.search.backend.directory.type` | String | `local-heap` | Index storage. `local-heap` = in-memory (local dev / tests). Set to `local-filesystem` for production disk-backed deployments. |
-| `TAXONOMY_SEARCH_DIRECTORY_ROOT` | `spring.jpa.properties.hibernate.search.backend.directory.root` | String | `/app/data/lucene-index` | Root directory for the Lucene index files (only used when `TAXONOMY_SEARCH_DIRECTORY_TYPE=local-filesystem`). |
-| — | `spring.jpa.properties.hibernate.search.configuration_property_checking.strategy` | String | `ignore` | Suppresses `HSEARCH000568` warning about `directory.root` being unused when `directory.type=local-heap`. |
-
----
-
-## Rate Limiting
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_RATE_LIMIT_PER_MINUTE` | `taxonomy.rate-limit.per-minute` | Integer | `10` | Maximum LLM-backed API requests per IP per minute. Protects against provider quota exhaustion. Set to `0` to disable rate limiting. |
-
-Protected endpoints: `POST /api/analyze`, `GET /api/analyze-stream`, `GET /api/analyze-node`, `POST /api/justify-leaf`.
-
-When the limit is exceeded, the server returns HTTP `429 Too Many Requests`. The client IP is extracted from the `X-Forwarded-For` header (with `X-Real-IP` fallback).
-
----
-
-## Login Brute-Force Protection
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_LOGIN_RATE_LIMIT` | `taxonomy.security.login-rate-limit.enabled` | Boolean | `true` | Enable/disable login brute-force protection. |
-| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `taxonomy.security.login-rate-limit.max-attempts` | Integer | `5` | Maximum failed login attempts before lockout. |
-| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `taxonomy.security.login-rate-limit.lockout-seconds` | Integer | `300` | Lockout duration in seconds after exceeding max attempts. |
-
-When locked out, the server returns HTTP `423 Locked` with a JSON body containing the retry-after time. Disable with `TAXONOMY_LOGIN_RATE_LIMIT=false` for development.
-
----
-
-## Password Policy
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_REQUIRE_PASSWORD_CHANGE` | `taxonomy.security.require-password-change` | Boolean | `false` | When `true`, users with the default password are redirected to `/change-password`. |
-
----
-
-## Swagger Access Control
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_SWAGGER_PUBLIC` | `taxonomy.security.swagger-public` | Boolean | `true` | When `true`, Swagger UI is accessible without authentication. Set to `false` in production to require authentication. |
-
----
-
-## Security Audit Logging
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_AUDIT_LOGGING` | `taxonomy.security.audit-logging` | Boolean | `false` | When `true`, logs authentication events (login success/failure, user management actions). |
-
----
-
-## Keycloak / OIDC Configuration
-
-Keycloak authentication is activated via the `keycloak` Spring profile (`SPRING_PROFILES_ACTIVE=keycloak`). When active, form login and HTTP Basic are replaced by OAuth2 Login (browser) and JWT Bearer tokens (REST API).
-
-| Variable | Property | Default | Description |
+| Variable | Spring property / scope | Default | Meaning |
 |---|---|---|---|
-| `KEYCLOAK_ISSUER_URI` | `spring.security.oauth2.client.provider.keycloak.issuer-uri` | `http://localhost:8180/realms/taxonomy` | Keycloak realm issuer URI. Used for OIDC discovery and JWT validation. |
-| `KEYCLOAK_CLIENT_ID` | `spring.security.oauth2.client.registration.keycloak.client-id` | `taxonomy-app` | OAuth2 client ID registered in Keycloak. |
-| `KEYCLOAK_CLIENT_SECRET` | `spring.security.oauth2.client.registration.keycloak.client-secret` | *(empty)* | OAuth2 client secret. **Must be set for production.** |
-| `KEYCLOAK_JWK_SET_URI` | `spring.security.oauth2.resourceserver.jwt.jwk-set-uri` | `http://localhost:8180/realms/taxonomy/protocol/openid-connect/certs` | JWKS endpoint for JWT signature validation. |
-| `KEYCLOAK_ADMIN_URL` | `taxonomy.keycloak.admin-console-url` | `http://localhost:8180` | Base URL of the Keycloak Admin Console (used for password change redirects). |
-| `KEYCLOAK_REALM` | `taxonomy.keycloak.realm` | `taxonomy` | Keycloak realm name. Used for Account Console redirect URLs. |
+| `PORT` | `server.port` | `8080` | HTTP listener port. |
+| `SPRING_PROFILES_ACTIVE` | Spring profile selection | default profile `hsqldb` | Comma-separated profiles, for example `production,postgres` or `postgres,kubernetes`. |
+| `TAXONOMY_INIT_ASYNC` | `taxonomy.init.async` | `false` | Opens the HTTP port before loading the catalogue. Useful on PaaS platforms; readiness remains false until loading completes. |
+| `TAXONOMY_INIT_RELOAD_EXISTING` | `taxonomy.init.reload-existing` | `false` | Destructively reloads the configured catalogue even when persisted nodes already exist. Use only after a restorable backup. |
+| `TAXONOMY_LAZY_INIT` | `spring.main.lazy-initialization` | `true` | Defers most Spring beans. `TaxonomyService` remains eager so catalogue readiness is authoritative. |
+| `TAXONOMY_THYMELEAF_CACHE` | `spring.thymeleaf.cache` | `true` | Caches compiled templates; normally disable only during local UI development. |
+| `TAXONOMY_SPRINGDOC_ENABLED` | SpringDoc API and UI switches | base `true`; production/Kubernetes `false` | Creates or suppresses `/v3/api-docs` and Swagger UI. This is independent of the authorization switch below. |
+| `TAXONOMY_FORWARD_HEADERS_STRATEGY` | `server.forward-headers-strategy` in Kubernetes profile | `framework` | Controls interpretation of trusted ingress `Forwarded`/`X-Forwarded-*` headers. |
+| `TAXONOMY_SHUTDOWN_TIMEOUT` | `spring.lifecycle.timeout-per-shutdown-phase` in Kubernetes profile | `30s` | Maximum graceful shutdown phase duration. |
+| `TAXONOMY_LOG_FILE` | `logging.file.name` in Kubernetes profile | empty | Optional log file. Keep empty with a read-only container filesystem and collect stdout instead. |
+| `TAXONOMY_CATALOGUE_RESOURCE` | `taxonomy.catalogue.resource` | bundled `C3_Taxonomy_Catalogue_25AUG2025.xlsx` | Spring resource used for catalogue loading and report provenance. |
+| `TAXONOMY_REPORT_TIME_ZONE` | `taxonomy.report.time-zone` | `Europe/Berlin` | Zone identifier used when rendering decision-report timestamps. |
+| `GIT_COMMIT` | `git.commit.id` | unset | Preferred build/source commit recorded in decision-report provenance. |
+| `GITHUB_SHA` | fallback for `git.commit.id` | `unknown` | Used only when `GIT_COMMIT` is absent. |
+| `TAXONOMY_SCHEMA_MIGRATION_ENABLED` | `taxonomy.schema-migration.enabled` | `true` | Runs idempotent portable schema-contract migrations. Disable only for controlled diagnostics. |
+| `TAXONOMY_COMMIT_INDEX_SEARCH_REBUILD_EMPTY` | `taxonomy.commit-index.search-rebuild-empty` | `true` | Rebuilds/purges the commit search index when the relational projection is empty. |
+| `TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION` | `taxonomy.jgit-storage.legacy-adoption` | `false` | One-start opt-in for the fail-closed legacy JGit schema adoption path. Requires backup and preflight; reset to `false` afterwards. |
+| `TAXONOMY_GIT_BOOTSTRAP` | `taxonomy.git.bootstrap` | `true` | Creates the initial `draft` commit after catalogue readiness when the system repository is empty. |
+| `TAXONOMY_FEATURES_MULTI_REPOSITORY_API_ENABLED` | `taxonomy.features.multi-repository-api.enabled` | `false` | Enables the currently opt-in `/api/repositories` management surface. It does not weaken repository membership checks. |
 
-**Properties automatically set in `keycloak` profile:**
+## Database and Hibernate Search
 
-| Property | Value | Effect |
-|---|---|---|
-| `taxonomy.security.local-users-enabled` | `false` | Disables `UserManagementController` (user CRUD via REST API) |
-| `taxonomy.security.change-password-enabled` | `false` | Disables local `ChangePasswordController` (redirects to Keycloak) |
+`TAXONOMY_DATASOURCE_URL` is the placeholder used by the supplied database profiles. `SPRING_DATASOURCE_URL` is Spring Boot's direct binding for the same `spring.datasource.url` property and has higher precedence. Choose one. The HSQLDB-specific pool variables below do not currently alter the fixed pool settings in the PostgreSQL, MSSQL or Oracle profile.
 
-See [Keycloak & SSO Setup](KEYCLOAK_SETUP.md) for full setup instructions and [Keycloak Migration Guide](KEYCLOAK_MIGRATION.md) for migrating from form login.
-
----
-
-## OpenAPI / Swagger UI
-
-The application exposes interactive API documentation via [springdoc-openapi](https://springdoc.org/).
-
-| Variable | Property | Type | Default | Description |
-|---|---|---|---|---|
-| `TAXONOMY_SPRINGDOC_ENABLED` | `springdoc.api-docs.enabled` / `springdoc.swagger-ui.enabled` | Boolean | `true` | Enable or disable the `/swagger-ui.html` and `/v3/api-docs` endpoints. Set to `false` in production to save memory and reduce attack surface. |
-
-| URL | Description |
-|---|---|
-| `/swagger-ui.html` | Interactive Swagger UI |
-| `/v3/api-docs` | OpenAPI 3.0 JSON specification |
-
----
-
-## Spring Boot Actuator (Monitoring)
-
-The application includes Spring Boot Actuator with Micrometer Prometheus for HTTP-based monitoring.
-This is the modern replacement for JMX (which is not available on Render Free Tier).
-
-### Available Endpoints
-
-| Endpoint | Auth Required | Description |
-|---|---|---|
-| `GET /actuator/health` | No | Application health status (always public — used by Render health checks) |
-| `GET /actuator/health/liveness` | No | Liveness probe (Kubernetes-compatible) |
-| `GET /actuator/health/readiness` | No | Readiness probe (Kubernetes-compatible) |
-| `GET /actuator/info` | No | Application info (name, version, Java, OS) |
-| `GET /actuator/metrics` | Yes (X-Admin-Token) | List of all available metric names |
-| `GET /actuator/metrics/{name}` | Yes (X-Admin-Token) | Value of a specific metric (e.g. `jvm.memory.used`) |
-| `GET /actuator/prometheus` | Yes (X-Admin-Token) | All metrics in Prometheus text format (for scraping) |
-
-### Accessing Protected Endpoints
-
-Endpoints marked "Yes" require the `X-Admin-Token` header when `ADMIN_PASSWORD` is configured:
-
-```bash
-# Health (public)
-curl https://your-app.onrender.com/actuator/health
-
-# Metrics (requires admin token)
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/metrics
-
-# Prometheus scrape
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/prometheus
-
-# Specific metric
-curl -H "X-Admin-Token: your-admin-password" \
-     https://your-app.onrender.com/actuator/metrics/jvm.memory.used
-```
-
-If `ADMIN_PASSWORD` is not set, all actuator endpoints are accessible without authentication
-(backward compatible with local development).
-
-### JMX Equivalents
-
-| JMX MBean | Actuator Equivalent |
-|---|---|
-| `java.lang:type=Memory` | `/actuator/metrics/jvm.memory.used`, `/actuator/metrics/jvm.memory.max` |
-| `java.lang:type=GarbageCollector` | `/actuator/metrics/jvm.gc.pause`, `/actuator/metrics/jvm.gc.memory.promoted` |
-| `java.lang:type=Threading` | `/actuator/metrics/jvm.threads.live`, `/actuator/metrics/jvm.threads.peak` |
-| `java.lang:type=OperatingSystem` | `/actuator/metrics/process.cpu.usage`, `/actuator/metrics/system.cpu.usage` |
-| `java.lang:type=Runtime` | `/actuator/info`, `/actuator/metrics/process.uptime` |
-| Custom MBeans | `/actuator/prometheus` (all metrics in one scrape) |
-
-### Taxonomy Health Indicator
-
-The `/actuator/health` endpoint includes a custom `taxonomy` component that reports:
-
-```json
-{
-  "status": "UP",
-  "components": {
-    "taxonomy": {
-      "status": "UP",
-      "details": {
-        "initStatus": "Async taxonomy initialization complete.",
-        "initialized": true,
-        "heapUsedMB": 256,
-        "heapMaxMB": 512,
-        "heapUsagePercent": 50
-      }
-    }
-  }
-}
-```
-
-Health component details are only shown when `management.endpoint.health.show-components=when-authorized`
-and the request includes a valid `X-Admin-Token` header.
-
----
-
-## Runtime Preferences
-
-In addition to environment variables, several settings can be changed at runtime through the Preferences API without restarting the application:
-
-| Preference Key | Type | Default | Description |
+| Variable | Spring property / scope | Default | Meaning |
 |---|---|---|---|
-| `llm.rpm` | int | `5` | Outgoing Gemini requests per minute |
-| `llm.rpm.custom_openai` | int | `0` | Outgoing custom-provider requests per minute; `0` disables throttling |
-| `llm.timeout.seconds` | int | `30` | HTTP read timeout for LLM calls |
-| `llm.retry.max` | int | `2` | Retry count for retryable LLM server errors and timeouts |
-| `rate-limit.per-minute` | int | `10` | Incoming rate limit for analysis endpoints |
-| `analysis.min-relevance-score` | int | `70` | Minimum score threshold for analysis results |
-| `dsl.default-branch` | string | `draft` | Active DSL branch for materialization |
-| `dsl.project-name` | string | `Taxonomy Architecture` | Project display name |
-| `dsl.auto-save.interval-seconds` | int | `0` | Auto-save frequency (0 = disabled) |
-| `dsl.remote.url` | string | *(empty)* | Remote Git URL for push/pull |
-| `dsl.remote.token` | string | *(empty)* | Remote Git authentication token |
-| `dsl.remote.push-on-commit` | boolean | `false` | Auto-push after local commits |
-| `limits.max-business-text` | int | `5000` | Max characters in requirement text |
-| `limits.max-architecture-nodes` | int | `50` | Max nodes in architecture view |
-| `limits.max-export-nodes` | int | `200` | Max nodes in export |
-| `diagram.policy` | string | `defaultImpact` | Diagram selection policy: `defaultImpact`, `leafOnly`, `clustering`, or `trace` |
+| `TAXONOMY_DATASOURCE_URL` | `spring.datasource.url` through supplied DB profiles | profile-dependent | Taxonomy alias for the JDBC URL. |
+| `SPRING_DATASOURCE_URL` | direct Spring binding to `spring.datasource.url` | unset | JDBC URL used by the Helm chart; overrides the Taxonomy alias when both are present. |
+| `SPRING_DATASOURCE_USERNAME` | `spring.datasource.username` | HSQLDB `sa`; PostgreSQL/Oracle `taxonomy`; MSSQL `sa` | Database account. Always use a secret-backed production value. |
+| `SPRING_DATASOURCE_PASSWORD` | `spring.datasource.password` | profile development defaults | Database password. Production must use a secret. |
+| `TAXONOMY_DB_MIN_IDLE` | HSQLDB Hikari `minimum-idle` | `1` | Minimum idle connections for the HSQLDB profile only. |
+| `TAXONOMY_DB_MAX_POOL_SIZE` | HSQLDB Hikari `maximum-pool-size` | `4` | Maximum HSQLDB pool size. |
+| `TAXONOMY_DB_CONNECTION_TIMEOUT_MS` | HSQLDB Hikari connection timeout | `30000` | HSQLDB connection-acquisition timeout in milliseconds. |
+| `TAXONOMY_DDL_AUTO` | `spring.jpa.hibernate.ddl-auto` | base `create`; production `update`; Kubernetes `validate` | Hibernate schema action. Never use `create` against persistent data. PostgreSQL/Flyway deployments should normally use `validate`. |
+| `TAXONOMY_SEARCH_DIRECTORY_TYPE` | Hibernate Search Lucene directory type | base/Kubernetes `local-heap`; production `local-filesystem` | Selects in-memory or filesystem Lucene storage. Multi-replica coordination is not provided by these local modes. |
+| `TAXONOMY_SEARCH_DIRECTORY_ROOT` | Hibernate Search directory root | `/app/data/lucene-index` | Root used by `local-filesystem`; ignored by `local-heap`. |
+| `TAXONOMY_SEARCH_SYNC_STRATEGY` | Hibernate Search indexing-plan synchronization | base `sync`; production/Kubernetes `write-sync` | `sync` waits for reader refresh; `write-sync` waits for writes but improves throughput. |
 
-See [Preferences](PREFERENCES.md) for the REST API and audit trail.
+## Generative LLM providers and analysis preferences
 
----
+A full Copilot run needs a configured generative provider. `LOCAL_ONNX` supplies limited local semantic scoring only; it is not a generative chat model. When `LLM_PROVIDER` is empty, complete providers are detected in this order: Gemini, OpenAI, DeepSeek, Qwen, Llama, Mistral, then `CUSTOM_OPENAI`.
 
-## Framework Import Configuration
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `LLM_PROVIDER` | `llm.provider` | empty / auto-detect | `GEMINI`, `OPENAI`, `DEEPSEEK`, `QWEN`, `LLAMA`, `MISTRAL`, `CUSTOM_OPENAI` or `LOCAL_ONNX`. |
+| `LLM_MOCK` | `llm.mock` | `false` | Uses deterministic fixture analysis. Intended for CI, screenshots and offline tests, not real architecture decisions. |
+| `GEMINI_API_KEY` | `gemini.api.key` | empty | Gemini credential. |
+| `OPENAI_API_KEY` | `openai.api.key` | empty | OpenAI credential. |
+| `DEEPSEEK_API_KEY` | `deepseek.api.key` | empty | DeepSeek credential. |
+| `DASHSCOPE_API_KEY` | `qwen.api.key` | empty | Alibaba DashScope/Qwen credential. |
+| `LLAMA_API_KEY` | `llama.api.key` | empty | Llama API credential. |
+| `MISTRAL_API_KEY` | `mistral.api.key` | empty | Mistral credential. |
+| `CUSTOM_LLM_URL` | `custom.llm.url` | empty | Full HTTP(S) OpenAI-compatible Chat Completions URL. It must contain a host, no embedded credentials, and end in `/chat/completions`. |
+| `CUSTOM_LLM_MODEL` | `custom.llm.model` | empty | Model identifier sent unchanged to the custom endpoint; required with `CUSTOM_OPENAI`. |
+| `CUSTOM_LLM_API_KEY` | `custom.llm.api.key` | empty | Optional bearer token for the custom endpoint. Empty means no `Authorization` header. |
+| `TAXONOMY_LLM_RPM` | repository-backed preference `taxonomy.llm.rpm` | `5` | Outbound per-provider request budget per minute. |
+| `TAXONOMY_LLM_TIMEOUT_SECONDS` | repository-backed preference `taxonomy.llm.timeout-seconds` | `30` | HTTP timeout for an individual LLM call. |
+| `TAXONOMY_ANALYSIS_MIN_SCORE` | repository-backed preference `taxonomy.analysis.min-score` | `70` | Minimum 0–100 relevance used by ordinary architecture-view selection. |
+| `TAXONOMY_RATE_LIMIT_PER_MINUTE` | repository-backed preference `taxonomy.rate-limit.per-minute` | `10` | Per-client limit for LLM-backed API requests; `0` disables this limiter. |
 
-The framework import pipeline is configured through mapping profiles. Available profiles can be listed at runtime:
+## LLM record/replay tooling
+
+These switches are for deterministic test evidence. A production process should normally leave all of them disabled.
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `LLM_RECORD` | `llm.record` | `false` | Records prompts and raw live responses. |
+| `LLM_REPLAY` | `llm.replay` | `false` | Replays a response whose prompt hash is already recorded. |
+| `LLM_REPLAY_FALLBACK` | `llm.replay.fallback` | `error` | `live` permits a missing recording to call the real provider and record it; any other value remains fail-closed. |
+| `LLM_PRUNE` | `llm.prune` | `false` | Marks manifest entries not replayed in the current JVM as stale. |
+| `LLM_PRUNE_DELETE` | `llm.prune.delete` | `false` | Deletes stale recording files when pruning runs. |
+| `LLM_RECORDINGS_DIR` | `llm.recordings.dir` | auto-detected test resource directory | Explicit recording directory. Its manifest is mutable; do not point production at a committed source tree. |
+
+## Local embeddings and vector indexing
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `TAXONOMY_EMBEDDING_ENABLED` | `embedding.enabled` | `false` | Enables local embedding inference and semantic search. Independent of the selected chat provider. |
+| `TAXONOMY_EMBEDDING_MODEL_DIR` | `embedding.model.dir` | empty | Mounted, pre-downloaded model directory. Preferred for offline and Kubernetes deployments. |
+| `TAXONOMY_EMBEDDING_MODEL_NAME` | `embedding.model.name` | BAAI `bge-small-en-v1.5` Hugging Face URL | Remote model reference or local model path used when no directory is supplied. |
+| `TAXONOMY_EMBEDDING_QUERY_PREFIX` | `embedding.query.prefix` | BGE retrieval prefix | Text prepended to queries for asymmetric retrieval. Set empty only for a model that does not require it. |
+| `TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD` | `embedding.allow-download` | `false` | Explicitly permits runtime model download. Also requires suitable network policy/egress. |
+| `TAXONOMY_EMBEDDING_INDEX_LOADER_THREADS` | `embedding.index.loader-threads` | `2`, clamped to at least `1` | Object-loader threads for each bounded mass-indexing phase. More threads also mean more simultaneous local inference. |
+| `TAXONOMY_EMBEDDING_INDEX_BATCH_SIZE` | `embedding.index.batch-size` | `16`, clamped to at least `1` | Number of entities loaded per indexing batch. |
+
+## Copilot and Autopilot
+
+The historical variable name `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` is retained unchanged. Its property is `taxonomy.ai.max-architecture-nodes`, and it applies to both the manual Copilot and Autopilot. A manual request cannot exceed this operator ceiling. The portfolio analysis service also enforces `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES`, so the effective ceiling is the lower of the two; keep the AI limit less than or equal to the general limit.
+
+Profiles accept `STANDARD`, `FULL` and `EXHAUSTIVE`. Verification-pass counts must be between 1 and 3; `EXHAUSTIVE` always performs at least two passes. Passes inside one operation run sequentially. Coordinator concurrency controls different operations, not passes within one operation.
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `TAXONOMY_AI_COST_POLICY` | `taxonomy.ai.cost-policy` | `METERED` | Operator declaration. Unattended Autopilot requires `UNMETERED`; manual Copilot works with a configured metered provider. |
+| `TAXONOMY_AI_COPILOT_PROFILE` | `taxonomy.ai.copilot.profile` | `FULL` | Default profile for manually initiated runs. |
+| `TAXONOMY_AI_AUTOPILOT_PROFILE` | `taxonomy.ai.autopilot.profile` | `EXHAUSTIVE` | Default profile for unattended runs. |
+| `TAXONOMY_AI_COPILOT_VERIFICATION_PASSES` | `taxonomy.ai.copilot.verification-passes` | `1` | Manual default, constrained to 1–3 and adjusted upward when required by the profile. |
+| `TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES` | `taxonomy.ai.autopilot.verification-passes` | `2` | Autopilot default, constrained to 1–3 and at least 2 for `EXHAUSTIVE`. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` | `taxonomy.ai.max-architecture-nodes` | `50`, minimum `1` | Operator ceiling for nodes in architecture views created by manual Copilot and Autopilot. Higher values increase processing, snapshot and diagram size; they do not increase project requirement batches. |
+| `TAXONOMY_AI_AUTOPILOT_ENABLED` | `taxonomy.ai.autopilot.enabled` | `false` | Explicit opt-in to unattended execution. It is insufficient without the cost policy and provider settings. |
+| `TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE` | `taxonomy.ai.autopilot.on-requirement-save` | `true` | Starts Autopilot after saving a new immutable requirement version, but only when Autopilot is otherwise ready. |
+| `TAXONOMY_AI_AUTOPILOT_PROVIDER` | `taxonomy.ai.autopilot.provider` | empty | Explicit provider for unattended work. It must be configured and is never inferred to be unmetered. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS` | `taxonomy.ai.autopilot.propose-solutions` | `true` | Creates deterministic `PROPOSED` solution links for non-`STANDARD` Autopilot profiles. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS` | `taxonomy.ai.autopilot.propose-products` | `true` | Creates `CANDIDATE` product proposals for non-`STANDARD` Autopilot profiles. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS` | `taxonomy.ai.autopilot.max-project-requirements` | `50`; valid 1–500 | Maximum explicit project-level Autopilot batch. Oversized selections are rejected, never silently truncated. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE` | `taxonomy.ai.product-proposals.minimum-coverage` | `25`, clamped to 0–100 | Minimum overlapping confirmed catalogue coverage for deterministic product proposals. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE` | `taxonomy.ai.product-proposals.minimum-confidence` | `0.25`, clamped to 0–1 | Minimum fraction of a solution's confirmed nodes covered by a candidate product. |
+| `TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS` | `taxonomy.ai.maximum-runtime-seconds` | `1800`, minimum effective `60` | How long the coordinator waits for a pass. Persisted jobs remain recoverable after the wait ends. |
+| `TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS` | `taxonomy.ai.coordinator.max-concurrent-operations` | `4`; valid 1–64 | Number of Copilot/Autopilot operations coordinated in parallel. Does not parallelise one operation's verification passes. |
+| `TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY` | `taxonomy.ai.coordinator.queue-capacity` | `100`; valid 1–10000 | In-memory coordinator queue; rejected operations remain persisted and can be resumed. |
+
+Effective policy and readiness can be inspected at `GET /api/ai-automation`. Generated mappings, responsibilities, products, procurement decisions and branch merges still require human approval.
+
+## Portfolio, imports, workers and working state
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `TAXONOMY_ANALYSIS_DRAFT_MAX_CHARACTERS` | `taxonomy.analysis-draft.max-characters` | `2000000`; minimum effective `10000` | Maximum serialized JSON characters in one workspace/repository/branch-scoped analysis draft. |
+| `TAXONOMY_CONTEXT_MAX_HISTORY` | `taxonomy.context.max-history` | `50` | In-memory navigation-history entries retained for each active workspace state. |
+| `TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS` | `taxonomy.portfolio.max-import-requirements` | `100`, minimum `1` | Maximum requirements accepted by one reviewed import. |
+| `TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS` | `taxonomy.portfolio.max-import-characters` | `500000`, minimum `1` | Maximum total text characters in one reviewed import. |
+| `TAXONOMY_PORTFOLIO_MAX_ANALYSIS_BATCH` | `taxonomy.portfolio.max-analysis-batch` | `100`, minimum `1` | Maximum requirements in one persisted portfolio analysis job. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS` | `taxonomy.portfolio.analysis-claim-timeout-seconds` | `900`, minimum effective `60` | Age after which an unfinished item claim can be recovered/retried. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY` | `taxonomy.portfolio.analysis-worker-concurrency` | `1`, minimum `1` | Parallel portfolio analysis worker threads. Provider quotas usually limit safe growth. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY` | `taxonomy.portfolio.analysis-worker-queue-capacity` | `100`, minimum effective `0` | In-memory dispatch queue. Persisted jobs survive rejection and can be resubmitted. |
+| `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS` | `taxonomy.portfolio.analysis-worker-shutdown-seconds` | `30`, minimum effective `0` | Grace period for worker termination. |
+| `TAXONOMY_PORTFOLIO_SNAPSHOT_STALE_AFTER_DAYS` | `taxonomy.portfolio.snapshot-stale-after-days` | `30`, minimum effective `1` | Age threshold used by portfolio stale-snapshot metrics; a snapshot for an old requirement version is stale regardless of age. |
+
+## Local security, administration and Keycloak
+
+`ADMIN_PASSWORD` and `TAXONOMY_ADMIN_PASSWORD` are deliberately separate. The former is an additional token for sensitive Actuator/admin-token checks. The latter bootstraps the local `admin` account. When local authentication starts outside the production profile without `TAXONOMY_ADMIN_PASSWORD`, the application generates and logs a one-time random bootstrap password and requires it to be changed. The production profile fails startup unless the configured password is non-placeholder and at least 16 characters.
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `ADMIN_PASSWORD` | `admin.token` | empty | Optional `X-Admin-Token`/Bearer value for sensitive Actuator and legacy admin-token checks. Empty disables this extra token layer; it does not replace role-based login authorization. |
+| `TAXONOMY_ADMIN_PASSWORD` | `taxonomy.admin-password` | empty outside production; required in production | Initial local administrator credential. Empty non-production starts use a one-time random bootstrap password. |
+| `TAXONOMY_LOGIN_RATE_LIMIT` | `taxonomy.security.login-rate-limit.enabled` | `true` | Enables failed-login rate limiting by client address. |
+| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `taxonomy.security.login-rate-limit.max-attempts` | `5` | Failed attempts allowed before lockout. |
+| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `taxonomy.security.login-rate-limit.lockout-seconds` | `300` | Lockout duration. |
+| `TAXONOMY_REQUIRE_PASSWORD_CHANGE` | `taxonomy.security.require-password-change` | base `false`; production `true` | Marks new/reset local passwords as temporary and enforces the change page. |
+| `TAXONOMY_SWAGGER_PUBLIC` | `taxonomy.security.swagger-public` | base `true`; production/Kubernetes `false` | When SpringDoc exists, controls whether its UI/API are public or require authentication. |
+| `TAXONOMY_AUDIT_LOGGING` | `taxonomy.security.audit-logging` | base `false`; production/Kubernetes `true` | Logs authentication success/failure events. |
+| `TAXONOMY_SECURITY_LOCAL_USERS_ENABLED` | `taxonomy.security.local-users-enabled` | base `true`; Keycloak `false` | Enables local user/role services. Do not override to true in Keycloak mode without a deliberate mixed-identity design. |
+| `TAXONOMY_SECURITY_CHANGE_PASSWORD_ENABLED` | `taxonomy.security.change-password-enabled` | base `true`; Keycloak `false` | Enables the local password-change surface. Keycloak normally owns credentials. |
+| `TAXONOMY_DIRECT_WORD_ENABLED` | `taxonomy.document-templates.direct-word-enabled` | base `true`; Keycloak `false` | Shows `ms-word:` direct-edit links. Enable only when Word can authenticate to the WebDAV endpoint. |
+| `KEYCLOAK_CLIENT_ID` | OAuth2 client registration | `taxonomy-app` | OIDC browser client ID. |
+| `KEYCLOAK_CLIENT_SECRET` | OAuth2 client registration | empty | Confidential-client secret; provide through a secret store. |
+| `KEYCLOAK_ISSUER_URI` | OAuth2 client and resource-server issuer | local realm URI | Public issuer URI used for discovery and token validation. |
+| `KEYCLOAK_JWK_SET_URI` | resource-server JWK endpoint | local realm certificates URI | Explicit key endpoint, useful when internal and public Keycloak routes differ. |
+| `KEYCLOAK_ADMIN_URL` | `taxonomy.keycloak.admin-console-url` | `http://localhost:8180` | Base URL used for account-console redirects. |
+| `KEYCLOAK_REALM` | `taxonomy.keycloak.realm` | `taxonomy` | Realm segment used by account-console redirects. |
+| `TAXONOMY_KEYCLOAK_ROLE_CLAIM_PATH` | `taxonomy.keycloak.role-claim-path` | `realm_access.roles` | Dot-separated JWT claim path. Values are filtered to the fixed application roles `ROLE_USER`, `ROLE_ARCHITECT` and `ROLE_ADMIN`; no configurable prefix transformation exists. |
+
+## DSL, repositories and external Git
+
+The first six settings below initialise repository-backed preferences. The `taxonomy.dsl.remote-*` connection is the historic DSL replication mechanism. External canonical repository credentials are deployment-only secrets read at call time and are not persisted in the Taxonomy database.
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `TAXONOMY_DSL_DEFAULT_BRANCH` | `taxonomy.dsl.default-branch` | `draft` | Initial branch preference for DSL work. |
+| `TAXONOMY_DSL_PROJECT_NAME` | `taxonomy.dsl.project-name` | `Taxonomy Architecture` | Project name in DSL/export metadata. |
+| `TAXONOMY_DSL_AUTO_SAVE_INTERVAL` | `taxonomy.dsl.auto-save-interval` | `0` | Auto-commit interval in seconds; `0` disables it. |
+| `TAXONOMY_DSL_REMOTE_URL` | `taxonomy.dsl.remote-url` | empty | Optional remote used by the historic DSL replication settings. |
+| `TAXONOMY_DSL_REMOTE_TOKEN` | `taxonomy.dsl.remote-token` | empty | Token for the DSL remote. Treat as a secret even though the preferences API masks it. |
+| `TAXONOMY_DSL_REMOTE_PUSH_ON_COMMIT` | `taxonomy.dsl.remote-push-on-commit` | `false` | Pushes after each DSL commit when a remote is configured. |
+| `TAXONOMY_EXTERNAL_GIT_USERNAME` | direct deployment credential | `oauth2` | Username supplied to the administrator-configured canonical external repository. |
+| `TAXONOMY_EXTERNAL_GIT_TOKEN` | direct deployment credential | empty | Write-only token for fetch/push; never persist or log it. |
+
+## Input, architecture, export and document limits
+
+The general architecture limit below applies to all persisted portfolio analyses. The Copilot/Autopilot-specific limit cannot effectively exceed it. Byte values use binary multiples.
+
+| Variable | Spring property / scope | Default | Meaning |
+|---|---|---|---|
+| `TAXONOMY_LIMITS_MAX_BUSINESS_TEXT` | repository-backed preference `taxonomy.limits.max-business-text` | `5000` characters | Maximum ordinary business-requirement input length. |
+| `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES` | repository-backed preference and portfolio operator limit `taxonomy.limits.max-architecture-nodes` | `50` | General maximum architecture-view node count and upper bound accepted by portfolio analysis requests. |
+| `TAXONOMY_LIMITS_MAX_EXPORT_NODES` | repository-backed preference `taxonomy.limits.max-export-nodes` | `200` | Maximum node count in bounded exports. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_UPLOAD_BYTES` | `taxonomy.limits.document.max-upload-bytes` | `52428800` (50 MiB) | Maximum uploaded document size. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_PDF_PAGES` | `taxonomy.limits.document.max-pdf-pages` | `500` | Maximum PDF pages processed. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_EXTRACTED_CHARACTERS` | `taxonomy.limits.document.max-extracted-characters` | `1000000` | Maximum characters retained after extraction. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_CANDIDATES` | `taxonomy.limits.document.max-candidates` | `2000` | Maximum provenance/candidate records produced from one document. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_LLM_CHARACTERS` | `taxonomy.limits.document.max-llm-characters` | `200000` | Maximum extracted characters sent to the LLM stage. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_ENTRY_BYTES` | `taxonomy.limits.document.max-docx-entry-bytes` | `67108864` (64 MiB) | Maximum expanded size of one DOCX ZIP entry. |
+| `TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_TEXT_BYTES` | `taxonomy.limits.document.max-docx-text-bytes` | `134217728` (128 MiB) | Maximum aggregate expanded DOCX text/XML bytes. |
+| `TAXONOMY_LIMITS_DOCUMENT_MIN_DOCX_INFLATE_RATIO` | `taxonomy.limits.document.min-docx-inflate-ratio` | `0.01` | Minimum compressed-to-expanded ratio accepted by the DOCX zip-bomb guard. |
+| `TAXONOMY_DIAGRAM_POLICY` | repository-backed preference `taxonomy.diagram.policy` | `defaultImpact` | Diagram selection policy: `defaultImpact`, `leafOnly`, `clustering` or `trace`. |
+
+## Deployment examples
+
+### Manual Copilot with a cloud provider
 
 ```bash
-curl -u admin:password http://localhost:8080/api/import/profiles
+LLM_PROVIDER=GEMINI
+GEMINI_API_KEY=secret
+TAXONOMY_AI_COPILOT_PROFILE=FULL
+TAXONOMY_AI_COPILOT_VERIFICATION_PASSES=1
+TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES=50
 ```
 
-| Profile ID | Framework | File Format |
-|---|---|---|
-| `uaf` | UAF / DoDAF | XMI / XML |
-| `apqc` | APQC PCF | CSV |
-| `apqc-excel` | APQC PCF | XLSX (Excel) |
-| `c4` | C4 / Structurizr | DSL |
+### Unattended Autopilot with an explicitly unmetered custom endpoint
 
-No additional environment variables are needed for framework import — profiles are registered automatically at startup.
+```bash
+LLM_PROVIDER=CUSTOM_OPENAI
+CUSTOM_LLM_URL=http://llm-server:8000/v1/chat/completions
+CUSTOM_LLM_MODEL=architecture-model
+TAXONOMY_AI_COST_POLICY=UNMETERED
+TAXONOMY_AI_AUTOPILOT_ENABLED=true
+TAXONOMY_AI_AUTOPILOT_PROVIDER=CUSTOM_OPENAI
+```
 
-See [Framework Import](FRAMEWORK_IMPORT.md) for detailed mapping tables and usage.
+For Docker Compose, copy `.env.example` to `.env`; the production Compose service forwards that file into the application container. For Helm, put non-secret values under `config`, credentials in the referenced Secret, and use `extraEnv` only for settings not promoted into the chart's default values.

--- a/docs/en/COPILOT_AUTOPILOT.md
+++ b/docs/en/COPILOT_AUTOPILOT.md
@@ -1,22 +1,48 @@
 # Copilot and Autopilot
 
-Taxonomy distinguishes an explicitly requested **Copilot full analysis** from unattended **Autopilot** execution.
+Taxonomy distinguishes an explicitly requested **Copilot full analysis** from unattended **Autopilot** execution. Both use persistent, tenant-, repository- and branch-bound portfolio analysis jobs. Reloading or navigating away does not lose an operation.
 
-## Copilot full analysis
+The canonical inventory for all application settings is [CONFIGURATION_REFERENCE.md](CONFIGURATION_REFERENCE.md). This page explains the AI-automation settings in their workflow context.
 
-A saved requirement is analyzed through persistent, tenant-bound analysis jobs. A full pass produces taxonomy scoring, architecture elements and relations, gap and pattern analysis, an architecture recommendation, and an immutable snapshot. Navigation or a browser reload does not lose the operation.
+## Manual Copilot full analysis
 
-The manual endpoint is:
+A saved immutable requirement version is processed through one or more bounded verification passes. A completed operation produces taxonomy scoring and reasons, a relation-aware architecture view, gap and pattern analysis, an architecture recommendation, immutable snapshots, and—when enabled—deterministic solution and product proposals.
 
 ```text
 POST /api/projects/{projectId}/requirements/{requirementId}/copilot
+GET  /api/projects/{projectId}/requirements/{requirementId}/copilot/latest
+GET  /api/projects/{projectId}/copilot-operations/{operationId}
+POST /api/projects/{projectId}/copilot-operations/{operationId}/cancel
 ```
 
-Existing operations can be resumed or cancelled through the operation endpoints. `STANDARD`, `FULL`, and `EXHAUSTIVE` profiles execute one to three bounded passes. Identical inputs reuse their persisted jobs unless `force=true` is requested.
+Profiles have these meanings:
+
+| Profile | Minimum passes | Solution/product proposals |
+|---|---:|---|
+| `STANDARD` | 1 | disabled |
+| `FULL` | configured Copilot default, at least 1 | enabled unless the request disables them |
+| `EXHAUSTIVE` | at least 2 | enabled unless the request disables them |
+
+All configured or request-supplied verification-pass counts must be between 1 and 3. Passes of one operation execute sequentially. Identical input state and settings reuse the persistent operation unless the caller deliberately requests `force=true`.
+
+Manual Copilot requires a ready provider but does **not** require `TAXONOMY_AI_COST_POLICY=UNMETERED`; the user explicitly starts every run.
+
+## Architecture-node limits
+
+`TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` keeps its historical name for compatibility, but its Spring property is `taxonomy.ai.max-architecture-nodes` and it applies to **both manual Copilot and Autopilot**. It is the operator ceiling for the architecture view built in every AI-automation pass. A manual API request may select a lower value but cannot exceed it.
+
+A second setting, `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES`, is the general portfolio-analysis ceiling. The effective limit is therefore the lower of both values. Keep them aligned unless a deliberately smaller AI-automation view is wanted:
+
+```text
+TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
+TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES=50
+```
+
+Increasing the value can retain more relevant nodes, but also enlarges pipeline work, snapshots, relation generation and diagrams. It does not change the number of project requirements processed in one Autopilot batch.
 
 ## Explicit Autopilot opt-in
 
-Taxonomy never assumes that a custom OpenAI-compatible endpoint is free. Unattended execution requires all three settings:
+Taxonomy never assumes that a custom OpenAI-compatible endpoint is free. Unattended execution requires all three deliberate settings:
 
 ```text
 TAXONOMY_AI_COST_POLICY=UNMETERED
@@ -24,9 +50,9 @@ TAXONOMY_AI_AUTOPILOT_ENABLED=true
 TAXONOMY_AI_AUTOPILOT_PROVIDER=CUSTOM_OPENAI
 ```
 
-The selected provider must also be completely configured. For `CUSTOM_OPENAI`, set `CUSTOM_LLM_URL` and `CUSTOM_LLM_MODEL`; the key remains optional for a trusted local server.
+The selected provider must also be fully configured. For `CUSTOM_OPENAI`, set `CUSTOM_LLM_URL` and `CUSTOM_LLM_MODEL`; the API key is optional for a trusted unauthenticated local server.
 
-`TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE=false` disables the automatic save hook without disabling explicit project Autopilot runs.
+`TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE=false` disables the automatic save hook without disabling explicitly requested project-wide runs.
 
 ## Project-wide execution
 
@@ -35,16 +61,36 @@ GET  /api/projects/{projectId}/autopilot
 POST /api/projects/{projectId}/autopilot/run
 ```
 
-The POST body may contain `requirementIds` and `maxRequirements`. The server never silently truncates a project: when the selected requirements exceed the configured batch limit, the request fails and asks the caller to select a smaller explicit batch or change the operator limit.
+The POST body may contain `requirementIds` and `maxRequirements`. The server never silently truncates a project. If the selection exceeds the effective request/operator batch limit, it rejects the call and requires a smaller explicit selection or a deliberate operator-limit change.
 
-Relevant limits include:
+## Configuration table
+
+| Environment variable | Default / validation | Effect |
+|---|---|---|
+| `TAXONOMY_AI_COST_POLICY` | `METERED`; enum | Operator cost declaration. Autopilot requires `UNMETERED`; manual Copilot does not. |
+| `TAXONOMY_AI_COPILOT_PROFILE` | `FULL` | Default profile for a manually initiated operation. |
+| `TAXONOMY_AI_AUTOPILOT_PROFILE` | `EXHAUSTIVE` | Profile used by unattended operations. |
+| `TAXONOMY_AI_COPILOT_VERIFICATION_PASSES` | `1`; valid 1–3 | Manual default before the profile minimum is applied. |
+| `TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES` | `2`; valid 1–3 | Unattended default; `EXHAUSTIVE` still requires at least 2. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` | `50`; minimum 1 | Node ceiling for architecture views from both manual Copilot and Autopilot. Also bounded by `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES`. |
+| `TAXONOMY_AI_AUTOPILOT_ENABLED` | `false` | First explicit opt-in for unattended execution. |
+| `TAXONOMY_AI_AUTOPILOT_PROVIDER` | empty | Explicit provider for Autopilot; it must be configured and match the operator's unmetered declaration. |
+| `TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE` | `true` | Starts an unattended operation for a newly saved immutable requirement version when Autopilot is otherwise ready. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS` | `true` | Enables deterministic `PROPOSED` solution links for non-`STANDARD` Autopilot runs. |
+| `TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS` | `true` | Enables deterministic `CANDIDATE` product proposals for non-`STANDARD` Autopilot runs. |
+| `TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS` | `50`; valid 1–500 | Maximum project-wide selection; oversized requests fail rather than being truncated. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE` | `25`; clamped to 0–100 | Minimum overlapping confirmed taxonomy coverage for a deterministic product proposal. |
+| `TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE` | `0.25`; clamped to 0–1 | Minimum fraction of a solution's confirmed nodes covered by the product. |
+| `TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS` | `1800`; minimum effective 60 | Maximum coordinator wait per pass. The persistent job remains recoverable after the wait ends. |
+| `TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS` | `4`; valid 1–64 | Number of different Copilot/Autopilot operations coordinated in parallel. It does not parallelize passes within one operation. |
+| `TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY` | `100`; valid 1–10000 | In-memory coordination queue. Persisted operations can be resumed after capacity rejection. |
+
+The portfolio analysis worker is a separate execution pool. Its settings are `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY`, `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY`, and `TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS`. Raising only the coordinator limit cannot make an individual provider call faster and may increase rate-limit pressure.
+
+The effective readiness and reason are available at:
 
 ```text
-TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS=50
-TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50
-TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS=4
-TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY=100
-TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS=1800
+GET /api/ai-automation
 ```
 
 ## Human review boundary

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorAdminTokenSecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorAdminTokenSecurityConfig.java
@@ -1,0 +1,44 @@
+package com.taxonomy.security.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * Lets the dedicated {@link ActuatorSecurityFilter} authenticate non-browser
+ * monitoring clients without weakening the ordinary form-login or Keycloak
+ * authorization rules.
+ *
+ * <p>When no admin token is configured this chain matches nothing, so sensitive
+ * Actuator endpoints retain the normal authenticated-user requirement. When a
+ * token is configured, only non-public Actuator paths enter this permit-all
+ * chain; the servlet filter still validates the actual X-Admin-Token or Bearer
+ * credential and rejects missing or incorrect values.</p>
+ *
+ * <p>CSRF protection remains enabled. The currently exposed token-authenticated
+ * Actuator endpoints are read-only; if a write-capable endpoint is exposed later,
+ * it must also satisfy Spring Security's CSRF protection.</p>
+ */
+@Configuration
+public class ActuatorAdminTokenSecurityConfig {
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    SecurityFilterChain actuatorAdminTokenSecurityFilterChain(
+            HttpSecurity http,
+            @Value("${admin.token:}") String adminToken) throws Exception {
+        RequestMatcher tokenProtectedActuator = request ->
+                adminToken != null
+                        && !adminToken.isBlank()
+                        && ActuatorSecurityFilter.isSensitiveActuatorPath(request);
+
+        http.securityMatcher(tokenProtectedActuator)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ActuatorSecurityFilter.java
@@ -15,16 +15,18 @@ import java.security.MessageDigest;
 
 /**
  * Protects sensitive Actuator endpoints (/actuator/metrics, /actuator/prometheus, etc.)
- * using the existing admin password mechanism.
+ * with the dedicated admin-token mechanism.
  *
  * <ul>
  *   <li>{@code /actuator/health} and {@code /actuator/health/**} are PUBLIC (needed for platform probes)</li>
  *   <li>{@code /actuator/info} is PUBLIC (non-sensitive)</li>
- *   <li>All other {@code /actuator/**} endpoints require either the legacy
+ *   <li>All other {@code /actuator/**} endpoints accept either the legacy
  *       {@code X-Admin-Token} header or an Authorization header in the form
  *       {@code Authorization: Bearer ADMIN_PASSWORD_VALUE}, where the Bearer
  *       value matches the {@code ADMIN_PASSWORD} environment variable.</li>
- *   <li>If no {@code ADMIN_PASSWORD} is configured, all endpoints are accessible (backward compatible).</li>
+ *   <li>When no {@code ADMIN_PASSWORD} is configured, this filter adds no token
+ *       requirement; the ordinary Spring Security authenticated-user rule remains
+ *       authoritative for sensitive Actuator endpoints.</li>
  * </ul>
  */
 @Component
@@ -39,22 +41,19 @@ public class ActuatorSecurityFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String path = request.getRequestURI();
+        String path = applicationPath(request);
 
-        // Only filter actuator paths
         if (!path.startsWith("/actuator/")) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Public endpoints: health and info
-        if (path.equals("/actuator/health") || path.startsWith("/actuator/health/")
-                || path.equals("/actuator/info")) {
+        if (isPublicActuatorPath(path)) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // If no admin password configured, allow all
+        // Without a machine token, defer to the ordinary authenticated-user rule.
         if (adminPassword == null || adminPassword.isBlank()) {
             filterChain.doFilter(request, response);
             return;
@@ -69,6 +68,28 @@ public class ActuatorSecurityFilter extends OncePerRequestFilter {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.getWriter().write("{\"error\":\"Admin authentication required for actuator endpoints\"}");
+    }
+
+    static boolean isSensitiveActuatorPath(HttpServletRequest request) {
+        String path = applicationPath(request);
+        return path.startsWith("/actuator/") && !isPublicActuatorPath(path);
+    }
+
+    static String applicationPath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null
+                && !contextPath.isBlank()
+                && path.startsWith(contextPath)) {
+            return path.substring(contextPath.length());
+        }
+        return path;
+    }
+
+    private static boolean isPublicActuatorPath(String path) {
+        return path.equals("/actuator/health")
+                || path.startsWith("/actuator/health/")
+                || path.equals("/actuator/info");
     }
 
     private boolean matchesBearerToken(String authorization) {

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
@@ -8,47 +8,80 @@ import org.springframework.core.annotation.Order;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Locale;
 import java.util.Set;
 
 /**
  * Fails production startup before any bootstrap account can be persisted when
- * the initial administrator credential is absent or unsafe.
+ * the initial administrator credential or optional machine token is unsafe.
  */
 @Component
 @Profile("production")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class ProductionSecurityGuard implements ApplicationRunner {
 
+    private static final int MINIMUM_SECRET_LENGTH = 16;
     private static final Set<String> FORBIDDEN_PASSWORDS = Set.of(
             "admin",
             "password",
             "changeme",
-            "change-me",
-            "change-me-to-a-strong-password",
-            "replace-with-a-long-random-password");
+            "change-me");
 
     private final String adminPassword;
+    private final String adminToken;
 
     public ProductionSecurityGuard(
-            @Value("${taxonomy.admin-password:}") String adminPassword) {
+            @Value("${taxonomy.admin-password:}") String adminPassword,
+            @Value("${admin.token:}") String adminToken) {
         this.adminPassword = adminPassword;
+        this.adminToken = adminToken;
     }
 
     @Override
     public void run(ApplicationArguments arguments) {
-        String normalized = adminPassword == null
+        requireStrongSecret(adminPassword, "TAXONOMY_ADMIN_PASSWORD");
+
+        if (adminToken != null && !adminToken.isBlank()) {
+            requireStrongSecret(adminToken, "ADMIN_PASSWORD");
+            if (constantTimeEquals(adminPassword, adminToken)) {
+                throw new IllegalStateException(
+                        "Production startup refused: ADMIN_PASSWORD must be a distinct "
+                                + "machine token and must not reuse TAXONOMY_ADMIN_PASSWORD.");
+            }
+        }
+    }
+
+    private static void requireStrongSecret(
+            String value,
+            String environmentVariable) {
+        String normalized = value == null
                 ? ""
-                : adminPassword.trim().toLowerCase(Locale.ROOT);
-        if (normalized.isEmpty() || FORBIDDEN_PASSWORDS.contains(normalized)) {
-            throw new IllegalStateException(
-                    "Production startup refused: configure a unique, strong "
-                            + "TAXONOMY_ADMIN_PASSWORD and do not use a documented placeholder.");
+                : value.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty()
+                || FORBIDDEN_PASSWORDS.contains(normalized)
+                || normalized.startsWith("replace-with-")) {
+            throw unsafeSecret(environmentVariable);
         }
-        if (adminPassword.length() < 16) {
+        if (value.length() < MINIMUM_SECRET_LENGTH) {
             throw new IllegalStateException(
-                    "Production startup refused: TAXONOMY_ADMIN_PASSWORD must contain "
-                            + "at least 16 characters.");
+                    "Production startup refused: " + environmentVariable
+                            + " must contain at least " + MINIMUM_SECRET_LENGTH
+                            + " characters.");
         }
+    }
+
+    private static IllegalStateException unsafeSecret(String environmentVariable) {
+        return new IllegalStateException(
+                "Production startup refused: configure a unique, strong "
+                        + environmentVariable
+                        + " and do not use a documented placeholder.");
+    }
+
+    private static boolean constantTimeEquals(String left, String right) {
+        return MessageDigest.isEqual(
+                left.getBytes(StandardCharsets.UTF_8),
+                right.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/taxonomy-app/src/main/resources/ai-automation-defaults.properties
+++ b/taxonomy-app/src/main/resources/ai-automation-defaults.properties
@@ -5,6 +5,8 @@ taxonomy.ai.copilot.profile=${TAXONOMY_AI_COPILOT_PROFILE:FULL}
 taxonomy.ai.autopilot.profile=${TAXONOMY_AI_AUTOPILOT_PROFILE:EXHAUSTIVE}
 taxonomy.ai.copilot.verification-passes=${TAXONOMY_AI_COPILOT_VERIFICATION_PASSES:1}
 taxonomy.ai.autopilot.verification-passes=${TAXONOMY_AI_AUTOPILOT_VERIFICATION_PASSES:2}
+# Historic variable name retained for compatibility: this is the operator ceiling for
+# both manually requested Copilot views and unattended Autopilot views.
 taxonomy.ai.max-architecture-nodes=${TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES:50}
 taxonomy.ai.autopilot.enabled=${TAXONOMY_AI_AUTOPILOT_ENABLED:false}
 taxonomy.ai.autopilot.on-requirement-save=${TAXONOMY_AI_AUTOPILOT_ON_REQUIREMENT_SAVE:true}
@@ -12,6 +14,8 @@ taxonomy.ai.autopilot.provider=${TAXONOMY_AI_AUTOPILOT_PROVIDER:}
 taxonomy.ai.autopilot.propose-solutions=${TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS:true}
 taxonomy.ai.autopilot.propose-products=${TAXONOMY_AI_AUTOPILOT_PROPOSE_PRODUCTS:true}
 taxonomy.ai.autopilot.max-project-requirements=${TAXONOMY_AI_AUTOPILOT_MAX_PROJECT_REQUIREMENTS:50}
+taxonomy.ai.product-proposals.minimum-coverage=${TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE:25}
+taxonomy.ai.product-proposals.minimum-confidence=${TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_CONFIDENCE:0.25}
 taxonomy.ai.maximum-runtime-seconds=${TAXONOMY_AI_MAXIMUM_RUNTIME_SECONDS:1800}
 taxonomy.ai.coordinator.max-concurrent-operations=${TAXONOMY_AI_COORDINATOR_MAX_CONCURRENT_OPERATIONS:4}
 taxonomy.ai.coordinator.queue-capacity=${TAXONOMY_AI_COORDINATOR_QUEUE_CAPACITY:100}

--- a/taxonomy-app/src/main/resources/application-keycloak.properties
+++ b/taxonomy-app/src/main/resources/application-keycloak.properties
@@ -19,8 +19,9 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_ISSUER_URI:http:
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_JWK_SET_URI:http://localhost:8180/realms/taxonomy/protocol/openid-connect/certs}
 
 # --- Keycloak-specific ---
-taxonomy.keycloak.role-claim-path=realm_access.roles
-taxonomy.keycloak.role-prefix=ROLE_
+# The converter recognizes the fixed application roles ROLE_USER, ROLE_ARCHITECT and
+# ROLE_ADMIN at this claim path; there is no configurable role-prefix transformation.
+taxonomy.keycloak.role-claim-path=${TAXONOMY_KEYCLOAK_ROLE_CLAIM_PATH:realm_access.roles}
 taxonomy.keycloak.admin-console-url=${KEYCLOAK_ADMIN_URL:http://localhost:8180}
 taxonomy.keycloak.realm=${KEYCLOAK_REALM:taxonomy}
 

--- a/taxonomy-app/src/main/resources/application-production.properties
+++ b/taxonomy-app/src/main/resources/application-production.properties
@@ -26,7 +26,7 @@ spring.jpa.hibernate.ddl-auto=${TAXONOMY_DDL_AUTO:update}
 spring.jpa.properties.hibernate.search.backend.directory.type=${TAXONOMY_SEARCH_DIRECTORY_TYPE:local-filesystem}
 spring.jpa.properties.hibernate.search.backend.directory.root=${TAXONOMY_SEARCH_DIRECTORY_ROOT:/app/data/lucene-index}
 # write-sync: waits for index writes but skips the refresh wait for better throughput
-spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=write-sync
+spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=${TAXONOMY_SEARCH_SYNC_STRATEGY:write-sync}
 
 # ── Performance: enable Thymeleaf template caching ─────────────────────────────
 spring.thymeleaf.cache=${TAXONOMY_THYMELEAF_CACHE:true}

--- a/taxonomy-app/src/main/resources/application.properties
+++ b/taxonomy-app/src/main/resources/application.properties
@@ -32,6 +32,10 @@ spring.jpa.open-in-view=false
 # Legacy adoption is a one-time, fail-closed operator action after backup/preflight.
 spring.flyway.enabled=false
 taxonomy.jgit-storage.legacy-adoption=${TAXONOMY_JGIT_STORAGE_LEGACY_ADOPTION:false}
+# Portable application contract migrations and the empty commit-index search rebuild
+# are enabled by default. Disable only for a controlled diagnostic start.
+taxonomy.schema-migration.enabled=${TAXONOMY_SCHEMA_MIGRATION_ENABLED:true}
+taxonomy.commit-index.search-rebuild-empty=${TAXONOMY_COMMIT_INDEX_SEARCH_REBUILD_EMPTY:true}
 
 # ── Memory optimization: JDBC batching ────────────────────────────────────────
 spring.jpa.properties.hibernate.jdbc.batch_size=50
@@ -95,9 +99,12 @@ embedding.allow-download=${TAXONOMY_EMBEDDING_ALLOW_DOWNLOAD:false}
 embedding.index.loader-threads=${TAXONOMY_EMBEDDING_INDEX_LOADER_THREADS:2}
 embedding.index.batch-size=${TAXONOMY_EMBEDDING_INDEX_BATCH_SIZE:16}
 
-# Admin auth token — set via environment variable ADMIN_PASSWORD to enable admin-only protection
-# If not set, all panels are visible (backward compatible)
+# ADMIN_PASSWORD is a separate legacy/admin-panel and Actuator token. It is not the
+# form-login administrator password.
 admin.token=${ADMIN_PASSWORD:}
+# Local form-login bootstrap credential. Outside production an empty value creates a
+# one-time random password; the production profile rejects empty, weak or placeholder values.
+taxonomy.admin-password=${TAXONOMY_ADMIN_PASSWORD:}
 
 # ── Startup optimization: lazy initialization ───────────────────────────────
 # Lazy bean initialization: only create beans when first accessed.
@@ -132,10 +139,9 @@ spring.jpa.properties.hibernate.search.backend.lucene_version=9.12.3
 spring.jpa.properties.hibernate.search.backend.directory.type=${TAXONOMY_SEARCH_DIRECTORY_TYPE:local-heap}
 spring.jpa.properties.hibernate.search.backend.directory.root=${TAXONOMY_SEARCH_DIRECTORY_ROOT:/app/data/lucene-index}
 spring.jpa.properties.hibernate.search.backend.analysis.configurer=bean:hibernateSearchAnalysisConfigurer
-# Synchronous indexing: guarantees index changes are visible to readers immediately
-# after the transaction commits. Safe for local-heap (in-memory) dev/test usage.
-# Production overrides this to write-sync for better throughput.
-spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=sync
+# Synchronous indexing guarantees visibility after commit. Production and Kubernetes
+# normally use write-sync for greater throughput.
+spring.jpa.properties.hibernate.search.indexing.plan.synchronization.strategy=${TAXONOMY_SEARCH_SYNC_STRATEGY:sync}
 
 # Suppress HSEARCH000568 warning about directory.root being unused when directory.type=local-heap
 spring.jpa.properties.hibernate.search.configuration_property_checking.strategy=ignore
@@ -171,75 +177,65 @@ springdoc.swagger-ui.enabled=${TAXONOMY_SPRINGDOC_ENABLED:true}
 
 # ── Rate Limiting ─────────────────────────────────────────────────────────────
 # Maximum LLM-backed API requests per IP per minute.
-# Set to 0 to disable. Protects against Gemini/OpenAI quota exhaustion.
+# Set to 0 to disable. Protects against provider quota exhaustion.
 taxonomy.rate-limit.per-minute=${TAXONOMY_RATE_LIMIT_PER_MINUTE:10}
 
-# ── Login Brute-Force Protection ──────────────────────────────────────────
-# Rate-limits failed login attempts per IP. Enabled by default.
+# ── Login brute-force protection and local identity mode ─────────────────────
 taxonomy.security.login-rate-limit.enabled=${TAXONOMY_LOGIN_RATE_LIMIT:true}
-# Maximum failed login attempts before lockout.
 taxonomy.security.login-rate-limit.max-attempts=${TAXONOMY_LOGIN_MAX_ATTEMPTS:5}
-# Lockout duration in seconds after exceeding max attempts.
 taxonomy.security.login-rate-limit.lockout-seconds=${TAXONOMY_LOGIN_LOCKOUT_SECONDS:300}
-
-# ── Password Policy ───────────────────────────────────────────────────────
-# When true, users with the default password are redirected to /change-password.
 taxonomy.security.require-password-change=${TAXONOMY_REQUIRE_PASSWORD_CHANGE:false}
-
-# ── Swagger Access Control ────────────────────────────────────────────────
-# When true, Swagger UI is publicly accessible. Set to false in production.
 taxonomy.security.swagger-public=${TAXONOMY_SWAGGER_PUBLIC:true}
-
-# ── Security Audit Logging ────────────────────────────────────────────────
-# When true, logs authentication events (login success/failure).
 taxonomy.security.audit-logging=${TAXONOMY_AUDIT_LOGGING:false}
+# Keycloak overrides these defaults to false. Do not enable local account management
+# in an OIDC deployment without a deliberate security review.
+taxonomy.security.local-users-enabled=${TAXONOMY_SECURITY_LOCAL_USERS_ENABLED:true}
+taxonomy.security.change-password-enabled=${TAXONOMY_SECURITY_CHANGE_PASSWORD_ENABLED:true}
 
-# ── Keycloak/OIDC Mode Defaults ──────────────────────────────────────────
-# Overridden in application-keycloak.properties when keycloak profile is active.
-taxonomy.security.local-users-enabled=true
-taxonomy.security.change-password-enabled=true
-
-# ── LLM Settings ───────────────────────────────────────────────────────────
-# Maximum outgoing requests per minute to the LLM provider.
-# Gemini free tier: 5 RPM; paid tiers allow higher values.
+# ── LLM and architecture-analysis preferences ────────────────────────────────
 taxonomy.llm.rpm=${TAXONOMY_LLM_RPM:5}
-# HTTP timeout for LLM API calls in seconds. A timeout error is returned instead of hanging.
 taxonomy.llm.timeout-seconds=${TAXONOMY_LLM_TIMEOUT_SECONDS:30}
-# Minimum relevance score (0–100) for a node to appear in architecture views.
 taxonomy.analysis.min-score=${TAXONOMY_ANALYSIS_MIN_SCORE:70}
 
-# ── DSL / JGit Settings ────────────────────────────────────────────────────
-# Default branch for new DSL commits.
+# ── DSL / JGit settings ──────────────────────────────────────────────────────
 taxonomy.dsl.default-branch=${TAXONOMY_DSL_DEFAULT_BRANCH:draft}
-# Project name used in exports and commit metadata.
 taxonomy.dsl.project-name=${TAXONOMY_DSL_PROJECT_NAME:Taxonomy Architecture}
-# Auto-commit interval in seconds (0 = disabled).
 taxonomy.dsl.auto-save-interval=${TAXONOMY_DSL_AUTO_SAVE_INTERVAL:0}
-# Remote Git repository URL to replicate/push to (empty = disabled).
 taxonomy.dsl.remote-url=${TAXONOMY_DSL_REMOTE_URL:}
-# Authentication token for the remote Git repository (stored securely, displayed masked).
 taxonomy.dsl.remote-token=${TAXONOMY_DSL_REMOTE_TOKEN:}
-# Automatically push to remote after each DSL commit.
 taxonomy.dsl.remote-push-on-commit=${TAXONOMY_DSL_REMOTE_PUSH_ON_COMMIT:false}
-
-# ── Size Limits ─────────────────────────────────────────────────────────────
-# Maximum length of business requirement text input.
-taxonomy.limits.max-business-text=${TAXONOMY_LIMITS_MAX_BUSINESS_TEXT:5000}
-# Maximum nodes in generated architecture views.
-taxonomy.limits.max-architecture-nodes=${TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES:50}
-# Maximum nodes in export outputs.
-taxonomy.limits.max-export-nodes=${TAXONOMY_LIMITS_MAX_EXPORT_NODES:200}
-
-# ── Diagram Policy ──────────────────────────────────────────────────────────
-# Selection policy for architecture diagrams.
-# Values: defaultImpact | leafOnly | clustering | trace
-taxonomy.diagram.policy=${TAXONOMY_DIAGRAM_POLICY:defaultImpact}
-
-# ── Git Bootstrap ──────────────────────────────────────────────────────────
-# Create an initial commit on the 'draft' branch at startup if it does not
-# already exist. Ensures the Git status bar, version history, and variant
-# features work from the first page load.
+taxonomy.context.max-history=${TAXONOMY_CONTEXT_MAX_HISTORY:50}
 taxonomy.git.bootstrap=${TAXONOMY_GIT_BOOTSTRAP:true}
+# The multi-repository REST API remains an explicit, disabled-by-default feature flag.
+taxonomy.features.multi-repository-api.enabled=${TAXONOMY_FEATURES_MULTI_REPOSITORY_API_ENABLED:false}
+
+# ── Portfolio imports, durable analysis jobs and working drafts ───────────────
+taxonomy.portfolio.max-import-requirements=${TAXONOMY_PORTFOLIO_MAX_IMPORT_REQUIREMENTS:100}
+taxonomy.portfolio.max-import-characters=${TAXONOMY_PORTFOLIO_MAX_IMPORT_CHARACTERS:500000}
+taxonomy.portfolio.max-analysis-batch=${TAXONOMY_PORTFOLIO_MAX_ANALYSIS_BATCH:100}
+taxonomy.portfolio.analysis-claim-timeout-seconds=${TAXONOMY_PORTFOLIO_ANALYSIS_CLAIM_TIMEOUT_SECONDS:900}
+taxonomy.portfolio.analysis-worker-concurrency=${TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_CONCURRENCY:1}
+taxonomy.portfolio.analysis-worker-queue-capacity=${TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_QUEUE_CAPACITY:100}
+taxonomy.portfolio.analysis-worker-shutdown-seconds=${TAXONOMY_PORTFOLIO_ANALYSIS_WORKER_SHUTDOWN_SECONDS:30}
+taxonomy.portfolio.snapshot-stale-after-days=${TAXONOMY_PORTFOLIO_SNAPSHOT_STALE_AFTER_DAYS:30}
+taxonomy.analysis-draft.max-characters=${TAXONOMY_ANALYSIS_DRAFT_MAX_CHARACTERS:2000000}
+
+# ── Input, architecture and export limits ────────────────────────────────────
+taxonomy.limits.max-business-text=${TAXONOMY_LIMITS_MAX_BUSINESS_TEXT:5000}
+taxonomy.limits.max-architecture-nodes=${TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES:50}
+taxonomy.limits.max-export-nodes=${TAXONOMY_LIMITS_MAX_EXPORT_NODES:200}
+taxonomy.limits.document.max-upload-bytes=${TAXONOMY_LIMITS_DOCUMENT_MAX_UPLOAD_BYTES:52428800}
+taxonomy.limits.document.max-pdf-pages=${TAXONOMY_LIMITS_DOCUMENT_MAX_PDF_PAGES:500}
+taxonomy.limits.document.max-extracted-characters=${TAXONOMY_LIMITS_DOCUMENT_MAX_EXTRACTED_CHARACTERS:1000000}
+taxonomy.limits.document.max-candidates=${TAXONOMY_LIMITS_DOCUMENT_MAX_CANDIDATES:2000}
+taxonomy.limits.document.max-llm-characters=${TAXONOMY_LIMITS_DOCUMENT_MAX_LLM_CHARACTERS:200000}
+taxonomy.limits.document.max-docx-entry-bytes=${TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_ENTRY_BYTES:67108864}
+taxonomy.limits.document.max-docx-text-bytes=${TAXONOMY_LIMITS_DOCUMENT_MAX_DOCX_TEXT_BYTES:134217728}
+taxonomy.limits.document.min-docx-inflate-ratio=${TAXONOMY_LIMITS_DOCUMENT_MIN_DOCX_INFLATE_RATIO:0.01}
+
+# ── Document templates and diagram policy ────────────────────────────────────
+taxonomy.document-templates.direct-word-enabled=${TAXONOMY_DIRECT_WORD_ENABLED:true}
+taxonomy.diagram.policy=${TAXONOMY_DIAGRAM_POLICY:defaultImpact}
 
 # Hierarchical decision rationale report provenance
 git.commit.id=${GIT_COMMIT:${GITHUB_SHA:unknown}}

--- a/taxonomy-app/src/test/java/com/taxonomy/config/ConfigurationReferenceContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/config/ConfigurationReferenceContractTest.java
@@ -1,0 +1,253 @@
+package com.taxonomy.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Prevents deployment-facing configuration from drifting away from the bilingual reference. */
+class ConfigurationReferenceContractTest {
+
+    private static final Pattern ENV_PLACEHOLDER = Pattern.compile(
+            "\\$\\{([A-Z][A-Z0-9_]+)(?::|})");
+    private static final Pattern EXPLICIT_PROPERTY_ENV = Pattern.compile(
+            "(?m)^\\s*([A-Za-z][A-Za-z0-9_.-]*)\\s*=\\s*"
+                    + "\\$\\{([A-Z][A-Z0-9_]+)(?::|})");
+    private static final Pattern VALUE_PROPERTY = Pattern.compile(
+            "@Value\\(\\s*\"\\$\\{([A-Za-z][A-Za-z0-9_.-]*)");
+    private static final Pattern CONDITIONAL = Pattern.compile(
+            "@ConditionalOnProperty\\s*\\((.*?)\\)", Pattern.DOTALL);
+    private static final Pattern PREFIX = Pattern.compile(
+            "prefix\\s*=\\s*\"([^\"]+)\"");
+    private static final Pattern NAME = Pattern.compile(
+            "name\\s*=\\s*\"([^\"]+)\"");
+    private static final Pattern CONFIGURATION_PROPERTIES = Pattern.compile(
+            "@ConfigurationProperties\\s*\\(\\s*prefix\\s*=\\s*\"([^\"]+)\"\\s*\\)");
+    private static final Pattern CONFIGURATION_FIELD = Pattern.compile(
+            "(?m)^\\s*private\\s+(?!static\\b)(?:final\\s+)?[A-Za-z0-9_<>, ?]+\\s+"
+                    + "([a-z][A-Za-z0-9]*)\\s*(?:=|;)");
+    private static final Pattern DOCUMENTED_VARIABLE = Pattern.compile(
+            "(?m)^\\|\\s*`([A-Z][A-Z0-9_]*)`\\s*\\|");
+
+    @Test
+    void bothLanguageReferencesCoverExactlyTheSupportedRuntimeVariables() throws Exception {
+        Path root = repositoryRoot();
+        Set<String> expected = discoverRuntimeVariables(root);
+        Set<String> english = documentedVariables(read(root,
+                "docs/en/CONFIGURATION_REFERENCE.md"));
+        Set<String> german = documentedVariables(read(root,
+                "docs/de/CONFIGURATION_REFERENCE.md"));
+
+        assertThat(english).as("English configuration-variable table").isEqualTo(expected);
+        assertThat(german).as("German configuration-variable table").isEqualTo(expected);
+    }
+
+    @Test
+    void architectureNodeLimitAndSecurityDefaultsAreExplainedTruthfully() throws Exception {
+        Path root = repositoryRoot();
+        String english = read(root, "docs/en/CONFIGURATION_REFERENCE.md");
+        String german = read(root, "docs/de/CONFIGURATION_REFERENCE.md");
+
+        assertThat(english)
+                .contains("`TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES`")
+                .contains("manual Copilot and Autopilot")
+                .contains("one-time random bootstrap password")
+                .doesNotContain("default password `admin`");
+        assertThat(german)
+                .contains("`TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES`")
+                .contains("manuellen Copilot als auch für den Autopiloten")
+                .contains("einmaliges zufälliges Startpasswort")
+                .doesNotContain("Standardpasswort `admin`");
+    }
+
+    @Test
+    void productionExamplesForwardSettingsAndKeepCredentialsSeparate() throws Exception {
+        Path root = repositoryRoot();
+        String environment = read(root, ".env.example");
+        String compose = read(root, "docker-compose.prod.yml");
+        String helm = read(root, "deploy/helm/taxonomy/values.yaml");
+        String helmValidation = read(root,
+                "deploy/helm/taxonomy/templates/validation.yaml");
+        String helmReadme = read(root, "deploy/helm/taxonomy/README.md");
+        String rancherGuide = read(root, "deploy/helm/taxonomy/RANCHER.md");
+
+        assertThat(environment)
+                .contains("LLM_PROVIDER=")
+                .doesNotContain("\nLLM_PROVIDER=LOCAL_ONNX\n")
+                .contains("TAXONOMY_EMBEDDING_ENABLED=false")
+                .contains("TAXONOMY_AI_COPILOT_PROFILE=FULL")
+                .contains("TAXONOMY_AI_AUTOPILOT_PROFILE=EXHAUSTIVE")
+                .contains("TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES=50")
+                .contains("# ADMIN_PASSWORD=replace-with-a-distinct-random-machine-token");
+        assertThat(compose)
+                .contains("env_file:\n      - .env")
+                .contains("TAXONOMY_EMBEDDING_ENABLED=${TAXONOMY_EMBEDDING_ENABLED:-false}");
+        assertThat(helm)
+                .contains("TAXONOMY_AI_COPILOT_PROFILE: FULL")
+                .contains("TAXONOMY_AI_AUTOPILOT_PROFILE: EXHAUSTIVE")
+                .contains("TAXONOMY_AI_AUTOPILOT_PROPOSE_SOLUTIONS: \"true\"")
+                .contains("TAXONOMY_AI_PRODUCT_PROPOSALS_MINIMUM_COVERAGE: \"25\"")
+                .contains("  TAXONOMY_ADMIN_PASSWORD:\n    key: ADMIN_PASSWORD")
+                .contains("  ADMIN_PASSWORD:\n    key: ADMIN_TOKEN")
+                .contains("secretKey: ADMIN_TOKEN")
+                .doesNotContain("  ADMIN_PASSWORD:\n    key: ADMIN_PASSWORD");
+        assertThat(helmValidation)
+                .contains("must use different Secret keys")
+                .contains("must read the Actuator/admin token from the same key");
+        assertThat(helmReadme)
+                .contains("--from-literal=ADMIN_TOKEN=")
+                .contains("jsonpath='{.data.ADMIN_TOKEN}'")
+                .contains("Never reuse the interactive login credential as the machine token");
+        assertThat(rancherGuide)
+                .contains("--from-literal=ADMIN_TOKEN=")
+                .contains("Never reuse the interactive `ADMIN_PASSWORD` value as `ADMIN_TOKEN`")
+                .contains("serviceMonitor.enabled=false");
+    }
+
+    private static Set<String> discoverRuntimeVariables(Path root) throws IOException {
+        Path resources = root.resolve("taxonomy-app/src/main/resources");
+        Map<String, String> explicitPropertyVariables = new HashMap<>();
+        Set<String> variables = new TreeSet<>(Set.of(
+                "SPRING_PROFILES_ACTIVE",
+                "SPRING_DATASOURCE_URL"));
+
+        try (Stream<Path> files = Files.list(resources)) {
+            for (Path file : files.filter(ConfigurationReferenceContractTest::isRuntimeProperties)
+                    .toList()) {
+                String source = Files.readString(file, StandardCharsets.UTF_8);
+                Matcher placeholder = ENV_PLACEHOLDER.matcher(source);
+                while (placeholder.find()) {
+                    variables.add(placeholder.group(1));
+                }
+                Matcher mapping = EXPLICIT_PROPERTY_ENV.matcher(source);
+                while (mapping.find()) {
+                    explicitPropertyVariables.put(mapping.group(1), mapping.group(2));
+                }
+            }
+        }
+
+        Path javaRoot = root.resolve("taxonomy-app/src/main/java");
+        try (Stream<Path> files = Files.walk(javaRoot)) {
+            for (Path file : files.filter(path -> path.toString().endsWith(".java")).toList()) {
+                String source = Files.readString(file, StandardCharsets.UTF_8);
+                collectValueProperties(source, explicitPropertyVariables, variables);
+                collectConditionalProperties(source, explicitPropertyVariables, variables);
+                collectConfigurationProperties(source, explicitPropertyVariables, variables);
+            }
+        }
+        return Set.copyOf(variables);
+    }
+
+    private static void collectValueProperties(
+            String source,
+            Map<String, String> explicitPropertyVariables,
+            Set<String> variables) {
+        Matcher matcher = VALUE_PROPERTY.matcher(source);
+        while (matcher.find()) {
+            addProperty(matcher.group(1), explicitPropertyVariables, variables);
+        }
+    }
+
+    private static void collectConditionalProperties(
+            String source,
+            Map<String, String> explicitPropertyVariables,
+            Set<String> variables) {
+        Matcher annotations = CONDITIONAL.matcher(source);
+        while (annotations.find()) {
+            String body = annotations.group(1);
+            Matcher nameMatcher = NAME.matcher(body);
+            if (!nameMatcher.find()) continue;
+            String name = nameMatcher.group(1);
+            String property = name;
+            Matcher prefixMatcher = PREFIX.matcher(body);
+            if (!name.startsWith("taxonomy.") && prefixMatcher.find()) {
+                property = prefixMatcher.group(1) + "." + name;
+            }
+            addProperty(property, explicitPropertyVariables, variables);
+        }
+    }
+
+    private static void collectConfigurationProperties(
+            String source,
+            Map<String, String> explicitPropertyVariables,
+            Set<String> variables) {
+        Matcher prefixMatcher = CONFIGURATION_PROPERTIES.matcher(source);
+        if (!prefixMatcher.find()) return;
+        String prefix = prefixMatcher.group(1);
+        if (!prefix.startsWith("taxonomy.")) return;
+
+        Matcher fields = CONFIGURATION_FIELD.matcher(source);
+        while (fields.find()) {
+            String property = prefix + "." + camelToKebab(fields.group(1));
+            addProperty(property, explicitPropertyVariables, variables);
+        }
+    }
+
+    private static void addProperty(
+            String property,
+            Map<String, String> explicitPropertyVariables,
+            Set<String> variables) {
+        if (property == null) return;
+        if (property.matches("[A-Z][A-Z0-9_]+")) {
+            variables.add(property);
+            return;
+        }
+        if (!property.startsWith("taxonomy.")) return;
+        variables.add(explicitPropertyVariables.getOrDefault(property, toEnvironmentName(property)));
+    }
+
+    private static Set<String> documentedVariables(String document) {
+        Set<String> variables = new TreeSet<>();
+        Matcher matcher = DOCUMENTED_VARIABLE.matcher(document);
+        while (matcher.find()) {
+            variables.add(matcher.group(1));
+        }
+        return Set.copyOf(variables);
+    }
+
+    private static boolean isRuntimeProperties(Path path) {
+        String name = path.getFileName().toString();
+        return name.equals("ai-automation-defaults.properties")
+                || name.startsWith("application-") && name.endsWith(".properties")
+                || name.equals("application.properties");
+    }
+
+    private static String camelToKebab(String value) {
+        return value.replaceAll("([a-z0-9])([A-Z])", "$1-$2")
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private static String toEnvironmentName(String property) {
+        return property.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]+", "_");
+    }
+
+    private static String read(Path root, String relative) throws IOException {
+        return Files.readString(root.resolve(relative), StandardCharsets.UTF_8);
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isDirectory(current.resolve("taxonomy-app"))
+                    && Files.isDirectory(current.resolve("docs/de"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/ProductionSecurityGuardTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/ProductionSecurityGuardTest.java
@@ -2,6 +2,8 @@ package com.taxonomy.security;
 
 import com.taxonomy.security.config.ProductionSecurityGuard;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.DefaultApplicationArguments;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -11,26 +13,82 @@ class ProductionSecurityGuardTest {
 
     private static final DefaultApplicationArguments NO_ARGS =
             new DefaultApplicationArguments(new String[0]);
+    private static final String STRONG_LOGIN_PASSWORD =
+            "correct-horse-battery-staple-2026";
+    private static final String STRONG_MACHINE_TOKEN =
+            "metrics-machine-token-2026-unique";
 
-    @Test
-    void rejectsMissingDefaultPlaceholderAndShortPasswords() {
-        assertThatThrownBy(() -> new ProductionSecurityGuard("").run(NO_ARGS))
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "admin",
+            "password",
+            "changeme",
+            "change-me",
+            "replace-with-a-long-random-password",
+            "replace-with-a-unique-random-password",
+            "replace-with-a-long-random-login-password",
+            "REPLACE-WITH-ANOTHER-DOCUMENTED-PLACEHOLDER"
+    })
+    void rejectsMissingKnownAndDocumentedLoginPlaceholders(String password) {
+        assertThatThrownBy(() -> guard(password, "").run(NO_ARGS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Production startup refused");
-        assertThatThrownBy(() -> new ProductionSecurityGuard("admin").run(NO_ARGS))
-                .isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> new ProductionSecurityGuard(
-                "replace-with-a-long-random-password").run(NO_ARGS))
-                .isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> new ProductionSecurityGuard("short-secret").run(NO_ARGS))
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "admin",
+            "password",
+            "replace-with-a-different-long-random-machine-token",
+            "REPLACE-WITH-ANOTHER-MACHINE-TOKEN"
+    })
+    void rejectsKnownAndDocumentedMachineTokenPlaceholders(String token) {
+        assertThatThrownBy(() -> guard(STRONG_LOGIN_PASSWORD, token).run(NO_ARGS))
                 .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ADMIN_PASSWORD");
+    }
+
+    @Test
+    void rejectsShortLoginPassword() {
+        assertThatThrownBy(() -> guard("short-secret", "").run(NO_ARGS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("TAXONOMY_ADMIN_PASSWORD")
                 .hasMessageContaining("16 characters");
     }
 
     @Test
-    void acceptsUniqueLongPassword() {
-        assertThatCode(() -> new ProductionSecurityGuard(
-                "correct-horse-battery-staple-2026").run(NO_ARGS))
+    void rejectsShortMachineToken() {
+        assertThatThrownBy(() -> guard(
+                STRONG_LOGIN_PASSWORD, "short-token").run(NO_ARGS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("ADMIN_PASSWORD")
+                .hasMessageContaining("16 characters");
+    }
+
+    @Test
+    void rejectsMachineTokenThatReusesTheLoginPassword() {
+        assertThatThrownBy(() -> guard(
+                STRONG_LOGIN_PASSWORD, STRONG_LOGIN_PASSWORD).run(NO_ARGS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("distinct machine token")
+                .hasMessageContaining("TAXONOMY_ADMIN_PASSWORD");
+    }
+
+    @Test
+    void acceptsStrongLoginPasswordWithoutOptionalMachineToken() {
+        assertThatCode(() -> guard(STRONG_LOGIN_PASSWORD, "").run(NO_ARGS))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void acceptsDistinctStrongLoginAndMachineCredentials() {
+        assertThatCode(() -> guard(
+                STRONG_LOGIN_PASSWORD, STRONG_MACHINE_TOKEN).run(NO_ARGS))
+                .doesNotThrowAnyException();
+    }
+
+    private static ProductionSecurityGuard guard(String loginPassword, String token) {
+        return new ProductionSecurityGuard(loginPassword, token);
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorAdminTokenSecurityTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorAdminTokenSecurityTests.java
@@ -1,0 +1,94 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Verifies the real servlet-filter and Spring-Security interaction for monitoring clients. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "admin.token=metrics-admin-token-1234567890",
+        "taxonomy.admin-password=local-admin-password-1234567890",
+        "taxonomy.security.require-password-change=false",
+        "gemini.api.key=",
+        "openai.api.key=",
+        "deepseek.api.key=",
+        "qwen.api.key=",
+        "llama.api.key=",
+        "mistral.api.key="
+})
+class ActuatorAdminTokenSecurityTests {
+
+    private static final String ADMIN_TOKEN = "metrics-admin-token-1234567890";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void configuredBearerTokenCanReadPrometheusWithoutInteractiveLogin()
+            throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void configuredLegacyHeaderCanReadPrometheusWithoutInteractiveLogin()
+            throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header("X-Admin-Token", ADMIN_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void configuredBearerTokenWorksBehindAContextPath() throws Exception {
+        mockMvc.perform(get("/taxonomy/actuator/prometheus")
+                        .contextPath("/taxonomy")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void missingTokenCannotReadPrometheus() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void contextPathCannotBypassMissingTokenProtection() throws Exception {
+        mockMvc.perform(get("/taxonomy/actuator/prometheus")
+                        .contextPath("/taxonomy"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void incorrectBearerTokenCannotReadPrometheus() throws Exception {
+        mockMvc.perform(get("/actuator/prometheus")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer wrong-token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void tokenAuthenticationDoesNotDisableCsrfForWritingRequests() throws Exception {
+        mockMvc.perform(post("/actuator/metrics")
+                        .with(csrf().useInvalidToken())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + ADMIN_TOKEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void healthProbeRemainsPublicWhenAdminTokenIsConfigured() throws Exception {
+        mockMvc.perform(get("/actuator/health/readiness"))
+                .andExpect(status().isOk());
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ActuatorSecurityFilterTest.java
@@ -38,6 +38,18 @@ class ActuatorSecurityFilterTest {
     }
 
     @Test
+    void contextPathCannotBypassSensitiveEndpointProtection() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                "GET", "/taxonomy/actuator/prometheus");
+        request.setContextPath("/taxonomy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @Test
     void sensitiveEndpointAcceptsLegacyAdminHeader() throws Exception {
         MockHttpServletResponse response = invoke(
                 "/actuator/prometheus", "X-Admin-Token", ADMIN_TOKEN);
@@ -62,7 +74,7 @@ class ActuatorSecurityFilterTest {
     }
 
     @Test
-    void blankAdminTokenPreservesDevelopmentCompatibility() throws Exception {
+    void blankAdminTokenDefersToTheFollowingSecurityChain() throws Exception {
         ReflectionTestUtils.setField(filter, "adminPassword", "");
 
         MockHttpServletResponse response = invoke("/actuator/prometheus", null, null);


### PR DESCRIPTION
## What it does

Closes #855 by replacing the incomplete German and English configuration references with an audited, code-backed inventory and by aligning the deployment examples with the actual runtime.

### Documentation

- documents every deployment-facing variable discovered from effective Spring property files, direct `@Value` bindings, feature flags, and `@ConfigurationProperties`;
- explains profile-dependent defaults and Spring-vs-Taxonomy datasource aliases;
- documents `TAXONOMY_AI_AUTOPILOT_MAX_ARCHITECTURE_NODES` without renaming it, including its actual scope for both manual Copilot and Autopilot, validation, performance effect, and interaction with `TAXONOMY_LIMITS_MAX_ARCHITECTURE_NODES`;
- expands both Copilot/Autopilot guides with every AI automation setting, profile/pass semantics, queue/concurrency boundaries, project batch behavior, and the human approval boundary;
- removes the obsolete fixed `admin` password claim and documents the random non-production bootstrap password plus the production guard;
- distinguishes the local login password (`TAXONOMY_ADMIN_PASSWORD`) from the separate admin/Actuator token (`ADMIN_PASSWORD`);
- updates the Rancher/RKE2 guide with a complete Secret example and an explicit `ADMIN_PASSWORD` versus `ADMIN_TOKEN` lifecycle.

### Configuration and deployment alignment

- makes previously implicit operator settings explicit while retaining their existing names and effective defaults;
- exposes product-proposal thresholds, portfolio worker limits, document-import limits, schema/index lifecycle switches, repository API feature flag, context history, and Keycloak role claim path;
- makes the production Hibernate Search synchronization strategy actually configurable through its documented variable;
- forwards `.env` into the production Compose application container and restores fail-closed, opt-in local embeddings;
- aligns Helm defaults with the documented Copilot profiles, proposal controls, node ceilings and product thresholds;
- keeps the existing Helm Secret key `ADMIN_PASSWORD` exclusively for the interactive login credential injected as `TAXONOMY_ADMIN_PASSWORD`;
- maps a distinct optional Secret key `ADMIN_TOKEN` to the historic application variable `ADMIN_PASSWORD` and to the ServiceMonitor Bearer credential;
- rejects chart rendering when the login credential is reused as the Actuator/admin token or when the application and ServiceMonitor select different keys from the same Secret;
- keeps CSRF protection enabled for the dedicated token-authenticated Actuator security chain and adds a regression test proving that an invalid CSRF token remains forbidden even with a valid Actuator token;
- updates Helm values, validation, executable verification, Rancher questions, generic installation examples, Rancher-specific instructions and protected-metrics examples consistently.

### Drift prevention

Adds `ConfigurationReferenceContractTest`, which discovers the supported runtime-variable set and requires both language references to match it exactly. It also guards the truthful Copilot node-limit scope, administrator-bootstrap behavior, Compose forwarding, fail-closed embedding default, Helm AI defaults, the separation of interactive and machine credentials, and the matching Rancher guidance.

## Compatibility

No existing environment variable is renamed or removed. Existing effective defaults are retained except where a deployment wrapper contradicted the application’s documented fail-closed default (`docker-compose.prod.yml` enabled embeddings automatically).

Existing Helm installations retain the `ADMIN_PASSWORD` Secret key for the local login. The new `ADMIN_TOKEN` key is optional while `serviceMonitor.enabled=false`; installations that enable protected metrics must add a distinct token value. Reusing the login value is intentionally rejected.

## Verification

The original failing head completed 3,309 of 3,310 canonical tests successfully. Its one failure was the existing Helm security contract detecting that the same Secret key had been reused for login and Actuator access. That design was corrected rather than weakening the test.

On corrected predecessor heads, CodeQL, Security Scan, document-template E2E, the production image build and all executable Helm/Rancher profile checks completed successfully. A later CodeQL result correctly identified that the dedicated Actuator chain disabled CSRF; the disabling call was removed. The first regression-test draft accidentally inherited the suite-wide valid CSRF token and therefore observed the endpoint's correct HTTP 405 instead of exercising CSRF. The final test explicitly supplies an invalid token and expects HTTP 403.

Exact head `e121cb85fe295517919e98a999ef4243235e28e5` is a single commit directly on the verified `main` commit `7c097e4ac67012efd2a66734ad98e32f82388d26`. It is running the complete CI/CD, database, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix.