### PR TITLE
Sanitize framework-level HTTP 5xx responses

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/GlobalExceptionHandler.java
@@ -34,6 +34,8 @@ import java.util.Map;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+    private static final String DEFAULT_INTERNAL_MESSAGE =
+            "An internal error occurred. Please try again or check the server logs.";
 
     private final MessageSource messageSource;
 
@@ -45,17 +47,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * Handles IllegalArgumentException (bad input from client).
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, Object>> handleBadRequest(IllegalArgumentException ex, WebRequest request) {
-        log.warn("Bad request: {}", ex.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    public ResponseEntity<Map<String, Object>> handleBadRequest(
+            IllegalArgumentException exception,
+            WebRequest request) {
+        log.warn("Bad request: {}", exception.getMessage());
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                clientErrorMessage(exception, HttpStatus.BAD_REQUEST),
+                request);
     }
 
     /** Return malformed or oversized working drafts as a stable client error. */
     @ExceptionHandler(AnalysisDraftValidationException.class)
     public ResponseEntity<Map<String, Object>> handleAnalysisDraftValidation(
-            AnalysisDraftValidationException ex, WebRequest request) {
-        log.warn("Invalid analysis draft on {}: {}", request.getDescription(false), ex.getMessage());
-        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+            AnalysisDraftValidationException exception,
+            WebRequest request) {
+        log.warn("Invalid analysis draft on {}: {}",
+                request.getDescription(false), exception.getMessage());
+        return buildErrorResponse(
+                HttpStatus.BAD_REQUEST,
+                clientErrorMessage(exception, HttpStatus.BAD_REQUEST),
+                request);
     }
 
     /**
@@ -64,9 +76,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(AnalysisDraftConflictException.class)
     public ResponseEntity<Map<String, Object>> handleAnalysisDraftConflict(
-            AnalysisDraftConflictException ex, WebRequest request) {
-        log.warn("Analysis draft conflict on {}: {}", request.getDescription(false), ex.getMessage());
-        return buildErrorResponse(HttpStatus.CONFLICT, ex.getMessage(), request);
+            AnalysisDraftConflictException exception,
+            WebRequest request) {
+        log.warn("Analysis draft conflict on {}: {}",
+                request.getDescription(false), exception.getMessage());
+        return buildErrorResponse(
+                HttpStatus.CONFLICT,
+                clientErrorMessage(exception, HttpStatus.CONFLICT),
+                request);
     }
 
     /**
@@ -75,8 +92,10 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Map<String, Object>> handleAccessDenied(
-            AccessDeniedException ex, WebRequest request) {
-        log.warn("Access denied on {}: {}", request.getDescription(false), ex.getMessage());
+            AccessDeniedException exception,
+            WebRequest request) {
+        log.warn("Access denied on {}: {}",
+                request.getDescription(false), exception.getMessage());
         Locale locale = LocaleContextHolder.getLocale();
         String message = messageSource.getMessage(
                 "error.forbidden", null, "Access denied.", locale);
@@ -88,12 +107,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * Logs the full stack trace server-side but only returns a safe message to the client.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex, WebRequest request) {
-        log.error("Unhandled exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
-        Locale locale = LocaleContextHolder.getLocale();
-        String message = messageSource.getMessage("error.internal", null,
-                "An internal error occurred. Please try again or check the server logs.", locale);
-        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, message, request);
+    public ResponseEntity<Map<String, Object>> handleGenericException(
+            Exception exception,
+            WebRequest request) {
+        log.error("Unhandled exception on {}: {}",
+                request.getDescription(false), exception.getMessage(), exception);
+        return buildErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                internalErrorMessage(),
+                request);
     }
 
     /**
@@ -102,26 +124,56 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
-            Exception ex, Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+            Exception exception,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
         HttpStatus status = HttpStatus.resolve(statusCode.value());
         if (status == null) {
             status = HttpStatus.INTERNAL_SERVER_ERROR;
         }
+
+        String message;
         if (status.is5xxServerError()) {
-            log.error("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
+            log.error("Spring MVC exception on {}",
+                    request.getDescription(false), exception);
+            message = internalErrorMessage();
         } else {
-            log.warn("Spring MVC exception on {}: {}", request.getDescription(false), ex.getMessage());
+            log.warn("Spring MVC exception on {}: {}",
+                    request.getDescription(false), exception.getMessage());
+            message = clientErrorMessage(exception, status);
         }
+
         Map<String, Object> errorBody = new LinkedHashMap<>();
         errorBody.put("timestamp", Instant.now().toString());
         errorBody.put("status", status.value());
         errorBody.put("error", status.getReasonPhrase());
-        errorBody.put("message", ex.getMessage());
+        errorBody.put("message", message);
         errorBody.put("path", request.getDescription(false).replace("uri=", ""));
         return ResponseEntity.status(status).headers(headers).body(errorBody);
     }
 
-    private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message, WebRequest request) {
+    private String internalErrorMessage() {
+        Locale locale = LocaleContextHolder.getLocale();
+        String message = messageSource.getMessage(
+                "error.internal", null, DEFAULT_INTERNAL_MESSAGE, locale);
+        return message == null || message.isBlank()
+                ? DEFAULT_INTERNAL_MESSAGE
+                : message;
+    }
+
+    private static String clientErrorMessage(Exception exception, HttpStatus status) {
+        String message = exception.getMessage();
+        return message == null || message.isBlank()
+                ? status.getReasonPhrase()
+                : message;
+    }
+
+    private ResponseEntity<Map<String, Object>> buildErrorResponse(
+            HttpStatus status,
+            String message,
+            WebRequest request) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("timestamp", Instant.now().toString());
         body.put("status", status.value());

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,152 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.context.support.StaticMessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private static final String SAFE_INTERNAL_MESSAGE =
+            "The request could not be completed safely.";
+    private static final String DEFAULT_INTERNAL_MESSAGE =
+            "An internal error occurred. Please try again or check the server logs.";
+
+    @AfterEach
+    void resetLocale() {
+        LocaleContextHolder.resetLocaleContext();
+    }
+
+    @Test
+    void frameworkServerErrorDoesNotExposeInternalExceptionMessage() {
+        ExposedHandler handler = handler(SAFE_INTERNAL_MESSAGE);
+        RuntimeException failure = new RuntimeException(
+                "private-template-path contained "
+                        + "jdbc:postgresql://internal-user:secret@database/taxonomy");
+
+        ResponseEntity<Object> response = handler.frameworkException(
+                failure,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                request("/api/failing"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        Map<String, Object> body = responseBody(response);
+        assertThat(body)
+                .containsEntry("status", 500)
+                .containsEntry("message", SAFE_INTERNAL_MESSAGE)
+                .containsEntry("path", "/api/failing");
+        assertThat(body.toString())
+                .doesNotContain("private-template-path")
+                .doesNotContain("jdbc:postgresql")
+                .doesNotContain("internal-user")
+                .doesNotContain("secret");
+    }
+
+    @Test
+    void genericServerErrorUsesTheSameSanitizedMessage() {
+        GlobalExceptionHandler handler = handler(SAFE_INTERNAL_MESSAGE);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleGenericException(
+                new RuntimeException("provider response contained private-value"),
+                request("/api/provider"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody())
+                .containsEntry("message", SAFE_INTERNAL_MESSAGE)
+                .containsEntry("path", "/api/provider");
+        assertThat(response.getBody().toString())
+                .doesNotContain("provider response")
+                .doesNotContain("private-value");
+    }
+
+    @Test
+    void blankLocalizedServerMessageFallsBackToSafeDefault() {
+        ExposedHandler handler = handler(" ");
+
+        ResponseEntity<Object> response = handler.frameworkException(
+                new RuntimeException("private provider response"),
+                HttpStatus.BAD_GATEWAY,
+                request("/api/provider"));
+
+        Map<String, Object> body = responseBody(response);
+        assertThat(body)
+                .containsEntry("status", 502)
+                .containsEntry("message", DEFAULT_INTERNAL_MESSAGE);
+        assertThat(body.toString()).doesNotContain("private provider response");
+    }
+
+    @Test
+    void frameworkClientErrorKeepsActionableValidationMessage() {
+        ExposedHandler handler = handler(SAFE_INTERNAL_MESSAGE);
+
+        ResponseEntity<Object> response = handler.frameworkException(
+                new IllegalArgumentException("required parameter is missing"),
+                HttpStatus.BAD_REQUEST,
+                request("/api/input"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(responseBody(response))
+                .containsEntry("status", 400)
+                .containsEntry("message", "required parameter is missing")
+                .containsEntry("path", "/api/input");
+    }
+
+    @Test
+    void blankClientErrorMessageFallsBackToReasonPhrase() {
+        GlobalExceptionHandler handler = handler(SAFE_INTERNAL_MESSAGE);
+
+        ResponseEntity<Map<String, Object>> response = handler.handleBadRequest(
+                new IllegalArgumentException(" "),
+                request("/api/input"));
+
+        assertThat(response.getBody())
+                .containsEntry("message", HttpStatus.BAD_REQUEST.getReasonPhrase());
+    }
+
+    private static ExposedHandler handler(String internalMessage) {
+        StaticMessageSource messages = new StaticMessageSource();
+        messages.addMessage("error.internal", Locale.ENGLISH, internalMessage);
+        LocaleContextHolder.setLocale(Locale.ENGLISH);
+        return new ExposedHandler(messages);
+    }
+
+    private static WebRequest request(String path) {
+        return new ServletWebRequest(new MockHttpServletRequest("GET", path));
+    }
+
+    private static Map<String, Object> responseBody(ResponseEntity<Object> response) {
+        assertThat(response.getBody()).isInstanceOf(Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        return body;
+    }
+
+    private static final class ExposedHandler extends GlobalExceptionHandler {
+        private ExposedHandler(StaticMessageSource messages) {
+            super(messages);
+        }
+
+        private ResponseEntity<Object> frameworkException(
+                Exception exception,
+                HttpStatus status,
+                WebRequest request) {
+            return handleExceptionInternal(
+                    exception,
+                    null,
+                    HttpHeaders.EMPTY,
+                    status,
+                    request);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`GlobalExceptionHandler.handleExceptionInternal(...)` formats Spring MVC framework exceptions separately from the generic catch-all. The previous implementation copied `exception.getMessage()` into every framework response body, including HTTP 5xx responses. Internal file paths, JDBC URLs, provider details or credentials embedded in such a message could therefore reach API clients.

## Change

- Framework-level 5xx responses use the localized `error.internal` message with a bounded nonblank fallback.
- The complete exception remains available only in server-side logs.
- The generic catch-all uses the same bounded internal-message helper.
- Framework-level and directly handled 4xx responses retain actionable validation details, with the HTTP reason phrase as a fallback for blank messages.

## Regression coverage

A focused test injects a private template path, a PostgreSQL URL, a synthetic username and a marker secret into a simulated framework-level 500 exception and proves that none reaches the response.

Additional tests prove that:

- the generic 500 path uses the same sanitized message;
- a blank localized internal message falls back to a stable safe default;
- an actionable framework 400 message remains available;
- a blank client-error message falls back to the HTTP reason phrase.

## Exact scope

- first parent: `30f28ed49318d7fd853219d980fb1942ef0255dc` (current `main` after #876);
- head: `d083ca5a30322c4849e967d25d0adacc287f1390`;
- exactly one commit;
- zero commits behind `main`;
- exactly two files:
  - `GlobalExceptionHandler.java`;
  - `GlobalExceptionHandlerTest.java`.

The prior run on the old base is diagnostic history only. This rebuilt exact head requires a fresh CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix before merge. No route, successful API payload, authentication grant, deployment setting, workflow or release request is changed.