### PR TITLE
Draft: enforce Unicode-safe production credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ TAXONOMY_ADMIN_PASSWORD=replace-with-a-unique-random-password
 
 # Optional, separate Actuator/admin token for X-Admin-Token and Bearer checks.
 # Never reuse the interactive login password above as this machine credential.
+# Use at least 16 ASCII letters/digits or . _ ~ - characters; `openssl rand -hex 24`
+# produces a compatible value without shell- or HTTP-header ambiguity.
 # ADMIN_PASSWORD=replace-with-a-distinct-random-machine-token
 
 # Existing pre-library installations only: after a restorable backup and successful

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Fails production startup before any bootstrap account can be persisted when
@@ -28,6 +29,9 @@ public class ProductionSecurityGuard implements ApplicationRunner {
             "password",
             "changeme",
             "change-me");
+    /** Conservative common subset for X-Admin-Token and RFC 6750 Bearer transport. */
+    private static final Pattern HTTP_MACHINE_TOKEN =
+            Pattern.compile("[A-Za-z0-9._~-]+");
 
     private final String adminPassword;
     private final String adminToken;
@@ -85,6 +89,12 @@ public class ProductionSecurityGuard implements ApplicationRunner {
             throw new IllegalStateException(
                     "Production startup refused: ADMIN_PASSWORD must not contain "
                             + "whitespace because it is used as an HTTP machine token.");
+        }
+        if (transportToken && !HTTP_MACHINE_TOKEN.matcher(value).matches()) {
+            throw new IllegalStateException(
+                    "Production startup refused: ADMIN_PASSWORD must contain only "
+                            + "ASCII letters, digits, period, underscore, tilde, or hyphen "
+                            + "for interoperable HTTP Bearer-token transport.");
         }
 
         String normalized = value.toLowerCase(Locale.ROOT);

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/ProductionSecurityGuard.java
@@ -3,9 +3,9 @@ package com.taxonomy.security.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -41,11 +41,17 @@ public class ProductionSecurityGuard implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments arguments) {
-        requireStrongSecret(adminPassword, "TAXONOMY_ADMIN_PASSWORD");
+        String canonicalAdminPassword = requireStrongSecret(
+                adminPassword,
+                "TAXONOMY_ADMIN_PASSWORD",
+                false);
 
-        if (adminToken != null && !adminToken.isBlank()) {
-            requireStrongSecret(adminToken, "ADMIN_PASSWORD");
-            if (constantTimeEquals(adminPassword, adminToken)) {
+        if (adminToken != null && !adminToken.isEmpty()) {
+            String canonicalAdminToken = requireStrongSecret(
+                    adminToken,
+                    "ADMIN_PASSWORD",
+                    true);
+            if (constantTimeEquals(canonicalAdminPassword, canonicalAdminToken)) {
                 throw new IllegalStateException(
                         "Production startup refused: ADMIN_PASSWORD must be a distinct "
                                 + "machine token and must not reuse TAXONOMY_ADMIN_PASSWORD.");
@@ -53,24 +59,72 @@ public class ProductionSecurityGuard implements ApplicationRunner {
         }
     }
 
-    private static void requireStrongSecret(
+    private static String requireStrongSecret(
             String value,
-            String environmentVariable) {
-        String normalized = value == null
-                ? ""
-                : value.trim().toLowerCase(Locale.ROOT);
-        if (normalized.isEmpty()
-                || FORBIDDEN_PASSWORDS.contains(normalized)
+            String environmentVariable,
+            boolean transportToken) {
+        if (value == null || value.isEmpty()) {
+            throw unsafeSecret(environmentVariable);
+        }
+        if (hasUnsafeEdgeCharacter(value)) {
+            throw new IllegalStateException(
+                    "Production startup refused: " + environmentVariable
+                            + " must not start or end with whitespace, control, "
+                            + "or formatting characters.");
+        }
+        if (value.codePoints().anyMatch(
+                codePoint -> isInvisibleOrLineBreaking(codePoint)
+                        || isNonAsciiSeparator(codePoint))) {
+            throw new IllegalStateException(
+                    "Production startup refused: " + environmentVariable
+                            + " must not contain control, formatting, line-breaking, "
+                            + "or non-ASCII separator characters.");
+        }
+        if (transportToken && value.codePoints().anyMatch(
+                codePoint -> codePoint == ' ' || Character.isWhitespace(codePoint))) {
+            throw new IllegalStateException(
+                    "Production startup refused: ADMIN_PASSWORD must not contain "
+                            + "whitespace because it is used as an HTTP machine token.");
+        }
+
+        String normalized = value.toLowerCase(Locale.ROOT);
+        if (FORBIDDEN_PASSWORDS.contains(normalized)
                 || normalized.startsWith("replace-with-")
                 || normalized.startsWith("change-me-to-")) {
             throw unsafeSecret(environmentVariable);
         }
-        if (value.length() < MINIMUM_SECRET_LENGTH) {
+        if (value.codePointCount(0, value.length()) < MINIMUM_SECRET_LENGTH) {
             throw new IllegalStateException(
                     "Production startup refused: " + environmentVariable
                             + " must contain at least " + MINIMUM_SECRET_LENGTH
                             + " characters.");
         }
+        return value;
+    }
+
+    private static boolean hasUnsafeEdgeCharacter(String value) {
+        int first = value.codePointAt(0);
+        int last = value.codePointBefore(value.length());
+        return first == ' '
+                || last == ' '
+                || Character.isWhitespace(first)
+                || Character.isWhitespace(last)
+                || Character.isSpaceChar(first)
+                || Character.isSpaceChar(last)
+                || isInvisibleOrLineBreaking(first)
+                || isInvisibleOrLineBreaking(last);
+    }
+
+    private static boolean isInvisibleOrLineBreaking(int codePoint) {
+        int type = Character.getType(codePoint);
+        return Character.isISOControl(codePoint)
+                || type == Character.FORMAT
+                || type == Character.LINE_SEPARATOR
+                || type == Character.PARAGRAPH_SEPARATOR;
+    }
+
+    private static boolean isNonAsciiSeparator(int codePoint) {
+        return codePoint != ' ' && Character.getType(codePoint) == Character.SPACE_SEPARATOR;
     }
 
     private static IllegalStateException unsafeSecret(String environmentVariable) {

--- a/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicator.java
@@ -7,9 +7,15 @@ import org.springframework.stereotype.Component;
 
 /**
  * Reports whether the mandatory decision-report template is present and structurally valid.
+ *
+ * <p>A missing or invalid template degrades only the DOCX decision-report feature. It must
+ * not make the complete application unavailable or prevent an administrator from repairing
+ * the template through the normal administration surface.</p>
  */
 @Component
 public final class DecisionRationaleTemplateHealthIndicator implements HealthIndicator {
+
+    private static final String DEGRADED = "DEGRADED";
 
     private final DocumentTemplateService templates;
 
@@ -24,14 +30,18 @@ public final class DecisionRationaleTemplateHealthIndicator implements HealthInd
             TemplateFile file = templates.downloadCurrentValidated(templateId);
             return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", "AVAILABLE")
                     .withDetail("commit", file.commitId())
                     .withDetail("packageSha256", file.manifest().packageSha256())
                     .withDetail("updatedBy", file.manifest().updatedBy())
                     .build();
         } catch (Exception exception) {
             String message = exception.getMessage();
-            return Health.down()
+            return Health.up()
                     .withDetail("templateId", templateId)
+                    .withDetail("availability", DEGRADED)
+                    .withDetail("affectedCapability", "decision-report-docx")
+                    .withDetail("remediation", "Restore or upload a valid decision-report template")
                     .withDetail("error", message == null
                             ? "Required decision-report template is unavailable"
                             : message)

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardUnicodeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardUnicodeTest.java
@@ -68,6 +68,18 @@ class ProductionSecurityGuardUnicodeTest {
     }
 
     @Test
+    void rejectsUnicodeAndNonBearerPunctuationInHttpMachineToken() {
+        assertRejected(
+                "Strong local password 2026!",
+                "Monitoring-token-ä-2026",
+                "ASCII letters");
+        assertRejected(
+                "Strong local password 2026!",
+                "Monitoring-token-2026!",
+                "ASCII letters");
+    }
+
+    @Test
     void measuresMinimumLengthInUnicodeCodePointsNotUtf16Units() {
         assertRejected(
                 "😀😀😀😀😀😀😀😀",
@@ -79,7 +91,7 @@ class ProductionSecurityGuardUnicodeTest {
     void permitsAsciiInternalSpacesInPasswordAndTransportSafeDistinctToken() {
         ProductionSecurityGuard guard = new ProductionSecurityGuard(
                 "Strong local password 2026!",
-                "Distinct-monitoring-token-2026!");
+                "Distinct-monitoring-token-2026");
 
         Throwable failure = catchThrowable(() -> guard.run(null));
 

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardUnicodeTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/ProductionSecurityGuardUnicodeTest.java
@@ -1,0 +1,106 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class ProductionSecurityGuardUnicodeTest {
+
+    @Test
+    void rejectsShortPasswordPaddedToMinimumLengthWithSpaces() {
+        assertRejected(
+                "ShortSecret123   ",
+                "",
+                "must not start or end");
+    }
+
+    @Test
+    void rejectsUnicodeSpaceAndFormattingCharactersAtCredentialEdges() {
+        assertRejected(
+                "\u00a0Strong-Local-Password-2026!",
+                "",
+                "must not start or end");
+        assertRejected(
+                "Strong-Local-Password-2026!\u200b",
+                "",
+                "must not start or end");
+    }
+
+    @Test
+    void rejectsInvisibleAndLineBreakingCharactersInsidePassword() {
+        assertRejected(
+                "Strong-Local\nPassword-2026!",
+                "",
+                "must not contain control");
+        assertRejected(
+                "Strong-Local\u200bPassword-2026!",
+                "",
+                "must not contain control");
+        assertRejected(
+                "Strong-Local\u2028Password-2026!",
+                "",
+                "must not contain control");
+        assertRejected(
+                "Strong-Local\u00a0Password-2026!",
+                "",
+                "non-ASCII separator");
+    }
+
+    @Test
+    void rejectsWhitespaceOnlyOptionalMachineTokenInsteadOfSilentlyDisablingIt() {
+        assertRejected(
+                "Strong-Local-Password-2026!",
+                "   ",
+                "ADMIN_PASSWORD");
+    }
+
+    @Test
+    void rejectsAsciiWhitespaceAnywhereInHttpMachineToken() {
+        assertRejected(
+                "Strong local password 2026!",
+                "Monitoring token 2026 distinct",
+                "HTTP machine token");
+        assertRejected(
+                "Strong local password 2026!",
+                "Monitoring\ttoken-2026-distinct",
+                "must not contain control");
+    }
+
+    @Test
+    void measuresMinimumLengthInUnicodeCodePointsNotUtf16Units() {
+        assertRejected(
+                "😀😀😀😀😀😀😀😀",
+                "",
+                "at least 16 characters");
+    }
+
+    @Test
+    void permitsAsciiInternalSpacesInPasswordAndTransportSafeDistinctToken() {
+        ProductionSecurityGuard guard = new ProductionSecurityGuard(
+                "Strong local password 2026!",
+                "Distinct-monitoring-token-2026!");
+
+        Throwable failure = catchThrowable(() -> guard.run(null));
+
+        assertThat(failure).isNull();
+    }
+
+    private static void assertRejected(
+            String adminPassword,
+            String adminToken,
+            String expectedMessage) {
+        ProductionSecurityGuard guard = new ProductionSecurityGuard(
+                adminPassword, adminToken);
+
+        Throwable failure = catchThrowable(() -> guard.run(null));
+
+        assertThat(failure)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(expectedMessage);
+        assertThat(failure.getMessage()).doesNotContain(adminPassword);
+        if (!adminToken.isBlank()) {
+            assertThat(failure.getMessage()).doesNotContain(adminToken);
+        }
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -1,0 +1,31 @@
+package com.taxonomy.templates;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DecisionRationaleTemplateHealthIndicatorTest {
+
+    @Test
+    void invalidTemplateDegradesOnlyTheReportCapability() {
+        DocumentTemplateService templates = mock(DocumentTemplateService.class);
+        when(templates.downloadCurrentValidated(
+                DecisionRationaleTemplateContract.TEMPLATE_ID))
+                .thenThrow(new IllegalStateException("word/document.xml is invalid"));
+
+        Health health = new DecisionRationaleTemplateHealthIndicator(templates).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails())
+                .containsEntry("availability", "DEGRADED")
+                .containsEntry("affectedCapability", "decision-report-docx")
+                .containsEntry("templateId", DecisionRationaleTemplateContract.TEMPLATE_ID);
+        assertThat(health.getDetails().get("remediation"))
+                .asString()
+                .contains("valid decision-report template");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/DecisionRationaleTemplateHealthIndicatorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.when;
 class DecisionRationaleTemplateHealthIndicatorTest {
 
     @Test
-    void invalidTemplateDegradesOnlyTheReportCapability() {
+    void invalidTemplateDegradesOnlyTheReportCapability() throws Exception {
         DocumentTemplateService templates = mock(DocumentTemplateService.class);
         when(templates.downloadCurrentValidated(
                 DecisionRationaleTemplateContract.TEMPLATE_ID))


### PR DESCRIPTION
## Retained fix

The production startup guard currently validates secret length on raw UTF-16 input and trims only for placeholder comparison. That leaves several ambiguous credential forms possible: trailing-space padding, invisible Unicode formatting or separator characters, supplementary characters counted as two Java `char` values, and an optional Actuator credential that is not guaranteed to be portable through both `X-Admin-Token` and Bearer transport.

The retained implementation:

- rejects leading/trailing ASCII or Unicode whitespace, separators, controls and formatting characters;
- rejects controls, formatting characters, line/paragraph separators and non-ASCII space separators anywhere;
- measures the minimum in Unicode code points;
- permits ordinary internal ASCII spaces in the interactive login password;
- restricts the optional HTTP machine token to ASCII letters, digits, period, underscore, tilde and hyphen;
- rejects whitespace-only optional tokens instead of silently treating them as disabled;
- preserves case-insensitive placeholder rejection, distinct-token enforcement and constant-time equality;
- never includes the supplied credential in an exception.

Focused tests cover ASCII padding, NBSP, zero-width formatting, line breaks, Unicode separators, token whitespace and punctuation, supplementary-character length inflation, and a valid distinct pair. `.env.example` documents the same transport contract and recommends a compatible random token command.

## Current status

The present branch is stale and stacked; it is not merge evidence. After the serialized preceding QA slices are integrated, exactly these three files will be reconstructed as one commit on the then-current `main`:

- `.env.example`;
- `ProductionSecurityGuard.java`;
- `ProductionSecurityGuardUnicodeTest.java`.

The unrelated report-template health files currently visible in the historic branch will not be included. A complete fresh exact-head matrix is required before merge, and no release request belongs to this PR.