### PR TITLE
Preserve workspace routing below a servlet context path

### DIFF
--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
@@ -1,0 +1,99 @@
+/* Context-path adapter for the analysis-session workspace transport. */
+(function () {
+    'use strict';
+    var C = window.__TaxonomyAnalysisSessionContext;
+    if (!C) throw new Error('Analysis session core must load before context-path routing');
+
+    var runtime = C.runtime;
+    var WORKSPACE_HEADER = 'X-Taxonomy-Workspace-Id';
+    var installRootFetchRouting = C.installWorkspaceFetchRouting;
+    var installRootEventSourceRouting = C.installWorkspaceEventSourceRouting;
+
+    function requestUrl(input) {
+        try {
+            if (typeof input === 'string') return new URL(input, window.location.href);
+            if (input && typeof input.url === 'string') {
+                return new URL(input.url, window.location.href);
+            }
+        } catch (error) {
+            return null;
+        }
+        return null;
+    }
+
+    function applicationApiPrefix() {
+        var resolved = requestUrl(window.TaxonomyI18n
+                && typeof window.TaxonomyI18n.resolveUrl === 'function'
+            ? window.TaxonomyI18n.resolveUrl('/api/')
+            : '/api/');
+        var prefix = resolved ? resolved.pathname : '/api/';
+        return prefix.endsWith('/') ? prefix : prefix + '/';
+    }
+
+    function isPrefixedApplicationApiUrl(url) {
+        if (!url || url.origin !== window.location.origin) return false;
+        var prefix = applicationApiPrefix();
+        if (prefix === '/api/') return false;
+        var root = prefix.substring(0, prefix.length - 1);
+        return url.pathname === root || url.pathname.indexOf(prefix) === 0;
+    }
+
+    C.installWorkspaceFetchRouting = function installWorkspaceFetchRouting() {
+        installRootFetchRouting();
+        if (window.fetch.__taxonomyContextPathWorkspaceRouting === true) return;
+        var previousFetch = window.fetch.bind(window);
+
+        function routedFetch(input, init) {
+            var url = requestUrl(input);
+            var request = Object.assign({}, init || {});
+            if (runtime.workspaceId && isPrefixedApplicationApiUrl(url)) {
+                var headers = new Headers(input instanceof Request ? input.headers : undefined);
+                new Headers(request.headers || {}).forEach(function (value, name) {
+                    headers.set(name, value);
+                });
+                headers.set(WORKSPACE_HEADER, runtime.workspaceId);
+                request.headers = headers;
+            }
+            return previousFetch(input, request);
+        }
+
+        Object.defineProperty(routedFetch, '__taxonomyContextPathWorkspaceRouting', {
+            configurable: false,
+            enumerable: false,
+            value: true,
+            writable: false
+        });
+        window.fetch = routedFetch;
+    };
+
+    C.installWorkspaceEventSourceRouting = function installWorkspaceEventSourceRouting() {
+        installRootEventSourceRouting();
+        var PreviousEventSource = window.EventSource;
+        if (typeof PreviousEventSource !== 'function'
+                || PreviousEventSource.__taxonomyContextPathWorkspaceRouting === true) return;
+
+        function RoutedEventSource(url, configuration) {
+            var resolved = requestUrl(url);
+            var target = url;
+            if (runtime.workspaceId && isPrefixedApplicationApiUrl(resolved)) {
+                resolved.searchParams.set('workspaceId', runtime.workspaceId);
+                target = resolved.href;
+            }
+            return new PreviousEventSource(target, configuration);
+        }
+
+        RoutedEventSource.prototype = PreviousEventSource.prototype;
+        ['CONNECTING', 'OPEN', 'CLOSED'].forEach(function (constant) {
+            if (constant in PreviousEventSource) {
+                RoutedEventSource[constant] = PreviousEventSource[constant];
+            }
+        });
+        Object.defineProperty(RoutedEventSource, '__taxonomyContextPathWorkspaceRouting', {
+            configurable: false,
+            enumerable: false,
+            value: true,
+            writable: false
+        });
+        window.EventSource = RoutedEventSource;
+    };
+}());

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session.js
@@ -7,6 +7,7 @@
     var sources = [
         '/js/api/analysis-session-api.js',
         '/js/core/taxonomy-analysis-session-core.js',
+        '/js/core/taxonomy-analysis-session-context-path-routing.js',
         '/js/core/taxonomy-analysis-session-api-routing.js',
         '/js/core/taxonomy-analysis-session-transport.js',
         '/js/core/taxonomy-analysis-session-ui.js',

--- a/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
@@ -1,0 +1,65 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Guards the workspace transport contract for reverse-proxy servlet prefixes. */
+class AnalysisSessionContextPathRoutingContractTest {
+
+    @Test
+    void loadsTheContextPathAdapterBeforeWorkspaceSessionStartup()
+            throws IOException {
+        String loader = Files.readString(findRepositoryFile(
+                "taxonomy-app/src/main/resources/static/js/core/"
+                        + "taxonomy-analysis-session.js"));
+
+        int core = loader.indexOf("taxonomy-analysis-session-core.js");
+        int adapter = loader.indexOf(
+                "taxonomy-analysis-session-context-path-routing.js");
+        int projects = loader.indexOf("taxonomy-analysis-session-projects.js");
+
+        assertThat(core).isGreaterThanOrEqualTo(0);
+        assertThat(adapter)
+                .as("the adapter requires the shared runtime exported by the core")
+                .isGreaterThan(core);
+        assertThat(projects)
+                .as("workspace startup must capture the decorated transport installers")
+                .isGreaterThan(adapter);
+    }
+
+    @Test
+    void routesBothFetchAndEventSourceThroughTheResolvedApplicationPrefix()
+            throws IOException {
+        String adapter = Files.readString(findRepositoryFile(
+                "taxonomy-app/src/main/resources/static/js/core/"
+                        + "taxonomy-analysis-session-context-path-routing.js"));
+
+        assertThat(adapter)
+                .contains("window.TaxonomyI18n.resolveUrl('/api/')")
+                .contains("url.origin !== window.location.origin")
+                .contains("headers.set(WORKSPACE_HEADER, runtime.workspaceId)")
+                .contains("resolved.searchParams.set('workspaceId', runtime.workspaceId)")
+                .contains("installRootFetchRouting()")
+                .contains("installRootEventSourceRouting()")
+                .contains("if (prefix === '/api/') return false");
+    }
+
+    private static Path findRepositoryFile(String relativePath) {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException(
+                "Repository file not found from the current working directory: "
+                        + relativePath);
+    }
+}


### PR DESCRIPTION
## What it does

Fixes a reverse-proxy/context-path defect in the analysis-session workspace transport.

The shared fetch and EventSource wrappers previously recognized only paths beginning exactly with `/api/`. In the supported Rancher-style deployment below `/taxonomy`, browser requests use `/taxonomy/api/...`; those requests could therefore lose the `X-Taxonomy-Workspace-Id` header or SSE `workspaceId` parameter and fall back to the wrong workspace authority.

This PR adds a narrow context-path adapter at the existing transport-installer boundary:

- the existing root-path routing is installed unchanged;
- the application API prefix is resolved through `TaxonomyI18n.resolveUrl('/api/')`;
- same-origin prefixed API requests receive the exact workspace header;
- prefixed EventSource URLs receive the exact workspace query parameter;
- `/api/` is explicitly excluded from the adapter so the existing root logic remains the sole owner there.

The adapter is loaded after the analysis-session core exports its runtime and before the projects/startup module captures the transport installers.

## Regression protection

A Maven/JUnit contract verifies loader ordering and both fetch/SSE prefix bindings. Existing base-path and browser suites continue to exercise the complete application URL resolver.

## Scope

One new focused adapter, one loader entry and one contract test. No API URL, workspace identity, server resolver or root deployment behavior changes.