### PR TITLE
Synchronize authoritative draft revision before UI scenario cleanup

### DIFF
--- a/.github/scripts/ui-role-state-isolation.mjs
+++ b/.github/scripts/ui-role-state-isolation.mjs
@@ -1,5 +1,18 @@
 const DEFAULT_TIMEOUT_MS = 90_000;
 
+async function waitForAnalysisSessionReady(page, timeout) {
+  await page.waitForFunction(() => {
+    const session = window.TaxonomyAnalysisSession;
+    const state = session?.state?.();
+    return Boolean(session
+      && window.TaxonomyBrowse
+      && Array.isArray(window.TaxonomyState?.taxonomyData)
+      && window.TaxonomyState.taxonomyData.length > 0
+      && state?.restoring === false
+      && state?.conflict === false);
+  }, null, { timeout });
+}
+
 /**
  * Give every role/state browser profile a deterministic ad-hoc analysis baseline.
  *
@@ -8,17 +21,24 @@ const DEFAULT_TIMEOUT_MS = 90_000;
  * the previous profile's text, scores and selected visualization. That behaviour
  * is correct for the product, but it must not leak between otherwise independent
  * acceptance scenarios.
+ *
+ * <p>The server's optimistic draft revision is authoritative. A fresh browser
+ * runtime starts without that revision, so it must first load the current remote
+ * draft before attempting to delete it. Otherwise the isolation itself creates a
+ * deterministic HTTP 409 by submitting {@code expectedVersion=null} for an
+ * existing draft.</p>
  */
 export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_MS) {
-  await page.waitForFunction(() => {
+  await waitForAnalysisSessionReady(page, timeout);
+
+  // Synchronize the browser runtime with the exact server-side draft revision.
+  // reload() is deliberately awaited before invalidation; treating a conflict as
+  // an allowed cleanup outcome would hide a real optimistic-concurrency defect.
+  await page.evaluate(async () => {
     const session = window.TaxonomyAnalysisSession;
-    const state = session?.state?.();
-    return Boolean(session
-      && window.TaxonomyBrowse
-      && Array.isArray(window.TaxonomyState?.taxonomyData)
-      && window.TaxonomyState.taxonomyData.length > 0
-      && state?.restoring === false);
-  }, null, { timeout });
+    await session.reload();
+  });
+  await waitForAnalysisSessionReady(page, timeout);
 
   await page.evaluate(async () => {
     const session = window.TaxonomyAnalysisSession;
@@ -28,6 +48,12 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       reason: 'role-state-acceptance-isolation'
     });
     await session.saveNow();
+
+    const state = session.state?.();
+    if (state?.conflict) {
+      throw new Error(
+        'Role-state isolation could not delete the authoritative draft revision');
+    }
 
     const input = document.getElementById('businessText');
     if (input) {
@@ -49,6 +75,7 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       && input?.value === ''
       && !input.classList.contains('stale-results')
       && document.querySelector('#taskStageDescribe[data-state="current"]')
-      && state?.restoring === false);
+      && state?.restoring === false
+      && state?.conflict === false);
   }, null, { timeout });
 }


### PR DESCRIPTION
## What it does

Fixes the deterministic HTTP 409 created by the role/state acceptance harness when several browser profiles reuse one application and one server-side resumable draft.

A fresh browser runtime begins without the server's optimistic draft revision. The previous cleanup immediately invalidated and saved local state, which could submit `expectedVersion=null` while the server already held revision `0` or later. The acceptance harness therefore manufactured a conflict before the actual role workflow began.

The isolation now:

1. waits for the analysis-session modules and taxonomy data;
2. reloads and awaits the authoritative remote draft revision;
3. waits for remote state rendering to settle;
4. invalidates the scenario state;
5. deletes/saves against that exact revision;
6. fails closed if the optimistic operation still reports a conflict.

A dependency-free Node test proves both the required ordering and the fail-closed conflict path. No production concurrency rule, API response or optimistic-lock behavior is weakened.

## Scope

- `.github/scripts/ui-role-state-isolation.mjs`
- `.github/scripts/ui-role-state-isolation.test.mjs`

## Verification

The exact-head CI remains authoritative, including the full role/state browser matrix. This change must eliminate the harness-generated 409 rather than adding a retry or accepting it as an expected response.