### PR TITLE
Superseded: synchronize shared browser draft isolation

### DIFF
--- a/.github/scripts/ui-role-state-isolation.mjs
+++ b/.github/scripts/ui-role-state-isolation.mjs
@@ -20,6 +20,20 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       && state?.restoring === false);
   }, null, { timeout });
 
+  // A new browser context has no in-memory optimistic-lock revision, while the
+  // role-scoped application may still hold a draft written by an earlier profile.
+  // Load that server state first so the subsequent deletion uses its exact version
+  // instead of manufacturing a legitimate HTTP 409 with expectedVersion=null.
+  await page.evaluate(async () => {
+    await window.TaxonomyAnalysisSession.reload();
+  });
+  await page.waitForFunction(() => {
+    const state = window.TaxonomyAnalysisSession?.state?.();
+    return Boolean(state
+      && state.restoring === false
+      && state.conflict === false);
+  }, null, { timeout });
+
   await page.evaluate(async () => {
     const session = window.TaxonomyAnalysisSession;
     session.invalidate({
@@ -49,6 +63,7 @@ export async function isolateRoleStateScenario(page, timeout = DEFAULT_TIMEOUT_M
       && input?.value === ''
       && !input.classList.contains('stale-results')
       && document.querySelector('#taskStageDescribe[data-state="current"]')
-      && state?.restoring === false);
+      && state?.restoring === false
+      && state?.conflict === false);
   }, null, { timeout });
 }

--- a/.github/scripts/ui-role-state-isolation.test.mjs
+++ b/.github/scripts/ui-role-state-isolation.test.mjs
@@ -3,13 +3,15 @@ import assert from 'node:assert/strict';
 
 import { isolateRoleStateScenario } from './ui-role-state-isolation.mjs';
 
-test('clears a restored draft and normalizes the role task to the list view', async () => {
+test('loads the server revision before clearing a restored draft and normalizes the role task', async () => {
   const previousWindow = globalThis.window;
   const previousDocument = globalThis.document;
   const previousEvent = globalThis.Event;
   const calls = [];
   let stale = true;
   let currentStage = 'analyze';
+  let restoring = false;
+  let conflict = false;
 
   const input = {
     value: 'Restored requirement from another browser profile',
@@ -53,7 +55,13 @@ test('clears a restored draft and normalizes the role task to the list view', as
       }
     },
     TaxonomyAnalysisSession: {
-      state: () => ({ restoring: false }),
+      state: () => ({ restoring, conflict }),
+      async reload() {
+        calls.push('reload');
+        restoring = true;
+        conflict = false;
+        restoring = false;
+      },
       invalidate(options) {
         calls.push({ invalidate: options });
         input.value = '';
@@ -96,6 +104,7 @@ test('clears a restored draft and normalizes the role task to the list view', as
   }
 
   assert.deepEqual(calls, [
+    'reload',
     {
       invalidate: {
         keepText: false,

--- a/taxonomy-app/src/test/java/com/taxonomy/UiRoleStateIsolationContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/UiRoleStateIsolationContractTest.java
@@ -1,0 +1,59 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Guards the optimistic-lock ordering of the shared role/state browser fixture. */
+class UiRoleStateIsolationContractTest {
+
+    @Test
+    void loadsTheServerDraftRevisionBeforeDeletingSharedScenarioState()
+            throws IOException {
+        String source = Files.readString(findRepositoryFile(
+                ".github/scripts/ui-role-state-isolation.mjs"));
+
+        int reload = source.indexOf(
+                "await window.TaxonomyAnalysisSession.reload()");
+        int synchronizedRevision = source.indexOf(
+                "state.conflict === false", reload);
+        int invalidate = source.indexOf("session.invalidate({", synchronizedRevision);
+        int persistedDeletion = source.indexOf("await session.saveNow()", invalidate);
+        int finalConflictGuard = source.indexOf(
+                "state?.conflict === false", persistedDeletion);
+
+        assertThat(reload)
+                .as("the fixture must load the exact server-side draft revision")
+                .isGreaterThanOrEqualTo(0);
+        assertThat(synchronizedRevision)
+                .as("the fixture must wait until forced draft restoration is conflict-free")
+                .isGreaterThan(reload);
+        assertThat(invalidate)
+                .as("draft invalidation must happen only after version synchronization")
+                .isGreaterThan(synchronizedRevision);
+        assertThat(persistedDeletion)
+                .as("the isolated empty state must be persisted before the scenario starts")
+                .isGreaterThan(invalidate);
+        assertThat(finalConflictGuard)
+                .as("the fixture must not hand a conflicted session to a browser scenario")
+                .isGreaterThan(persistedDeletion);
+    }
+
+    private static Path findRepositoryFile(String relativePath) {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException(
+                "Repository file not found from the current working directory: "
+                        + relativePath);
+    }
+}


### PR DESCRIPTION
Superseded by the stricter authoritative remote-cleanup contract retained for exact-base reconstruction in #876.

This branch is not merge evidence: it synchronizes the optimistic revision but does not independently prove that the server-side draft is absent after cleanup. The retained slice additionally fails closed on missing workspace identity, conflict state or UI evidence, surviving HTTP 200 state, HTTP 503 verification failure and transport failure.

The final implementation will be rebuilt as exactly one two-file commit on the then-current `main` after #885 is integrated.