### PR TITLE
Reject legacy production credential placeholders

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
@@ -61,7 +61,8 @@ public class ProductionSecurityGuard implements ApplicationRunner {
                 : value.trim().toLowerCase(Locale.ROOT);
         if (normalized.isEmpty()
                 || FORBIDDEN_PASSWORDS.contains(normalized)
-                || normalized.startsWith("replace-with-")) {
+                || normalized.startsWith("replace-with-")
+                || normalized.startsWith("change-me-to-")) {
             throw unsafeSecret(environmentVariable);
         }
         if (value.length() < MINIMUM_SECRET_LENGTH) {

--- a/taxonomy-app/src/test/java/com/taxonomy/security/ProductionSecurityGuardTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/ProductionSecurityGuardTest.java
@@ -25,6 +25,8 @@ class ProductionSecurityGuardTest {
             "password",
             "changeme",
             "change-me",
+            "change-me-to-a-strong-password",
+            "CHANGE-ME-TO-ANOTHER-DOCUMENTED-PLACEHOLDER",
             "replace-with-a-long-random-password",
             "replace-with-a-unique-random-password",
             "replace-with-a-long-random-login-password",
@@ -40,6 +42,7 @@ class ProductionSecurityGuardTest {
     @ValueSource(strings = {
             "admin",
             "password",
+            "change-me-to-a-strong-machine-token",
             "replace-with-a-different-long-random-machine-token",
             "REPLACE-WITH-ANOTHER-MACHINE-TOKEN"
     })


### PR DESCRIPTION
## What it does

Restores the fail-closed production credential contract after the configuration-security refactor merged through #856.

The previous implementation explicitly rejected `change-me-to-a-strong-password`. The refactored guard retained exact weak values and generic `replace-with-…` placeholders, but accidentally stopped rejecting the older `change-me-to-…` family. Because the historic example is longer than the minimum length, it could otherwise pass the production startup guard.

This change:

- rejects every case-insensitive `change-me-to-…` placeholder for both the local administrator password and the optional machine token;
- retains the existing exact weak-value, `replace-with-…`, minimum-length, and credential-separation checks;
- adds regression cases for the historic value, an uppercase variant, and a machine-token variant.

## Scope

Exactly one commit directly on current `main` commit `df87d631109c98d9dfc65224f1056f6d43fa840e`, changing only:

- `ProductionSecurityGuard.java`;
- `ProductionSecurityGuardTest.java`.

No deployment values, release notes, release request, version, or unrelated behavior is changed.

## Verification

The focused parameterized tests cover both placeholder families and both credential roles. The full exact-head CI, database, CodeQL, and Security matrix remains the merge authority.

Release-preparation safety fix for #711.