### PR TITLE
Preserve a sanitized 503 for unavailable decision-report templates

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.taxonomy.architecture.decision;
+
+import com.taxonomy.templates.DecisionReportAvailabilityContract;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Stable REST contract for a missing or invalid mandatory decision-report template. */
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public final class DecisionReportTemplateExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            DecisionReportTemplateExceptionHandler.class);
+
+    @ExceptionHandler(DecisionReportTemplateUnavailableException.class)
+    public ResponseEntity<Map<String, Object>> handleUnavailableTemplate(
+            HttpServletRequest request) {
+        // Detailed template validation belongs to the authorized administration surface.
+        // This boundary records only the route and returns the shared bounded contract.
+        log.warn("Decision report template unavailable on {}", request.getRequestURI());
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", HttpStatus.SERVICE_UNAVAILABLE.value());
+        body.put("error", HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase());
+        body.put("code", DecisionReportAvailabilityContract.PROBLEM_CODE);
+        body.put("message", DecisionReportAvailabilityContract.SAFE_UNAVAILABLE_SUMMARY);
+        body.put("remediation", DecisionReportAvailabilityContract.REMEDIATION);
+        body.put("capability", DecisionReportAvailabilityContract.CAPABILITY);
+        body.put("path", request.getRequestURI());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(body);
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/architecture/decision/DecisionReportTemplateExceptionHandlerTest.java
@@ -1,0 +1,91 @@
+package com.taxonomy.architecture.decision;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.taxonomy.shared.config.GlobalExceptionHandler;
+import com.taxonomy.templates.DecisionReportAvailabilityContract;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class DecisionReportTemplateExceptionHandlerTest {
+
+    @Test
+    void specificHandlerKeepsTemplateFailureAtSanitized503AheadOfGenericCatchAll()
+            throws Exception {
+        Logger logger = (Logger) LoggerFactory.getLogger(
+                DecisionReportTemplateExceptionHandler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            MockMvc mockMvc = MockMvcBuilders
+                    .standaloneSetup(new FailingReportController())
+                    .setControllerAdvice(
+                            new GlobalExceptionHandler(new StaticMessageSource()),
+                            new DecisionReportTemplateExceptionHandler())
+                    .build();
+
+            String body = mockMvc.perform(get("/api/decision-report/fixture")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isServiceUnavailable())
+                    .andExpect(jsonPath("$.status").value(503))
+                    .andExpect(jsonPath("$.code").value(
+                            DecisionReportAvailabilityContract.PROBLEM_CODE))
+                    .andExpect(jsonPath("$.message").value(
+                            DecisionReportAvailabilityContract.SAFE_UNAVAILABLE_SUMMARY))
+                    .andExpect(jsonPath("$.remediation").value(
+                            DecisionReportAvailabilityContract.REMEDIATION))
+                    .andExpect(jsonPath("$.capability").value(
+                            DecisionReportAvailabilityContract.CAPABILITY))
+                    .andExpect(jsonPath("$.path").value(
+                            "/api/decision-report/fixture"))
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString();
+
+            assertThat(body)
+                    .doesNotContain("jdbc:postgresql://database.internal")
+                    .doesNotContain("private-template-path")
+                    .doesNotContain("private validation detail");
+
+            List<ILoggingEvent> handlerEvents = appender.list.stream()
+                    .filter(event -> event.getFormattedMessage().startsWith(
+                            "Decision report template unavailable on "))
+                    .toList();
+            assertThat(handlerEvents).singleElement().satisfies(event -> {
+                assertThat(event.getFormattedMessage()).isEqualTo(
+                        "Decision report template unavailable on "
+                                + "/api/decision-report/fixture");
+                assertThat(event.getThrowableProxy()).isNull();
+            });
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+
+    @RestController
+    private static final class FailingReportController {
+
+        @GetMapping("/api/decision-report/fixture")
+        void render() {
+            throw new DecisionReportTemplateUnavailableException(
+                    "private-template-path contained jdbc:postgresql://database.internal",
+                    new IllegalStateException("private validation detail"));
+        }
+    }
+}


### PR DESCRIPTION
## What it does

Closes the runtime error-mapping and disclosure gap that remains after the repair-safe health contract in #865.

`DecisionReportTemplateUnavailableException` carries `@ResponseStatus(503)`, but Taxonomy also has a global `@ExceptionHandler(Exception.class)`. A dedicated highest-precedence REST handler is therefore required so the expected DOCX capability outage cannot become a generic HTTP 500.

The handler returns:

- HTTP 503;
- the shared code `DECISION_REPORT_TEMPLATE_UNAVAILABLE` from `DecisionReportAvailabilityContract`;
- the shared non-sensitive summary and remediation;
- the affected capability `decision-report-docx`;
- the request path;
- no exception message, cause, template path, validation payload, database URL or credential.

The handler method deliberately receives no exception object. The server log records only the bounded request URI, while detailed validation remains available through the authorized template administration surface.

## Regression coverage

The standalone MockMvc test installs both the existing generic global handler and the new specific handler. It proves that the specific contract wins and returns the shared sanitized 503 response.

The test also attaches a real Logback `ListAppender` and verifies at runtime that:

- exactly the bounded route message is emitted;
- no throwable proxy is attached;
- neither the outer exception text nor the deliberately sensitive cause text appears in the response.

This replaces the earlier substring-based source check and addresses both review findings on the previous head.

## Exact scope

- first parent: `a0df69b1027a18b1d0165830443c0706516bed1b` (current `main` after #865);
- exactly one commit;
- zero commits behind `main`;
- exactly two new files;
- no report calculation, template validation, health status, successful DOCX response, workflow, deployment or release-request change.

The complete exact-head CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix remains the merge authority.