### PR TITLE
Preserve workspace routing below a servlet context path

### DIFF
--- a/.github/scripts/ui-role-state-isolation.mjs
+++ b/.github/scripts/ui-role-state-isolation.mjs
@@ -1,15 +1,6 @@
 const DEFAULT_TIMEOUT_MS = 90_000;
 
-/**
- * Give every role/state browser profile a deterministic ad-hoc analysis baseline.
- *
- * The role matrix deliberately reuses one application per role. Resumable drafts
- * are therefore real shared server state and a later browser profile can restore
- * the previous profile's text, scores and selected visualization. That behaviour
- * is correct for the product, but it must not leak between otherwise independent
- * acceptance scenarios.
- */
-export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_MS) {
+async function waitForAnalysisSessionReady(page, timeout) {
   await page.waitForFunction(() => {
     const session = window.TaxonomyAnalysisSession;
     const state = session?.state?.();
@@ -19,6 +10,34 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       && window.TaxonomyState.taxonomyData.length > 0
       && state?.restoring === false);
   }, null, { timeout });
+}
+
+/**
+ * Give every role/state browser profile a deterministic ad-hoc analysis baseline.
+ *
+ * The role matrix deliberately reuses one application per role. Resumable drafts
+ * are therefore real shared server state and a later browser profile can restore
+ * the previous profile's text, scores and selected visualization. That behaviour
+ * is correct for the product, but it must not leak between otherwise independent
+ * acceptance scenarios.
+ *
+ * The server's optimistic draft revision is authoritative. A fresh browser
+ * runtime starts without that revision, so it must first load the current remote
+ * draft before attempting to delete it. Otherwise the isolation itself creates a
+ * deterministic HTTP 409 by submitting expectedVersion=null for an existing
+ * draft.
+ */
+export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_MS) {
+  await waitForAnalysisSessionReady(page, timeout);
+
+  // Synchronize the browser runtime with the exact server-side draft revision.
+  // reload() is deliberately awaited before invalidation; treating a conflict as
+  // an allowed cleanup outcome would hide a real optimistic-concurrency defect.
+  await page.evaluate(async () => {
+    const session = window.TaxonomyAnalysisSession;
+    await session.reload();
+  });
+  await waitForAnalysisSessionReady(page, timeout);
 
   await page.evaluate(async () => {
     const session = window.TaxonomyAnalysisSession;
@@ -28,6 +47,14 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       reason: 'role-state-acceptance-isolation'
     });
     await session.saveNow();
+
+    const state = session.state?.();
+    const conflictMessage = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
+    if (state?.conflict === true || conflictMessage) {
+      throw new Error(
+        'Role-state isolation could not delete the authoritative draft revision');
+    }
 
     const input = document.getElementById('businessText');
     if (input) {
@@ -43,12 +70,16 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
     const tree = document.getElementById('taxonomyTree');
     const input = document.getElementById('businessText');
     const state = window.TaxonomyAnalysisSession?.state?.();
+    const conflictMessage = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
     return Boolean(tree
       && tree.dataset.viewRendered === 'list'
       && tree.querySelector('[role="treeitem"]')
       && input?.value === ''
       && !input.classList.contains('stale-results')
       && document.querySelector('#taskStageDescribe[data-state="current"]')
-      && state?.restoring === false);
+      && state?.restoring === false
+      && state?.conflict !== true
+      && !conflictMessage);
   }, null, { timeout });
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
@@ -7,9 +7,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * Reports whether the mandatory decision-report template is present and structurally valid.
+ *
+ * <p>A missing or invalid template degrades only the DOCX decision-report feature. It must
+ * not make the complete application unavailable or prevent an administrator from repairing
+ * the template through the normal administration surface.</p>
  */
 @Component
 public final class DecisionRationaleTemplateHealthIndicator implements HealthIndicator {
+
+    private static final String DEGRADED = "DEGRADED";
 
     private final DocumentTemplateService templates;
 
@@ -24,14 +30,18 @@ public final class DecisionRationaleTemplateHealthIndicator implements HealthInd
             TemplateFile file = templates.downloadCurrentValidated(templateId);
             return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", "AVAILABLE")
                     .withDetail("commit", file.commitId())
                     .withDetail("packageSha256", file.manifest().packageSha256())
                     .withDetail("updatedBy", file.manifest().updatedBy())
                     .build();
         } catch (Exception exception) {
             String message = exception.getMessage();
-            return Health.down()
+            return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", DEGRADED)
+                    .withDetail("affectedCapability", "decision-report-docx")
+                    .withDetail("remediation", "Restore or upload a valid decision-report template")
                     .withDetail("error", message == null
                             ? "Required decision-report template is unavailable"
                             : message)

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -1,0 +1,31 @@
+package com.taxonomy.templates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DecisionRationaleTemplateHealthIndicatorTest {
+
+    @Test
+    void invalidTemplateDegradesOnlyTheReportCapability() {
+        DocumentTemplateService templates = mock(DocumentTemplateService.class);
+        when(templates.downloadCurrentValidated(
+                DecisionRationaleTemplateContract.TEMPLATE_ID))
+                .thenThrow(new IllegalStateException("word/document.xml is invalid"));
+
+        Health health = new DecisionRationaleTemplateHealthIndicator(templates).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails())
+                .containsEntry("availability", "DEGRADED")
+                .containsEntry("affectedCapability", "decision-report-docx")
+                .containsEntry("templateId", DecisionRationaleTemplateContract.TEMPLATE_ID);
+        assertThat(health.getDetails().get("remediation"))
+                .asString()
+                .contains("valid decision-report template");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 class DecisionRationaleTemplateHealthIndicatorTest {
 
     @Test
-    void invalidTemplateDegradesOnlyTheReportCapability() {
+    void invalidTemplateDegradesOnlyTheReportCapability() throws Exception {
         DocumentTemplateService templates = mock(DocumentTemplateService.class);
         when(templates.downloadCurrentValidated(
                 DecisionRationaleTemplateContract.TEMPLATE_ID))


### PR DESCRIPTION
Superseded before merge: the first adapter version did not propagate the root routing marker, so an unexpected repeated installer call could stack wrappers. Replaced by a corrected idempotent revision; no code from this PR should be merged.