### PR TITLE
Enforce distinct password and HTTP machine-token secret contracts

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
@@ -3,9 +3,9 @@ package com.taxonomy.security.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -41,11 +41,17 @@ public class ProductionSecurityGuard implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments arguments) {
-        requireStrongSecret(adminPassword, "TAXONOMY_ADMIN_PASSWORD");
+        String canonicalAdminPassword = requireStrongSecret(
+                adminPassword,
+                "TAXONOMY_ADMIN_PASSWORD",
+                false);
 
-        if (adminToken != null && !adminToken.isBlank()) {
-            requireStrongSecret(adminToken, "ADMIN_PASSWORD");
-            if (constantTimeEquals(adminPassword, adminToken)) {
+        if (adminToken != null && !adminToken.isEmpty()) {
+            String canonicalAdminToken = requireStrongSecret(
+                    adminToken,
+                    "ADMIN_PASSWORD",
+                    true);
+            if (constantTimeEquals(canonicalAdminPassword, canonicalAdminToken)) {
                 throw new IllegalStateException(
                         "Production startup refused: ADMIN_PASSWORD must be a distinct "
                                 + "machine token and must not reuse TAXONOMY_ADMIN_PASSWORD.");
@@ -53,24 +59,60 @@ public class ProductionSecurityGuard implements ApplicationRunner {
         }
     }
 
-    private static void requireStrongSecret(
+    private static String requireStrongSecret(
             String value,
-            String environmentVariable) {
-        String normalized = value == null
-                ? ""
-                : value.trim().toLowerCase(Locale.ROOT);
-        if (normalized.isEmpty()
-                || FORBIDDEN_PASSWORDS.contains(normalized)
+            String environmentVariable,
+            boolean transportToken) {
+        if (value == null || value.isEmpty()) {
+            throw unsafeSecret(environmentVariable);
+        }
+        if (hasUnsafeEdgeCharacter(value)) {
+            throw new IllegalStateException(
+                    "Production startup refused: " + environmentVariable
+                            + " must not start or end with whitespace, control, "
+                            + "or formatting characters.");
+        }
+        if (value.codePoints().anyMatch(Character::isISOControl)) {
+            throw new IllegalStateException(
+                    "Production startup refused: " + environmentVariable
+                            + " must not contain control characters.");
+        }
+        if (transportToken && value.codePoints().anyMatch(
+                ProductionSecurityGuard::isTransportSeparator)) {
+            throw new IllegalStateException(
+                    "Production startup refused: ADMIN_PASSWORD must not contain "
+                            + "whitespace or formatting characters because it is "
+                            + "used as an HTTP machine token.");
+        }
+
+        String normalized = value.toLowerCase(Locale.ROOT);
+        if (FORBIDDEN_PASSWORDS.contains(normalized)
                 || normalized.startsWith("replace-with-")
                 || normalized.startsWith("change-me-to-")) {
             throw unsafeSecret(environmentVariable);
         }
-        if (value.length() < MINIMUM_SECRET_LENGTH) {
+        if (value.codePointCount(0, value.length()) < MINIMUM_SECRET_LENGTH) {
             throw new IllegalStateException(
                     "Production startup refused: " + environmentVariable
                             + " must contain at least " + MINIMUM_SECRET_LENGTH
                             + " characters.");
         }
+        return value;
+    }
+
+    private static boolean hasUnsafeEdgeCharacter(String value) {
+        int first = value.codePointAt(0);
+        int last = value.codePointBefore(value.length());
+        return isTransportSeparator(first)
+                || isTransportSeparator(last)
+                || Character.isISOControl(first)
+                || Character.isISOControl(last);
+    }
+
+    private static boolean isTransportSeparator(int codePoint) {
+        return Character.isWhitespace(codePoint)
+                || Character.isSpaceChar(codePoint)
+                || Character.getType(codePoint) == Character.FORMAT;
     }
 
     private static IllegalStateException unsafeSecret(String environmentVariable) {

--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
@@ -7,9 +7,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * Reports whether the mandatory decision-report template is present and structurally valid.
+ *
+ * <p>A missing or invalid template degrades only the DOCX decision-report feature. It must
+ * not make the complete application unavailable or prevent an administrator from repairing
+ * the template through the normal administration surface.</p>
  */
 @Component
 public final class DecisionRationaleTemplateHealthIndicator implements HealthIndicator {
+
+    private static final String DEGRADED = "DEGRADED";
 
     private final DocumentTemplateService templates;
 
@@ -24,14 +30,18 @@ public final class DecisionRationaleTemplateHealthIndicator implements HealthInd
             TemplateFile file = templates.downloadCurrentValidated(templateId);
             return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", "AVAILABLE")
                     .withDetail("commit", file.commitId())
                     .withDetail("packageSha256", file.manifest().packageSha256())
                     .withDetail("updatedBy", file.manifest().updatedBy())
                     .build();
         } catch (Exception exception) {
             String message = exception.getMessage();
-            return Health.down()
+            return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", DEGRADED)
+                    .withDetail("affectedCapability", "decision-report-docx")
+                    .withDetail("remediation", "Restore or upload a valid decision-report template")
                     .withDetail("error", message == null
                             ? "Required decision-report template is unavailable"
                             : message)

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardTransportTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardTransportTest.java
@@ -1,0 +1,90 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class ProductionSecurityGuardTransportTest {
+
+    @Test
+    void rejectsShortPasswordPaddedToMinimumLengthWithSpaces() {
+        assertRejected(
+                "ShortSecret123   ",
+                "",
+                "must not start or end");
+    }
+
+    @Test
+    void rejectsUnicodeSpaceAndFormattingCharactersAtCredentialEdges() {
+        assertRejected(
+                "\u00a0Strong-Local-Password-2026!",
+                "",
+                "must not start or end");
+        assertRejected(
+                "Strong-Local-Password-2026!\u200b",
+                "",
+                "must not start or end");
+    }
+
+    @Test
+    void rejectsControlCharactersInsidePassword() {
+        assertRejected(
+                "Strong-Local\nPassword-2026!",
+                "",
+                "must not contain control characters");
+    }
+
+    @Test
+    void rejectsWhitespaceOnlyOptionalMachineTokenInsteadOfSilentlyDisablingIt() {
+        assertRejected(
+                "Strong-Local-Password-2026!",
+                "   ",
+                "ADMIN_PASSWORD");
+    }
+
+    @Test
+    void rejectsInternalWhitespaceInHttpMachineToken() {
+        assertRejected(
+                "Strong local password 2026!",
+                "Monitoring token 2026 distinct",
+                "HTTP machine token");
+    }
+
+    @Test
+    void measuresMinimumLengthInUnicodeCodePointsNotUtf16Units() {
+        assertRejected(
+                "😀😀😀😀😀😀😀😀",
+                "",
+                "at least 16 characters");
+    }
+
+    @Test
+    void permitsInternalSpacesInPasswordAndTransportSafeDistinctToken() {
+        ProductionSecurityGuard guard = new ProductionSecurityGuard(
+                "Strong local password 2026!",
+                "Distinct-monitoring-token-2026!");
+
+        Throwable failure = catchThrowable(() -> guard.run(null));
+
+        assertThat(failure).isNull();
+    }
+
+    private static void assertRejected(
+            String adminPassword,
+            String adminToken,
+            String expectedMessage) {
+        ProductionSecurityGuard guard = new ProductionSecurityGuard(
+                adminPassword, adminToken);
+
+        Throwable failure = catchThrowable(() -> guard.run(null));
+
+        assertThat(failure)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(expectedMessage);
+        assertThat(failure.getMessage()).doesNotContain(adminPassword);
+        if (!adminToken.isBlank()) {
+            assertThat(failure.getMessage()).doesNotContain(adminToken);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -1,0 +1,31 @@
+package com.taxonomy.templates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DecisionRationaleTemplateHealthIndicatorTest {
+
+    @Test
+    void invalidTemplateDegradesOnlyTheReportCapability() {
+        DocumentTemplateService templates = mock(DocumentTemplateService.class);
+        when(templates.downloadCurrentValidated(
+                DecisionRationaleTemplateContract.TEMPLATE_ID))
+                .thenThrow(new IllegalStateException("word/document.xml is invalid"));
+
+        Health health = new DecisionRationaleTemplateHealthIndicator(templates).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails())
+                .containsEntry("availability", "DEGRADED")
+                .containsEntry("affectedCapability", "decision-report-docx")
+                .containsEntry("templateId", DecisionRationaleTemplateContract.TEMPLATE_ID);
+        assertThat(health.getDetails().get("remediation"))
+                .asString()
+                .contains("valid decision-report template");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 class DecisionRationaleTemplateHealthIndicatorTest {
 
     @Test
-    void invalidTemplateDegradesOnlyTheReportCapability() {
+    void invalidTemplateDegradesOnlyTheReportCapability() throws Exception {
         DocumentTemplateService templates = mock(DocumentTemplateService.class);
         when(templates.downloadCurrentValidated(
                 DecisionRationaleTemplateContract.TEMPLATE_ID))


### PR DESCRIPTION
## What it does

Replaces the initial whitespace-only draft with the complete production credential transport contract.

The previous guard measured minimum length on the raw UTF-16 string. A short password could be padded with trailing spaces, and an HTTP machine token could contain separators that Bearer/header parsing may normalize differently.

The guard now:

- rejects leading/trailing Unicode whitespace, space separators, control characters and formatting characters for both credentials;
- rejects control characters anywhere;
- measures minimum length in Unicode code points, not UTF-16 code units;
- allows internal spaces in the interactive login password;
- rejects whitespace and formatting characters anywhere in `ADMIN_PASSWORD`, because it is transported as an HTTP machine token;
- rejects a non-empty whitespace-only machine-token configuration rather than silently treating it as disabled;
- retains placeholder rejection and constant-time equality checks;
- never echoes a rejected secret in an exception.

Tests cover ASCII padding, non-breaking spaces, zero-width formatting characters, embedded newline, whitespace-only tokens, internal token separators, surrogate-pair length inflation, and a valid spaced password with a transport-safe distinct token.

The first parent is the exact PR #865 head `205eebc74eb6f0666058fc4a344f5c9c888723ab`. This PR remains Draft until the preceding serialized QA slices are integrated and a fresh exact-base Security/CI matrix succeeds.