### PR TITLE
Make full-tree CodeQL gating baseline-aware without weakening policy

### DIFF
--- a/.github/codeql-sarif-baseline.json
+++ b/.github/codeql-sarif-baseline.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "trackingIssue": 857,
+  "entries": [
+    {
+      "ruleId": "java/user-controlled-bypass",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java",
+      "primaryLocationLineHash": "fddf021f421e71e8:1",
+      "rationale": "Existing bulk-proposal review dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/user-controlled-bypass",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java",
+      "primaryLocationLineHash": "bc1e87a17bceed95:1",
+      "rationale": "Existing bulk-proposal review dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/user-controlled-bypass",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/relations/controller/ProposalApiController.java",
+      "primaryLocationLineHash": "65e7cc55cc484ad9:1",
+      "rationale": "Existing bulk-proposal review dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/user-controlled-bypass",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/security/webdav/WebDavApplicationCredentialService.java",
+      "primaryLocationLineHash": "ff38a5229c23de45:1",
+      "rationale": "Existing WebDAV credential authorization dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/sensitive-log",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/catalog/service/TaxonomyRelationService.java",
+      "primaryLocationLineHash": "9c9cc85f29714170:1",
+      "rationale": "Existing relation audit-log dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/sensitive-log",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/dsl/export/DslMaterializeService.java",
+      "primaryLocationLineHash": "435739d0edc19d1e:1",
+      "rationale": "Existing DSL relation warning dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/sensitive-log",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/dsl/export/DslMaterializeService.java",
+      "primaryLocationLineHash": "64c585095996ba6b:1",
+      "rationale": "Existing DSL hypothesis warning dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/sensitive-log",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityDataInitializer.java",
+      "primaryLocationLineHash": "960f66a8f61eea7e:1",
+      "rationale": "Existing one-time bootstrap credential delivery is documented and tracked for safer replacement in #857."
+    },
+    {
+      "ruleId": "java/sensitive-log",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/versioning/service/HypothesisService.java",
+      "primaryLocationLineHash": "64d3fb8a5c0e0545:1",
+      "rationale": "Existing hypothesis validation warning dataflow tracked for remediation in #857."
+    },
+    {
+      "ruleId": "java/tainted-arithmetic",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/relations/service/GraphSearchService.java",
+      "primaryLocationLineHash": "e5aab1ae4c4acf21:1",
+      "rationale": "Existing graph-search result-limit arithmetic tracked for bounded-input remediation in #857."
+    },
+    {
+      "ruleId": "java/tainted-arithmetic",
+      "artifactUri": "taxonomy-app/src/main/java/com/taxonomy/shared/service/LocalEmbeddingService.java",
+      "primaryLocationLineHash": "4664648c565ae25f:1",
+      "rationale": "Existing similar-node result-limit arithmetic tracked for bounded-input remediation in #857."
+    },
+    {
+      "ruleId": "js/insecure-temporary-file",
+      "artifactUri": ".github/scripts/accessibility-audit.mjs",
+      "primaryLocationLineHash": "b2951d158917d08c:1",
+      "rationale": "Existing accessibility JSON fallback path tracked for secure temporary-directory remediation in #857."
+    },
+    {
+      "ruleId": "js/insecure-temporary-file",
+      "artifactUri": ".github/scripts/accessibility-audit.mjs",
+      "primaryLocationLineHash": "5f3922a65db94c26:1",
+      "rationale": "Existing accessibility text fallback path tracked for secure temporary-directory remediation in #857."
+    },
+    {
+      "ruleId": "js/insecure-temporary-file",
+      "artifactUri": ".github/scripts/ui-acceptance.mjs",
+      "primaryLocationLineHash": "376d7b76ed98d335:1",
+      "rationale": "Existing UI acceptance fallback path tracked for secure temporary-directory remediation in #857."
+    }
+  ]
+}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
       - 'pom.xml'
       - 'taxonomy-*/pom.xml'
       - 'taxonomy-*/src/**'
+      - '.github/scripts/**'
       - '.github/codeql-sarif-baseline.json'
       - '.github/workflows/codeql.yml'
   push:
@@ -15,6 +16,7 @@ on:
       - 'pom.xml'
       - 'taxonomy-*/pom.xml'
       - 'taxonomy-*/src/**'
+      - '.github/scripts/**'
       - '.github/codeql-sarif-baseline.json'
       - '.github/workflows/codeql.yml'
   schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
       - 'pom.xml'
       - 'taxonomy-*/pom.xml'
       - 'taxonomy-*/src/**'
+      - '.github/codeql-sarif-baseline.json'
       - '.github/workflows/codeql.yml'
   push:
     branches: [ main ]
@@ -14,6 +15,7 @@ on:
       - 'pom.xml'
       - 'taxonomy-*/pom.xml'
       - 'taxonomy-*/src/**'
+      - '.github/codeql-sarif-baseline.json'
       - '.github/workflows/codeql.yml'
   schedule:
     - cron: '19 3 * * 1'
@@ -34,6 +36,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      security-events: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -89,6 +92,7 @@ jobs:
             find codeql-java -type f -name '*.sarif' -print0 | sort -z
           )
           java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-codeql-sarif \
+            --baseline .github/codeql-sarif-baseline.json \
             --report target/codeql-java-gate.json \
             "${reports[@]}"
 
@@ -109,6 +113,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
+      security-events: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -157,6 +162,7 @@ jobs:
             find codeql-javascript -type f -name '*.sarif' -print0 | sort -z
           )
           java -jar "$RUNNER_TEMP/taxonomy-tooling.jar" check-codeql-sarif \
+            --baseline .github/codeql-sarif-baseline.json \
             --report target/codeql-javascript-gate.json \
             "${reports[@]}"
 

--- a/taxonomy-tooling/src/main/java/com/taxonomy/tooling/CodeQlSarifGate.java
+++ b/taxonomy-tooling/src/main/java/com/taxonomy/tooling/CodeQlSarifGate.java
@@ -2,21 +2,26 @@ package com.taxonomy.tooling;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /** Fail-closed high-severity gate for one or more CodeQL SARIF reports. */
 final class CodeQlSarifGate {
 
     private static final String SUPPORTED_SARIF_VERSION = "2.1.0";
+    private static final long SUPPORTED_BASELINE_SCHEMA_VERSION = 1L;
     private static final double MAX_SECURITY_SEVERITY = 10.0;
 
     private CodeQlSarifGate() {
@@ -35,11 +40,18 @@ final class CodeQlSarifGate {
                     rawArguments, workingDirectory);
             report = arguments.report();
             Inspection inspection = inspect(
-                    arguments.sarifPaths(), arguments.threshold());
+                    arguments.sarifPaths(),
+                    arguments.threshold(),
+                    arguments.baseline());
             writeReport(report, inspection);
 
             output.println("CodeQL results: " + inspection.resultCount()
                     + "; blocking: " + inspection.blocking().size());
+            if (inspection.baselineFile() != null) {
+                output.println("CodeQL baseline accepted: "
+                        + inspection.acceptedBaseline().size()
+                        + "; unused: " + inspection.unusedBaseline().size());
+            }
             for (Finding finding : inspection.blocking()) {
                 error.println("- [" + finding.level()
                         + "/security-severity="
@@ -56,6 +68,13 @@ final class CodeQlSarifGate {
 
     static Inspection inspect(List<Path> candidates, double threshold)
             throws IOException {
+        return inspect(candidates, threshold, null);
+    }
+
+    static Inspection inspect(
+            List<Path> candidates,
+            double threshold,
+            Path baselinePath) throws IOException {
         if (!Double.isFinite(threshold)
                 || threshold < 0.0
                 || threshold > MAX_SECURITY_SEVERITY) {
@@ -83,6 +102,9 @@ final class CodeQlSarifGate {
                                     .orElse("<unknown>"));
         }
 
+        Baseline baseline = Baseline.load(baselinePath);
+        Set<FindingKey> usedBaseline = new LinkedHashSet<>();
+        List<Finding> acceptedBaseline = new ArrayList<>();
         List<Finding> blocking = new ArrayList<>();
         int resultCount = 0;
         for (Path path : requested) {
@@ -125,12 +147,21 @@ final class CodeQlSarifGate {
                     requireKnownLevel(level);
                     String message = messageText(result);
                     if (severity >= threshold || "error".equals(level)) {
-                        blocking.add(new Finding(
+                        Finding finding = new Finding(
                                 path.toString(),
                                 ruleId,
                                 severity,
                                 level,
-                                message));
+                                message,
+                                primaryArtifactUri(result),
+                                primaryLocationLineHash(result));
+                        FindingKey key = finding.key();
+                        if (key != null && baseline.contains(key)) {
+                            acceptedBaseline.add(finding);
+                            usedBaseline.add(key);
+                        } else {
+                            blocking.add(finding);
+                        }
                     }
                 }
             }
@@ -139,6 +170,9 @@ final class CodeQlSarifGate {
                 List.copyOf(requested),
                 resultCount,
                 threshold,
+                baseline.path(),
+                List.copyOf(acceptedBaseline),
+                baseline.unusedEntries(usedBaseline),
                 List.copyOf(blocking));
     }
 
@@ -245,6 +279,55 @@ final class CodeQlSarifGate {
                 "SARIF result message must contain text or markdown");
     }
 
+    private static String primaryArtifactUri(Map<String, Object> result) {
+        List<?> locations = listField(
+                result,
+                "locations",
+                "result locations");
+        if (locations.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> location = object(
+                locations.get(0),
+                "SARIF result location");
+        Map<String, Object> physicalLocation = optionalObjectField(
+                location,
+                "physicalLocation",
+                "SARIF result physicalLocation");
+        if (physicalLocation == null) {
+            return null;
+        }
+        Map<String, Object> artifactLocation = optionalObjectField(
+                physicalLocation,
+                "artifactLocation",
+                "SARIF result artifactLocation");
+        if (artifactLocation == null
+                || !artifactLocation.containsKey("uri")) {
+            return null;
+        }
+        String uri = requiredStringField(
+                artifactLocation,
+                "uri",
+                "SARIF result artifact URI");
+        return uri.isBlank() ? null : uri;
+    }
+
+    private static String primaryLocationLineHash(Map<String, Object> result) {
+        Map<String, Object> partialFingerprints = optionalObjectField(
+                result,
+                "partialFingerprints",
+                "SARIF result partialFingerprints");
+        if (partialFingerprints == null
+                || !partialFingerprints.containsKey("primaryLocationLineHash")) {
+            return null;
+        }
+        String fingerprint = requiredStringField(
+                partialFingerprints,
+                "primaryLocationLineHash",
+                "SARIF primaryLocationLineHash");
+        return fingerprint.isBlank() ? null : fingerprint;
+    }
+
     private static void writeReport(Path report, Inspection inspection)
             throws IOException {
         Path absolute = report.toAbsolutePath().normalize();
@@ -255,6 +338,14 @@ final class CodeQlSarifGate {
         }
         Files.createDirectories(parent);
 
+        List<Object> accepted = inspection.acceptedBaseline().stream()
+                .map(Finding::toJson)
+                .map(value -> (Object) value)
+                .toList();
+        List<Object> unused = inspection.unusedBaseline().stream()
+                .map(BaselineEntry::toJson)
+                .map(value -> (Object) value)
+                .toList();
         List<Object> findings = inspection.blocking().stream()
                 .map(Finding::toJson)
                 .map(value -> (Object) value)
@@ -265,6 +356,11 @@ final class CodeQlSarifGate {
                 .toList());
         payload.put("resultCount", (long) inspection.resultCount());
         payload.put("threshold", inspection.threshold());
+        if (inspection.baselineFile() != null) {
+            payload.put("baselineFile", inspection.baselineFile().toString());
+            payload.put("acceptedBaseline", accepted);
+            payload.put("unusedBaseline", unused);
+        }
         payload.put("blocking", findings);
         payload.put("status", findings.isEmpty() ? "PASS" : "FAIL");
         Files.writeString(
@@ -383,6 +479,9 @@ final class CodeQlSarifGate {
             List<Path> sarifFiles,
             int resultCount,
             double threshold,
+            Path baselineFile,
+            List<Finding> acceptedBaseline,
+            List<BaselineEntry> unusedBaseline,
             List<Finding> blocking) {
     }
 
@@ -391,7 +490,18 @@ final class CodeQlSarifGate {
             String ruleId,
             double securitySeverity,
             String level,
-            String message) {
+            String message,
+            String artifactUri,
+            String primaryLocationLineHash) {
+        FindingKey key() {
+            return artifactUri == null || primaryLocationLineHash == null
+                    ? null
+                    : new FindingKey(
+                            ruleId,
+                            artifactUri,
+                            primaryLocationLineHash);
+        }
+
         Map<String, Object> toJson() {
             LinkedHashMap<String, Object> value = new LinkedHashMap<>();
             value.put("file", file);
@@ -399,6 +509,171 @@ final class CodeQlSarifGate {
             value.put("securitySeverity", securitySeverity);
             value.put("level", level);
             value.put("message", message);
+            if (artifactUri != null) {
+                value.put("artifactUri", artifactUri);
+            }
+            if (primaryLocationLineHash != null) {
+                value.put(
+                        "primaryLocationLineHash",
+                        primaryLocationLineHash);
+            }
+            return value;
+        }
+    }
+
+    private record FindingKey(
+            String ruleId,
+            String artifactUri,
+            String primaryLocationLineHash) {
+    }
+
+    record BaselineEntry(
+            String ruleId,
+            String artifactUri,
+            String primaryLocationLineHash,
+            String rationale) {
+        FindingKey key() {
+            return new FindingKey(
+                    ruleId,
+                    artifactUri,
+                    primaryLocationLineHash);
+        }
+
+        Map<String, Object> toJson() {
+            LinkedHashMap<String, Object> value = new LinkedHashMap<>();
+            value.put("ruleId", ruleId);
+            value.put("artifactUri", artifactUri);
+            value.put(
+                    "primaryLocationLineHash",
+                    primaryLocationLineHash);
+            value.put("rationale", rationale);
+            return value;
+        }
+    }
+
+    private record Baseline(
+            Path path,
+            Map<FindingKey, BaselineEntry> entries) {
+
+        static Baseline load(Path candidate) throws IOException {
+            if (candidate == null) {
+                return new Baseline(null, Map.of());
+            }
+            Path path = candidate.normalize();
+            if (!Files.isRegularFile(path)) {
+                throw new IllegalArgumentException(
+                        "CodeQL baseline is missing or not a regular file: "
+                                + path);
+            }
+            Map<String, Object> payload = FlatJson.parseObject(
+                    Files.readString(path, StandardCharsets.UTF_8));
+            long schemaVersion = requiredIntegralField(
+                    payload,
+                    "schemaVersion",
+                    "CodeQL baseline schemaVersion");
+            if (schemaVersion != SUPPORTED_BASELINE_SCHEMA_VERSION) {
+                throw new IllegalArgumentException(
+                        "Unsupported CodeQL baseline schemaVersion: "
+                                + schemaVersion);
+            }
+
+            LinkedHashMap<FindingKey, BaselineEntry> entries =
+                    new LinkedHashMap<>();
+            for (Object rawEntry : requiredEntries(payload)) {
+                Map<String, Object> entry = object(
+                        rawEntry,
+                        "CodeQL baseline entry");
+                String ruleId = requiredNonBlankStringField(
+                        entry,
+                        "ruleId",
+                        "CodeQL baseline ruleId");
+                String artifactUri = requiredNonBlankStringField(
+                        entry,
+                        "artifactUri",
+                        "CodeQL baseline artifactUri");
+                String fingerprint = requiredNonBlankStringField(
+                        entry,
+                        "primaryLocationLineHash",
+                        "CodeQL baseline primaryLocationLineHash");
+                String rationale = requiredNonBlankStringField(
+                        entry,
+                        "rationale",
+                        "CodeQL baseline rationale");
+                BaselineEntry baselineEntry = new BaselineEntry(
+                        ruleId,
+                        artifactUri,
+                        fingerprint,
+                        rationale);
+                if (entries.putIfAbsent(
+                        baselineEntry.key(), baselineEntry) != null) {
+                    throw new IllegalArgumentException(
+                            "CodeQL baseline contains duplicate entry for rule '"
+                                    + ruleId + "', artifact '" + artifactUri
+                                    + "' and fingerprint '" + fingerprint
+                                    + "'");
+                }
+            }
+            return new Baseline(
+                    path,
+                    Collections.unmodifiableMap(
+                            new LinkedHashMap<>(entries)));
+        }
+
+        boolean contains(FindingKey key) {
+            return entries.containsKey(key);
+        }
+
+        List<BaselineEntry> unusedEntries(Set<FindingKey> used) {
+            return entries.entrySet().stream()
+                    .filter(entry -> !used.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .toList();
+        }
+
+        private static List<?> requiredEntries(
+                Map<String, Object> payload) {
+            if (!payload.containsKey("entries")) {
+                throw new IllegalArgumentException(
+                        "CodeQL baseline entries are required");
+            }
+            Object value = payload.get("entries");
+            if (!(value instanceof List<?> entries)) {
+                throw new IllegalArgumentException(
+                        "CodeQL baseline entries must be an array");
+            }
+            return entries;
+        }
+
+        private static long requiredIntegralField(
+                Map<String, Object> owner,
+                String field,
+                String description) {
+            if (!owner.containsKey(field)) {
+                throw new IllegalArgumentException(
+                        description + " is required");
+            }
+            Object value = owner.get(field);
+            if (!(value instanceof Number number)) {
+                throw new IllegalArgumentException(
+                        description + " must be an integer");
+            }
+            try {
+                return new BigDecimal(number.toString()).longValueExact();
+            } catch (NumberFormatException | ArithmeticException invalid) {
+                throw new IllegalArgumentException(
+                        description + " must be an integer", invalid);
+            }
+        }
+
+        private static String requiredNonBlankStringField(
+                Map<String, Object> owner,
+                String field,
+                String description) {
+            String value = requiredStringField(owner, field, description);
+            if (value.isBlank()) {
+                throw new IllegalArgumentException(
+                        description + " must not be blank");
+            }
             return value;
         }
     }
@@ -406,7 +681,8 @@ final class CodeQlSarifGate {
     private record CommandArguments(
             List<Path> sarifPaths,
             double threshold,
-            Path report) {
+            Path report,
+            Path baseline) {
 
         static CommandArguments parse(
                 String[] rawArguments,
@@ -414,6 +690,7 @@ final class CodeQlSarifGate {
             List<Path> paths = new ArrayList<>();
             double threshold = 7.0;
             Path report = workingDirectory.resolve("target/codeql-gate.json");
+            Path baseline = null;
             for (int index = 0; index < rawArguments.length; index++) {
                 String token = rawArguments[index];
                 if ("--threshold".equals(token)) {
@@ -421,6 +698,10 @@ final class CodeQlSarifGate {
                             requiredValue(rawArguments, ++index, token));
                 } else if ("--report".equals(token)) {
                     report = resolve(
+                            workingDirectory,
+                            requiredValue(rawArguments, ++index, token));
+                } else if ("--baseline".equals(token)) {
+                    baseline = resolve(
                             workingDirectory,
                             requiredValue(rawArguments, ++index, token));
                 } else if (token.startsWith("--")) {
@@ -431,7 +712,7 @@ final class CodeQlSarifGate {
                 }
             }
             return new CommandArguments(
-                    List.copyOf(paths), threshold, report);
+                    List.copyOf(paths), threshold, report, baseline);
         }
 
         static Path reportPath(
@@ -441,7 +722,8 @@ final class CodeQlSarifGate {
             for (int index = 0; index < rawArguments.length - 1; index++) {
                 if ("--report".equals(rawArguments[index])
                         && !rawArguments[index + 1].startsWith("--")) {
-                    report = resolve(workingDirectory, rawArguments[index + 1]);
+                    report = resolve(
+                            workingDirectory, rawArguments[index + 1]);
                 }
             }
             return report;

--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/CodeQlSarifBaselineTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/CodeQlSarifBaselineTest.java
@@ -1,0 +1,257 @@
+package com.taxonomy.tooling;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CodeQlSarifBaselineTest {
+
+    @Test
+    void exactFingerprintAcceptsOnlyTheReviewedOccurrence(
+            @TempDir Path root) throws Exception {
+        Path sarif = root.resolve("result.sarif");
+        Path baseline = root.resolve("baseline.json");
+        writeSarif(
+                sarif,
+                result("reviewed-fingerprint:1", "reviewed occurrence")
+                        + ",\n"
+                        + result("new-fingerprint:1", "new occurrence"));
+        writeBaseline(
+                baseline,
+                entry(
+                        "java/high",
+                        "src/Reviewed.java",
+                        "reviewed-fingerprint:1",
+                        "Reviewed in issue #857"));
+
+        CodeQlSarifGate.Inspection inspection = CodeQlSarifGate.inspect(
+                List.of(sarif), 7.0, baseline);
+
+        assertThat(inspection.resultCount()).isEqualTo(2);
+        assertThat(inspection.acceptedBaseline())
+                .extracting(
+                        CodeQlSarifGate.Finding::primaryLocationLineHash)
+                .containsExactly("reviewed-fingerprint:1");
+        assertThat(inspection.blocking())
+                .extracting(
+                        CodeQlSarifGate.Finding::primaryLocationLineHash)
+                .containsExactly("new-fingerprint:1");
+        assertThat(inspection.unusedBaseline()).isEmpty();
+    }
+
+    @Test
+    void findingWithoutFingerprintCannotUseTheBaseline(
+            @TempDir Path root) throws Exception {
+        Path sarif = root.resolve("result.sarif");
+        Path baseline = root.resolve("baseline.json");
+        writeSarif(sarif, resultWithoutFingerprint("unfingerprinted"));
+        writeBaseline(
+                baseline,
+                entry(
+                        "java/high",
+                        "src/Reviewed.java",
+                        "reviewed-fingerprint:1",
+                        "Reviewed in issue #857"));
+
+        CodeQlSarifGate.Inspection inspection = CodeQlSarifGate.inspect(
+                List.of(sarif), 7.0, baseline);
+
+        assertThat(inspection.acceptedBaseline()).isEmpty();
+        assertThat(inspection.blocking()).singleElement()
+                .extracting(CodeQlSarifGate.Finding::ruleId)
+                .isEqualTo("java/high");
+        assertThat(inspection.unusedBaseline()).singleElement()
+                .extracting(
+                        CodeQlSarifGate.BaselineEntry::primaryLocationLineHash)
+                .isEqualTo("reviewed-fingerprint:1");
+    }
+
+    @Test
+    void duplicateAndMalformedBaselineEntriesFailClosed(
+            @TempDir Path root) throws Exception {
+        Path sarif = root.resolve("result.sarif");
+        Path baseline = root.resolve("baseline.json");
+        writeSarif(sarif, result("reviewed-fingerprint:1", "message"));
+        String duplicate = entry(
+                "java/high",
+                "src/Reviewed.java",
+                "reviewed-fingerprint:1",
+                "Reviewed in issue #857");
+        Files.writeString(
+                baseline,
+                """
+                {
+                  "schemaVersion": 1,
+                  "entries": [
+                %s,
+                %s
+                  ]
+                }
+                """.formatted(duplicate, duplicate),
+                StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> CodeQlSarifGate.inspect(
+                List.of(sarif), 7.0, baseline))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate entry")
+                .hasMessageContaining("reviewed-fingerprint:1");
+
+        Files.writeString(
+                baseline,
+                """
+                {
+                  "schemaVersion": 2,
+                  "entries": []
+                }
+                """,
+                StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> CodeQlSarifGate.inspect(
+                List.of(sarif), 7.0, baseline))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported CodeQL baseline schemaVersion");
+    }
+
+    @Test
+    void cliWritesAcceptedAndUnusedBaselineEvidence(
+            @TempDir Path root) throws Exception {
+        Path sarif = root.resolve("result.sarif");
+        Path baseline = root.resolve("baseline.json");
+        Path report = root.resolve("evidence/codeql-gate.json");
+        writeSarif(sarif, result("reviewed-fingerprint:1", "reviewed"));
+        writeBaseline(
+                baseline,
+                entry(
+                        "java/high",
+                        "src/Reviewed.java",
+                        "reviewed-fingerprint:1",
+                        "Reviewed in issue #857"),
+                entry(
+                        "java/other",
+                        "src/Unused.java",
+                        "unused-fingerprint:1",
+                        "Tracked but absent from this diff analysis"));
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+
+        int exit = CodeQlSarifGate.run(
+                new String[]{
+                        sarif.toString(),
+                        "--baseline", baseline.toString(),
+                        "--report", report.toString()},
+                root,
+                new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                new PrintStream(
+                        OutputStream.nullOutputStream(),
+                        true,
+                        StandardCharsets.UTF_8));
+
+        assertThat(exit).isZero();
+        assertThat(stdout.toString(StandardCharsets.UTF_8))
+                .contains("CodeQL results: 1; blocking: 0")
+                .contains("CodeQL baseline accepted: 1; unused: 1");
+        Map<String, Object> evidence = FlatJson.parseObject(
+                Files.readString(report, StandardCharsets.UTF_8));
+        assertThat(evidence)
+                .containsEntry("status", "PASS")
+                .containsKey("baselineFile");
+        assertThat((List<?>) evidence.get("acceptedBaseline")).hasSize(1);
+        assertThat((List<?>) evidence.get("unusedBaseline")).hasSize(1);
+        assertThat((List<?>) evidence.get("blocking")).isEmpty();
+    }
+
+    private static void writeSarif(Path path, String results)
+            throws Exception {
+        Files.writeString(
+                path,
+                """
+                {
+                  "version": "2.1.0",
+                  "runs": [{
+                    "tool": {"driver": {"name": "CodeQL", "rules": [{
+                      "id": "java/high",
+                      "properties": {"security-severity": "8.1"}
+                    }]}},
+                    "results": [
+                %s
+                    ]
+                  }]
+                }
+                """.formatted(results),
+                StandardCharsets.UTF_8);
+    }
+
+    private static String result(String fingerprint, String message) {
+        return """
+                    {
+                      "ruleId": "java/high",
+                      "level": "warning",
+                      "message": {"text": "%s"},
+                      "locations": [{
+                        "physicalLocation": {
+                          "artifactLocation": {"uri": "src/Reviewed.java"}
+                        }
+                      }],
+                      "partialFingerprints": {
+                        "primaryLocationLineHash": "%s"
+                      }
+                    }""".formatted(message, fingerprint);
+    }
+
+    private static String resultWithoutFingerprint(String message) {
+        return """
+                    {
+                      "ruleId": "java/high",
+                      "level": "warning",
+                      "message": {"text": "%s"},
+                      "locations": [{
+                        "physicalLocation": {
+                          "artifactLocation": {"uri": "src/Reviewed.java"}
+                        }
+                      }]
+                    }""".formatted(message);
+    }
+
+    private static String entry(
+            String ruleId,
+            String artifactUri,
+            String fingerprint,
+            String rationale) {
+        return """
+                    {
+                      "ruleId": "%s",
+                      "artifactUri": "%s",
+                      "primaryLocationLineHash": "%s",
+                      "rationale": "%s"
+                    }""".formatted(
+                            ruleId,
+                            artifactUri,
+                            fingerprint,
+                            rationale);
+    }
+
+    private static void writeBaseline(Path path, String... entries)
+            throws Exception {
+        Files.writeString(
+                path,
+                """
+                {
+                  "schemaVersion": 1,
+                  "entries": [
+                %s
+                  ]
+                }
+                """.formatted(String.join(",\n", entries)),
+                StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## What it does

Fixes the red `CodeQL Source Analysis` state on `main` caused when the newly fail-closed gate was first applied to a full-tree push analysis.

The earlier assumption that the SARIF parser failed was incorrect: it successfully parsed the reports and blocked 11 Java plus 3 JavaScript findings that predated activation of the gate. This PR introduces a narrow migration baseline for those exact occurrences.

- keeps the blocking threshold at `security-severity >= 7.0` and continues to block explicit result-level errors;
- matches a reviewed occurrence only by the triple `(ruleId, artifactUri, primaryLocationLineHash)`;
- blocks a new occurrence of the same rule, the same source text in another file, or any finding without a complete fingerprint;
- validates the baseline schema and fails closed for missing files, malformed entries, unsupported schema versions, blank fields and duplicate keys;
- records accepted, unused and blocking findings separately in the archived JSON evidence;
- adds `security-events: read` so CodeQL can access its own API endpoints without the current permission warnings;
- makes baseline changes trigger both pull-request and push CodeQL workflows;
- also triggers CodeQL when `.github/scripts/**` changes, covering the JavaScript files that the JavaScript job actually scans.

The 14 existing occurrences remain explicitly documented and individually removable in `.github/codeql-sarif-baseline.json`. Their source-level remediation is tracked in #857; this PR does not lower severity, disable queries, exclude source paths or silently discard results.

Closes the immediate gate-activation defect identified from the full logs; contributes to #857.

## How to test

- `CodeQlSarifBaselineTest` verifies that only the exact reviewed path/fingerprint is accepted.
- A second occurrence of the same high-severity rule remains blocking.
- Findings without fingerprints remain blocking.
- Duplicate and unsupported baseline data fail closed.
- CLI evidence records accepted, unused and blocking sets.
- The CodeQL workflow runs both Java and JavaScript analysis against the same exact baseline.
- Changes to the scanned JavaScript helper scripts trigger the workflow immediately rather than waiting for the weekly schedule.