### PR TITLE
Make role-state draft cleanup race-safe, authoritative and uncached

### DIFF
--- a/.github/scripts/ui-role-state-isolation.mjs
+++ b/.github/scripts/ui-role-state-isolation.mjs
@@ -1,5 +1,36 @@
 const DEFAULT_TIMEOUT_MS = 90_000;
 
+async function waitForAnalysisSessionReady(page, timeout) {
+  await page.waitForFunction(() => {
+    const session = window.TaxonomyAnalysisSession;
+    const state = session?.state?.();
+    return Boolean(session
+      && window.TaxonomyAnalysisSessionApi
+      && window.TaxonomyBrowse
+      && Array.isArray(window.TaxonomyState?.taxonomyData)
+      && window.TaxonomyState.taxonomyData.length > 0
+      && state?.restoring === false);
+  }, null, { timeout });
+}
+
+async function authoritativeWorkspaceId(page) {
+  return page.evaluate(() => {
+    const session = window.TaxonomyAnalysisSession;
+    const state = session?.state?.();
+    const conflictMessage = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
+    if (state?.conflict === true || conflictMessage) {
+      throw new Error(
+        'Role-state isolation cannot mutate while a draft conflict is active');
+    }
+    if (!state?.workspaceId) {
+      throw new Error(
+        'Role-state isolation cannot verify cleanup without an authoritative workspace ID');
+    }
+    return state.workspaceId;
+  });
+}
+
 /**
  * Give every role/state browser profile a deterministic ad-hoc analysis baseline.
  *
@@ -8,26 +39,69 @@ const DEFAULT_TIMEOUT_MS = 90_000;
  * the previous profile's text, scores and selected visualization. That behaviour
  * is correct for the product, but it must not leak between otherwise independent
  * acceptance scenarios.
+ *
+ * The server's optimistic draft revision is authoritative. A fresh browser
+ * runtime first loads that revision, checks that restoration ended conflict-free,
+ * deletes the draft through the public session API and then performs an uncached
+ * read through the public draft endpoint to prove that no remote state remains.
  */
 export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_MS) {
-  await page.waitForFunction(() => {
-    const session = window.TaxonomyAnalysisSession;
-    const state = session?.state?.();
-    return Boolean(session
-      && window.TaxonomyBrowse
-      && Array.isArray(window.TaxonomyState?.taxonomyData)
-      && window.TaxonomyState.taxonomyData.length > 0
-      && state?.restoring === false);
-  }, null, { timeout });
+  await waitForAnalysisSessionReady(page, timeout);
 
   await page.evaluate(async () => {
+    await window.TaxonomyAnalysisSession.reload();
+  });
+  await waitForAnalysisSessionReady(page, timeout);
+  const workspaceId = await authoritativeWorkspaceId(page);
+
+  await page.evaluate(async (expectedWorkspaceId) => {
     const session = window.TaxonomyAnalysisSession;
+    // Re-check inside the same browser task that performs the mutation. A second
+    // tab may change the active workspace or create a conflict after the first
+    // readiness check; invalidate() would otherwise clear that new conflict.
+    const stateBeforeMutation = session.state?.();
+    const conflictBeforeMutation = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
+    if (stateBeforeMutation?.conflict === true || conflictBeforeMutation) {
+      throw new Error(
+        'Role-state isolation cannot mutate while a draft conflict is active');
+    }
+    if (stateBeforeMutation?.workspaceId !== expectedWorkspaceId) {
+      throw new Error(
+        'Role-state isolation workspace changed before authoritative cleanup');
+    }
+
     session.invalidate({
       keepText: false,
       silent: true,
       reason: 'role-state-acceptance-isolation'
     });
     await session.saveNow();
+
+    const state = session.state?.();
+    const conflictMessage = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
+    if (state?.conflict === true || conflictMessage) {
+      throw new Error(
+        'Role-state isolation could not delete the authoritative draft revision');
+    }
+    if (state?.workspaceId !== expectedWorkspaceId) {
+      throw new Error(
+        'Role-state isolation workspace changed during authoritative cleanup');
+    }
+
+    const response = await window.TaxonomyAnalysisSessionApi.request(
+      '/api/analysis-drafts/' + encodeURIComponent(expectedWorkspaceId),
+      {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        cache: 'no-store'
+      }
+    );
+    if (response.status !== 204) {
+      throw new Error(
+        `Role-state isolation verification returned HTTP ${response.status}, expected 204`);
+    }
 
     const input = document.getElementById('businessText');
     if (input) {
@@ -37,18 +111,22 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
     if (window.TaxonomyState.currentView !== 'list') {
       window.TaxonomyBrowse.switchView('list');
     }
-  });
+  }, workspaceId);
 
   await page.waitForFunction(() => {
     const tree = document.getElementById('taxonomyTree');
     const input = document.getElementById('businessText');
     const state = window.TaxonomyAnalysisSession?.state?.();
+    const conflictMessage = document.querySelector(
+      '#statusArea[data-analysis-session-message="conflict"]');
     return Boolean(tree
       && tree.dataset.viewRendered === 'list'
       && tree.querySelector('[role="treeitem"]')
       && input?.value === ''
       && !input.classList.contains('stale-results')
       && document.querySelector('#taskStageDescribe[data-state="current"]')
-      && state?.restoring === false);
+      && state?.restoring === false
+      && state?.conflict !== true
+      && !conflictMessage);
   }, null, { timeout });
 }

--- a/.github/scripts/ui-role-state-isolation.test.mjs
+++ b/.github/scripts/ui-role-state-isolation.test.mjs
@@ -3,13 +3,21 @@ import assert from 'node:assert/strict';
 
 import { isolateRoleStateScenario } from './ui-role-state-isolation.mjs';
 
-test('clears a restored draft and normalizes the role task to the list view', async () => {
+function installHarness(options = {}) {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
   const previousEvent = globalThis.Event;
   const calls = [];
   let stale = true;
   let currentStage = 'analyze';
+  let restoring = false;
+  let conflict = false;
+  let visibleConflict = Boolean(options.conflictMarker);
+  let currentWorkspaceId = options.workspaceId === undefined
+    ? 'workspace-42' : options.workspaceId;
+  const remoteStatus = options.remoteStatus === undefined
+    ? 204 : options.remoteStatus;
+  let evaluateCount = 0;
 
   const input = {
     value: 'Restored requirement from another browser profile',
@@ -38,9 +46,9 @@ test('clears a restored draft and normalizes the role task to the list view', as
   };
 
   globalThis.Event = class TestEvent {
-    constructor(type, options = {}) {
+    constructor(type, eventOptions = {}) {
       this.type = type;
-      this.bubbles = Boolean(options.bubbles);
+      this.bubbles = Boolean(eventOptions.bubbles);
     }
   };
   globalThis.window = {
@@ -52,15 +60,33 @@ test('clears a restored draft and normalizes the role task to the list view', as
         tree.dataset.viewRendered = view;
       }
     },
+    TaxonomyAnalysisSessionApi: {
+      async request(path, requestOptions) {
+        calls.push({ request: path, options: requestOptions });
+        if (options.remoteError) throw options.remoteError;
+        return { status: remoteStatus };
+      }
+    },
     TaxonomyAnalysisSession: {
-      state: () => ({ restoring: false }),
-      invalidate(options) {
-        calls.push({ invalidate: options });
+      state: () => ({ restoring, conflict, workspaceId: currentWorkspaceId }),
+      async reload() {
+        calls.push('reload');
+        restoring = true;
+        restoring = false;
+        if (options.conflictAfterReload) conflict = true;
+      },
+      invalidate(invalidateOptions) {
+        calls.push({ invalidate: invalidateOptions });
         input.value = '';
         stale = false;
+        conflict = false;
       },
       async saveNow() {
         calls.push('save');
+        if (options.conflictAfterSave) conflict = true;
+        if (options.workspaceIdAfterSave !== undefined) {
+          currentWorkspaceId = options.workspaceIdAfterSave;
+        }
       }
     }
   };
@@ -71,6 +97,9 @@ test('clears a restored draft and normalizes the role task to the list view', as
       return null;
     },
     querySelector(selector) {
+      if (selector === '#statusArea[data-analysis-session-message="conflict"]') {
+        return visibleConflict ? { id: 'statusArea' } : null;
+      }
       return selector === '#taskStageDescribe[data-state="current"]'
         && currentStage === 'describe'
         ? { id: 'taskStageDescribe' }
@@ -82,34 +111,202 @@ test('clears a restored draft and normalizes the role task to the list view', as
     async waitForFunction(predicate) {
       assert.equal(predicate(), true);
     },
-    async evaluate(callback) {
-      return callback();
+    async evaluate(callback, argument) {
+      evaluateCount++;
+      // Evaluation 1 reloads, evaluation 2 captures the authoritative identity,
+      // and evaluation 3 performs the mutation. Inject races immediately before 3.
+      if (evaluateCount === 3) {
+        if (options.conflictBeforeMutation) conflict = true;
+        if (options.conflictMarkerBeforeMutation) visibleConflict = true;
+        if (options.workspaceIdBeforeMutation !== undefined) {
+          currentWorkspaceId = options.workspaceIdBeforeMutation;
+        }
+      }
+      return callback(argument);
     }
   };
 
-  try {
-    await isolateRoleStateScenario(page, 1_000);
-  } finally {
-    globalThis.window = previousWindow;
-    globalThis.document = previousDocument;
-    globalThis.Event = previousEvent;
-  }
+  return {
+    page,
+    calls,
+    input,
+    tree,
+    taxonomyState,
+    restore() {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+      globalThis.Event = previousEvent;
+    }
+  };
+}
 
-  assert.deepEqual(calls, [
-    {
-      invalidate: {
-        keepText: false,
-        silent: true,
-        reason: 'role-state-acceptance-isolation'
-      }
-    },
-    'save',
-    'event:input',
-    'view:list'
-  ]);
-  assert.equal(input.value, '');
-  assert.equal(stale, false);
-  assert.equal(currentStage, 'describe');
-  assert.equal(taxonomyState.currentView, 'list');
-  assert.equal(tree.dataset.viewRendered, 'list');
+test(
+  'reloads the exact revision, deletes it and verifies uncached authoritative absence',
+  async () => {
+    const harness = installHarness();
+    try {
+      await isolateRoleStateScenario(harness.page, 1_000);
+
+      assert.deepEqual(harness.calls, [
+        'reload',
+        {
+          invalidate: {
+            keepText: false,
+            silent: true,
+            reason: 'role-state-acceptance-isolation'
+          }
+        },
+        'save',
+        {
+          request: '/api/analysis-drafts/workspace-42',
+          options: {
+            method: 'GET',
+            headers: { Accept: 'application/json' },
+            cache: 'no-store'
+          }
+        },
+        'event:input',
+        'view:list'
+      ]);
+      assert.equal(harness.input.value, '');
+      assert.equal(harness.taxonomyState.currentView, 'list');
+      assert.equal(harness.tree.dataset.viewRendered, 'list');
+    } finally {
+      harness.restore();
+    }
+  }
+);
+
+test('fails before mutation when reload leaves a conflict state', async () => {
+  const harness = installHarness({ conflictAfterReload: true });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /cannot mutate while a draft conflict is active/);
+    assert.deepEqual(harness.calls, ['reload']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails before mutation when visible conflict evidence remains', async () => {
+  const harness = installHarness({ conflictMarker: true });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /cannot mutate while a draft conflict is active/);
+    assert.deepEqual(harness.calls, ['reload']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails before mutation without an authoritative workspace identity', async () => {
+  const harness = installHarness({ workspaceId: null });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /without an authoritative workspace ID/);
+    assert.deepEqual(harness.calls, ['reload']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails before mutation when a conflict appears between checks', async () => {
+  const harness = installHarness({ conflictBeforeMutation: true });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /cannot mutate while a draft conflict is active/);
+    assert.deepEqual(harness.calls, ['reload']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails before mutation when the workspace changes between checks', async () => {
+  const harness = installHarness({ workspaceIdBeforeMutation: 'workspace-other' });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /workspace changed before authoritative cleanup/);
+    assert.deepEqual(harness.calls, ['reload']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails closed when optimistic deletion enters conflict state', async () => {
+  const harness = installHarness({ conflictAfterSave: true });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /could not delete the authoritative draft revision/);
+    assert.deepEqual(
+      harness.calls.map(call => typeof call === 'string'
+        ? call : Object.keys(call)[0]),
+      ['reload', 'invalidate', 'save']);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails closed when the workspace changes during cleanup', async () => {
+  const harness = installHarness({ workspaceIdAfterSave: 'workspace-other' });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /workspace changed during authoritative cleanup/);
+    assert.equal(
+      harness.calls.some(call => typeof call === 'object' && call.request),
+      false);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails closed when remote cleanup verification finds a surviving draft', async () => {
+  const harness = installHarness({ remoteStatus: 200 });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /returned HTTP 200, expected 204/);
+    assert.equal(harness.calls.some(call => call === 'event:input'), false);
+    assert.equal(harness.calls.some(call => call === 'view:list'), false);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails closed when remote cleanup verification returns HTTP 503', async () => {
+  const unavailable = Object.assign(
+    new Error('HTTP 503: Service Unavailable'),
+    { status: 503 }
+  );
+  const harness = installHarness({ remoteError: unavailable });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /HTTP 503: Service Unavailable/);
+    assert.equal(harness.calls.some(call => call === 'event:input'), false);
+    assert.equal(harness.calls.some(call => call === 'view:list'), false);
+  } finally {
+    harness.restore();
+  }
+});
+
+test('fails closed when remote cleanup verification cannot be completed', async () => {
+  const harness = installHarness({
+    remoteError: new Error('draft cleanup verification unavailable')
+  });
+  try {
+    await assert.rejects(
+      () => isolateRoleStateScenario(harness.page, 1_000),
+      /draft cleanup verification unavailable/);
+    assert.equal(harness.calls.some(call => call === 'event:input'), false);
+    assert.equal(harness.calls.some(call => call === 'view:list'), false);
+  } finally {
+    harness.restore();
+  }
 });

--- a/taxonomy-app/src/main/java/com/taxonomy/analysis/session/AnalysisWorkingDraftController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/analysis/session/AnalysisWorkingDraftController.java
@@ -43,7 +43,7 @@ public class AnalysisWorkingDraftController {
         requireMatchingExplicitPin(request, workspaceId);
         return service.read(workspaceResolver.resolveCurrentUsername(), workspaceId)
                 .map(this::versionedResponse)
-                .orElseGet(() -> ResponseEntity.noContent().build());
+                .orElseGet(AnalysisWorkingDraftController::noContentResponse);
     }
 
     @PutMapping("/{workspaceId}")
@@ -67,7 +67,7 @@ public class AnalysisWorkingDraftController {
         requireMatchingExplicitPin(request, workspaceId);
         service.delete(
                 workspaceResolver.resolveCurrentUsername(), workspaceId, expectedVersion);
-        return ResponseEntity.noContent().build();
+        return noContentResponse();
     }
 
     private static void requireMatchingExplicitPin(
@@ -94,5 +94,11 @@ public class AnalysisWorkingDraftController {
                 .cacheControl(CacheControl.noStore())
                 .eTag("\"" + view.version() + "\"")
                 .body(view);
+    }
+
+    private static <T> ResponseEntity<T> noContentResponse() {
+        return ResponseEntity.noContent()
+                .cacheControl(CacheControl.noStore())
+                .build();
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/analysis/session/AnalysisWorkingDraftMvcContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/analysis/session/AnalysisWorkingDraftMvcContractTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +28,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -109,6 +112,30 @@ class AnalysisWorkingDraftMvcContractTest {
                 .isEqualTo(1);
         assertThat(request.getValue().payload().path("scores").path("BP-1000").asInt())
                 .isEqualTo(82);
+    }
+
+    @Test
+    @WithMockUser(username = "analyst", roles = "USER")
+    void absentDraftResponseIsExplicitlyNoStore() throws Exception {
+        when(service.read("analyst", "workspace-a")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/analysis-drafts/{workspaceId}", "workspace-a"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+
+        verify(service).read("analyst", "workspace-a");
+    }
+
+    @Test
+    @WithMockUser(username = "analyst", roles = "USER")
+    void deleteResponseIsExplicitlyNoStoreAndUsesExpectedRevision() throws Exception {
+        mockMvc.perform(delete("/api/analysis-drafts/{workspaceId}", "workspace-a")
+                        .with(csrf())
+                        .param("expectedVersion", "6"))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+
+        verify(service).delete("analyst", "workspace-a", 6L);
     }
 
     @Test


### PR DESCRIPTION
## What it fixes

The role/state browser matrix reuses one application process per role while opening fresh browser contexts. A later context can therefore have no in-memory optimistic revision even though an earlier context stored a server draft. Immediate invalidation then sends `expectedVersion=null` and legitimately receives HTTP 409. That exact failure was recorded by the canonical Maven/UI suite on #885.

This change covers the full authoritative absence contract:

1. wait for the analysis-session API and rendered taxonomy;
2. force-load the server draft and its optimistic revision;
3. reject session or visible conflict evidence and retain the exact workspace ID;
4. immediately before mutation, re-check conflict and workspace inside the same browser task so `invalidate()` cannot erase a newly created conflict or delete a newly selected workspace;
5. invalidate and await the real save/delete path;
6. reject a post-save conflict or workspace switch;
7. perform an explicit uncached GET for the same workspace and accept only HTTP 204;
8. after the awaited GET, re-check conflict and workspace again before normalizing any UI;
9. only then clear visible scenario input and normalize the list view.

The last post-request check closes the remaining race in which another browser task could switch the workspace or establish a conflict while the verification request was in flight.

The server boundary is tightened at the same time: both a missing-draft GET response and a successful DELETE response carry `Cache-Control: no-store`. This prevents a cached HTTP 204 from falsifying later restore or cleanup verification.

## Regression coverage

The executable Node harness covers thirteen cases:

- exact successful order;
- conflict after reload;
- visible conflict evidence;
- missing workspace identity;
- conflict appearing between the initial check and mutation;
- workspace change between the initial check and mutation;
- conflict after deletion;
- workspace change during cleanup;
- surviving HTTP 200 state;
- rejected HTTP 503 verification;
- transport failure;
- conflict appearing while verification is in flight;
- workspace change while verification is in flight.

The focused MVC contract verifies `no-store` on GET 204 and DELETE 204 and proves that DELETE receives the requested optimistic revision.

## Scope and merge authority

The branch changes exactly four files:

- `.github/scripts/ui-role-state-isolation.mjs`;
- `.github/scripts/ui-role-state-isolation.test.mjs`;
- `AnalysisWorkingDraftController.java`;
- `AnalysisWorkingDraftMvcContractTest.java`.

No production optimistic-lock rule is relaxed, no 409 is ignored, no retry is added, and no release request is changed. The branch remains Draft while the fresh exact-head matrix runs. Before merge, the final head must pass CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained Kubernetes; merge history will be squashed into one commit.