### PR TITLE
Synchronize browser draft authority before role-state isolation

### DIFF
--- a/.github/scripts/ui-role-state-isolation.mjs
+++ b/.github/scripts/ui-role-state-isolation.mjs
@@ -8,6 +8,10 @@ const DEFAULT_TIMEOUT_MS = 90_000;
  * the previous profile's text, scores and selected visualization. That behaviour
  * is correct for the product, but it must not leak between otherwise independent
  * acceptance scenarios.
+ *
+ * Synchronize the server draft first so clearing it uses the authoritative
+ * optimistic-lock version. Otherwise a later profile can start with version null,
+ * issue a PUT against an existing draft and manufacture a 409 conflict itself.
  */
 export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_MS) {
   await page.waitForFunction(() => {
@@ -19,6 +23,13 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       && window.TaxonomyState.taxonomyData.length > 0
       && state?.restoring === false);
   }, null, { timeout });
+
+  await page.evaluate(async () => {
+    await window.TaxonomyAnalysisSession.reload();
+  });
+  await page.waitForFunction(() =>
+    window.TaxonomyAnalysisSession?.state?.().restoring === false,
+  null, { timeout });
 
   await page.evaluate(async () => {
     const session = window.TaxonomyAnalysisSession;

--- a/.github/scripts/ui-role-state-isolation.test.mjs
+++ b/.github/scripts/ui-role-state-isolation.test.mjs
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 
 import { isolateRoleStateScenario } from './ui-role-state-isolation.mjs';
 
-test('clears a restored draft and normalizes the role task to the list view', async () => {
+test('reloads the authoritative draft version before clearing the role scenario', async () => {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
   const previousEvent = globalThis.Event;
   const calls = [];
   let stale = true;
   let currentStage = 'analyze';
+  let authoritativeVersion = null;
 
   const input = {
     value: 'Restored requirement from another browser profile',
@@ -54,12 +55,20 @@ test('clears a restored draft and normalizes the role task to the list view', as
     },
     TaxonomyAnalysisSession: {
       state: () => ({ restoring: false }),
+      async reload() {
+        calls.push('reload');
+        authoritativeVersion = 7;
+      },
       invalidate(options) {
+        assert.equal(authoritativeVersion, 7,
+          'the server draft version must be loaded before invalidation');
         calls.push({ invalidate: options });
         input.value = '';
         stale = false;
       },
       async saveNow() {
+        assert.equal(authoritativeVersion, 7,
+          'the authoritative version must still own the clearing mutation');
         calls.push('save');
       }
     }
@@ -96,6 +105,7 @@ test('clears a restored draft and normalizes the role task to the list view', as
   }
 
   assert.deepEqual(calls, [
+    'reload',
     {
       invalidate: {
         keepText: false,


### PR DESCRIPTION
## What it does

Fixes the optimistic-lock conflict manufactured by the Maven-owned role/state browser matrix.

The matrix reuses one application and one real server-side analysis workspace per role. A later browser profile can therefore encounter an existing saved draft while its newly loaded client still has `version=null`. The previous isolation helper invalidated the local state immediately and then called `saveNow()`, producing a `PUT` with a null expected version against the existing server draft. The resulting HTTP 409 put the analysis session into conflict mode and later made the deterministic provider-error assertion time out.

The helper now:

1. force-loads the current server draft and its authoritative optimistic-lock version;
2. waits until draft restoration is complete;
3. invalidates the derived/local state;
4. persists the clear using that exact version;
5. normalizes the visible task and list view as before.

A focused Node test proves that reload happens before invalidation and that the clearing save still owns the loaded server version.

## Scope

Exactly two Maven-owned browser-verification files:

- `.github/scripts/ui-role-state-isolation.mjs`
- `.github/scripts/ui-role-state-isolation.test.mjs`

No product API, persistence rule, conflict handling or release metadata is weakened.

## Evidence

The defect was reproduced on PR #864 in CI/CD run `32808567111`: the Firefox role-state profile recorded `PUT /api/analysis-drafts/{workspaceId} -> 409`, followed by the timeout at `ui-role-state-flow.mjs:549`.

The full exact-head matrix remains merge authority.