### PR TITLE
Harden framework errors and LLM rate-limit identity

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 /**
  * Global exception handler for all REST controllers.
- * Prevents stack traces from leaking to clients and returns
+ * Prevents stack traces and internal exception details from leaking to clients and returns
  * consistent JSON error responses.
  *
  * <p>Extends {@link ResponseEntityExceptionHandler} so that Spring MVC binding
@@ -90,10 +90,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex, WebRequest request) {
         log.error("Unhandled exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
-        Locale locale = LocaleContextHolder.getLocale();
-        String message = messageSource.getMessage("error.internal", null,
-                "An internal error occurred. Please try again or check the server logs.", locale);
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, message, request);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, internalErrorMessage(), request);
     }
 
     /**
@@ -107,18 +104,29 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         if (status == null) {
             status = HttpStatus.INTERNAL_SERVER_ERROR;
         }
+
+        String message;
         if (status.is5xxServerError()) {
             log.error("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
+            message = internalErrorMessage();
         } else {
             log.warn("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage());
+            message = ex.getMessage();
         }
+
         Map<String, Object> errorBody = new LinkedHashMap<>();
         errorBody.put("timestamp", Instant.now().toString());
         errorBody.put("status", status.value());
         errorBody.put("error", status.getReasonPhrase());
-        errorBody.put("message", ex.getMessage());
+        errorBody.put("message", message);
         errorBody.put("path", request.getDescription(false).replace("uri=", ""));
         return ResponseEntity.status(status).headers(headers).body(errorBody);
+    }
+
+    private String internalErrorMessage() {
+        Locale locale = LocaleContextHolder.getLocale();
+        return messageSource.getMessage("error.internal", null,
+                "An internal error occurred. Please try again or check the server logs.", locale);
     }
 
     private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message, WebRequest request) {

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
@@ -12,13 +12,15 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Simple in-memory rate limiter for LLM-backed API endpoints.
- * Limits requests per IP address per minute to prevent quota exhaustion.
+ * Limits requests per authenticated account per minute, with a direct-peer-address
+ * fallback before authentication is available, to prevent quota exhaustion.
  *
  * <p>Protected endpoints:
  * <ul>
@@ -49,7 +51,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                       FilterChain filterChain) throws ServletException, IOException {
-        String path = request.getRequestURI();
+        String path = requestPath(request);
 
         // Only rate-limit LLM-backed endpoints
         if (!isRateLimitedPath(path)) {
@@ -68,8 +70,8 @@ public class RateLimitFilter extends OncePerRequestFilter {
             return;
         }
 
-        String clientIp = getClientIp(request);
-        WindowCounter counter = counters.computeIfAbsent(clientIp, k -> new WindowCounter());
+        String clientKey = rateLimitKey(request);
+        WindowCounter counter = counters.computeIfAbsent(clientKey, key -> new WindowCounter());
 
         if (counter.incrementAndCheck(effectiveLimit)) {
             filterChain.doFilter(request, response);
@@ -83,28 +85,40 @@ public class RateLimitFilter extends OncePerRequestFilter {
         }
     }
 
-    /** Visible for testing — clears all per-IP rate limit counters. */
+    /** Visible for testing — clears all rate limit counters. */
     public void clearCounters() {
         counters.clear();
     }
 
-    private boolean isRateLimitedPath(String path) {
+    private static String requestPath(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty()
+                && requestUri != null && requestUri.startsWith(contextPath)) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri == null ? "" : requestUri;
+    }
+
+    private static boolean isRateLimitedPath(String path) {
         return path.equals("/api/analyze")
             || path.equals("/api/analyze-stream")
             || path.equals("/api/analyze-node")
             || path.equals("/api/justify-leaf");
     }
 
-    private String getClientIp(HttpServletRequest request) {
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isBlank()) {
-            return xff.split(",")[0].trim();
+    private static String rateLimitKey(HttpServletRequest request) {
+        Principal principal = request.getUserPrincipal();
+        if (principal != null && principal.getName() != null
+                && !principal.getName().isBlank()) {
+            return "user:" + principal.getName();
         }
-        return request.getRemoteAddr();
+        String remoteAddress = request.getRemoteAddr();
+        return "ip:" + (remoteAddress == null ? "unknown" : remoteAddress);
     }
 
     /**
-     * Sliding window counter per minute.
+     * Fixed one-minute window counter.
      */
     static class WindowCounter {
         private final AtomicInteger count = new AtomicInteger(0);
@@ -127,4 +141,3 @@ public class RateLimitFilter extends OncePerRequestFilter {
         }
     }
 }
-

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,67 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    @AfterEach
+    void resetLocale() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @Test
+    void frameworkLevelServerErrorDoesNotExposeInternalExceptionMessage() {
+        StaticMessageSource messages = new StaticMessageSource();
+        messages.addMessage("error.internal", Locale.ENGLISH, "Safe internal error.");
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(messages);
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+
+        ResponseEntity<Object> response = handler.handleExceptionInternal(
+                new IllegalStateException("jdbc:postgresql://admin:secret@database/internal"),
+                null,
+                HttpHeaders.EMPTY,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                request("/api/internal"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isInstanceOf(Map.class);
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertThat(body.get("message")).isEqualTo("Safe internal error.");
+        assertThat(body.toString()).doesNotContain("secret", "database/internal");
+    }
+
+    @Test
+    void frameworkLevelClientErrorRetainsActionableMessage() {
+        GlobalExceptionHandler handler = new GlobalExceptionHandler(new StaticMessageSource());
+
+        ResponseEntity<Object> response = handler.handleExceptionInternal(
+                new IllegalArgumentException("Required parameter 'projectId' is missing"),
+                null,
+                HttpHeaders.EMPTY,
+                HttpStatus.BAD_REQUEST,
+                request("/api/projects"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isInstanceOf(Map.class);
+        Map<?, ?> body = (Map<?, ?>) response.getBody();
+        assertThat(body.get("message"))
+                .isEqualTo("Required parameter 'projectId' is missing");
+    }
+
+    private static ServletWebRequest request(String uri) {
+        return new ServletWebRequest(new MockHttpServletRequest("GET", uri));
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
@@ -1,0 +1,84 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Principal;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitFilterTest {
+
+    private RateLimitFilter filter;
+    private AtomicInteger passedRequests;
+
+    @BeforeEach
+    void setUp() {
+        filter = new RateLimitFilter();
+        ReflectionTestUtils.setField(filter, "maxRequestsPerMinute", 1);
+        passedRequests = new AtomicInteger();
+    }
+
+    @Test
+    void servletContextPathDoesNotBypassProtectedEndpointMatching() throws Exception {
+        MockHttpServletResponse first = invoke(request(
+                "/taxonomy/api/analyze", "/taxonomy", "alice", null));
+        MockHttpServletResponse second = invoke(request(
+                "/taxonomy/api/analyze", "/taxonomy", "alice", null));
+
+        assertThat(first.getStatus()).isEqualTo(200);
+        assertThat(second.getStatus()).isEqualTo(429);
+        assertThat(passedRequests).hasValue(1);
+    }
+
+    @Test
+    void spoofedForwardedForDoesNotCreateAnotherAuthenticatedUserBudget() throws Exception {
+        MockHttpServletResponse first = invoke(request(
+                "/api/analyze", "", "alice", "198.51.100.10"));
+        MockHttpServletResponse second = invoke(request(
+                "/api/analyze", "", "alice", "203.0.113.20"));
+
+        assertThat(first.getStatus()).isEqualTo(200);
+        assertThat(second.getStatus()).isEqualTo(429);
+        assertThat(passedRequests).hasValue(1);
+    }
+
+    @Test
+    void authenticatedUsersHaveIndependentBudgets() throws Exception {
+        MockHttpServletResponse alice = invoke(request(
+                "/api/analyze", "", "alice", "198.51.100.10"));
+        MockHttpServletResponse bob = invoke(request(
+                "/api/analyze", "", "bob", "198.51.100.10"));
+
+        assertThat(alice.getStatus()).isEqualTo(200);
+        assertThat(bob.getStatus()).isEqualTo(200);
+        assertThat(passedRequests).hasValue(2);
+    }
+
+    private MockHttpServletResponse invoke(MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilterInternal(request, response,
+                (servletRequest, servletResponse) -> passedRequests.incrementAndGet());
+        return response;
+    }
+
+    private static MockHttpServletRequest request(
+            String requestUri,
+            String contextPath,
+            String username,
+            String forwardedFor) {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", requestUri);
+        request.setContextPath(contextPath);
+        request.setRemoteAddr("10.0.0.15");
+        Principal principal = () -> username;
+        request.setUserPrincipal(principal);
+        if (forwardedFor != null) {
+            request.addHeader("X-Forwarded-For", forwardedFor);
+        }
+        return request;
+    }
+}


### PR DESCRIPTION
## What it does

Closes three security and deployment defects found during the comprehensive QA pass.

### Safe framework-level 5xx responses

`GlobalExceptionHandler` already sanitized exceptions handled by its generic catch-all, but the inherited Spring MVC path still copied `ex.getMessage()` into every response, including HTTP 5xx responses. Internal database URLs, file paths, provider details or other exception text could therefore reach API clients.

This change uses the localized `error.internal` message for every framework-level 5xx response while retaining actionable exception messages for 4xx client errors. A focused unit test proves that a secret-bearing internal exception remains server-side.

### Trusted and deployment-safe LLM rate limiting

The previous limiter:

- trusted the first caller-supplied `X-Forwarded-For` value, so an authenticated client could create a fresh budget on every request;
- created a counter for every spoofed header value;
- matched `request.getRequestURI()` directly, so `/api/analyze` was not protected when Taxonomy ran below a context path such as `/taxonomy`;
- grouped all users behind one reverse proxy when no spoofed header was supplied.

The limiter now keys authenticated requests by the trusted authenticated principal and falls back only to the direct peer address before authentication. It strips the servlet context path before matching protected endpoints.

Regression tests prove that:

- `/taxonomy/api/analyze` remains rate-limited;
- changing `X-Forwarded-For` does not reset one authenticated user's budget;
- separate authenticated users retain independent budgets.

## Scope

Four files in the HTTP hardening boundary only:

- `GlobalExceptionHandler.java`;
- `RateLimitFilter.java`;
- `GlobalExceptionHandlerTest.java`;
- `RateLimitFilterTest.java`.

No API route, configured limit, authentication rule, deployment value or release request is changed.

## Verification

The new tests are isolated and deterministic. The full exact-head CI/CD, database, CodeQL, Security Scan and constrained-Kubernetes matrix remains the merge authority.