### PR TITLE
Draft: prepare a future Taxonomy 1.4.0 dry run

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -4,6 +4,6 @@
   "skip_tests": false,
   "dry_run": true,
   "resume_staged_release": false,
-  "request_revision": 8,
-  "requested_after_commit": "b4f2847f0d940803c4d666b5986197362ee04e78"
+  "request_revision": 9,
+  "requested_after_commit": "a6ec1e48b3ebc716a7aba3cbe15d32eedb207f8e"
 }


### PR DESCRIPTION
## Superseded and closed

This historical dry-run request was never a valid publication result and is now obsolete.

Taxonomy 1.4.0 was prepared through a fresh serialized sequence built from the actual release-candidate `main`:

- final release notes from the integrated source state;
- a separate non-publishing dry-run request with a new revision and exact parent binding;
- independent verification that the dry run created neither tag nor GitHub release;
- a separate fresh publication request;
- post-publication verification of tag ancestry, release text, checksums, SBOM/VEX, Helm assets, OCI/provenance evidence, Maven/release workflow completion, and `main` advancing to `1.4.1-SNAPSHOT`.

The commits and workflow runs on this stale branch are retained only as historical diagnostics and must not be merged or treated as release evidence.

Tracked and completed by #711.