### PR TITLE
Harden HTTP error disclosure and bounded LLM rate limiting

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportAvailabilityExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportAvailabilityExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.taxonomy.architecture.decision;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Preserves the explicit temporary-unavailability contract for DOCX decision
+ * reports ahead of the global catch-all exception handler.
+ */
+@ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public final class DecisionReportAvailabilityExceptionHandler {
+
+    static final String PROBLEM_CODE = "DECISION_REPORT_TEMPLATE_UNAVAILABLE";
+    static final String SAFE_MESSAGE =
+            "Decision report generation is temporarily unavailable because its "
+                    + "template requires administrator attention.";
+
+    private static final Logger log = LoggerFactory.getLogger(
+            DecisionReportAvailabilityExceptionHandler.class);
+
+    @ExceptionHandler(DecisionReportTemplateUnavailableException.class)
+    public ResponseEntity<Map<String, Object>> handleUnavailableTemplate(
+            DecisionReportTemplateUnavailableException exception,
+            WebRequest request) {
+        String path = requestPath(request);
+        log.warn("Decision report template unavailable on {} ({})",
+                path, exception.getClass().getSimpleName());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", HttpStatus.SERVICE_UNAVAILABLE.value());
+        body.put("error", HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase());
+        body.put("code", PROBLEM_CODE);
+        body.put("message", SAFE_MESSAGE);
+        body.put("path", path);
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+    }
+
+    private static String requestPath(WebRequest request) {
+        String description = request.getDescription(false);
+        return description.startsWith("uri=")
+                ? description.substring("uri=".length())
+                : description;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
@@ -34,6 +34,8 @@ import java.util.Map;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private static final String DEFAULT_INTERNAL_MESSAGE =
+            "An internal error occurred. Please try again or check the server logs.";
 
     private final MessageSource messageSource;
 
@@ -45,17 +47,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * Handles IllegalArgumentException (bad input from client).
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, Object>> handleBadRequest(IllegalArgumentException ex, WebRequest request) {
-        log.warn("Bad request: {}", ex.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    public ResponseEntity<Map<String, Object>> handleBadRequest(
+            IllegalArgumentException ex,
+            WebRequest request) {
+        log.warn("Bad request on {} ({})", requestPath(request), ex.getClass().getSimpleName());
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                clientMessage(ex.getMessage(), HttpStatus.BAD_REQUEST),
+                request);
     }
 
     /** Return malformed or oversized working drafts as a stable client error. */
     @ExceptionHandler(AnalysisDraftValidationException.class)
     public ResponseEntity<Map<String, Object>> handleAnalysisDraftValidation(
-            AnalysisDraftValidationException ex, WebRequest request) {
-        log.warn("Invalid analysis draft on {}: {}", request.getDescription(false), ex.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+            AnalysisDraftValidationException ex,
+            WebRequest request) {
+        log.warn("Invalid analysis draft on {} ({})",
+                requestPath(request), ex.getClass().getSimpleName());
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                clientMessage(ex.getMessage(), HttpStatus.BAD_REQUEST),
+                request);
     }
 
     /**
@@ -64,9 +76,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(AnalysisDraftConflictException.class)
     public ResponseEntity<Map<String, Object>> handleAnalysisDraftConflict(
-            AnalysisDraftConflictException ex, WebRequest request) {
-        log.warn("Analysis draft conflict on {}: {}", request.getDescription(false), ex.getMessage());
-        return buildErrorResponse(HttpStatus.CONFLICT, ex.getMessage(), request);
+            AnalysisDraftConflictException ex,
+            WebRequest request) {
+        log.warn("Analysis draft conflict on {} ({})",
+                requestPath(request), ex.getClass().getSimpleName());
+        return buildErrorResponse(
+                HttpStatus.CONFLICT,
+                clientMessage(ex.getMessage(), HttpStatus.CONFLICT),
+                request);
     }
 
     /**
@@ -75,8 +92,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Map<String, Object>> handleAccessDenied(
-            AccessDeniedException ex, WebRequest request) {
-        log.warn("Access denied on {}: {}", request.getDescription(false), ex.getMessage());
+            AccessDeniedException ex,
+            WebRequest request) {
+        log.warn("Access denied on {} ({})",
+                requestPath(request), ex.getClass().getSimpleName());
         Locale locale = LocaleContextHolder.getLocale();
         String message = messageSource.getMessage(
                 "error.forbidden", null, "Access denied.", locale);
@@ -88,46 +107,89 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * Logs the full stack trace server-side but only returns a safe message to the client.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex, WebRequest request) {
-        log.error("Unhandled exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
-        Locale locale = LocaleContextHolder.getLocale();
-        String message = messageSource.getMessage("error.internal", null,
-                "An internal error occurred. Please try again or check the server logs.", locale);
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, message, request);
+    public ResponseEntity<Map<String, Object>> handleGenericException(
+            Exception ex,
+            WebRequest request) {
+        log.error("Unhandled exception on {} ({})",
+                requestPath(request), ex.getClass().getName(), ex);
+        return buildErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                internalMessage(),
+                request);
     }
 
     /**
      * Override the Spring MVC base handler to return our consistent JSON format
      * for framework-level exceptions (missing params, type mismatches, etc.).
+     * Framework-originated 5xx exceptions must not copy their internal message
+     * into the response body.
      */
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
-            Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+            Exception ex,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
         HttpStatus status = HttpStatus.resolve(statusCode.value());
         if (status == null) {
             status = HttpStatus.INTERNAL_SERVER_ERROR;
         }
+
+        String message;
         if (status.is5xxServerError()) {
-            log.error("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
+            log.error("Spring MVC exception on {} ({})",
+                    requestPath(request), ex.getClass().getName(), ex);
+            message = internalMessage();
         } else {
-            log.warn("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage());
+            log.warn("Spring MVC client exception on {}: {} ({})",
+                    requestPath(request), status.value(), ex.getClass().getSimpleName());
+            message = clientMessage(ex.getMessage(), status);
         }
-        Map<String, Object> errorBody = new LinkedHashMap<>();
-        errorBody.put("timestamp", Instant.now().toString());
-        errorBody.put("status", status.value());
-        errorBody.put("error", status.getReasonPhrase());
-        errorBody.put("message", ex.getMessage());
-        errorBody.put("path", request.getDescription(false).replace("uri=", ""));
+
+        Map<String, Object> errorBody = errorBody(status, message, request);
         return ResponseEntity.status(status).headers(headers).body(errorBody);
     }
 
-    private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message, WebRequest request) {
+    private String internalMessage() {
+        Locale locale = LocaleContextHolder.getLocale();
+        return messageSource.getMessage(
+                "error.internal",
+                null,
+                DEFAULT_INTERNAL_MESSAGE,
+                locale);
+    }
+
+    private static String clientMessage(String message, HttpStatus fallbackStatus) {
+        return message == null || message.isBlank()
+                ? fallbackStatus.getReasonPhrase()
+                : message;
+    }
+
+    private static String requestPath(WebRequest request) {
+        String description = request.getDescription(false);
+        return description.startsWith("uri=")
+                ? description.substring("uri=".length())
+                : description;
+    }
+
+    private ResponseEntity<Map<String, Object>> buildErrorResponse(
+            HttpStatus status,
+            String message,
+            WebRequest request) {
+        return ResponseEntity.status(status).body(errorBody(status, message, request));
+    }
+
+    private static Map<String, Object> errorBody(
+            HttpStatus status,
+            String message,
+            WebRequest request) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", Instant.now().toString());
         body.put("status", status.value());
         body.put("error", status.getReasonPhrase());
         body.put("message", message);
-        body.put("path", request.getDescription(false).replace("uri=", ""));
-        return ResponseEntity.status(status).body(body);
+        body.put("path", requestPath(request));
+        return body;
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
@@ -12,32 +12,48 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 /**
- * Simple in-memory rate limiter for LLM-backed API endpoints.
- * Limits requests per IP address per minute to prevent quota exhaustion.
+ * Bounded in-memory rate limiter for LLM-backed API endpoints.
  *
- * <p>Protected endpoints:
+ * <p>Authenticated requests are keyed by the principal established by the
+ * security filter chain. Requests without a principal fall back to the direct
+ * network peer supplied by the servlet container; caller-controlled forwarding
+ * headers are deliberately ignored. The tracked-client map has a hard bound and
+ * expired entries are removed, so high-cardinality addresses cannot create
+ * unbounded application state.</p>
+ *
+ * <p>Protected operations:
  * <ul>
  *   <li>{@code POST /api/analyze}</li>
  *   <li>{@code GET /api/analyze-stream}</li>
  *   <li>{@code GET /api/analyze-node}</li>
  *   <li>{@code POST /api/justify-leaf}</li>
  * </ul>
+ * OPTIONS, HEAD and wrong-method requests do not consume an LLM budget.
  *
  * <p>The effective limit is read at request time from {@link PreferencesService}
  * (key {@code rate-limit.per-minute}) when available, falling back to the
  * {@code TAXONOMY_RATE_LIMIT_PER_MINUTE} property (default: 10).
- * Set to 0 to disable rate limiting.
+ * Set to 0 to disable rate limiting.</p>
  */
 @Component
 public class RateLimitFilter extends OncePerRequestFilter {
 
+    private static final long WINDOW_MILLIS = 60_000L;
+    private static final long ENTRY_RETENTION_MILLIS = 2 * WINDOW_MILLIS;
+    private static final long CLEANUP_INTERVAL_MILLIS = WINDOW_MILLIS;
+    private static final int MAX_TRACKED_CLIENTS = 10_000;
+
     @Value("${taxonomy.rate-limit.per-minute:10}")
-    private int maxRequestsPerMinute;
+    private int maxRequestsPerMinute = 10;
 
     /** Optional — injected lazily to avoid circular dependencies. */
     @Autowired(required = false)
@@ -45,86 +61,193 @@ public class RateLimitFilter extends OncePerRequestFilter {
     private PreferencesService preferencesService;
 
     private final Map<String, WindowCounter> counters = new ConcurrentHashMap<>();
+    private final WindowCounter overflowCounter;
+    private final Object admissionMonitor = new Object();
+    private final AtomicLong nextCleanupAt = new AtomicLong();
+    private final LongSupplier currentTimeMillis;
+
+    public RateLimitFilter() {
+        this(System::currentTimeMillis);
+    }
+
+    RateLimitFilter(LongSupplier currentTimeMillis) {
+        this.currentTimeMillis = Objects.requireNonNull(currentTimeMillis);
+        long now = currentTimeMillis.getAsLong();
+        this.overflowCounter = new WindowCounter(now);
+        this.nextCleanupAt.set(now + CLEANUP_INTERVAL_MILLIS);
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                      FilterChain filterChain) throws ServletException, IOException {
-        String path = request.getRequestURI();
-
-        // Only rate-limit LLM-backed endpoints
-        if (!isRateLimitedPath(path)) {
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String path = applicationPath(request);
+        if (!isRateLimitedOperation(request.getMethod(), path)) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Effective limit: prefer runtime preference, fall back to property value
-        int effectiveLimit = (preferencesService != null)
-                ? preferencesService.getInt("rate-limit.per-minute", maxRequestsPerMinute)
-                : maxRequestsPerMinute;
-
-        // Disabled if set to 0
+        int effectiveLimit = preferencesService == null
+                ? maxRequestsPerMinute
+                : preferencesService.getInt(
+                        "rate-limit.per-minute", maxRequestsPerMinute);
         if (effectiveLimit <= 0) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String clientIp = getClientIp(request);
-        WindowCounter counter = counters.computeIfAbsent(clientIp, k -> new WindowCounter());
-
-        if (counter.incrementAndCheck(effectiveLimit)) {
+        long now = currentTimeMillis.getAsLong();
+        WindowCounter counter = counterFor(clientKey(request), now);
+        if (counter.tryAcquire(effectiveLimit, now)) {
             filterChain.doFilter(request, response);
-        } else {
-            response.setStatus(429);
-            response.setContentType("application/json");
-            response.getWriter().write(
-                    "{\"error\":\"Rate limit exceeded. Maximum " + effectiveLimit
+            return;
+        }
+
+        writeRateLimitResponse(response, effectiveLimit, counter.retryAfterSeconds(now));
+    }
+
+    /** Visible for testing — clears all per-client and overflow counters. */
+    public void clearCounters() {
+        long now = currentTimeMillis.getAsLong();
+        synchronized (admissionMonitor) {
+            counters.clear();
+            overflowCounter.reset(now);
+            nextCleanupAt.set(now + CLEANUP_INTERVAL_MILLIS);
+        }
+    }
+
+    int trackedClientCount() {
+        return counters.size();
+    }
+
+    private WindowCounter counterFor(String clientKey, long now) {
+        cleanupExpiredEntries(now, false);
+        WindowCounter existing = counters.get(clientKey);
+        if (existing != null) {
+            return existing;
+        }
+
+        synchronized (admissionMonitor) {
+            existing = counters.get(clientKey);
+            if (existing != null) {
+                return existing;
+            }
+            if (counters.size() >= MAX_TRACKED_CLIENTS) {
+                cleanupExpiredEntries(now, true);
+            }
+            if (counters.size() >= MAX_TRACKED_CLIENTS) {
+                return overflowCounter;
+            }
+            WindowCounter created = new WindowCounter(now);
+            counters.put(clientKey, created);
+            return created;
+        }
+    }
+
+    private void cleanupExpiredEntries(long now, boolean force) {
+        if (!force && now < nextCleanupAt.get()) {
+            return;
+        }
+        synchronized (admissionMonitor) {
+            if (!force && now < nextCleanupAt.get()) {
+                return;
+            }
+            counters.entrySet().removeIf(
+                    entry -> entry.getValue().isExpired(now));
+            nextCleanupAt.set(now + CLEANUP_INTERVAL_MILLIS);
+        }
+    }
+
+    private static String applicationPath(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (servletPath != null && !servletPath.isBlank()) {
+            return servletPath;
+        }
+
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isBlank()
+                && requestUri.startsWith(contextPath)) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
+    }
+
+    private static boolean isRateLimitedOperation(String method, String path) {
+        return ("POST".equalsIgnoreCase(method)
+                    && ("/api/analyze".equals(path)
+                        || "/api/justify-leaf".equals(path)))
+                || ("GET".equalsIgnoreCase(method)
+                    && ("/api/analyze-stream".equals(path)
+                        || "/api/analyze-node".equals(path)));
+    }
+
+    private static String clientKey(HttpServletRequest request) {
+        Principal principal = request.getUserPrincipal();
+        if (principal != null && principal.getName() != null
+                && !principal.getName().isBlank()) {
+            return "principal:" + principal.getName();
+        }
+        String peer = request.getRemoteAddr();
+        return "peer:" + (peer == null || peer.isBlank() ? "unknown" : peer);
+    }
+
+    private static void writeRateLimitResponse(
+            HttpServletResponse response,
+            int effectiveLimit,
+            long retryAfterSeconds) throws IOException {
+        response.setStatus(429);
+        response.setHeader("Retry-After", Long.toString(retryAfterSeconds));
+        response.setHeader("Cache-Control", "no-store");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType("application/json");
+        response.getWriter().write(
+                "{\"error\":\"Rate limit exceeded. Maximum " + effectiveLimit
                     + " LLM requests per minute. Please wait.\","
                     + "\"status\":429}");
+    }
+
+    /** Fixed-window counter with explicit last-use tracking for bounded eviction. */
+    static final class WindowCounter {
+        private int count;
+        private long windowStart;
+        private long lastSeen;
+
+        WindowCounter(long now) {
+            reset(now);
         }
-    }
 
-    /** Visible for testing — clears all per-IP rate limit counters. */
-    public void clearCounters() {
-        counters.clear();
-    }
-
-    private boolean isRateLimitedPath(String path) {
-        return path.equals("/api/analyze")
-            || path.equals("/api/analyze-stream")
-            || path.equals("/api/analyze-node")
-            || path.equals("/api/justify-leaf");
-    }
-
-    private String getClientIp(HttpServletRequest request) {
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isBlank()) {
-            return xff.split(",")[0].trim();
-        }
-        return request.getRemoteAddr();
-    }
-
-    /**
-     * Sliding window counter per minute.
-     */
-    static class WindowCounter {
-        private final AtomicInteger count = new AtomicInteger(0);
-        private volatile long windowStart = System.currentTimeMillis();
-
-        boolean incrementAndCheck(int max) {
-            long now = System.currentTimeMillis();
-            // Reset window every 60 seconds — synchronized to prevent a race between
-            // the reset check and the increment that would count against the new window
-            if (now - windowStart > 60_000) {
-                synchronized (this) {
-                    if (now - windowStart > 60_000) {
-                        count.set(1);
-                        windowStart = now;
-                        return true;
-                    }
-                }
+        synchronized boolean tryAcquire(int maximum, long now) {
+            rotateWindowIfNeeded(now);
+            lastSeen = now;
+            if (count >= maximum) {
+                return false;
             }
-            return count.incrementAndGet() <= max;
+            count++;
+            return true;
+        }
+
+        synchronized long retryAfterSeconds(long now) {
+            rotateWindowIfNeeded(now);
+            long remainingMillis = Math.max(1L, WINDOW_MILLIS - (now - windowStart));
+            return Math.max(1L, (remainingMillis + 999L) / 1_000L);
+        }
+
+        synchronized boolean isExpired(long now) {
+            return now - lastSeen >= ENTRY_RETENTION_MILLIS;
+        }
+
+        synchronized void reset(long now) {
+            count = 0;
+            windowStart = now;
+            lastSeen = now;
+        }
+
+        private void rotateWindowIfNeeded(long now) {
+            if (now - windowStart >= WINDOW_MILLIS) {
+                reset(now);
+            }
         }
     }
 }
-

--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionHardeningTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionHardeningTests.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Tests for {@link com.taxonomy.shared.config.RateLimitFilter} and
+ * Integration tests for {@link RateLimitFilter} and
  * {@link com.taxonomy.shared.config.GlobalExceptionHandler}.
  */
 @SpringBootTest
@@ -68,16 +68,13 @@ class ProductionHardeningTests {
         // Pin the runtime preference that has precedence over the test property.
         when(preferencesService.getInt("rate-limit.per-minute", 3)).thenReturn(3);
 
-        // Clear the per-IP counters between tests to avoid cross-test interference.
+        // Clear per-principal/peer counters between tests.
         rateLimitFilter.clearCounters();
     }
 
-    // ── RateLimitFilter Tests ────────────────────────────────────────────────
-
     @Test
     void rateLimitFilterAllowsRequestsUnderLimit() throws Exception {
-        // With limit=3, first 3 requests should succeed
-        for (int i = 0; i < 3; i++) {
+        for (int index = 0; index < 3; index++) {
             mockMvc.perform(get("/api/analyze-node")
                             .param("parentCode", "BP")
                             .param("businessText", "test requirement")
@@ -88,15 +85,13 @@ class ProductionHardeningTests {
 
     @Test
     void rateLimitFilterBlocks429AfterLimitExceeded() throws Exception {
-        // Exhaust the limit (3 requests)
-        for (int i = 0; i < 3; i++) {
+        for (int index = 0; index < 3; index++) {
             mockMvc.perform(get("/api/analyze-node")
                             .param("parentCode", "BP")
                             .param("businessText", "test requirement")
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk());
         }
-        // 4th request should be rate limited
         mockMvc.perform(get("/api/analyze-node")
                         .param("parentCode", "BP")
                         .param("businessText", "test requirement")
@@ -106,15 +101,13 @@ class ProductionHardeningTests {
 
     @Test
     void rateLimitFilter429ResponseContainsJsonError() throws Exception {
-        // Exhaust the limit
-        for (int i = 0; i < 3; i++) {
+        for (int index = 0; index < 3; index++) {
             mockMvc.perform(get("/api/analyze-node")
                             .param("parentCode", "BP")
                             .param("businessText", "test")
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk());
         }
-        // 4th should be rate limited with JSON body
         mockMvc.perform(get("/api/analyze-node")
                         .param("parentCode", "BP")
                         .param("businessText", "test")
@@ -127,35 +120,19 @@ class ProductionHardeningTests {
 
     @Test
     void rateLimitFilterDoesNotAffectNonLlmEndpoints() throws Exception {
-        // Non-LLM endpoints like /api/taxonomy should never be rate-limited
-        // even when the limit has been exhausted for LLM endpoints
-        for (int i = 0; i < 5; i++) {
+        for (int index = 0; index < 5; index++) {
             mockMvc.perform(get("/api/taxonomy").accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk());
         }
     }
 
     @Test
-    void rateLimitWindowCounterResetsAfterMinute() {
-        // Rate limit is 3 in this test context. Exhaust the limit.
-        // Then verify the /api/taxonomy endpoint (not rate-limited) still works to confirm
-        // other endpoints are unaffected regardless of counter state.
-        assertThat(rateLimitFilter).isNotNull();
-        // Verify the filter is properly configured with the test property value
-        // (indirectly verified by the 429 test above passing with limit=3)
-    }
-
-    @Test
     void rateLimitFilterBeanIsRegistered() {
-        // Verify the filter bean is properly instantiated in the application context
         assertThat(rateLimitFilter).isNotNull();
     }
-
-    // ── GlobalExceptionHandler Tests ─────────────────────────────────────────
 
     @Test
     void illegalArgumentExceptionReturnsBadRequestJson() throws Exception {
-        // /api/search with blank query triggers IllegalArgumentException in SearchService
         mockMvc.perform(get("/api/search")
                         .param("q", "")
                         .accept(MediaType.APPLICATION_JSON))
@@ -164,7 +141,6 @@ class ProductionHardeningTests {
 
     @Test
     void analyzeEndpointReturnsBadRequestForEmptyText() throws Exception {
-        // Empty businessText should return 400 (not a stack trace)
         mockMvc.perform(post("/api/analyze")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"businessText\":\"\"}"))

--- a/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportAvailabilityExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportAvailabilityExceptionHandlerTest.java
@@ -1,0 +1,47 @@
+package com.taxonomy.architecture.decision;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DecisionReportAvailabilityExceptionHandlerTest {
+
+    @Test
+    void returnsTypedServiceUnavailableWithoutTemplateInternals() {
+        DecisionReportAvailabilityExceptionHandler handler =
+                new DecisionReportAvailabilityExceptionHandler();
+        DecisionReportTemplateUnavailableException exception =
+                new DecisionReportTemplateUnavailableException(
+                        "word/document.xml failed at /srv/private/template.dotx",
+                        new IllegalArgumentException("private template payload"));
+
+        ResponseEntity<Map<String, Object>> response =
+                handler.handleUnavailableTemplate(
+                        exception,
+                        new ServletWebRequest(
+                                new MockHttpServletRequest(
+                                        "GET", "/api/decision-report/example.docx")));
+
+        assertThat(response.getStatusCode())
+                .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody())
+                .containsEntry("status", 503)
+                .containsEntry(
+                        "code",
+                        DecisionReportAvailabilityExceptionHandler.PROBLEM_CODE)
+                .containsEntry(
+                        "message",
+                        DecisionReportAvailabilityExceptionHandler.SAFE_MESSAGE)
+                .containsEntry("path", "/api/decision-report/example.docx");
+        assertThat(response.getBody().toString())
+                .doesNotContain("word/document.xml")
+                .doesNotContain("/srv/private")
+                .doesNotContain("private template payload");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,112 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private static final String SAFE_INTERNAL_MESSAGE =
+            "The request could not be completed safely.";
+
+    @AfterEach
+    void resetLocale() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @Test
+    void frameworkServerErrorDoesNotExposeInternalExceptionMessage() {
+        ExposedHandler handler = handler();
+        WebRequest request = request("/api/failing");
+        RuntimeException failure = new RuntimeException(
+                "jdbc:postgresql://db.internal/taxonomy?password=private-value");
+
+        ResponseEntity<Object> response = handler.frameworkException(
+                failure,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body)
+                .containsEntry("status", 500)
+                .containsEntry("message", SAFE_INTERNAL_MESSAGE)
+                .containsEntry("path", "/api/failing");
+        assertThat(body.toString())
+                .doesNotContain("db.internal")
+                .doesNotContain("private-value");
+    }
+
+    @Test
+    void frameworkClientErrorKeepsActionableValidationMessage() {
+        ExposedHandler handler = handler();
+
+        ResponseEntity<Object> response = handler.frameworkException(
+                new IllegalArgumentException("required parameter is missing"),
+                HttpStatus.BAD_REQUEST,
+                request("/api/input"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertThat(body)
+                .containsEntry("status", 400)
+                .containsEntry("message", "required parameter is missing")
+                .containsEntry("path", "/api/input");
+    }
+
+    @Test
+    void directBadRequestUsesReasonPhraseWhenExceptionMessageIsBlank() {
+        GlobalExceptionHandler handler = handler();
+
+        ResponseEntity<Map<String, Object>> response = handler.handleBadRequest(
+                new IllegalArgumentException(" "),
+                request("/api/input"));
+
+        assertThat(response.getBody())
+                .containsEntry("message", HttpStatus.BAD_REQUEST.getReasonPhrase());
+    }
+
+    private static ExposedHandler handler() {
+        StaticMessageSource messages = new StaticMessageSource();
+        messages.addMessage("error.internal", Locale.ENGLISH, SAFE_INTERNAL_MESSAGE);
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+        return new ExposedHandler(messages);
+    }
+
+    private static WebRequest request(String path) {
+        return new ServletWebRequest(new MockHttpServletRequest("GET", path));
+    }
+
+    private static final class ExposedHandler extends GlobalExceptionHandler {
+        private ExposedHandler(StaticMessageSource messages) {
+            super(messages);
+        }
+
+        private ResponseEntity<Object> frameworkException(
+                Exception exception,
+                HttpStatus status,
+                WebRequest request) {
+            return handleExceptionInternal(
+                    exception,
+                    null,
+                    HttpHeaders.EMPTY,
+                    status,
+                    request);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
@@ -1,0 +1,172 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Principal;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitFilterTest {
+
+    @Test
+    void contextPathAndSpoofedForwardingHeadersCannotResetPrincipalBudget()
+            throws Exception {
+        AtomicLong now = new AtomicLong(1_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        MockHttpServletResponse first = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "alice", "198.51.100.1", "203.0.113.1");
+        MockHttpServletResponse second = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "alice", "198.51.100.1", "203.0.113.99");
+        MockHttpServletResponse otherUser = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "bob", "198.51.100.1", "203.0.113.99");
+
+        assertThat(first.getStatus()).isEqualTo(200);
+        assertThat(second.getStatus()).isEqualTo(429);
+        assertThat(second.getHeader("Retry-After")).isEqualTo("60");
+        assertThat(second.getHeader("Cache-Control")).isEqualTo("no-store");
+        assertThat(second.getContentAsString()).contains("\"status\":429");
+        assertThat(otherUser.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void unauthenticatedFallbackUsesDirectPeerNotForwardingHeader()
+            throws Exception {
+        AtomicLong now = new AtomicLong(10_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        MockHttpServletResponse first = perform(
+                filter, "GET", "", "/api/analyze-node",
+                null, "192.0.2.10", "203.0.113.1");
+        MockHttpServletResponse second = perform(
+                filter, "GET", "", "/api/analyze-node",
+                null, "192.0.2.10", "203.0.113.2");
+
+        assertThat(first.getStatus()).isEqualTo(200);
+        assertThat(second.getStatus()).isEqualTo(429);
+        assertThat(filter.trackedClientCount()).isEqualTo(1);
+    }
+
+    @Test
+    void preflightAndWrongMethodRequestsDoNotConsumeLlmBudget()
+            throws Exception {
+        AtomicLong now = new AtomicLong(20_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        assertThat(perform(
+                filter, "OPTIONS", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void fixedWindowResetsExactlyAtOneMinute() throws Exception {
+        AtomicLong now = new AtomicLong(30_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(429);
+
+        now.addAndGet(60_000L);
+
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void expiredClientEntriesAreRemoved() throws Exception {
+        AtomicLong now = new AtomicLong(40_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        for (int index = 0; index < 3; index++) {
+            perform(filter, "GET", "", "/api/analyze-stream",
+                    "user-" + index, "192.0.2." + index, null);
+        }
+        assertThat(filter.trackedClientCount()).isEqualTo(3);
+
+        now.addAndGet(120_000L);
+        perform(filter, "GET", "", "/api/analyze-stream",
+                "current-user", "192.0.2.100", null);
+
+        assertThat(filter.trackedClientCount()).isEqualTo(1);
+    }
+
+    @Test
+    void trackedClientStateHasAHardUpperBound() throws Exception {
+        AtomicLong now = new AtomicLong(50_000L);
+        RateLimitFilter filter = filter(now, 1);
+
+        for (int index = 0; index < 10_050; index++) {
+            perform(filter, "GET", "", "/api/analyze-node",
+                    "principal-" + index, "192.0.2.1", null);
+        }
+
+        assertThat(filter.trackedClientCount()).isEqualTo(10_000);
+    }
+
+    @Test
+    void zeroLimitDisablesTrackingAndLimiting() throws Exception {
+        AtomicLong now = new AtomicLong(60_000L);
+        RateLimitFilter filter = filter(now, 0);
+
+        for (int index = 0; index < 3; index++) {
+            assertThat(perform(
+                    filter, "POST", "", "/api/analyze",
+                    "alice", "192.0.2.60", null).getStatus()).isEqualTo(200);
+        }
+        assertThat(filter.trackedClientCount()).isZero();
+    }
+
+    private static RateLimitFilter filter(AtomicLong now, int limit) {
+        RateLimitFilter filter = new RateLimitFilter(now::get);
+        ReflectionTestUtils.setField(filter, "maxRequestsPerMinute", limit);
+        return filter;
+    }
+
+    private static MockHttpServletResponse perform(
+            RateLimitFilter filter,
+            String method,
+            String contextPath,
+            String servletPath,
+            String username,
+            String remoteAddress,
+            String forwardedFor) throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                method, contextPath + servletPath);
+        request.setContextPath(contextPath);
+        request.setServletPath(servletPath);
+        request.setRemoteAddr(remoteAddress);
+        if (username != null) {
+            Principal principal = () -> username;
+            request.setUserPrincipal(principal);
+        }
+        if (forwardedFor != null) {
+            request.addHeader("X-Forwarded-For", forwardedFor);
+        }
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+        return response;
+    }
+}


### PR DESCRIPTION
## What it does

Replaces the earlier HTTP-hardening draft with a complete correction built directly on the exact PR #865 head.

### Framework 5xx disclosure

Spring MVC exceptions handled by `ResponseEntityExceptionHandler` no longer copy `Exception.getMessage()` into 5xx JSON responses. The full exception remains in the server log, while clients receive the localized `error.internal` message. Framework 4xx responses retain actionable validation details, and blank client messages receive the HTTP reason phrase.

Client-error logging now records the bounded request path, status and exception type rather than echoing arbitrary client-controlled exception text.

### Canonical LLM rate-limit identity and path

The limiter now:

- keys authenticated calls by the server-established principal;
- falls back only to the direct servlet peer and ignores `X-Forwarded-For`;
- uses the servlet path, so `/taxonomy/api/...` and root deployments share one contract;
- counts only the actual supported method/path pairs;
- does not charge OPTIONS, HEAD or wrong-method requests against an LLM budget;
- returns `Retry-After` and `Cache-Control: no-store` with HTTP 429.

### Bounded state

Expired client entries are evicted and the map has a hard 10,000-client ceiling. Additional high-cardinality identities share one fail-closed overflow counter instead of allocating unbounded state.

## Tests

Focused tests prove:

- internal JDBC/credential text cannot cross a framework 5xx response;
- 4xx details remain actionable;
- context-path calls are limited;
- changing a forwarding header cannot reset a principal or peer budget;
- users have independent budgets;
- preflight/wrong-method calls do not consume quota;
- the window resets at exactly one minute;
- stale entries are removed;
- tracked state cannot exceed the hard ceiling;
- limit `0` disables both tracking and blocking.

## Integration

Base: the exact PR #865 head `205eebc74eb6f0666058fc4a344f5c9c888723ab`. This supersedes #864; it must be retargeted to `main` only after #865 is integrated and must pass the complete exact-head matrix.