### PR TITLE
Preserve a sanitized 503 for unavailable decision-report templates

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -110,7 +110,7 @@ class ProductionPersistenceRestartIT {
         return ContainerTestUtils.appContainer()
                 .withCreateContainerCmdModifier(command -> command.getHostConfig()
                         .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
-                .waitingFor(Wait.forHttp("/actuator/health")
+                .waitingFor(Wait.forHttp("/actuator/health/readiness")
                         .forStatusCode(200)
                         .forPort(8080)
                         .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))


### PR DESCRIPTION
Superseded before merge. Review found that logging the exception object could retain the internal template validation detail that the HTTP response deliberately suppresses. Replaced by a revision that logs only the bounded request path and keeps the full client/server disclosure boundary consistent.