### PR TITLE
Draft: preserve workspace fetch routing below a servlet context path

### DIFF
--- a/.github/scripts/test-taxonomy-base-path.mjs
+++ b/.github/scripts/test-taxonomy-base-path.mjs
@@ -160,31 +160,14 @@ function loadOrderedSessionParts() {
   return appendedScripts;
 }
 
-function contextPathRoutingRuntime() {
+function contextPathFetchRuntime() {
   const fetchCalls = [];
-  const eventSourceCalls = [];
   const nativeFetch = async (input, init) => {
     fetchCalls.push({ input, init });
     return { ok: true };
   };
-
-  class NativeEventSource {
-    static CONNECTING = 0;
-    static OPEN = 1;
-    static CLOSED = 2;
-
-    constructor(url, configuration) {
-      this.url = url;
-      this.configuration = configuration;
-      eventSourceCalls.push({ url, configuration });
-    }
-  }
-
-  const analysisContext = {
-    runtime: { workspaceId: 'workspace-42' },
-    installWorkspaceFetchRouting: () => undefined,
-    installWorkspaceEventSourceRouting: () => undefined
-  };
+  const runtime = { workspaceId: 'workspace-42' };
+  const analysisContext = { runtime };
   const window = {
     __TaxonomyAnalysisSessionContext: analysisContext,
     TaxonomyI18n: { resolveUrl: resolvePrefixed },
@@ -193,9 +176,35 @@ function contextPathRoutingRuntime() {
       origin: 'https://taxonomy.example.test'
     },
     fetch: nativeFetch,
-    EventSource: NativeEventSource,
     console
   };
+
+  analysisContext.installWorkspaceFetchRouting = function installRootFetchRouting() {
+    if (window.fetch.__taxonomyWorkspaceRouting === true) return;
+    const previousFetch = window.fetch.bind(window);
+    function routedFetch(input, init) {
+      let url = null;
+      try {
+        url = new URL(typeof input === 'string' ? input : input.url, window.location.href);
+      } catch {
+        // Preserve the native fetch failure for malformed inputs.
+      }
+      const request = { ...(init || {}) };
+      if (runtime.workspaceId && url && url.origin === window.location.origin
+          && (url.pathname === '/api' || url.pathname.startsWith('/api/'))) {
+        const headers = new Headers(input instanceof Request ? input.headers : undefined);
+        new Headers(request.headers || {}).forEach((value, name) => headers.set(name, value));
+        headers.set('X-Taxonomy-Workspace-Id', runtime.workspaceId);
+        request.headers = headers;
+      }
+      return previousFetch(input, request);
+    }
+    Object.defineProperty(routedFetch, '__taxonomyWorkspaceRouting', {
+      value: true
+    });
+    window.fetch = routedFetch;
+  };
+
   vm.runInNewContext(sessionContextPathRoutingSource, {
     window,
     console,
@@ -205,7 +214,7 @@ function contextPathRoutingRuntime() {
     Object,
     String
   }, { filename: 'taxonomy-analysis-session-context-path-routing.js' });
-  return { window, analysisContext, fetchCalls, eventSourceCalls };
+  return { window, analysisContext, fetchCalls };
 }
 
 async function promotedNavigationTarget() {
@@ -317,7 +326,7 @@ async function promotedNavigationTarget() {
 }
 
 {
-  const runtime = contextPathRoutingRuntime();
+  const runtime = contextPathFetchRuntime();
   runtime.analysisContext.installWorkspaceFetchRouting();
   const installedFetch = runtime.window.fetch;
   runtime.analysisContext.installWorkspaceFetchRouting();
@@ -348,28 +357,10 @@ async function promotedNavigationTarget() {
   assert.equal(requestHeaders.get('X-Taxonomy-Workspace-Id'), 'workspace-42');
   assert.equal(requestHeaders.get('X-Request'), 'request-header');
   assert.equal(requestHeaders.get('X-Init'), 'init-header');
-  assert.equal(
-    new Headers(runtime.fetchCalls[2].init.headers).get('X-Taxonomy-Workspace-Id'),
-    null
-  );
+  const rootHeaders = new Headers(runtime.fetchCalls[2].init.headers);
+  assert.equal(rootHeaders.get('X-Taxonomy-Workspace-Id'), 'workspace-42');
+  assert.equal(rootHeaders.get('X-Root'), 'root-header');
   assert.equal(runtime.fetchCalls[3].init.headers, undefined);
-
-  runtime.analysisContext.installWorkspaceEventSourceRouting();
-  const InstalledEventSource = runtime.window.EventSource;
-  runtime.analysisContext.installWorkspaceEventSourceRouting();
-  assert.equal(runtime.window.EventSource, InstalledEventSource);
-  assert.equal(InstalledEventSource.__taxonomyWorkspaceRouting, true);
-  assert.equal(InstalledEventSource.__taxonomyContextPathWorkspaceRouting, true);
-
-  new runtime.window.EventSource('/taxonomy/api/analyze-stream?existing=1');
-  new runtime.window.EventSource('/api/analyze-stream');
-  new runtime.window.EventSource('https://provider.example.test/events');
-  const prefixedEventUrl = new URL(runtime.eventSourceCalls[0].url);
-  assert.equal(prefixedEventUrl.pathname, '/taxonomy/api/analyze-stream');
-  assert.equal(prefixedEventUrl.searchParams.get('existing'), '1');
-  assert.equal(prefixedEventUrl.searchParams.get('workspaceId'), 'workspace-42');
-  assert.equal(runtime.eventSourceCalls[1].url, '/api/analyze-stream');
-  assert.equal(runtime.eventSourceCalls[2].url, 'https://provider.example.test/events');
 }
 
 {

--- a/.github/scripts/test-taxonomy-base-path.mjs
+++ b/.github/scripts/test-taxonomy-base-path.mjs
@@ -20,6 +20,14 @@ const sessionLoaderSource = await readFile(
   ),
   'utf8'
 );
+const sessionContextPathRoutingSource = await readFile(
+  new URL(
+    '../../taxonomy-app/src/main/resources/static/js/core/' +
+      'taxonomy-analysis-session-context-path-routing.js',
+    import.meta.url
+  ),
+  'utf8'
+);
 const sessionProjectsSource = await readFile(
   new URL(
     '../../taxonomy-app/src/main/resources/static/js/core/' +
@@ -152,6 +160,54 @@ function loadOrderedSessionParts() {
   return appendedScripts;
 }
 
+function contextPathRoutingRuntime() {
+  const fetchCalls = [];
+  const eventSourceCalls = [];
+  const nativeFetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return { ok: true };
+  };
+
+  class NativeEventSource {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSED = 2;
+
+    constructor(url, configuration) {
+      this.url = url;
+      this.configuration = configuration;
+      eventSourceCalls.push({ url, configuration });
+    }
+  }
+
+  const analysisContext = {
+    runtime: { workspaceId: 'workspace-42' },
+    installWorkspaceFetchRouting: () => undefined,
+    installWorkspaceEventSourceRouting: () => undefined
+  };
+  const window = {
+    __TaxonomyAnalysisSessionContext: analysisContext,
+    TaxonomyI18n: { resolveUrl: resolvePrefixed },
+    location: {
+      href: 'https://taxonomy.example.test/taxonomy/',
+      origin: 'https://taxonomy.example.test'
+    },
+    fetch: nativeFetch,
+    EventSource: NativeEventSource,
+    console
+  };
+  vm.runInNewContext(sessionContextPathRoutingSource, {
+    window,
+    console,
+    URL,
+    Headers,
+    Request,
+    Object,
+    String
+  }, { filename: 'taxonomy-analysis-session-context-path-routing.js' });
+  return { window, analysisContext, fetchCalls, eventSourceCalls };
+}
+
 async function promotedNavigationTarget() {
   const assigned = [];
   const invalidations = [];
@@ -258,6 +314,62 @@ async function promotedNavigationTarget() {
     '/taxonomy/js/core/taxonomy-analysis-session-draft.js',
     '/taxonomy/js/core/taxonomy-analysis-session-projects.js'
   ]);
+}
+
+{
+  const runtime = contextPathRoutingRuntime();
+  runtime.analysisContext.installWorkspaceFetchRouting();
+  const installedFetch = runtime.window.fetch;
+  runtime.analysisContext.installWorkspaceFetchRouting();
+  assert.equal(runtime.window.fetch, installedFetch);
+  assert.equal(installedFetch.__taxonomyWorkspaceRouting, true);
+  assert.equal(installedFetch.__taxonomyContextPathWorkspaceRouting, true);
+
+  await runtime.window.fetch('/taxonomy/api/status', {
+    headers: { 'X-Caller': 'preserved' }
+  });
+  const request = new Request(
+    'https://taxonomy.example.test/taxonomy/api/request', {
+      headers: { 'X-Request': 'request-header' }
+    }
+  );
+  await runtime.window.fetch(request, {
+    headers: { 'X-Init': 'init-header' }
+  });
+  await runtime.window.fetch('/api/status', {
+    headers: { 'X-Root': 'root-header' }
+  });
+  await runtime.window.fetch('https://provider.example.test/v1/status');
+
+  const prefixedHeaders = new Headers(runtime.fetchCalls[0].init.headers);
+  assert.equal(prefixedHeaders.get('X-Taxonomy-Workspace-Id'), 'workspace-42');
+  assert.equal(prefixedHeaders.get('X-Caller'), 'preserved');
+  const requestHeaders = new Headers(runtime.fetchCalls[1].init.headers);
+  assert.equal(requestHeaders.get('X-Taxonomy-Workspace-Id'), 'workspace-42');
+  assert.equal(requestHeaders.get('X-Request'), 'request-header');
+  assert.equal(requestHeaders.get('X-Init'), 'init-header');
+  assert.equal(
+    new Headers(runtime.fetchCalls[2].init.headers).get('X-Taxonomy-Workspace-Id'),
+    null
+  );
+  assert.equal(runtime.fetchCalls[3].init.headers, undefined);
+
+  runtime.analysisContext.installWorkspaceEventSourceRouting();
+  const InstalledEventSource = runtime.window.EventSource;
+  runtime.analysisContext.installWorkspaceEventSourceRouting();
+  assert.equal(runtime.window.EventSource, InstalledEventSource);
+  assert.equal(InstalledEventSource.__taxonomyWorkspaceRouting, true);
+  assert.equal(InstalledEventSource.__taxonomyContextPathWorkspaceRouting, true);
+
+  new runtime.window.EventSource('/taxonomy/api/analyze-stream?existing=1');
+  new runtime.window.EventSource('/api/analyze-stream');
+  new runtime.window.EventSource('https://provider.example.test/events');
+  const prefixedEventUrl = new URL(runtime.eventSourceCalls[0].url);
+  assert.equal(prefixedEventUrl.pathname, '/taxonomy/api/analyze-stream');
+  assert.equal(prefixedEventUrl.searchParams.get('existing'), '1');
+  assert.equal(prefixedEventUrl.searchParams.get('workspaceId'), 'workspace-42');
+  assert.equal(runtime.eventSourceCalls[1].url, '/api/analyze-stream');
+  assert.equal(runtime.eventSourceCalls[2].url, 'https://provider.example.test/events');
 }
 
 {

--- a/.github/scripts/test-taxonomy-base-path.mjs
+++ b/.github/scripts/test-taxonomy-base-path.mjs
@@ -251,6 +251,7 @@ async function promotedNavigationTarget() {
   assert.deepEqual(parts.map(script => script.src), [
     '/taxonomy/js/api/analysis-session-api.js',
     '/taxonomy/js/core/taxonomy-analysis-session-core.js',
+    '/taxonomy/js/core/taxonomy-analysis-session-context-path-routing.js',
     '/taxonomy/js/core/taxonomy-analysis-session-api-routing.js',
     '/taxonomy/js/core/taxonomy-analysis-session-transport.js',
     '/taxonomy/js/core/taxonomy-analysis-session-ui.js',

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
@@ -1,4 +1,4 @@
-/* Context-path adapter for the analysis-session workspace transport. */
+/* Context-path adapter for analysis-session workspace fetch transport. */
 (function () {
     'use strict';
     var C = window.__TaxonomyAnalysisSessionContext;
@@ -9,7 +9,6 @@
     var ROOT_MARKER = '__taxonomyWorkspaceRouting';
     var CONTEXT_PATH_MARKER = '__taxonomyContextPathWorkspaceRouting';
     var installRootFetchRouting = C.installWorkspaceFetchRouting;
-    var installRootEventSourceRouting = C.installWorkspaceEventSourceRouting;
 
     function requestUrl(input) {
         try {
@@ -52,6 +51,9 @@
     }
 
     C.installWorkspaceFetchRouting = function installWorkspaceFetchRouting() {
+        // Preserve the core route for ordinary /api/** callers. This additional
+        // wrapper covers callers that already resolved the servlet prefix before
+        // invoking fetch, for example Request objects created with /taxonomy/api/**.
         installRootFetchRouting();
         if (window.fetch[CONTEXT_PATH_MARKER] === true) return;
         var previousFetch = window.fetch.bind(window);
@@ -74,29 +76,6 @@
         window.fetch = routedFetch;
     };
 
-    C.installWorkspaceEventSourceRouting = function installWorkspaceEventSourceRouting() {
-        installRootEventSourceRouting();
-        var PreviousEventSource = window.EventSource;
-        if (typeof PreviousEventSource !== 'function'
-                || PreviousEventSource[CONTEXT_PATH_MARKER] === true) return;
-
-        function RoutedEventSource(url, configuration) {
-            var resolved = requestUrl(url);
-            var target = url;
-            if (runtime.workspaceId && isPrefixedApplicationApiUrl(resolved)) {
-                resolved.searchParams.set('workspaceId', runtime.workspaceId);
-                target = resolved.href;
-            }
-            return new PreviousEventSource(target, configuration);
-        }
-
-        RoutedEventSource.prototype = PreviousEventSource.prototype;
-        ['CONNECTING', 'OPEN', 'CLOSED'].forEach(function (constant) {
-            if (constant in PreviousEventSource) {
-                RoutedEventSource[constant] = PreviousEventSource[constant];
-            }
-        });
-        markRoutingInstalled(RoutedEventSource);
-        window.EventSource = RoutedEventSource;
-    };
+    // SSE remains owned by taxonomy-analysis-session-api-routing.js, which loads
+    // next and already resolves the base path plus the workspace query parameter.
 }());

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session-context-path-routing.js
@@ -1,0 +1,102 @@
+/* Context-path adapter for the analysis-session workspace transport. */
+(function () {
+    'use strict';
+    var C = window.__TaxonomyAnalysisSessionContext;
+    if (!C) throw new Error('Analysis session core must load before context-path routing');
+
+    var runtime = C.runtime;
+    var WORKSPACE_HEADER = 'X-Taxonomy-Workspace-Id';
+    var ROOT_MARKER = '__taxonomyWorkspaceRouting';
+    var CONTEXT_PATH_MARKER = '__taxonomyContextPathWorkspaceRouting';
+    var installRootFetchRouting = C.installWorkspaceFetchRouting;
+    var installRootEventSourceRouting = C.installWorkspaceEventSourceRouting;
+
+    function requestUrl(input) {
+        try {
+            if (typeof input === 'string') return new URL(input, window.location.href);
+            if (input && typeof input.url === 'string') {
+                return new URL(input.url, window.location.href);
+            }
+        } catch (error) {
+            return null;
+        }
+        return null;
+    }
+
+    function applicationApiPrefix() {
+        var resolved = requestUrl(window.TaxonomyI18n
+                && typeof window.TaxonomyI18n.resolveUrl === 'function'
+            ? window.TaxonomyI18n.resolveUrl('/api/')
+            : '/api/');
+        var prefix = resolved ? resolved.pathname : '/api/';
+        return prefix.endsWith('/') ? prefix : prefix + '/';
+    }
+
+    function isPrefixedApplicationApiUrl(url) {
+        if (!url || url.origin !== window.location.origin) return false;
+        var prefix = applicationApiPrefix();
+        if (prefix === '/api/') return false;
+        var root = prefix.substring(0, prefix.length - 1);
+        return url.pathname === root || url.pathname.indexOf(prefix) === 0;
+    }
+
+    function markRoutingInstalled(target) {
+        [ROOT_MARKER, CONTEXT_PATH_MARKER].forEach(function (marker) {
+            Object.defineProperty(target, marker, {
+                configurable: false,
+                enumerable: false,
+                value: true,
+                writable: false
+            });
+        });
+    }
+
+    C.installWorkspaceFetchRouting = function installWorkspaceFetchRouting() {
+        installRootFetchRouting();
+        if (window.fetch[CONTEXT_PATH_MARKER] === true) return;
+        var previousFetch = window.fetch.bind(window);
+
+        function routedFetch(input, init) {
+            var url = requestUrl(input);
+            var request = Object.assign({}, init || {});
+            if (runtime.workspaceId && isPrefixedApplicationApiUrl(url)) {
+                var headers = new Headers(input instanceof Request ? input.headers : undefined);
+                new Headers(request.headers || {}).forEach(function (value, name) {
+                    headers.set(name, value);
+                });
+                headers.set(WORKSPACE_HEADER, runtime.workspaceId);
+                request.headers = headers;
+            }
+            return previousFetch(input, request);
+        }
+
+        markRoutingInstalled(routedFetch);
+        window.fetch = routedFetch;
+    };
+
+    C.installWorkspaceEventSourceRouting = function installWorkspaceEventSourceRouting() {
+        installRootEventSourceRouting();
+        var PreviousEventSource = window.EventSource;
+        if (typeof PreviousEventSource !== 'function'
+                || PreviousEventSource[CONTEXT_PATH_MARKER] === true) return;
+
+        function RoutedEventSource(url, configuration) {
+            var resolved = requestUrl(url);
+            var target = url;
+            if (runtime.workspaceId && isPrefixedApplicationApiUrl(resolved)) {
+                resolved.searchParams.set('workspaceId', runtime.workspaceId);
+                target = resolved.href;
+            }
+            return new PreviousEventSource(target, configuration);
+        }
+
+        RoutedEventSource.prototype = PreviousEventSource.prototype;
+        ['CONNECTING', 'OPEN', 'CLOSED'].forEach(function (constant) {
+            if (constant in PreviousEventSource) {
+                RoutedEventSource[constant] = PreviousEventSource[constant];
+            }
+        });
+        markRoutingInstalled(RoutedEventSource);
+        window.EventSource = RoutedEventSource;
+    };
+}());

--- a/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session.js
+++ b/taxonomy-app/src/main/resources/static/js/core/taxonomy-analysis-session.js
@@ -7,6 +7,7 @@
     var sources = [
         '/js/api/analysis-session-api.js',
         '/js/core/taxonomy-analysis-session-core.js',
+        '/js/core/taxonomy-analysis-session-context-path-routing.js',
         '/js/core/taxonomy-analysis-session-api-routing.js',
         '/js/core/taxonomy-analysis-session-transport.js',
         '/js/core/taxonomy-analysis-session-ui.js',

--- a/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AnalysisSessionContextPathRoutingContractTest {
 
     @Test
-    void loadsTheContextPathAdapterBeforeWorkspaceSessionStartup()
+    void loadsTheFetchAdapterBetweenCoreAndCanonicalApiRouting()
             throws IOException {
         String loader = Files.readString(findRepositoryFile(
                 "taxonomy-app/src/main/resources/static/js/core/"
@@ -21,19 +21,23 @@ class AnalysisSessionContextPathRoutingContractTest {
         int core = loader.indexOf("taxonomy-analysis-session-core.js");
         int adapter = loader.indexOf(
                 "taxonomy-analysis-session-context-path-routing.js");
+        int apiRouting = loader.indexOf("taxonomy-analysis-session-api-routing.js");
         int projects = loader.indexOf("taxonomy-analysis-session-projects.js");
 
         assertThat(core).isGreaterThanOrEqualTo(0);
         assertThat(adapter)
-                .as("the adapter requires the shared runtime exported by the core")
+                .as("the fetch adapter requires the shared runtime exported by the core")
                 .isGreaterThan(core);
-        assertThat(projects)
-                .as("workspace startup must capture the decorated transport installers")
+        assertThat(apiRouting)
+                .as("the canonical API adapter remains the single SSE routing owner")
                 .isGreaterThan(adapter);
+        assertThat(projects)
+                .as("workspace startup must capture the final transport installers")
+                .isGreaterThan(apiRouting);
     }
 
     @Test
-    void routesFetchAndEventSourceThroughOneIdempotentResolvedPrefixAdapter()
+    void decoratesOnlyAlreadyPrefixedFetchCallsAndLeavesSseToApiRouting()
             throws IOException {
         String adapter = Files.readString(findRepositoryFile(
                 "taxonomy-app/src/main/resources/static/js/core/"
@@ -43,14 +47,14 @@ class AnalysisSessionContextPathRoutingContractTest {
                 .contains("window.TaxonomyI18n.resolveUrl('/api/')")
                 .contains("url.origin !== window.location.origin")
                 .contains("headers.set(WORKSPACE_HEADER, runtime.workspaceId)")
-                .contains("resolved.searchParams.set('workspaceId', runtime.workspaceId)")
                 .contains("installRootFetchRouting()")
-                .contains("installRootEventSourceRouting()")
                 .contains("if (prefix === '/api/') return false")
                 .contains("ROOT_MARKER = '__taxonomyWorkspaceRouting'")
                 .contains("CONTEXT_PATH_MARKER = '__taxonomyContextPathWorkspaceRouting'")
                 .contains("markRoutingInstalled(routedFetch)")
-                .contains("markRoutingInstalled(RoutedEventSource)");
+                .contains("SSE remains owned by taxonomy-analysis-session-api-routing.js")
+                .doesNotContain("installRootEventSourceRouting")
+                .doesNotContain("RoutedEventSource");
     }
 
     private static Path findRepositoryFile(String relativePath) {

--- a/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/AnalysisSessionContextPathRoutingContractTest.java
@@ -1,0 +1,69 @@
+package com.taxonomy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Guards the workspace transport contract for reverse-proxy servlet prefixes. */
+class AnalysisSessionContextPathRoutingContractTest {
+
+    @Test
+    void loadsTheContextPathAdapterBeforeWorkspaceSessionStartup()
+            throws IOException {
+        String loader = Files.readString(findRepositoryFile(
+                "taxonomy-app/src/main/resources/static/js/core/"
+                        + "taxonomy-analysis-session.js"));
+
+        int core = loader.indexOf("taxonomy-analysis-session-core.js");
+        int adapter = loader.indexOf(
+                "taxonomy-analysis-session-context-path-routing.js");
+        int projects = loader.indexOf("taxonomy-analysis-session-projects.js");
+
+        assertThat(core).isGreaterThanOrEqualTo(0);
+        assertThat(adapter)
+                .as("the adapter requires the shared runtime exported by the core")
+                .isGreaterThan(core);
+        assertThat(projects)
+                .as("workspace startup must capture the decorated transport installers")
+                .isGreaterThan(adapter);
+    }
+
+    @Test
+    void routesFetchAndEventSourceThroughOneIdempotentResolvedPrefixAdapter()
+            throws IOException {
+        String adapter = Files.readString(findRepositoryFile(
+                "taxonomy-app/src/main/resources/static/js/core/"
+                        + "taxonomy-analysis-session-context-path-routing.js"));
+
+        assertThat(adapter)
+                .contains("window.TaxonomyI18n.resolveUrl('/api/')")
+                .contains("url.origin !== window.location.origin")
+                .contains("headers.set(WORKSPACE_HEADER, runtime.workspaceId)")
+                .contains("resolved.searchParams.set('workspaceId', runtime.workspaceId)")
+                .contains("installRootFetchRouting()")
+                .contains("installRootEventSourceRouting()")
+                .contains("if (prefix === '/api/') return false")
+                .contains("ROOT_MARKER = '__taxonomyWorkspaceRouting'")
+                .contains("CONTEXT_PATH_MARKER = '__taxonomyContextPathWorkspaceRouting'")
+                .contains("markRoutingInstalled(routedFetch)")
+                .contains("markRoutingInstalled(RoutedEventSource)");
+    }
+
+    private static Path findRepositoryFile(String relativePath) {
+        Path current = Path.of("").toAbsolutePath().normalize();
+        while (current != null) {
+            Path candidate = current.resolve(relativePath);
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException(
+                "Repository file not found from the current working directory: "
+                        + relativePath);
+    }
+}


### PR DESCRIPTION
## Retained fix

The shared core fetch wrapper recognizes root `/api/**` calls. In supported deployments below a servlet context path such as `/taxonomy`, callers may already pass `/taxonomy/api/**`; those calls need the same `X-Taxonomy-Workspace-Id` binding.

The retained adapter is deliberately **fetch-only**:

- it invokes the established root-path installer first;
- resolves the application API prefix through `TaxonomyI18n.resolveUrl('/api/')`;
- decorates only same-origin calls already below a non-root prefix;
- preserves headers from both a `Request` object and explicit init options;
- propagates both installation markers so repeated installation is idempotent;
- leaves root `/api/**` calls to the core wrapper;
- leaves EventSource exclusively to `taxonomy-analysis-session-api-routing.js`, which already handles base paths and the workspace query parameter.

The Node base-path harness executes this adapter and checks loader order, prefix binding, header preservation, root/cross-origin behavior and idempotency. All prior review threads about overwritten SSE installers and the missing runtime fixture are resolved.

## Current status

This branch is a stale Draft and is not merge evidence. After the serialized preceding QA slices are integrated, the four-file change will be reconstructed as one commit directly on the then-current `main` and must pass the complete exact-head matrix. No release request is part of this PR.