### PR TITLE
Harden HTTP disclosure, typed report 503 and bounded LLM rate limiting

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
@@ -7,9 +7,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * Reports whether the mandatory decision-report template is present and structurally valid.
+ *
+ * <p>A missing or invalid template degrades only the DOCX decision-report feature. It must
+ * not make the complete application unavailable or prevent an administrator from repairing
+ * the template through the normal administration surface.</p>
  */
 @Component
 public final class DecisionRationaleTemplateHealthIndicator implements HealthIndicator {
+
+    private static final String DEGRADED = "DEGRADED";
 
     private final DocumentTemplateService templates;
 
@@ -24,14 +30,18 @@ public final class DecisionRationaleTemplateHealthIndicator implements HealthInd
             TemplateFile file = templates.downloadCurrentValidated(templateId);
             return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", "AVAILABLE")
                     .withDetail("commit", file.commitId())
                     .withDetail("packageSha256", file.manifest().packageSha256())
                     .withDetail("updatedBy", file.manifest().updatedBy())
                     .build();
         } catch (Exception exception) {
             String message = exception.getMessage();
-            return Health.down()
+            return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", DEGRADED)
+                    .withDetail("affectedCapability", "decision-report-docx")
+                    .withDetail("remediation", "Restore or upload a valid decision-report template")
                     .withDetail("error", message == null
                             ? "Required decision-report template is unavailable"
                             : message)

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -110,7 +110,7 @@ class ProductionPersistenceRestartIT {
         return ContainerTestUtils.appContainer()
                 .withCreateContainerCmdModifier(command -> command.getHostConfig()
                         .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
-                .waitingFor(Wait.forHttp("/actuator/health")
+                .waitingFor(Wait.forHttp("/actuator/health/readiness")
                         .forStatusCode(200)
                         .forPort(8080)
                         .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -1,0 +1,31 @@
+package com.taxonomy.templates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DecisionRationaleTemplateHealthIndicatorTest {
+
+    @Test
+    void invalidTemplateDegradesOnlyTheReportCapability() {
+        DocumentTemplateService templates = mock(DocumentTemplateService.class);
+        when(templates.downloadCurrentValidated(
+                DecisionRationaleTemplateContract.TEMPLATE_ID))
+                .thenThrow(new IllegalStateException("word/document.xml is invalid"));
+
+        Health health = new DecisionRationaleTemplateHealthIndicator(templates).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails())
+                .containsEntry("availability", "DEGRADED")
+                .containsEntry("affectedCapability", "decision-report-docx")
+                .containsEntry("templateId", DecisionRationaleTemplateContract.TEMPLATE_ID);
+        assertThat(health.getDetails().get("remediation"))
+                .asString()
+                .contains("valid decision-report template");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 class DecisionRationaleTemplateHealthIndicatorTest {
 
     @Test
-    void invalidTemplateDegradesOnlyTheReportCapability() {
+    void invalidTemplateDegradesOnlyTheReportCapability() throws Exception {
         DocumentTemplateService templates = mock(DocumentTemplateService.class);
         when(templates.downloadCurrentValidated(
                 DecisionRationaleTemplateContract.TEMPLATE_ID))


### PR DESCRIPTION
## What it does

Replaces #864 with a complete HTTP-hardening correction whose first parent is the exact PR #865 head `205eebc74eb6f0666058fc4a344f5c9c888723ab`.

### Framework 5xx disclosure

Spring MVC exceptions handled by `ResponseEntityExceptionHandler` no longer copy `Exception.getMessage()` into 5xx JSON responses. The full exception remains in the server log; clients receive the localized `error.internal` message. Framework 4xx responses retain actionable validation details, with the HTTP reason phrase as a blank-message fallback.

Client-error logging records request path, status and exception type rather than echoing arbitrary exception text.

### Typed report-template failure

A highest-priority, exception-specific advice preserves HTTP 503 for `DecisionReportTemplateUnavailableException` before the global `Exception` catch-all can intercept it. The response exposes stable code `DECISION_REPORT_TEMPLATE_UNAVAILABLE` and a safe remediation message, never XML paths, local filesystem paths or template payload details.

### Canonical LLM rate-limit identity and route

The limiter now:

- keys authenticated requests by the server-established principal;
- falls back only to the direct servlet peer and ignores `X-Forwarded-For`;
- uses the servlet path, so root and `/taxonomy` deployments share one contract;
- counts only the actual supported method/path pairs;
- does not charge OPTIONS, HEAD or wrong-method requests;
- returns `Retry-After` and `Cache-Control: no-store` with HTTP 429.

### Bounded state

Expired client entries are evicted, and the map has a hard 10,000-client ceiling. Further high-cardinality identities share one fail-closed overflow counter rather than allocating unbounded memory.

The old integration test that claimed to exercise a window reset but only asserted bean existence is removed; deterministic unit coverage now advances a controllable clock to the exact one-minute boundary.

## Verification coverage

Focused tests prove:

- internal JDBC/credential text cannot cross a framework 5xx response;
- 4xx details remain actionable;
- report-template failure remains typed HTTP 503 and sanitized;
- context-path calls are limited;
- forwarding-header changes cannot reset principal or peer budgets;
- users retain independent budgets;
- preflight/wrong-method calls do not consume quota;
- the window resets at exactly one minute;
- stale entries are removed;
- tracked state cannot exceed the hard ceiling;
- limit `0` disables tracking and blocking.

This PR remains Draft until #865 is integrated. It then requires a fresh exact-base CI/CD, database, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix before merge.