### PR TITLE
Use the supported readiness boundary for persistence restart verification

### DIFF
--- a/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/ProductionPersistenceRestartIT.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -107,13 +106,12 @@ class ProductionPersistenceRestartIT {
     }
 
     private GenericContainer<?> persistentAppContainer(String dataVolume) {
+        // Retain ContainerTestUtils' canonical /actuator/health/readiness wait strategy.
+        // Aggregate health may contain optional capabilities and is not the supported
+        // application-availability boundary for container replacement.
         return ContainerTestUtils.appContainer()
                 .withCreateContainerCmdModifier(command -> command.getHostConfig()
                         .withBinds(new Bind(dataVolume, new Volume("/app/data"))))
-                .waitingFor(Wait.forHttp("/actuator/health")
-                        .forStatusCode(200)
-                        .forPort(8080)
-                        .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT))
                 .withStartupTimeout(PRODUCTION_STARTUP_TIMEOUT)
                 .withEnv("SPRING_PROFILES_ACTIVE", "production,hsqldb")
                 .withEnv("TAXONOMY_DATASOURCE_URL",


### PR DESCRIPTION
## What it does

Fixes the second independent failure exposed while validating the Log4j security update.

`ProductionPersistenceRestartIT` starts the same production container twice against one persistent `/app/data` volume. `ContainerTestUtils.appContainer()` already installs the canonical `/actuator/health/readiness` wait strategy used by the Docker image and Helm chart. The persistence test replaced that strategy with aggregate `/actuator/health`.

Aggregate health can include optional or repairable capabilities and is not the supported container-replacement boundary. That replacement made an unrelated component state capable of failing the persistence restart proof before the test could exercise any write or restart.

The test now retains the shared readiness strategy and only extends its startup timeout to three minutes for the production/file-database profile.

## Scope

One integration-test file only. No production endpoint, health component, image, Helm value, persistence setting or timeout policy is changed.

## Verification

The authoritative check is the real two-container `ProductionPersistenceRestartIT` inside the canonical Maven suite, followed by the exact-head CI/CD, database, CodeQL, Security Scan and constrained-Kubernetes matrix.