### PR TITLE
Preserve a sanitized 503 for unavailable decision-report templates

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.taxonomy.architecture.decision;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Stable REST contract for a missing or invalid mandatory decision-report template. */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public final class DecisionReportTemplateExceptionHandler {
+
+    public static final String PROBLEM_CODE =
+            "DECISION_REPORT_TEMPLATE_UNAVAILABLE";
+    public static final String CLIENT_MESSAGE =
+            "Decision report generation is temporarily unavailable because the "
+                    + "required template is missing or invalid. An administrator must "
+                    + "restore a valid decision-report template.";
+
+    private static final Logger log = LoggerFactory.getLogger(
+            DecisionReportTemplateExceptionHandler.class);
+
+    @ExceptionHandler(DecisionReportTemplateUnavailableException.class)
+    public ResponseEntity<Map<String, Object>> handleUnavailableTemplate(
+            DecisionReportTemplateUnavailableException exception,
+            HttpServletRequest request) {
+        log.warn("Decision report template unavailable on {}",
+                request.getRequestURI(), exception);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", HttpStatus.SERVICE_UNAVAILABLE.value());
+        body.put("error", HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase());
+        body.put("code", PROBLEM_CODE);
+        body.put("message", CLIENT_MESSAGE);
+        body.put("path", request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandlerTest.java
@@ -1,0 +1,57 @@
+package com.taxonomy.architecture.decision;
+
+import com.taxonomy.shared.config.GlobalExceptionHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DecisionReportTemplateExceptionHandlerTest {
+
+    @Test
+    void specificHandlerKeepsTemplateFailureAt503AheadOfGenericCatchAll()
+            throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new FailingReportController())
+                .setControllerAdvice(
+                        new GlobalExceptionHandler(new StaticMessageSource()),
+                        new DecisionReportTemplateExceptionHandler())
+                .build();
+
+        String body = mockMvc.perform(get("/api/decision-report/fixture")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(jsonPath("$.status").value(503))
+                .andExpect(jsonPath("$.code").value(
+                        DecisionReportTemplateExceptionHandler.PROBLEM_CODE))
+                .andExpect(jsonPath("$.path").value(
+                        "/api/decision-report/fixture"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(body)
+                .contains(DecisionReportTemplateExceptionHandler.CLIENT_MESSAGE)
+                .doesNotContain("jdbc:postgresql://database.internal")
+                .doesNotContain("private-template-path");
+    }
+
+    @RestController
+    private static final class FailingReportController {
+
+        @GetMapping("/api/decision-report/fixture")
+        void render() {
+            throw new DecisionReportTemplateUnavailableException(
+                    "private-template-path contained jdbc:postgresql://database.internal",
+                    new IllegalStateException("private validation detail"));
+        }
+    }
+}


### PR DESCRIPTION
## What it does

Closes a runtime error-mapping gap found while validating the repair-safe template health change.

`DecisionReportTemplateUnavailableException` carries `@ResponseStatus(503)`, but Taxonomy also has a global `@ExceptionHandler(Exception.class)`. Spring resolves controller-advice handlers before the fallback response-status resolver, so the generic catch-all could turn this expected capability outage into HTTP 500.

This PR adds a dedicated highest-precedence handler that returns:

- HTTP 503;
- stable code `DECISION_REPORT_TEMPLATE_UNAVAILABLE`;
- a bounded remediation message;
- the request path;
- no template path, database URL, validation payload or exception text.

The original exception annotation remains as a fallback outside MVC advice resolution.

## Regression coverage

A standalone MockMvc test installs both the existing generic global handler and the new specific handler. It proves that the specific contract wins, remains 503, and does not expose deliberately injected internal details.

## Scope

Two new files only. Report calculations, template validation, health status and successful DOCX responses are unchanged.