### PR TITLE
Keep invalid report templates repairable without leaking health details

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * Reports whether the mandatory decision-report template is present and structurally valid.
+ *
+ * <p>A missing or invalid template degrades only the DOCX decision-report capability. It must
+ * not make the complete application unavailable or expose package, filesystem or validation
+ * details through an operational health endpoint.</p>
  */
 @Component
 public final class DecisionRationaleTemplateHealthIndicator implements HealthIndicator {
@@ -24,17 +28,23 @@ public final class DecisionRationaleTemplateHealthIndicator implements HealthInd
             TemplateFile file = templates.downloadCurrentValidated(templateId);
             return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", DecisionReportAvailabilityContract.AVAILABLE)
                     .withDetail("commit", file.commitId())
                     .withDetail("packageSha256", file.manifest().packageSha256())
                     .withDetail("updatedBy", file.manifest().updatedBy())
                     .build();
-        } catch (Exception exception) {
-            String message = exception.getMessage();
-            return Health.down()
+        } catch (Exception ignored) {
+            return Health.up()
                     .withDetail("templateId", templateId)
-                    .withDetail("error", message == null
-                            ? "Required decision-report template is unavailable"
-                            : message)
+                    .withDetail("availability", DecisionReportAvailabilityContract.DEGRADED)
+                    .withDetail("affectedCapability",
+                            DecisionReportAvailabilityContract.CAPABILITY)
+                    .withDetail("problemCode",
+                            DecisionReportAvailabilityContract.PROBLEM_CODE)
+                    .withDetail("summary",
+                            DecisionReportAvailabilityContract.SAFE_UNAVAILABLE_SUMMARY)
+                    .withDetail("remediation",
+                            DecisionReportAvailabilityContract.REMEDIATION)
                     .build();
         }
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionReportAvailabilityContract.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionReportAvailabilityContract.java
@@ -1,0 +1,20 @@
+package com.taxonomy.templates;
+
+/**
+ * Stable, non-sensitive availability contract for the mandatory decision-report template.
+ */
+public final class DecisionReportAvailabilityContract {
+
+    public static final String CAPABILITY = "decision-report-docx";
+    public static final String PROBLEM_CODE =
+            "DECISION_REPORT_TEMPLATE_UNAVAILABLE";
+    public static final String AVAILABLE = "AVAILABLE";
+    public static final String DEGRADED = "DEGRADED";
+    public static final String SAFE_UNAVAILABLE_SUMMARY =
+            "Required decision-report template is unavailable";
+    public static final String REMEDIATION =
+            "Restore or upload a valid decision-report template";
+
+    private DecisionReportAvailabilityContract() {
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -1,0 +1,45 @@
+package com.taxonomy.templates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DecisionRationaleTemplateHealthIndicatorTest {
+
+    @Test
+    void invalidTemplateDegradesOnlyTheReportCapabilityWithoutDisclosingDetails()
+            throws IOException {
+        DocumentTemplateService templates = mock(DocumentTemplateService.class);
+        when(templates.downloadCurrentValidated(
+                DecisionRationaleTemplateContract.TEMPLATE_ID))
+                .thenThrow(new IOException(
+                        "private-template-path contained "
+                                + "jdbc:postgresql://internal-user:secret@database/taxonomy"));
+
+        Health health = new DecisionRationaleTemplateHealthIndicator(templates).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails())
+                .containsEntry("availability", DecisionReportAvailabilityContract.DEGRADED)
+                .containsEntry("affectedCapability",
+                        DecisionReportAvailabilityContract.CAPABILITY)
+                .containsEntry("problemCode",
+                        DecisionReportAvailabilityContract.PROBLEM_CODE)
+                .containsEntry("templateId", DecisionRationaleTemplateContract.TEMPLATE_ID)
+                .containsEntry("summary",
+                        DecisionReportAvailabilityContract.SAFE_UNAVAILABLE_SUMMARY)
+                .containsEntry("remediation",
+                        DecisionReportAvailabilityContract.REMEDIATION);
+        assertThat(health.getDetails().toString())
+                .doesNotContain("private-template-path")
+                .doesNotContain("jdbc:postgresql")
+                .doesNotContain("internal-user")
+                .doesNotContain("secret");
+    }
+}


### PR DESCRIPTION
## What it does

Fixes the operational-availability defect at the core of #838 without turning the health endpoint into a diagnostic disclosure surface.

The mandatory decision-report template is required for DOCX decision reports, but not for login, administration, taxonomy browsing, architecture editing, search or unrelated exports. A missing or invalid template therefore no longer marks the complete application `DOWN`.

The health component now remains `UP` and reports a bounded, machine-readable capability state:

- `availability=DEGRADED`;
- `affectedCapability=decision-report-docx`;
- `problemCode=DECISION_REPORT_TEMPLATE_UNAVAILABLE`;
- a stable non-sensitive summary;
- a concrete remediation action.

The raw exception message is deliberately not copied into health details. Template paths, OOXML validation payloads, database URLs, credentials and other internal information remain outside this operational endpoint. Authorized template administration remains the place for detailed validation diagnostics.

A valid template reports `availability=AVAILABLE` together with its commit, package SHA-256 and updater as before.

## Scope

Exactly one commit directly on current `main`, changing three files:

- a shared non-sensitive availability contract;
- the health indicator;
- a focused regression test.

The production persistence/readiness correction was integrated separately through #879 and is not duplicated here.

## Regression coverage

The test injects a deliberately secret-bearing internal exception and proves that:

- application health remains `UP`;
- the DOCX report capability is marked degraded;
- the stable problem code and remediation are present;
- the filesystem path, JDBC URL, username and secret do not cross the health boundary.

## Merge authority

Only the complete exact-head CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix may authorize merge.

Closes the core repair-safe health boundary in #838; administrator warning UX and typed HTTP 503 handling remain separately reviewable.