### PR TITLE
Enforce stable LLM quotas after authorization

### DIFF
--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/KeycloakSecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/KeycloakSecurityConfig.java
@@ -5,6 +5,7 @@ import com.taxonomy.security.keycloak.KeycloakJwtAuthConverter;
 import com.taxonomy.security.keycloak.KeycloakLogoutHandler;
 import com.taxonomy.security.keycloak.KeycloakOidcUserService;
 import com.taxonomy.security.webdav.WebDavApplicationCredentialFilter;
+import com.taxonomy.shared.config.RateLimitFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -16,6 +17,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
@@ -33,6 +35,7 @@ public class KeycloakSecurityConfig {
     private final KeycloakLogoutHandler logoutHandler;
     private final KeycloakAuthenticationEntryPoint authenticationEntryPoint;
     private final WebDavApplicationCredentialFilter webDavCredentialFilter;
+    private final RateLimitFilter rateLimitFilter;
 
     @Autowired
     public KeycloakSecurityConfig(
@@ -41,13 +44,15 @@ public class KeycloakSecurityConfig {
             KeycloakOidcUserService oidcUserService,
             KeycloakLogoutHandler logoutHandler,
             KeycloakAuthenticationEntryPoint authenticationEntryPoint,
-            WebDavApplicationCredentialFilter webDavCredentialFilter) {
+            WebDavApplicationCredentialFilter webDavCredentialFilter,
+            RateLimitFilter rateLimitFilter) {
         this.authRules = authRules;
         this.jwtAuthConverter = jwtAuthConverter;
         this.oidcUserService = oidcUserService;
         this.logoutHandler = logoutHandler;
         this.authenticationEntryPoint = authenticationEntryPoint;
         this.webDavCredentialFilter = webDavCredentialFilter;
+        this.rateLimitFilter = rateLimitFilter;
     }
 
     /** Backward-compatible constructor for focused security configuration tests. */
@@ -58,7 +63,19 @@ public class KeycloakSecurityConfig {
             KeycloakLogoutHandler logoutHandler,
             KeycloakAuthenticationEntryPoint authenticationEntryPoint) {
         this(authRules, jwtAuthConverter, oidcUserService, logoutHandler,
-                authenticationEntryPoint, null);
+                authenticationEntryPoint, null, null);
+    }
+
+    /** Backward-compatible constructor for WebDAV security tests. */
+    public KeycloakSecurityConfig(
+            AuthorizationRulesConfigurer authRules,
+            KeycloakJwtAuthConverter jwtAuthConverter,
+            KeycloakOidcUserService oidcUserService,
+            KeycloakLogoutHandler logoutHandler,
+            KeycloakAuthenticationEntryPoint authenticationEntryPoint,
+            WebDavApplicationCredentialFilter webDavCredentialFilter) {
+        this(authRules, jwtAuthConverter, oidcUserService, logoutHandler,
+                authenticationEntryPoint, webDavCredentialFilter, null);
     }
 
     @Bean
@@ -90,6 +107,11 @@ public class KeycloakSecurityConfig {
         if (webDavCredentialFilter != null) {
             http.addFilterBefore(
                     webDavCredentialFilter, BearerTokenAuthenticationFilter.class);
+        }
+        if (rateLimitFilter != null) {
+            // OIDC/Bearer authentication and request authorization must both
+            // succeed before a request may consume quota.
+            http.addFilterAfter(rateLimitFilter, AuthorizationFilter.class);
         }
         return http.build();
     }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.taxonomy.security.config;
 
 import com.taxonomy.security.webdav.WebDavApplicationCredentialFilter;
+import com.taxonomy.shared.config.RateLimitFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,7 @@ import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
@@ -25,22 +27,33 @@ public class SecurityConfig {
     private final AuthorizationRulesConfigurer authRules;
     private final PasswordChangeRequiredFilter passwordChangeRequiredFilter;
     private final WebDavApplicationCredentialFilter webDavCredentialFilter;
+    private final RateLimitFilter rateLimitFilter;
 
     @Autowired
     public SecurityConfig(
             AuthorizationRulesConfigurer authRules,
             PasswordChangeRequiredFilter passwordChangeRequiredFilter,
-            WebDavApplicationCredentialFilter webDavCredentialFilter) {
+            WebDavApplicationCredentialFilter webDavCredentialFilter,
+            RateLimitFilter rateLimitFilter) {
         this.authRules = authRules;
         this.passwordChangeRequiredFilter = passwordChangeRequiredFilter;
         this.webDavCredentialFilter = webDavCredentialFilter;
+        this.rateLimitFilter = rateLimitFilter;
     }
 
     /** Backward-compatible constructor for focused configuration tests. */
     SecurityConfig(
             AuthorizationRulesConfigurer authRules,
             PasswordChangeRequiredFilter passwordChangeRequiredFilter) {
-        this(authRules, passwordChangeRequiredFilter, null);
+        this(authRules, passwordChangeRequiredFilter, null, null);
+    }
+
+    /** Backward-compatible constructor for tests of the WebDAV filter boundary. */
+    SecurityConfig(
+            AuthorizationRulesConfigurer authRules,
+            PasswordChangeRequiredFilter passwordChangeRequiredFilter,
+            WebDavApplicationCredentialFilter webDavCredentialFilter) {
+        this(authRules, passwordChangeRequiredFilter, webDavCredentialFilter, null);
     }
 
     @Bean
@@ -67,6 +80,11 @@ public class SecurityConfig {
             http.addFilterBefore(webDavCredentialFilter, BasicAuthenticationFilter.class);
         }
         http.addFilterAfter(passwordChangeRequiredFilter, BasicAuthenticationFilter.class);
+        if (rateLimitFilter != null) {
+            // Authorization must succeed before a request may consume quota or
+            // allocate per-principal state.
+            http.addFilterAfter(rateLimitFilter, AuthorizationFilter.class);
+        }
         return http.build();
     }
 

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilter.java
@@ -8,19 +8,38 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Objects;
+import java.util.function.LongSupplier;
 
 /**
- * Simple in-memory rate limiter for LLM-backed API endpoints.
- * Limits requests per IP address per minute to prevent quota exhaustion.
+ * Bounded in-memory quota for authenticated LLM-backed API operations.
  *
- * <p>Protected endpoints:
+ * <p>The filter is installed inside Spring Security after request authorization.
+ * Each admitted local request is keyed by a digest of its authenticated username.
+ * Keycloak browser and bearer requests are keyed by the same immutable
+ * issuer/subject pair, never by the editable {@code preferred_username} claim.
+ * Forwarding headers and peer addresses are not quota identities.</p>
+ *
+ * <p>Protected operations are:</p>
  * <ul>
  *   <li>{@code POST /api/analyze}</li>
  *   <li>{@code GET /api/analyze-stream}</li>
@@ -29,102 +48,298 @@ import java.util.concurrent.atomic.AtomicInteger;
  * </ul>
  *
  * <p>The effective limit is read at request time from {@link PreferencesService}
- * (key {@code rate-limit.per-minute}) when available, falling back to the
- * {@code TAXONOMY_RATE_LIMIT_PER_MINUTE} property (default: 10).
- * Set to 0 to disable rate limiting.
+ * key {@code rate-limit.per-minute}, falling back to the configured property.
+ * Exactly {@code 0} disables limiting. Negative values fail closed to one request
+ * per minute rather than silently disabling protection.</p>
  */
 @Component
 public class RateLimitFilter extends OncePerRequestFilter {
 
-    @Value("${taxonomy.rate-limit.per-minute:10}")
-    private int maxRequestsPerMinute;
+    static final long WINDOW_NANOS = Duration.ofMinutes(1).toNanos();
+    static final long ENTRY_RETENTION_NANOS = Duration.ofMinutes(2).toNanos();
+    static final long CLEANUP_INTERVAL_NANOS = Duration.ofMinutes(1).toNanos();
+    static final int DEFAULT_MAX_TRACKED_PRINCIPALS = 10_000;
 
-    /** Optional — injected lazily to avoid circular dependencies. */
+    @Value("${taxonomy.rate-limit.per-minute:10}")
+    private int maxRequestsPerMinute = 10;
+
+    /** Optional and lazy to preserve the established bootstrap dependency boundary. */
     @Autowired(required = false)
     @Lazy
     private PreferencesService preferencesService;
 
-    private final Map<String, WindowCounter> counters = new ConcurrentHashMap<>();
+    private final Object stateMonitor = new Object();
+    private final Map<String, WindowCounter> counters = new HashMap<>();
+    private final WindowCounter overflowCounter;
+    private final LongSupplier monotonicNanos;
+    private final int maxTrackedPrincipals;
+    private long nextCleanupAt;
+
+    public RateLimitFilter() {
+        this(System::nanoTime, DEFAULT_MAX_TRACKED_PRINCIPALS);
+    }
+
+    RateLimitFilter(LongSupplier monotonicNanos, int maxTrackedPrincipals) {
+        this.monotonicNanos = Objects.requireNonNull(
+                monotonicNanos, "monotonicNanos");
+        if (maxTrackedPrincipals <= 0) {
+            throw new IllegalArgumentException(
+                    "maxTrackedPrincipals must be positive");
+        }
+        this.maxTrackedPrincipals = maxTrackedPrincipals;
+        long now = monotonicNanos.getAsLong();
+        overflowCounter = new WindowCounter(now);
+        nextCleanupAt = now + CLEANUP_INTERVAL_NANOS;
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                      FilterChain filterChain) throws ServletException, IOException {
-        String path = request.getRequestURI();
-
-        // Only rate-limit LLM-backed endpoints
-        if (!isRateLimitedPath(path)) {
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        if (!isRateLimitedOperation(request.getMethod(), applicationPath(request))) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        // Effective limit: prefer runtime preference, fall back to property value
-        int effectiveLimit = (preferencesService != null)
-                ? preferencesService.getInt("rate-limit.per-minute", maxRequestsPerMinute)
-                : maxRequestsPerMinute;
+        int configuredLimit = preferencesService == null
+                ? maxRequestsPerMinute
+                : preferencesService.getInt(
+                        "rate-limit.per-minute", maxRequestsPerMinute);
+        if (configuredLimit == 0) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        int effectiveLimit = configuredLimit < 0 ? 1 : configuredLimit;
 
-        // Disabled if set to 0
-        if (effectiveLimit <= 0) {
+        String principalKey = authenticatedPrincipalKey();
+        if (principalKey == null) {
+            writeAuthenticationRequired(response);
+            return;
+        }
+
+        long now = monotonicNanos.getAsLong();
+        Acquisition acquisition = acquire(
+                principalKey, effectiveLimit, now);
+        if (acquisition.allowed()) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        String clientIp = getClientIp(request);
-        WindowCounter counter = counters.computeIfAbsent(clientIp, k -> new WindowCounter());
-
-        if (counter.incrementAndCheck(effectiveLimit)) {
-            filterChain.doFilter(request, response);
-        } else {
-            response.setStatus(429);
-            response.setContentType("application/json");
-            response.getWriter().write(
-                    "{\"error\":\"Rate limit exceeded. Maximum " + effectiveLimit
-                    + " LLM requests per minute. Please wait.\","
-                    + "\"status\":429}");
-        }
+        writeRateLimitResponse(
+                response,
+                effectiveLimit,
+                acquisition.retryAfterSeconds());
     }
 
-    /** Visible for testing — clears all per-IP rate limit counters. */
+    /** Visible for tests and administrative test isolation. */
     public void clearCounters() {
-        counters.clear();
-    }
-
-    private boolean isRateLimitedPath(String path) {
-        return path.equals("/api/analyze")
-            || path.equals("/api/analyze-stream")
-            || path.equals("/api/analyze-node")
-            || path.equals("/api/justify-leaf");
-    }
-
-    private String getClientIp(HttpServletRequest request) {
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isBlank()) {
-            return xff.split(",")[0].trim();
+        long now = monotonicNanos.getAsLong();
+        synchronized (stateMonitor) {
+            counters.clear();
+            overflowCounter.reset(now);
+            nextCleanupAt = now + CLEANUP_INTERVAL_NANOS;
         }
-        return request.getRemoteAddr();
     }
 
-    /**
-     * Sliding window counter per minute.
-     */
-    static class WindowCounter {
-        private final AtomicInteger count = new AtomicInteger(0);
-        private volatile long windowStart = System.currentTimeMillis();
+    /** Visible for security-chain tests; identities themselves are never exposed. */
+    int trackedPrincipalCount() {
+        synchronized (stateMonitor) {
+            return counters.size();
+        }
+    }
 
-        boolean incrementAndCheck(int max) {
-            long now = System.currentTimeMillis();
-            // Reset window every 60 seconds — synchronized to prevent a race between
-            // the reset check and the increment that would count against the new window
-            if (now - windowStart > 60_000) {
-                synchronized (this) {
-                    if (now - windowStart > 60_000) {
-                        count.set(1);
-                        windowStart = now;
-                        return true;
-                    }
+    private Acquisition acquire(
+            String principalKey,
+            int effectiveLimit,
+            long now) {
+        synchronized (stateMonitor) {
+            cleanupExpiredEntries(now, false);
+            WindowCounter counter = counters.get(principalKey);
+            if (counter == null) {
+                if (counters.size() >= maxTrackedPrincipals) {
+                    cleanupExpiredEntries(now, true);
+                }
+                if (counters.size() >= maxTrackedPrincipals) {
+                    counter = overflowCounter;
+                } else {
+                    counter = new WindowCounter(now);
+                    counters.put(principalKey, counter);
                 }
             }
-            return count.incrementAndGet() <= max;
+
+            boolean allowed = counter.tryAcquire(effectiveLimit, now);
+            return new Acquisition(
+                    allowed,
+                    allowed ? 0 : counter.retryAfterSeconds(now));
+        }
+    }
+
+    private void cleanupExpiredEntries(long now, boolean force) {
+        if (!force && now - nextCleanupAt < 0) {
+            return;
+        }
+        counters.entrySet().removeIf(
+                entry -> entry.getValue().isExpired(now));
+        nextCleanupAt = now + CLEANUP_INTERVAL_NANOS;
+    }
+
+    static String applicationPath(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (servletPath != null
+                && !servletPath.isBlank()
+                && !"/".equals(servletPath)) {
+            return servletPath;
+        }
+
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null
+                && !contextPath.isBlank()
+                && requestUri.startsWith(contextPath)) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
+    }
+
+    static boolean isRateLimitedOperation(String method, String path) {
+        return ("POST".equalsIgnoreCase(method)
+                    && ("/api/analyze".equals(path)
+                        || "/api/justify-leaf".equals(path)))
+                || ("GET".equalsIgnoreCase(method)
+                    && ("/api/analyze-stream".equals(path)
+                        || "/api/analyze-node".equals(path)));
+    }
+
+    private static String authenticatedPrincipalKey() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        if (authentication instanceof JwtAuthenticationToken jwtAuthentication) {
+            return oidcPrincipalKey(jwtAuthentication.getToken().getClaims());
+        }
+        if (authentication.getPrincipal() instanceof OidcUser oidcUser) {
+            return oidcPrincipalKey(oidcUser.getIdToken().getClaims());
+        }
+
+        String username = authentication.getName();
+        return username == null || username.isBlank()
+                ? null
+                : digestIdentity("local", username);
+    }
+
+    private static String oidcPrincipalKey(Map<String, Object> claims) {
+        String issuer = requiredClaim(claims, "iss");
+        String subject = requiredClaim(claims, "sub");
+        if (issuer == null || subject == null) {
+            return null;
+        }
+        return digestIdentity("oidc", issuer + '\u0000' + subject);
+    }
+
+    private static String requiredClaim(
+            Map<String, Object> claims,
+            String claimName) {
+        Object value = claims.get(claimName);
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString();
+        return text.isBlank() ? null : text;
+    }
+
+    private static String digestIdentity(String category, String identity) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(category.getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+            return HexFormat.of().formatHex(
+                    digest.digest(identity.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                    "SHA-256 is unavailable", exception);
+        }
+    }
+
+    private static void writeAuthenticationRequired(
+            HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(
+                "{\"error\":\"Authentication is required for this LLM operation.\","
+                    + "\"status\":401}");
+    }
+
+    private static void writeRateLimitResponse(
+            HttpServletResponse response,
+            int effectiveLimit,
+            long retryAfterSeconds) throws IOException {
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader(
+                HttpHeaders.RETRY_AFTER,
+                Long.toString(retryAfterSeconds));
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(
+                "{\"error\":\"Rate limit exceeded. Maximum " + effectiveLimit
+                    + " LLM requests per minute. Please wait.\","
+                    + "\"status\":429}");
+    }
+
+    private record Acquisition(boolean allowed, long retryAfterSeconds) {
+    }
+
+    /** Fixed-window state; every access is serialized by {@link #stateMonitor}. */
+    static final class WindowCounter {
+        private int count;
+        private long windowStart;
+        private long lastSeen;
+
+        WindowCounter(long now) {
+            reset(now);
+        }
+
+        boolean tryAcquire(int maximum, long now) {
+            rotateWindowIfNeeded(now);
+            lastSeen = now;
+            if (count >= maximum) {
+                return false;
+            }
+            count++;
+            return true;
+        }
+
+        long retryAfterSeconds(long now) {
+            long elapsed = now - windowStart;
+            long remaining = Math.max(1L, WINDOW_NANOS - elapsed);
+            return Math.max(
+                    1L,
+                    (remaining + Duration.ofSeconds(1).toNanos() - 1L)
+                            / Duration.ofSeconds(1).toNanos());
+        }
+
+        boolean isExpired(long now) {
+            return now - lastSeen >= ENTRY_RETENTION_NANOS;
+        }
+
+        void reset(long now) {
+            count = 0;
+            windowStart = now;
+            lastSeen = now;
+        }
+
+        private void rotateWindowIfNeeded(long now) {
+            if (now - windowStart >= WINDOW_NANOS) {
+                reset(now);
+            }
         }
     }
 }
-

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilterConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/RateLimitFilterConfiguration.java
@@ -1,0 +1,19 @@
+package com.taxonomy.shared.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Keeps the LLM quota filter exclusively inside the Spring Security chains. */
+@Configuration(proxyBeanMethods = false)
+public class RateLimitFilterConfiguration {
+
+    @Bean
+    FilterRegistrationBean<RateLimitFilter> disableContainerRateLimitFilter(
+            RateLimitFilter filter) {
+        FilterRegistrationBean<RateLimitFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/KeycloakRateLimitFilterConfigurationTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/KeycloakRateLimitFilterConfigurationTest.java
@@ -1,0 +1,93 @@
+package com.taxonomy.security.config;
+
+import com.taxonomy.security.keycloak.KeycloakAuthenticationEntryPoint;
+import com.taxonomy.security.keycloak.KeycloakJwtAuthConverter;
+import com.taxonomy.security.keycloak.KeycloakLogoutHandler;
+import com.taxonomy.security.keycloak.KeycloakOidcUserService;
+import com.taxonomy.shared.config.RateLimitFilter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
+import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Verifies that the Keycloak chain applies the same post-authorization quota boundary. */
+@ExtendWith(MockitoExtension.class)
+class KeycloakRateLimitFilterConfigurationTest {
+
+    @Mock
+    private AuthorizationRulesConfigurer authorizationRules;
+    @Mock
+    private KeycloakJwtAuthConverter jwtAuthConverter;
+    @Mock
+    private KeycloakOidcUserService oidcUserService;
+    @Mock
+    private KeycloakLogoutHandler logoutHandler;
+    @Mock
+    private KeycloakAuthenticationEntryPoint authenticationEntryPoint;
+    @Mock
+    private RateLimitFilter rateLimitFilter;
+
+    @Test
+    void keycloakChainPlacesLimiterAfterAuthorizationFilter() throws Exception {
+        StaticApplicationContext context = new StaticApplicationContext();
+        HttpSecurity http = mock(HttpSecurity.class, Answers.RETURNS_SELF);
+        DefaultSecurityFilterChain chain = mock(DefaultSecurityFilterChain.class);
+
+        CsrfConfigurer<HttpSecurity> csrf = new CsrfConfigurer<>(context);
+        HeadersConfigurer<HttpSecurity> headers = new HeadersConfigurer<>();
+        OAuth2LoginConfigurer<HttpSecurity> oauth2Login = new OAuth2LoginConfigurer<>();
+        OAuth2ResourceServerConfigurer<HttpSecurity> resourceServer =
+                new OAuth2ResourceServerConfigurer<>(context);
+        LogoutConfigurer<HttpSecurity> logout = new LogoutConfigurer<>();
+
+        doAnswer(customize(null, http)).when(http).authorizeHttpRequests(any());
+        doAnswer(customize(csrf, http)).when(http).csrf(any());
+        doAnswer(customize(headers, http)).when(http).headers(any());
+        doAnswer(customize(oauth2Login, http)).when(http).oauth2Login(any());
+        doAnswer(customize(resourceServer, http)).when(http).oauth2ResourceServer(any());
+        doAnswer(customize(logout, http)).when(http).logout(any());
+        when(http.build()).thenReturn(chain);
+
+        KeycloakSecurityConfig config = new KeycloakSecurityConfig(
+                authorizationRules,
+                jwtAuthConverter,
+                oidcUserService,
+                logoutHandler,
+                authenticationEntryPoint,
+                null,
+                rateLimitFilter);
+
+        assertThat(config.securityFilterChain(http)).isSameAs(chain);
+        verify(authorizationRules).configure(null);
+        verify(http).addFilterAfter(rateLimitFilter, AuthorizationFilter.class);
+    }
+
+    private static org.mockito.stubbing.Answer<HttpSecurity> customize(
+            Object target,
+            HttpSecurity http) {
+        return invocation -> {
+            @SuppressWarnings("unchecked")
+            Customizer<Object> customizer = invocation.getArgument(0);
+            customizer.customize(target);
+            return http;
+        };
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterSecurityChainTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterSecurityChainTest.java
@@ -1,0 +1,150 @@
+package com.taxonomy.shared.config;
+
+import com.taxonomy.preferences.PreferencesService;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Proves the productive form-login chain authorizes before consuming LLM quota. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "llm.mock=true",
+    "taxonomy.rate-limit.per-minute=1"
+})
+class RateLimitFilterSecurityChainTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RateLimitFilter rateLimitFilter;
+
+    @Autowired
+    private FilterRegistrationBean<RateLimitFilter> rateLimitRegistration;
+
+    @Autowired
+    @Qualifier("springSecurityFilterChain")
+    private FilterChainProxy securityFilterChain;
+
+    @MockitoBean
+    private PreferencesService preferencesService;
+
+    @BeforeEach
+    void configureLimit() {
+        when(preferencesService.getInt(
+                eq("rate-limit.per-minute"), anyInt())).thenReturn(1);
+        rateLimitFilter.clearCounters();
+    }
+
+    @Test
+    void limiterRunsExactlyOnceAfterAuthorizationAndNotAsAContainerFilter() {
+        List<Filter> filters = securityFilterChain.getFilters("/api/analyze-node");
+
+        int authorizationIndex = indexOf(filters, AuthorizationFilter.class);
+        int limiterIndex = filters.indexOf(rateLimitFilter);
+
+        assertThat(rateLimitRegistration.isEnabled()).isFalse();
+        assertThat(authorizationIndex).isGreaterThanOrEqualTo(0);
+        assertThat(limiterIndex).isGreaterThan(authorizationIndex);
+        assertThat(filters.stream().filter(rateLimitFilter::equals)).hasSize(1);
+    }
+
+    @Test
+    void unauthenticatedRequestIsRejectedBeforeLimiterAllocatesState()
+            throws Exception {
+        mockMvc.perform(get("/api/analyze-node")
+                        .param("parentCode", "BP")
+                        .param("businessText", "resilient communications"))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(rateLimitFilter.trackedPrincipalCount()).isZero();
+    }
+
+    @Test
+    void invalidCsrfMutationDoesNotConsumeOrAllocateQuota() throws Exception {
+        mockMvc.perform(post("/api/analyze")
+                        .with(user("alice").roles("ADMIN"))
+                        .with(csrf().useInvalidToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"businessText\":\"resilient communications\"}"))
+                .andExpect(status().isForbidden());
+
+        assertThat(rateLimitFilter.trackedPrincipalCount()).isZero();
+    }
+
+    @Test
+    void forwardingHeaderCannotResetAuthenticatedPrincipalBudget()
+            throws Exception {
+        analyzeNode("", "alice", "203.0.113.10")
+                .andExpect(status().isOk());
+        analyzeNode("", "alice", "203.0.113.99")
+                .andExpect(status().isTooManyRequests());
+    }
+
+    @Test
+    void authenticatedPrincipalsBehindOnePeerHaveIndependentBudgets()
+            throws Exception {
+        analyzeNode("", "alice", "203.0.113.10")
+                .andExpect(status().isOk());
+        analyzeNode("", "bob", "203.0.113.10")
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void servletContextPathReceivesTheSamePrincipalQuota() throws Exception {
+        analyzeNode("/taxonomy", "alice", "203.0.113.10")
+                .andExpect(status().isOk());
+        analyzeNode("/taxonomy", "alice", "203.0.113.99")
+                .andExpect(status().isTooManyRequests());
+    }
+
+    private ResultActions analyzeNode(
+            String contextPath,
+            String username,
+            String forwardedFor) throws Exception {
+        String requestPath = contextPath + "/api/analyze-node";
+        var request = get(requestPath)
+                .with(user(username).roles("ADMIN"))
+                .header("X-Forwarded-For", forwardedFor)
+                .param("parentCode", "BP")
+                .param("businessText", "resilient communications");
+        if (!contextPath.isEmpty()) {
+            request.contextPath(contextPath).servletPath("/api/analyze-node");
+        }
+        return mockMvc.perform(request);
+    }
+
+    private static int indexOf(List<Filter> filters, Class<? extends Filter> type) {
+        for (int index = 0; index < filters.size(); index++) {
+            if (type.isInstance(filters.get(index))) {
+                return index;
+            }
+        }
+        return -1;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/shared/config/RateLimitFilterTest.java
@@ -1,0 +1,418 @@
+package com.taxonomy.shared.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitFilterTest {
+
+    private static final List<SimpleGrantedAuthority> USER_AUTHORITIES =
+            List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+    @Test
+    void contextPathAndForwardingHeadersCannotResetPrincipalBudget()
+            throws Exception {
+        AtomicLong now = new AtomicLong(1_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+
+        MockHttpServletResponse first = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "alice", "198.51.100.1", "203.0.113.1");
+        MockHttpServletResponse second = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "alice", "198.51.100.1", "203.0.113.99");
+        MockHttpServletResponse otherUser = perform(
+                filter, "POST", "/taxonomy", "/api/analyze",
+                "bob", "198.51.100.1", "203.0.113.99");
+
+        assertThat(first.getStatus()).isEqualTo(200);
+        assertThat(second.getStatus()).isEqualTo(429);
+        assertThat(second.getHeader("Retry-After")).isEqualTo("60");
+        assertThat(second.getHeader("Cache-Control")).isEqualTo("no-store");
+        assertThat(second.getContentAsString()).contains("\"status\":429");
+        assertThat(otherUser.getStatus()).isEqualTo(200);
+        assertThat(filter.trackedPrincipalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void keycloakBrowserAndBearerShareImmutableIssuerSubjectBudget()
+            throws Exception {
+        AtomicLong now = new AtomicLong(5_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+        String issuer = "https://identity.example/realms/taxonomy";
+        String subject = "550e8400-e29b-41d4-a716-446655440000";
+
+        Authentication bearer = jwtAuthentication(
+                issuer, subject, "old-display-name");
+        Authentication browser = oidcAuthentication(
+                issuer, subject, "renamed-display-name");
+        Authentication otherSubject = jwtAuthentication(
+                issuer, "different-subject", "old-display-name");
+        Authentication otherIssuer = oidcAuthentication(
+                "https://other-issuer.example/realms/taxonomy",
+                subject,
+                "renamed-display-name");
+
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                bearer, "192.0.2.5", "203.0.113.1").getStatus())
+                .isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                browser, "192.0.2.5", "203.0.113.99").getStatus())
+                .isEqualTo(429);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                otherSubject, "192.0.2.5", null).getStatus())
+                .isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                otherIssuer, "192.0.2.5", null).getStatus())
+                .isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                "renamed-display-name", "192.0.2.5", null).getStatus())
+                .isEqualTo(200);
+
+        assertThat(filter.trackedPrincipalCount()).isEqualTo(4);
+    }
+
+    @Test
+    void keycloakAuthenticationWithoutIssuerOrSubjectFailsClosedWithoutState()
+            throws Exception {
+        AtomicLong now = new AtomicLong(7_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+        Instant issuedAt = Instant.now();
+        Jwt missingIssuer = Jwt.withTokenValue("missing-issuer")
+                .header("alg", "RS256")
+                .subject("stable-subject")
+                .claim("preferred_username", "display-name")
+                .issuedAt(issuedAt)
+                .expiresAt(issuedAt.plusSeconds(300))
+                .build();
+        Jwt missingSubject = Jwt.withTokenValue("missing-subject")
+                .header("alg", "RS256")
+                .claim("iss", "https://identity.example/realms/taxonomy")
+                .claim("preferred_username", "display-name")
+                .issuedAt(issuedAt)
+                .expiresAt(issuedAt.plusSeconds(300))
+                .build();
+
+        for (Jwt jwt : List.of(missingIssuer, missingSubject)) {
+            Authentication authentication = new JwtAuthenticationToken(
+                    jwt, USER_AUTHORITIES, "display-name");
+            MockHttpServletResponse response = perform(
+                    filter, "GET", "", "/api/analyze-node",
+                    authentication, "192.0.2.7", null);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+        }
+        assertThat(filter.trackedPrincipalCount()).isZero();
+    }
+
+    @Test
+    void unauthenticatedProtectedRequestFailsClosedWithoutAllocatingIdentity()
+            throws Exception {
+        AtomicLong now = new AtomicLong(10_000L);
+        RateLimitFilter filter = filter(now, 3, 10);
+
+        MockHttpServletResponse response = perform(
+                filter, "GET", "", "/api/analyze-node",
+                (Authentication) null, "192.0.2.10", "203.0.113.1");
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getHeader("Cache-Control")).isEqualTo("no-store");
+        assertThat(response.getContentAsString()).contains("\"status\":401");
+        assertThat(filter.trackedPrincipalCount()).isZero();
+    }
+
+    @Test
+    void preflightHeadAndWrongMethodRequestsDoNotConsumeBudget()
+            throws Exception {
+        AtomicLong now = new AtomicLong(20_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+
+        assertThat(perform(
+                filter, "OPTIONS", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "HEAD", "", "/api/analyze-node",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(filter.trackedPrincipalCount()).isZero();
+
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.20", null).getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void fixedWindowUsesMonotonicMinuteBoundary() throws Exception {
+        AtomicLong now = new AtomicLong(30_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(429);
+
+        now.addAndGet(Duration.ofMinutes(1).toNanos());
+
+        assertThat(perform(
+                filter, "POST", "", "/api/justify-leaf",
+                "alice", "192.0.2.30", null).getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void expiredPrincipalEntriesAreRemoved() throws Exception {
+        AtomicLong now = new AtomicLong(40_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+
+        for (int index = 0; index < 3; index++) {
+            perform(filter, "GET", "", "/api/analyze-stream",
+                    "user-" + index, "192.0.2." + index, null);
+        }
+        assertThat(filter.trackedPrincipalCount()).isEqualTo(3);
+
+        now.addAndGet(Duration.ofMinutes(2).toNanos());
+        perform(filter, "GET", "", "/api/analyze-stream",
+                "current-user", "192.0.2.100", null);
+
+        assertThat(filter.trackedPrincipalCount()).isEqualTo(1);
+    }
+
+    @Test
+    void trackedPrincipalStateHasAHardBoundAndSharedOverflowFailsClosed()
+            throws Exception {
+        AtomicLong now = new AtomicLong(50_000L);
+        RateLimitFilter filter = filter(now, 1, 2);
+
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                "alice", "192.0.2.1", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                "bob", "192.0.2.1", null).getStatus()).isEqualTo(200);
+
+        MockHttpServletResponse firstOverflow = perform(
+                filter, "GET", "", "/api/analyze-node",
+                "charlie", "192.0.2.1", null);
+        MockHttpServletResponse secondOverflow = perform(
+                filter, "GET", "", "/api/analyze-node",
+                "dora", "192.0.2.1", null);
+
+        assertThat(filter.trackedPrincipalCount()).isEqualTo(2);
+        assertThat(firstOverflow.getStatus()).isEqualTo(200);
+        assertThat(secondOverflow.getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void cleanupAndConcurrentReadmissionCannotCreateParallelFreshCounters()
+            throws Exception {
+        AtomicLong now = new AtomicLong(60_000L);
+        RateLimitFilter filter = filter(now, 1, 10);
+        assertThat(perform(
+                filter, "GET", "", "/api/analyze-node",
+                "alice", "192.0.2.60", null).getStatus()).isEqualTo(200);
+
+        now.addAndGet(Duration.ofMinutes(2).toNanos());
+        int callers = 12;
+        ExecutorService executor = Executors.newFixedThreadPool(callers);
+        CountDownLatch ready = new CountDownLatch(callers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Integer>> results = new ArrayList<>();
+        try {
+            for (int index = 0; index < callers; index++) {
+                results.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return perform(
+                            filter, "GET", "", "/api/analyze-node",
+                            "alice", "192.0.2.60", null).getStatus();
+                }));
+            }
+            ready.await();
+            start.countDown();
+
+            List<Integer> statuses = new ArrayList<>();
+            for (Future<Integer> result : results) {
+                statuses.add(result.get());
+            }
+            assertThat(statuses).containsExactlyInAnyOrderElementsOf(
+                    expectedStatuses(callers));
+            assertThat(filter.trackedPrincipalCount()).isEqualTo(1);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void negativeLimitFailsClosedInsteadOfDisablingProtection() throws Exception {
+        AtomicLong now = new AtomicLong(70_000L);
+        RateLimitFilter filter = filter(now, -7, 10);
+
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.70", null).getStatus()).isEqualTo(200);
+        assertThat(perform(
+                filter, "POST", "", "/api/analyze",
+                "alice", "192.0.2.70", null).getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void zeroLimitDisablesTrackingAndLimiting() throws Exception {
+        AtomicLong now = new AtomicLong(80_000L);
+        RateLimitFilter filter = filter(now, 0, 10);
+
+        for (int index = 0; index < 3; index++) {
+            assertThat(perform(
+                    filter, "POST", "", "/api/analyze",
+                    (Authentication) null, "192.0.2.80", null).getStatus())
+                    .isEqualTo(200);
+        }
+        assertThat(filter.trackedPrincipalCount()).isZero();
+    }
+
+    private static Authentication jwtAuthentication(
+            String issuer,
+            String subject,
+            String preferredUsername) {
+        Instant now = Instant.now();
+        Jwt jwt = Jwt.withTokenValue("jwt-" + subject + '-' + preferredUsername)
+                .header("alg", "RS256")
+                .claim("iss", issuer)
+                .subject(subject)
+                .claim("preferred_username", preferredUsername)
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+        return new JwtAuthenticationToken(
+                jwt, USER_AUTHORITIES, preferredUsername);
+    }
+
+    private static Authentication oidcAuthentication(
+            String issuer,
+            String subject,
+            String preferredUsername) {
+        Instant now = Instant.now();
+        OidcIdToken idToken = new OidcIdToken(
+                "id-" + subject + '-' + preferredUsername,
+                now,
+                now.plusSeconds(300),
+                Map.of(
+                        "iss", issuer,
+                        "sub", subject,
+                        "preferred_username", preferredUsername));
+        DefaultOidcUser user = new DefaultOidcUser(
+                USER_AUTHORITIES, idToken, "preferred_username");
+        return new OAuth2AuthenticationToken(
+                user, USER_AUTHORITIES, "keycloak");
+    }
+
+    private static List<Integer> expectedStatuses(int callers) {
+        List<Integer> statuses = new ArrayList<>();
+        statuses.add(200);
+        for (int index = 1; index < callers; index++) {
+            statuses.add(429);
+        }
+        return statuses;
+    }
+
+    private static RateLimitFilter filter(
+            AtomicLong now,
+            int limit,
+            int maxTrackedPrincipals) {
+        RateLimitFilter filter = new RateLimitFilter(
+                now::get, maxTrackedPrincipals);
+        ReflectionTestUtils.setField(
+                filter, "maxRequestsPerMinute", limit);
+        return filter;
+    }
+
+    private static MockHttpServletResponse perform(
+            RateLimitFilter filter,
+            String method,
+            String contextPath,
+            String servletPath,
+            String username,
+            String remoteAddress,
+            String forwardedFor) throws Exception {
+        Authentication authentication = username == null
+                ? null
+                : new TestingAuthenticationToken(
+                        username, "[PROTECTED]", "ROLE_USER");
+        return perform(
+                filter,
+                method,
+                contextPath,
+                servletPath,
+                authentication,
+                remoteAddress,
+                forwardedFor);
+    }
+
+    private static MockHttpServletResponse perform(
+            RateLimitFilter filter,
+            String method,
+            String contextPath,
+            String servletPath,
+            Authentication authentication,
+            String remoteAddress,
+            String forwardedFor) throws Exception {
+        SecurityContext previous = SecurityContextHolder.getContext();
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        if (authentication != null) {
+            context.setAuthentication(authentication);
+        }
+        SecurityContextHolder.setContext(context);
+        try {
+            MockHttpServletRequest request = new MockHttpServletRequest(
+                    method, contextPath + servletPath);
+            request.setContextPath(contextPath);
+            request.setServletPath(servletPath);
+            request.setRemoteAddr(remoteAddress);
+            if (forwardedFor != null) {
+                request.addHeader("X-Forwarded-For", forwardedFor);
+            }
+
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            filter.doFilter(request, response, new MockFilterChain());
+            return response;
+        } finally {
+            SecurityContextHolder.setContext(previous);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`RateLimitFilter` is currently an implicitly registered servlet filter. Spring Boot places the Spring Security proxy at container order `-100` and otherwise unordered filter registrations at lowest precedence, so the existing limiter normally runs after a successful security chain—not before it.

The current implementation is nevertheless unsafe and operationally incorrect:

- successful callers can rotate the first `X-Forwarded-For` value and reset their quota;
- the identity map has neither expiry nor a hard cardinality bound;
- `/taxonomy/api/**` can bypass raw root-path comparisons;
- wall-clock adjustments control window rotation;
- negative values silently disable protection;
- HTTP 429 lacks `Retry-After` and `Cache-Control: no-store`;
- its security-relative position is implicit rather than a tested chain contract.

Closes #886.

## Security and identity boundary

- Disable ordinary servlet-container registration.
- Install the same bean exactly once after `AuthorizationFilter` in both form-login and Keycloak chains.
- Local accounts use a fixed-size SHA-256 digest of their authenticated username.
- Keycloak browser OIDC and bearer JWT requests use the same digest of the exact immutable `iss` and `sub` claims.
- Editable `preferred_username` values never define quota identity.
- Missing authentication or missing/blank OIDC issuer or subject fails closed without allocating state.
- Forwarding headers and peer addresses never define LLM quota identity.

## Bounded concurrency model

- Match exact HTTP method/path pairs after removing the servlet context path.
- Use monotonic time for fixed-window rotation.
- Retire inactive principals after two minutes.
- Cap tracked principals at 10,000.
- Route further identities through one shared fail-closed overflow bucket.
- Serialize admission and retirement under one short state lock so concurrent expiry/readmission cannot create parallel fresh windows.
- Treat exactly `0` as explicit disablement; negative values fail closed to one request per minute.
- Return UTF-8 JSON 429 with `Retry-After` and `Cache-Control: no-store`.

## Regression coverage

The focused tests prove:

- servlet registration is disabled and the form-login chain contains the limiter exactly once after `AuthorizationFilter`;
- unauthenticated and explicitly invalid-CSRF requests allocate no quota state;
- forwarding-header rotation cannot reset a local principal budget;
- local principals remain independent behind one peer;
- one Keycloak subject shares a budget across browser OIDC and bearer JWT even when `preferred_username` changes;
- different subjects, different issuers and a same-named local account remain independent;
- missing Keycloak issuer **or** subject fails closed without state;
- `/taxonomy/api/**` matches the root quota;
- OPTIONS, HEAD and wrong-method calls consume no budget;
- monotonic rotation, expiry, hard capacity, shared overflow, concurrent readmission, zero and negative configuration are deterministic;
- the Keycloak configuration installs the same post-authorization position.

## Exact scope

- first parent: `8f3d3083b4261209b6d9289662740555d9c33cac`;
- exact head: `2d8f569ec5048d47aca878ce5089c997b71b12c3`;
- exactly one commit;
- zero commits behind `main`;
- exactly seven files;
- no release request, deployment workflow, successful API payload or authorization grant is changed.

## Diagnostic history

- `7fd0b242…` failed compilation because Jakarta Servlet has no `SC_TOO_MANY_REQUESTS` constant.
- `c8a2edb0…` compiled, but its negative-CSRF test relied on an implicit missing-token assumption; the real MockMvc call returned HTTP 200.
- `18dec910…` made that test deterministic and passed every side matrix, but the identity audit showed that `Authentication.getName()` is `preferred_username` in both Keycloak adapters and therefore not a stable cross-transport account key.
- `3eee56fe…` introduced issuer/subject identity; the final review removed claim trimming and added explicit missing-subject coverage so distinct signed claim values cannot collapse onto one key.

Those historical heads are diagnostic evidence only. A completely fresh CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes matrix on `2d8f569e…` is the sole merge authority. The wording/UI update is separately bounded by #890.