### PR TITLE
Draft: harden OOXML hyperlink target decoding

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/templates/OoxmlActiveContentValidator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/OoxmlActiveContentValidator.java
@@ -10,8 +10,13 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -35,9 +40,7 @@ public final class OoxmlActiveContentValidator {
             Set.of("https", "mailto");
     private static final Pattern URI_SCHEME = Pattern.compile(
             "^([A-Za-z][A-Za-z0-9+.-]*):");
-    private static final Pattern ENCODED_CONTROL = Pattern.compile(
-            "(?i)%(?:0[0-9a-f]|1[0-9a-f]|7f)");
-    private static final Pattern ENCODED_PERCENT = Pattern.compile("(?i)%25");
+    private static final int MAX_PERCENT_DECODE_ROUNDS = 8;
     private static final Pattern UNSAFE_FIELD = Pattern.compile(
             "(?i)(?<![A-Z0-9_])"
                     + "(DDEAUTO|DDE|INCLUDETEXT|INCLUDEPICTURE|LINK|DATABASE|"
@@ -105,7 +108,7 @@ public final class OoxmlActiveContentValidator {
     private static void validateExternalHyperlink(String path, String target) {
         if (target == null || target.isBlank()
                 || containsControlCharacter(target)
-                || containsEncodedControlCharacter(target)) {
+                || containsUnsafePercentEncoding(target)) {
             throw invalid("external hyperlink target is invalid in " + path);
         }
 
@@ -145,22 +148,73 @@ public final class OoxmlActiveContentValidator {
     }
 
     private static boolean containsControlCharacter(String value) {
-        return value.chars().anyMatch(character ->
-                character < 0x20 || character == 0x7f);
+        return value.codePoints().anyMatch(Character::isISOControl);
     }
 
-    private static boolean containsEncodedControlCharacter(String value) {
+    /**
+     * Decode valid percent-octet runs as strict UTF-8 and inspect every resulting layer.
+     * The bounded loop handles intentionally nested encodings without allowing an
+     * attacker-controlled quadratic decode chain. A ninth layer is rejected fail-closed.
+     */
+    private static boolean containsUnsafePercentEncoding(String value) {
         String normalized = value;
-        while (true) {
-            if (ENCODED_CONTROL.matcher(normalized).find()) {
+        for (int round = 0; round < MAX_PERCENT_DECODE_ROUNDS; round++) {
+            PercentDecodeResult decoded = decodePercentEscapes(normalized);
+            if (!decoded.valid()) {
                 return true;
             }
-            String decodedPercent = ENCODED_PERCENT.matcher(normalized).replaceAll("%");
-            if (decodedPercent.equals(normalized)) {
+            if (!decoded.changed()) {
                 return false;
             }
-            normalized = decodedPercent;
+            normalized = decoded.value();
+            if (containsControlCharacter(normalized)) {
+                return true;
+            }
         }
+        return decodePercentEscapes(normalized).changed();
+    }
+
+    private static PercentDecodeResult decodePercentEscapes(String value) {
+        StringBuilder decoded = new StringBuilder(value.length());
+        boolean changed = false;
+        for (int index = 0; index < value.length();) {
+            if (!isEncodedOctet(value, index)) {
+                decoded.append(value.charAt(index));
+                index++;
+                continue;
+            }
+
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            while (isEncodedOctet(value, index)) {
+                bytes.write((hex(value.charAt(index + 1)) << 4)
+                        | hex(value.charAt(index + 2)));
+                index += 3;
+            }
+            try {
+                decoded.append(StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT)
+                        .decode(ByteBuffer.wrap(bytes.toByteArray())));
+            } catch (CharacterCodingException exception) {
+                return new PercentDecodeResult(value, changed, false);
+            }
+            changed = true;
+        }
+        return new PercentDecodeResult(decoded.toString(), changed, true);
+    }
+
+    private static boolean isEncodedOctet(String value, int index) {
+        return index + 2 < value.length()
+                && value.charAt(index) == '%'
+                && hex(value.charAt(index + 1)) >= 0
+                && hex(value.charAt(index + 2)) >= 0;
+    }
+
+    private static int hex(char value) {
+        return Character.digit(value, 16);
+    }
+
+    private record PercentDecodeResult(String value, boolean changed, boolean valid) {
     }
 
     private static void validateWordFields(String path, byte[] content) {

--- a/taxonomy-app/src/main/java/com/taxonomy/templates/OoxmlActiveContentValidator.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/templates/OoxmlActiveContentValidator.java
@@ -35,6 +35,9 @@ public final class OoxmlActiveContentValidator {
             Set.of("https", "mailto");
     private static final Pattern URI_SCHEME = Pattern.compile(
             "^([A-Za-z][A-Za-z0-9+.-]*):");
+    private static final Pattern ENCODED_CONTROL = Pattern.compile(
+            "(?i)%(?:0[0-9a-f]|1[0-9a-f]|7f)");
+    private static final Pattern ENCODED_PERCENT = Pattern.compile("(?i)%25");
     private static final Pattern UNSAFE_FIELD = Pattern.compile(
             "(?i)(?<![A-Z0-9_])"
                     + "(DDEAUTO|DDE|INCLUDETEXT|INCLUDEPICTURE|LINK|DATABASE|"
@@ -101,8 +104,8 @@ public final class OoxmlActiveContentValidator {
 
     private static void validateExternalHyperlink(String path, String target) {
         if (target == null || target.isBlank()
-                || target.indexOf('\r') >= 0 || target.indexOf('\n') >= 0
-                || target.indexOf('\0') >= 0) {
+                || containsControlCharacter(target)
+                || containsEncodedControlCharacter(target)) {
             throw invalid("external hyperlink target is invalid in " + path);
         }
 
@@ -138,6 +141,25 @@ public final class OoxmlActiveContentValidator {
                 throw exception;
             }
             throw invalid("external hyperlink target is invalid in " + path, exception);
+        }
+    }
+
+    private static boolean containsControlCharacter(String value) {
+        return value.chars().anyMatch(character ->
+                character < 0x20 || character == 0x7f);
+    }
+
+    private static boolean containsEncodedControlCharacter(String value) {
+        String normalized = value;
+        while (true) {
+            if (ENCODED_CONTROL.matcher(normalized).find()) {
+                return true;
+            }
+            String decodedPercent = ENCODED_PERCENT.matcher(normalized).replaceAll("%");
+            if (decodedPercent.equals(normalized)) {
+                return false;
+            }
+            normalized = decodedPercent;
         }
     }
 

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/OoxmlActiveContentValidatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/OoxmlActiveContentValidatorTest.java
@@ -75,6 +75,27 @@ class OoxmlActiveContentValidatorTest {
     }
 
     @Test
+    void rejectsLiteralAndEncodedControlCharactersInAllowedHyperlinkSchemes() {
+        for (String target : new String[]{
+                "mailto:office@example.org?subject=ok%0d%0abcc:attacker@example.org",
+                "https://example.org/help%09hidden",
+                "mailto:office@example.org?subject=ok%250d%250abcc:attacker@example.org",
+                "https://example.org/help\u007fhidden"}) {
+            loadFreshParts();
+            String rels = text("word/_rels/document.xml.rels");
+            String relation = "<Relationship Id=\"unsafe\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\""
+                    + target + "\" TargetMode=\"External\"/>";
+            parts.put("word/_rels/document.xml.rels",
+                    insertBefore(rels, "</Relationships>", relation));
+
+            assertThatThrownBy(() -> validator.validate(parts))
+                    .as(target)
+                    .hasMessageContaining("hyperlink target is invalid")
+                    .hasMessageNotContaining("attacker@example.org");
+        }
+    }
+
+    @Test
     void acceptsOrdinaryFieldsAndHttpsOrMailtoHyperlinks() {
         String xml = text("word/document.xml");
         parts.put("word/document.xml", insertBefore(xml, "</w:body>",

--- a/taxonomy-app/src/test/java/com/taxonomy/templates/OoxmlActiveContentValidatorTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/templates/OoxmlActiveContentValidatorTest.java
@@ -75,12 +75,14 @@ class OoxmlActiveContentValidatorTest {
     }
 
     @Test
-    void rejectsLiteralAndEncodedControlCharactersInAllowedHyperlinkSchemes() {
+    void rejectsLiteralEncodedAndDeeplyNestedControlsInAllowedSchemes() {
         for (String target : new String[]{
                 "mailto:office@example.org?subject=ok%0d%0abcc:attacker@example.org",
                 "https://example.org/help%09hidden",
                 "mailto:office@example.org?subject=ok%250d%250abcc:attacker@example.org",
-                "https://example.org/help\u007fhidden"}) {
+                "https://example.org/help%C2%85hidden",
+                "https://example.org/help\u007fhidden",
+                deeplyNestedControlTarget()}) {
             loadFreshParts();
             String rels = text("word/_rels/document.xml.rels");
             String relation = "<Relationship Id=\"unsafe\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\""
@@ -96,7 +98,7 @@ class OoxmlActiveContentValidatorTest {
     }
 
     @Test
-    void acceptsOrdinaryFieldsAndHttpsOrMailtoHyperlinks() {
+    void acceptsOrdinaryFieldsAndHttpsMailtoOrEncodedUnicodeHyperlinks() {
         String xml = text("word/document.xml");
         parts.put("word/document.xml", insertBefore(xml, "</w:body>",
                 "<w:p><w:fldSimple w:instr=\" PAGE \"/><w:fldSimple w:instr=\" NUMPAGES \"/>"
@@ -104,11 +106,20 @@ class OoxmlActiveContentValidatorTest {
                         + "<w:fldSimple w:instr=\" REF internalBookmark \"/></w:p>"));
         String rels = text("word/_rels/document.xml.rels");
         String links = "<Relationship Id=\"https\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"https://example.org/help\" TargetMode=\"External\"/>"
+                + "<Relationship Id=\"unicode\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"https://example.org/%C3%A4\" TargetMode=\"External\"/>"
                 + "<Relationship Id=\"mail\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"mailto:office@example.org\" TargetMode=\"External\"/>";
         parts.put("word/_rels/document.xml.rels",
                 insertBefore(rels, "</Relationships>", links));
 
         validator.validate(parts);
+    }
+
+    private static String deeplyNestedControlTarget() {
+        String encoded = "%0d";
+        for (int level = 0; level < 16; level++) {
+            encoded = encoded.replace("%", "%25");
+        }
+        return "https://example.org/help" + encoded;
     }
 
     private void loadFreshParts() {


### PR DESCRIPTION
## Retained fix

External OOXML hyperlinks remain limited to `https:` and `mailto:`. The retained implementation decodes percent-octet runs as strict UTF-8, checks each decoded layer, caps decoding at eight rounds and rejects deeper chains. The former unbounded replacement loop has been removed, and its review thread is resolved.

## Remaining QA before reconstruction

The final exact-base slice will also reject Unicode formatting and separator characters after every decode layer, reduce avoidable allocation on very large relationship parts, preserve ordinary HTTPS, mailto and valid encoded Unicode paths, and keep validation messages free of the hyperlink target.

## Current status

This branch is stale and is not merge evidence. The final validator and focused test will be rebuilt as one two-file commit on the then-current `main` after the preceding QA slices, followed by the complete exact-head matrix. No document contents are rewritten and no release request is included.