### PR TITLE
Enforce bounded authoritative login lockout

### DIFF
--- a/docs/de/LOGIN_BRUTE_FORCE_PROTECTION.md
+++ b/docs/de/LOGIN_BRUTE_FORCE_PROTECTION.md
@@ -1,0 +1,47 @@
+# Schutz vor Brute-Force-Anmeldungen
+
+Taxonomy verwendet eine begrenzte Peer-Sperre nur im lokalen Benutzermodus. Keycloak-Bereitstellungen überlassen Zugangsdatenprüfung und Brute-Force-Schutz dem Identitätsanbieter.
+
+## Authentifizierungsgrenze
+
+Der Login-Begrenzer wird genau einmal innerhalb der Spring-Security-Filterkette registriert. Er läuft, nachdem `SecurityContextHolderFilter` eine vertrauenswürdige Browser-Sitzung wiederhergestellt hat, und bevor `UsernamePasswordAuthenticationFilter` sowie `BasicAuthenticationFilter` neue Zugangsdaten prüfen.
+
+Daraus folgt:
+
+- eine bereits authentifizierte, nicht anonyme Sitzung umgeht die Peer-Sperre;
+- ein neuer Form-Login- oder HTTP-Basic-Versuch eines gesperrten Peers wird vor der Zugangsdatenprüfung abgewiesen;
+- der Begrenzer dupliziert nicht die Passwortprüfung von Spring Security;
+- nur das maßgebliche nachgelagerte Authentifizierungsergebnis verändert den Fehlversuchszustand.
+
+Ein fehlgeschlagenes `POST /login` zählt, wenn Spring Security die Login-Fehlerantwort liefert. Eine Antwort unter `/api/**` zählt nur, wenn die Anfrage einen ausdrücklichen Header `Authorization: Basic ...` enthielt und Spring Security HTTP `401` zurückgab. Fehlende Zugangsdaten, Bearer-Zugangsdaten und andere Autorisierungsfehler erzeugen oder erhöhen keinen Sperrzustand.
+
+## Peer-Identität und vertrauenswürdiger Ingress
+
+Der Begrenzer verwendet ausschließlich den vom Framework aufgelösten Wert `HttpServletRequest.getRemoteAddr()`. Er wertet `Forwarded`, `X-Forwarded-For` oder ähnliche Header niemals selbst aus. In Kubernetes darf die Framework-Verarbeitung von Weiterleitungs-Headern nur hinter einem vertrauenswürdigen Ingress aktiviert sein; direkter Clientzugriff auf den Anwendungsport muss verhindert werden.
+
+Die In-Memory-Sperrtabelle speichert einen SHA-256-Digest fester Länge des aufgelösten Peers, nicht die rohe Adresse. HTTP-Antworten und Begrenzerprotokolle geben weder die rohe Adresse noch übermittelte Zugangsdaten aus.
+
+## Kapazität und Ablauf
+
+Fehlversuchsfenster verwenden monotone Zeit, damit Änderungen der Systemuhr eine Sperre weder verlängern noch verkürzen. Inaktive Einträge laufen global ab. Die normale Peer-Tabelle ist pro laufender Anwendungsinstanz hart auf 10.000 Einträge begrenzt. Weitere Peers teilen ein fehlgeschlossenes Überlaufkontingent; sie können bestehende Sperren weder löschen noch verdrängen.
+
+Der Zustand gilt jeweils nur für eine Anwendungsinstanz. Mehrere Replikate führen daher getrennte Peer-Sperrtabellen. Benötigt eine Bereitstellung ein clusterweites Authentifizierungskontingent, muss davor eine geeignete vertrauenswürdige Schutzschicht eingerichtet werden.
+
+## Konfiguration
+
+| Umgebungsvariable | Standard | Vertrag |
+|---|---:|---|
+| `TAXONOMY_LOGIN_RATE_LIMIT` | `true` | Aktiviert den Login-Begrenzer des lokalen Benutzermodus. |
+| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `5` | Positive Zahl maßgeblicher Fehlversuche vor der Sperre. Null und negative Werte verhindern den Start. |
+| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `300` | Positives Fehlversuchsfenster und Sperrdauer in Sekunden. Null und negative Werte verhindern den Start. |
+
+Dieselbe Pfaderkennung gilt am Root-Kontext und unter einem Servlet-Kontextpfad wie `/taxonomy`.
+
+## Antwort bei Sperre
+
+Ein blockierter neuer Authentifizierungsversuch erhält UTF-8-JSON mit HTTP `423 Locked`. Die Antwort enthält:
+
+- `Retry-After` mit den verbleibenden ganzen Sekunden;
+- `Cache-Control: no-store`;
+- `status: 423` und `retryAfterSeconds` im JSON-Inhalt;
+- keine Peer-Adresse, keinen Benutzernamen und kein Zugangsdatenmaterial.

--- a/docs/en/LOGIN_BRUTE_FORCE_PROTECTION.md
+++ b/docs/en/LOGIN_BRUTE_FORCE_PROTECTION.md
@@ -1,0 +1,47 @@
+# Login brute-force protection
+
+Taxonomy applies a bounded peer lockout only in the local-user profile. Keycloak deployments delegate credential validation and brute-force protection to the identity provider.
+
+## Authentication boundary
+
+The login limiter is installed exactly once inside the Spring Security filter chain. It runs after `SecurityContextHolderFilter` has restored a trusted browser session and before `UsernamePasswordAuthenticationFilter` and `BasicAuthenticationFilter` evaluate new credentials.
+
+Consequently:
+
+- an already authenticated, non-anonymous session bypasses peer lockout;
+- a new form-login or HTTP-Basic attempt from a locked peer is rejected before credentials are evaluated;
+- the limiter does not duplicate Spring Security password validation;
+- only the authoritative downstream authentication result changes failure state.
+
+A failed `POST /login` counts when Spring Security returns the login-error response. An `/api/**` response counts only when the request supplied an explicit `Authorization: Basic ...` header and Spring Security returned HTTP `401`. Missing credentials, Bearer credentials and unrelated authorization failures do not allocate or increment lockout state.
+
+## Peer identity and trusted ingress
+
+The limiter uses only the framework-resolved `HttpServletRequest.getRemoteAddr()` value. It never parses `Forwarded`, `X-Forwarded-For` or similar headers itself. In Kubernetes, configure framework forwarding-header processing only behind a trusted ingress and prevent clients from reaching the application port directly.
+
+The in-memory lockout table stores a fixed-size SHA-256 digest of the resolved peer, not the raw address. HTTP responses and limiter log messages never echo the raw address or supplied credentials.
+
+## Capacity and expiry
+
+Failure windows use monotonic time so wall-clock changes cannot extend or shorten a lockout. Inactive entries expire globally. The normal peer table is hard-capped at 10,000 entries per running application instance. New peers above that cap share one fail-closed overflow budget; they cannot clear or replace existing lockouts.
+
+State is local to one application instance. Multiple replicas therefore maintain separate peer lockout tables. A deployment that requires a cluster-wide authentication budget must add an appropriate trusted outer control.
+
+## Configuration
+
+| Environment variable | Default | Contract |
+|---|---:|---|
+| `TAXONOMY_LOGIN_RATE_LIMIT` | `true` | Enables the local-user login limiter. |
+| `TAXONOMY_LOGIN_MAX_ATTEMPTS` | `5` | Positive number of authoritative failures before lockout. Zero and negative values stop startup. |
+| `TAXONOMY_LOGIN_LOCKOUT_SECONDS` | `300` | Positive failure window and lockout duration in seconds. Zero and negative values stop startup. |
+
+The same route matching applies at the root context and below a servlet context path such as `/taxonomy`.
+
+## Locked response
+
+A blocked new authentication attempt receives UTF-8 JSON with HTTP `423 Locked`. The response includes:
+
+- `Retry-After` with the remaining whole seconds;
+- `Cache-Control: no-store`;
+- `status: 423` and `retryAfterSeconds` in the JSON body;
+- no peer address, username or credential material.

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/LoginRateLimitFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/LoginRateLimitFilter.java
@@ -6,35 +6,41 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
+import java.util.function.LongSupplier;
 
 /**
- * Brute-force protection filter for login endpoints.
- * <p>
- * Tracks failed authentication attempts per IP address and locks out IPs that exceed
- * the configured maximum number of attempts within the lockout window.
- * <p>
- * Applies to:
- * <ul>
- *   <li>{@code POST /login} — form-based login</li>
- *   <li>{@code /api/**} — HTTP Basic authentication (tracked via 401 responses)</li>
- * </ul>
- * <p>
- * Enabled by default. Disable with {@code TAXONOMY_LOGIN_RATE_LIMIT=false}.
- * Only active in form-login mode (without Keycloak). In the Keycloak profile,
- * brute-force protection is handled by the identity provider.
+ * Bounded peer lockout for new local form-login and HTTP-Basic authentication attempts.
+ *
+ * <p>The filter is installed inside Spring Security after the security context has been
+ * restored and before the form-login and HTTP-Basic authentication filters. An existing
+ * authenticated session therefore bypasses peer lockout, while a new authentication attempt
+ * from a locked peer is rejected before credentials are evaluated.</p>
+ *
+ * <p>Only authoritative authentication outcomes are counted: a failed {@code POST /login}
+ * response and an HTTP {@code 401} response to an explicit Basic credential on
+ * {@code /api/**}. Missing credentials, bearer credentials and unrelated authorization
+ * failures do not allocate peer state.</p>
  */
 @Component
 @Profile("!keycloak")
@@ -42,143 +48,331 @@ import java.util.concurrent.ConcurrentHashMap;
         havingValue = "true", matchIfMissing = true)
 public class LoginRateLimitFilter extends OncePerRequestFilter {
 
-    private static final Logger log = LoggerFactory.getLogger(LoginRateLimitFilter.class);
+    static final int DEFAULT_MAX_TRACKED_PEERS = 10_000;
+    private static final long MAX_CLEANUP_INTERVAL_NANOS =
+            Duration.ofMinutes(1).toNanos();
+    private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
+    private static final Logger log =
+            LoggerFactory.getLogger(LoginRateLimitFilter.class);
 
-    @Value("${taxonomy.security.login-rate-limit.max-attempts:5}")
-    private int maxAttempts;
+    private final Object stateMonitor = new Object();
+    private final Map<String, FailureTracker> trackers = new HashMap<>();
+    private final FailureTracker overflowTracker;
+    private final LongSupplier monotonicNanos;
+    private final int maxTrackedPeers;
+    private final int maxAttempts;
+    private final long lockoutNanos;
+    private final long cleanupIntervalNanos;
+    private long nextCleanupAt;
 
-    @Value("${taxonomy.security.login-rate-limit.lockout-seconds:300}")
-    private int lockoutSeconds;
+    @Autowired
+    public LoginRateLimitFilter(
+            @Value("${taxonomy.security.login-rate-limit.max-attempts:5}")
+            int maxAttempts,
+            @Value("${taxonomy.security.login-rate-limit.lockout-seconds:300}")
+            int lockoutSeconds) {
+        this(System::nanoTime, DEFAULT_MAX_TRACKED_PEERS,
+                maxAttempts, lockoutSeconds);
+    }
 
-    private final Map<String, FailureTracker> trackers = new ConcurrentHashMap<>();
+    LoginRateLimitFilter(
+            LongSupplier monotonicNanos,
+            int maxTrackedPeers,
+            int maxAttempts,
+            int lockoutSeconds) {
+        this.monotonicNanos = Objects.requireNonNull(
+                monotonicNanos, "monotonicNanos");
+        if (maxTrackedPeers <= 0) {
+            throw new IllegalArgumentException(
+                    "maxTrackedPeers must be positive");
+        }
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException(
+                    "taxonomy.security.login-rate-limit.max-attempts must be positive");
+        }
+        if (lockoutSeconds <= 0) {
+            throw new IllegalArgumentException(
+                    "taxonomy.security.login-rate-limit.lockout-seconds must be positive");
+        }
+        this.maxTrackedPeers = maxTrackedPeers;
+        this.maxAttempts = maxAttempts;
+        this.lockoutNanos = Duration.ofSeconds(lockoutSeconds).toNanos();
+        this.cleanupIntervalNanos = Math.min(
+                lockoutNanos, MAX_CLEANUP_INTERVAL_NANOS);
+        long now = monotonicNanos.getAsLong();
+        this.overflowTracker = new FailureTracker(now);
+        this.nextCleanupAt = now + cleanupIntervalNanos;
+    }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
-        String clientIp = getClientIp(request);
-        boolean isLoginPost = "POST".equalsIgnoreCase(request.getMethod())
-                && "/login".equals(request.getRequestURI());
-        boolean isApiPath = request.getRequestURI().startsWith("/api/");
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        String path = applicationPath(request);
+        boolean formLoginAttempt = isFormLoginAttempt(request.getMethod(), path);
+        boolean basicApiAttempt = isBasicApiAttempt(request, path);
 
-        // Authenticated users must not be blocked by brute-force protection —
-        // they have already proven their identity via session or HTTP Basic.
-        // Explicitly exclude AnonymousAuthenticationToken so that unauthenticated
-        // API requests remain subject to lockout.
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        boolean isAuthenticated = auth != null
-                && auth.isAuthenticated()
-                && !(auth instanceof AnonymousAuthenticationToken);
-
-        // Check if IP is currently locked out
-        FailureTracker tracker = trackers.get(clientIp);
-        if (tracker != null && tracker.isLockedOut(maxAttempts, lockoutSeconds)) {
-            if (isLoginPost || (isApiPath && !isAuthenticated)) {
-                log.warn("LOGIN_LOCKED ip={} attempts={}", clientIp, tracker.getCount());
-                response.setStatus(423); // 423 Locked
-                response.setContentType("application/json");
-                long remainingSeconds = tracker.getRemainingLockoutSeconds(lockoutSeconds);
-                response.getWriter().write(
-                        "{\"error\":\"Too many failed login attempts. Try again in "
-                        + remainingSeconds + " seconds.\","
-                        + "\"status\":423,"
-                        + "\"retryAfterSeconds\":" + remainingSeconds + "}");
-                return;
-            }
+        if (!formLoginAttempt && !basicApiAttempt) {
+            filterChain.doFilter(request, response);
+            return;
         }
 
-        // Proceed with the filter chain
+        if (isAuthenticated()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String peerKey = peerKey(request);
+        long now = monotonicNanos.getAsLong();
+        LockState currentLock = currentLock(peerKey, now);
+        if (currentLock.locked()) {
+            log.warn("LOGIN_LOCKED peerDigest={} attempts={}",
+                    peerKey, currentLock.failureCount());
+            writeLockedResponse(response, currentLock.retryAfterSeconds());
+            return;
+        }
+
         filterChain.doFilter(request, response);
 
-        // After the request: track failures
-        int status = response.getStatus();
-
-        if (isLoginPost && status == 302) {
-            // Form login: 302 redirect to /login?error means failure
-            String redirectLocation = response.getHeader("Location");
-            if (redirectLocation != null && redirectLocation.contains("error")) {
-                recordFailure(clientIp);
-            } else {
-                // Successful login — clear the tracker
-                trackers.remove(clientIp);
+        int responseStatus = response.getStatus();
+        boolean errorRedirect = hasErrorRedirect(response);
+        boolean failed = (formLoginAttempt && errorRedirect)
+                || (basicApiAttempt
+                    && responseStatus == HttpServletResponse.SC_UNAUTHORIZED);
+        if (failed) {
+            int count = recordFailure(peerKey, monotonicNanos.getAsLong());
+            if (count >= maxAttempts) {
+                log.warn("LOGIN_RATE_LIMIT_TRIGGERED peerDigest={} attempts={}",
+                        peerKey, count);
             }
-        } else if (isApiPath && status == 401) {
-            // HTTP Basic: 401 Unauthorized means bad credentials
-            recordFailure(clientIp);
+            return;
+        }
+
+        boolean successfulFormResponse = formLoginAttempt
+                && isRedirect(responseStatus)
+                && !errorRedirect;
+        if (isAuthenticated() || successfulFormResponse) {
+            clearFailures(peerKey);
         }
     }
 
-    private void recordFailure(String clientIp) {
-        FailureTracker tracker = trackers.computeIfAbsent(clientIp, k -> new FailureTracker());
-        int count = tracker.recordFailure(lockoutSeconds);
-        if (count >= maxAttempts) {
-            log.warn("LOGIN_RATE_LIMIT_TRIGGERED ip={} attempts={}", clientIp, count);
+    /** Removes the servlet context path before matching security routes. */
+    static String applicationPath(HttpServletRequest request) {
+        String servletPath = request.getServletPath();
+        if (servletPath != null
+                && !servletPath.isBlank()
+                && !"/".equals(servletPath)) {
+            return servletPath;
         }
+
+        String requestUri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null
+                && !contextPath.isBlank()
+                && requestUri.startsWith(contextPath)) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
     }
 
-    private String getClientIp(HttpServletRequest request) {
-        String xff = request.getHeader("X-Forwarded-For");
-        if (xff != null && !xff.isBlank()) {
-            return xff.split(",")[0].trim();
-        }
-        return request.getRemoteAddr();
+    static boolean isFormLoginAttempt(String method, String path) {
+        return "POST".equalsIgnoreCase(method) && "/login".equals(path);
     }
 
-    /** Visible for testing — clears all failure trackers. */
+    static boolean isBasicApiAttempt(HttpServletRequest request, String path) {
+        if (path == null || !path.startsWith("/api/")) {
+            return false;
+        }
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authorization != null
+                && authorization.regionMatches(true, 0, "Basic ", 0, 6);
+    }
+
+    /** Visible for test isolation without exposing peer identities or mutable state. */
     public void clearTrackers() {
-        trackers.clear();
+        long now = monotonicNanos.getAsLong();
+        synchronized (stateMonitor) {
+            trackers.clear();
+            overflowTracker.reset(now);
+            nextCleanupAt = now + cleanupIntervalNanos;
+        }
     }
 
-    /** Visible for testing — returns the tracker map. */
-    public Map<String, FailureTracker> getTrackers() {
-        return trackers;
+    /** Visible for tests and diagnostics; peer keys remain private. */
+    public int trackedPeerCount() {
+        synchronized (stateMonitor) {
+            return trackers.size();
+        }
     }
 
-    /**
-     * Tracks failed login attempts for a single IP address.
-     */
-    static class FailureTracker {
-        private int count = 0;
-        private long firstFailureTime = 0;
+    int overflowFailureCount() {
+        synchronized (stateMonitor) {
+            return overflowTracker.failureCount();
+        }
+    }
 
-        synchronized int recordFailure(int lockoutSeconds) {
-            long now = System.currentTimeMillis();
-            long windowMs = lockoutSeconds * 1000L;
-
-            // If the window has expired, reset the counter
-            if (firstFailureTime > 0 && (now - firstFailureTime) > windowMs) {
-                count = 0;
-                firstFailureTime = now;
+    private LockState currentLock(String peerKey, long now) {
+        synchronized (stateMonitor) {
+            cleanupExpiredEntries(now, false);
+            FailureTracker tracker = trackers.get(peerKey);
+            if (tracker == null && trackers.size() >= maxTrackedPeers) {
+                cleanupExpiredEntries(now, true);
+                if (trackers.size() >= maxTrackedPeers) {
+                    tracker = overflowTracker;
+                }
             }
+            return tracker == null
+                    ? LockState.unlocked()
+                    : tracker.lockState(maxAttempts, now, lockoutNanos);
+        }
+    }
 
-            if (firstFailureTime == 0) {
-                firstFailureTime = now;
+    private int recordFailure(String peerKey, long now) {
+        synchronized (stateMonitor) {
+            cleanupExpiredEntries(now, false);
+            FailureTracker tracker = trackers.get(peerKey);
+            if (tracker == null) {
+                if (trackers.size() >= maxTrackedPeers) {
+                    cleanupExpiredEntries(now, true);
+                }
+                if (trackers.size() >= maxTrackedPeers) {
+                    tracker = overflowTracker;
+                } else {
+                    tracker = new FailureTracker(now);
+                    trackers.put(peerKey, tracker);
+                }
             }
-            return ++count;
+            return tracker.recordFailure(now, lockoutNanos);
+        }
+    }
+
+    private void clearFailures(String peerKey) {
+        synchronized (stateMonitor) {
+            trackers.remove(peerKey);
+        }
+    }
+
+    private void cleanupExpiredEntries(long now, boolean force) {
+        if (!force && now - nextCleanupAt < 0) {
+            return;
+        }
+        trackers.entrySet().removeIf(
+                entry -> entry.getValue().isExpired(now, lockoutNanos));
+        if (overflowTracker.isExpired(now, lockoutNanos)) {
+            overflowTracker.reset(now);
+        }
+        nextCleanupAt = now + cleanupIntervalNanos;
+    }
+
+    private static boolean isAuthenticated() {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        return authentication != null
+                && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken);
+    }
+
+    private static boolean hasErrorRedirect(HttpServletResponse response) {
+        String location = response.getHeader(HttpHeaders.LOCATION);
+        return isRedirect(response.getStatus())
+                && location != null
+                && location.contains("login?error");
+    }
+
+    private static boolean isRedirect(int status) {
+        return status >= 300 && status < 400;
+    }
+
+    private static String peerKey(HttpServletRequest request) {
+        String remoteAddress = request.getRemoteAddr();
+        return digestPeer(remoteAddress == null ? "" : remoteAddress);
+    }
+
+    private static String digestPeer(String remoteAddress) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update("login-peer".getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+            return HexFormat.of().formatHex(
+                    digest.digest(remoteAddress.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is unavailable", impossible);
+        }
+    }
+
+    private static void writeLockedResponse(
+            HttpServletResponse response,
+            long retryAfterSeconds) throws IOException {
+        response.setStatus(423);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader(HttpHeaders.RETRY_AFTER,
+                Long.toString(retryAfterSeconds));
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.getWriter().write(
+                "{\"error\":\"Too many failed login attempts.\","
+                        + "\"status\":423,"
+                        + "\"retryAfterSeconds\":" + retryAfterSeconds + "}");
+    }
+
+    private record LockState(
+            boolean locked,
+            long retryAfterSeconds,
+            int failureCount) {
+
+        private static LockState unlocked() {
+            return new LockState(false, 0, 0);
+        }
+    }
+
+    private static final class FailureTracker {
+        private int failureCount;
+        private long windowStartedAt;
+
+        private FailureTracker(long now) {
+            reset(now);
         }
 
-        synchronized boolean isLockedOut(int maxAttempts, int lockoutSeconds) {
-            if (count < maxAttempts) {
-                return false;
+        private int recordFailure(long now, long windowNanos) {
+            if (isExpired(now, windowNanos)) {
+                reset(now);
             }
-            long elapsed = System.currentTimeMillis() - firstFailureTime;
-            long windowMs = lockoutSeconds * 1000L;
-            if (elapsed > windowMs) {
-                // Lockout expired — reset
-                count = 0;
-                firstFailureTime = 0;
-                return false;
+            if (failureCount == 0) {
+                windowStartedAt = now;
             }
-            return true;
+            return ++failureCount;
         }
 
-        synchronized long getRemainingLockoutSeconds(int lockoutSeconds) {
-            long elapsed = System.currentTimeMillis() - firstFailureTime;
-            long remaining = (lockoutSeconds * 1000L - elapsed) / 1000;
-            return Math.max(0, remaining);
+        private LockState lockState(
+                int maximumAttempts,
+                long now,
+                long windowNanos) {
+            if (isExpired(now, windowNanos)) {
+                reset(now);
+                return LockState.unlocked();
+            }
+            if (failureCount < maximumAttempts) {
+                return LockState.unlocked();
+            }
+            long elapsed = now - windowStartedAt;
+            long remaining = Math.max(1L, windowNanos - elapsed);
+            long retryAfter = Math.max(1L,
+                    (remaining + NANOS_PER_SECOND - 1L) / NANOS_PER_SECOND);
+            return new LockState(true, retryAfter, failureCount);
         }
 
-        synchronized int getCount() {
-            return count;
+        private boolean isExpired(long now, long windowNanos) {
+            return failureCount == 0 || now - windowStartedAt >= windowNanos;
+        }
+
+        private int failureCount() {
+            return failureCount;
+        }
+
+        private void reset(long now) {
+            failureCount = 0;
+            windowStartedAt = now;
         }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/LoginRateLimitFilterConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/LoginRateLimitFilterConfiguration.java
@@ -1,0 +1,24 @@
+package com.taxonomy.security.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/** Keeps login lockout exclusively inside the form-login Spring Security chain. */
+@Configuration(proxyBeanMethods = false)
+@Profile("!keycloak")
+@ConditionalOnProperty(name = "taxonomy.security.login-rate-limit.enabled",
+        havingValue = "true", matchIfMissing = true)
+public class LoginRateLimitFilterConfiguration {
+
+    @Bean
+    FilterRegistrationBean<LoginRateLimitFilter> disableContainerLoginRateLimitFilter(
+            LoginRateLimitFilter filter) {
+        FilterRegistrationBean<LoginRateLimitFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/SecurityConfig.java
@@ -14,9 +14,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.header.HeaderWriterFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import java.util.Optional;
 
 /** Spring Security configuration for form-login mode. */
 @Configuration
@@ -28,24 +31,27 @@ public class SecurityConfig {
     private final PasswordChangeRequiredFilter passwordChangeRequiredFilter;
     private final WebDavApplicationCredentialFilter webDavCredentialFilter;
     private final RateLimitFilter rateLimitFilter;
+    private final LoginRateLimitFilter loginRateLimitFilter;
 
     @Autowired
     public SecurityConfig(
             AuthorizationRulesConfigurer authRules,
             PasswordChangeRequiredFilter passwordChangeRequiredFilter,
             WebDavApplicationCredentialFilter webDavCredentialFilter,
-            RateLimitFilter rateLimitFilter) {
+            RateLimitFilter rateLimitFilter,
+            Optional<LoginRateLimitFilter> loginRateLimitFilter) {
         this.authRules = authRules;
         this.passwordChangeRequiredFilter = passwordChangeRequiredFilter;
         this.webDavCredentialFilter = webDavCredentialFilter;
         this.rateLimitFilter = rateLimitFilter;
+        this.loginRateLimitFilter = loginRateLimitFilter.orElse(null);
     }
 
     /** Backward-compatible constructor for focused configuration tests. */
     SecurityConfig(
             AuthorizationRulesConfigurer authRules,
             PasswordChangeRequiredFilter passwordChangeRequiredFilter) {
-        this(authRules, passwordChangeRequiredFilter, null, null);
+        this(authRules, passwordChangeRequiredFilter, null, null, Optional.empty());
     }
 
     /** Backward-compatible constructor for tests of the WebDAV filter boundary. */
@@ -53,7 +59,18 @@ public class SecurityConfig {
             AuthorizationRulesConfigurer authRules,
             PasswordChangeRequiredFilter passwordChangeRequiredFilter,
             WebDavApplicationCredentialFilter webDavCredentialFilter) {
-        this(authRules, passwordChangeRequiredFilter, webDavCredentialFilter, null);
+        this(authRules, passwordChangeRequiredFilter,
+                webDavCredentialFilter, null, Optional.empty());
+    }
+
+    /** Backward-compatible constructor for focused LLM-quota tests. */
+    SecurityConfig(
+            AuthorizationRulesConfigurer authRules,
+            PasswordChangeRequiredFilter passwordChangeRequiredFilter,
+            WebDavApplicationCredentialFilter webDavCredentialFilter,
+            RateLimitFilter rateLimitFilter) {
+        this(authRules, passwordChangeRequiredFilter,
+                webDavCredentialFilter, rateLimitFilter, Optional.empty());
     }
 
     @Bean
@@ -78,6 +95,11 @@ public class SecurityConfig {
 
         if (webDavCredentialFilter != null) {
             http.addFilterBefore(webDavCredentialFilter, BasicAuthenticationFilter.class);
+        }
+        if (loginRateLimitFilter != null) {
+            // Restore a trusted session first, then wrap the authoritative form-login
+            // and HTTP-Basic authentication filters exactly once.
+            http.addFilterAfter(loginRateLimitFilter, SecurityContextHolderFilter.class);
         }
         http.addFilterAfter(passwordChangeRequiredFilter, BasicAuthenticationFilter.class);
         if (rateLimitFilter != null) {

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/config/I18nConfig.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/config/I18nConfig.java
@@ -18,6 +18,7 @@ public class I18nConfig {
             "messages_document_templates",
             "messages_document_template_detail",
             "messages_webdav_credentials",
+            "messages_security",
             "messages_jgit_storage",
             "messages_observability",
             "messages_portfolio",

--- a/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/shared/controller/HelpController.java
@@ -84,6 +84,7 @@ public class HelpController {
         new String[]{"CONTAINER_IMAGE",           "🐳", "help.toc.CONTAINER_IMAGE",               "help.audience.devops"},
         new String[]{"OBSERVABILITY",             "📈", "help.toc.OBSERVABILITY",                 "help.audience.devops"},
         new String[]{"SECURITY",                  "🔒", "help.toc.SECURITY",                      "help.audience.admins"},
+        new String[]{"LOGIN_BRUTE_FORCE_PROTECTION", "🛡️", "help.toc.LOGIN_BRUTE_FORCE_PROTECTION", "help.audience.admins"},
         new String[]{"DATABASE_SETUP",            "🗄️", "help.toc.DATABASE_SETUP",                "help.audience.devops"},
         new String[]{"DEPLOYMENT_CHECKLIST",      "✅", "help.toc.DEPLOYMENT_CHECKLIST",           "help.audience.devops"},
         new String[]{"OPERATIONS_GUIDE",          "📋", "help.toc.OPERATIONS_GUIDE",              "help.audience.devops"},

--- a/taxonomy-app/src/main/resources/i18n/messages_security.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_security.properties
@@ -1,0 +1,2 @@
+# Security help navigation
+help.toc.LOGIN_BRUTE_FORCE_PROTECTION=Login brute-force protection

--- a/taxonomy-app/src/main/resources/i18n/messages_security_de.properties
+++ b/taxonomy-app/src/main/resources/i18n/messages_security_de.properties
@@ -1,0 +1,2 @@
+# Navigation der Sicherheitshilfe
+help.toc.LOGIN_BRUTE_FORCE_PROTECTION=Schutz vor Brute-Force-Anmeldungen

--- a/taxonomy-app/src/test/java/com/taxonomy/SecurityImprovementTests.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/SecurityImprovementTests.java
@@ -2,7 +2,6 @@ package com.taxonomy;
 
 import com.taxonomy.security.config.LoginRateLimitFilter;
 import com.taxonomy.security.model.AppUser;
-import com.taxonomy.security.repository.RoleRepository;
 import com.taxonomy.security.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,12 +13,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,9 +51,6 @@ class SecurityImprovementTests {
     private UserRepository userRepository;
 
     @Autowired
-    private RoleRepository roleRepository;
-
-    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Autowired(required = false)
@@ -73,32 +70,29 @@ class SecurityImprovementTests {
 
     @Test
     void loginRateLimitFilterTrackerIsInitiallyEmpty() {
-        assertThat(loginRateLimitFilter.getTrackers()).isEmpty();
+        assertThat(loginRateLimitFilter.trackedPeerCount()).isZero();
     }
 
     @Test
-    void authenticatedUserIsNotBlockedByLockout() throws Exception {
+    void authenticatedUserIsNotBlockedByAnonymousPeerLockout() throws Exception {
         assertThat(loginRateLimitFilter)
                 .as("LoginRateLimitFilter bean must be present")
                 .isNotNull();
+        String peer = "10.99.99.99";
 
-        int maxAttempts = (int) ReflectionTestUtils.getField(
-                loginRateLimitFilter, "maxAttempts");
-        for (int index = 0; index < maxAttempts; index++) {
-            ReflectionTestUtils.invokeMethod(
-                    loginRateLimitFilter, "recordFailure", "10.99.99.99");
+        for (int index = 0; index < 3; index++) {
+            mockMvc.perform(get("/api/taxonomy")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(remoteAddress(peer))
+                            .with(httpBasic("admin", "wrong-password")))
+                    .andExpect(status().isUnauthorized());
         }
-        assertThat(loginRateLimitFilter.getTrackers()).containsKey("10.99.99.99");
+        assertThat(loginRateLimitFilter.trackedPeerCount()).isEqualTo(1);
 
         mockMvc.perform(get("/api/taxonomy")
                         .accept(MediaType.APPLICATION_JSON)
-                        .header("X-Forwarded-For", "10.99.99.99"))
-                .andExpect(status().isUnauthorized());
-
-        mockMvc.perform(get("/api/taxonomy")
-                        .accept(MediaType.APPLICATION_JSON)
-                        .with(user("admin").roles("USER"))
-                        .header("X-Forwarded-For", "10.99.99.99"))
+                        .with(remoteAddress(peer))
+                        .with(user("admin").roles("USER")))
                 .andExpect(status().isOk());
     }
 
@@ -221,5 +215,12 @@ class SecurityImprovementTests {
         assertThat(admin).isPresent();
         assertThat(admin.get().isMustChangePassword()).isTrue();
         assertThat(passwordEncoder.matches("admin", admin.get().getPasswordHash())).isFalse();
+    }
+
+    private static RequestPostProcessor remoteAddress(String address) {
+        return request -> {
+            request.setRemoteAddr(address);
+            return request;
+        };
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitDocumentationContractTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitDocumentationContractTest.java
@@ -1,0 +1,62 @@
+package com.taxonomy.security.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Keeps the operator-facing login lockout contract aligned in English and German. */
+class LoginRateLimitDocumentationContractTest {
+
+    @Test
+    void documentationDescribesAuthoritativeBoundedPeerLockout() throws Exception {
+        Path root = repositoryRoot();
+        String english = read(root, "docs/en/LOGIN_BRUTE_FORCE_PROTECTION.md");
+        String german = read(root, "docs/de/LOGIN_BRUTE_FORCE_PROTECTION.md");
+
+        assertThat(english)
+                .contains("after `SecurityContextHolderFilter`")
+                .contains("before `UsernamePasswordAuthenticationFilter`")
+                .contains("explicit `Authorization: Basic ...` header")
+                .contains("framework-resolved `HttpServletRequest.getRemoteAddr()`")
+                .contains("hard-capped at 10,000 entries")
+                .contains("fail-closed overflow budget")
+                .contains("`Retry-After`")
+                .contains("`Cache-Control: no-store`")
+                .contains("`/taxonomy`")
+                .doesNotContain("trusts `X-Forwarded-For`");
+        assertThat(german)
+                .contains("nachdem `SecurityContextHolderFilter`")
+                .contains("bevor `UsernamePasswordAuthenticationFilter`")
+                .contains("Header `Authorization: Basic ...`")
+                .contains("`HttpServletRequest.getRemoteAddr()`")
+                .contains("hart auf 10.000 Einträge begrenzt")
+                .contains("fehlgeschlossenes Überlaufkontingent")
+                .contains("`Retry-After`")
+                .contains("`Cache-Control: no-store`")
+                .contains("`/taxonomy`")
+                .doesNotContain("vertraut `X-Forwarded-For`");
+    }
+
+    private static String read(Path root, String relative) throws IOException {
+        return Files.readString(root.resolve(relative), StandardCharsets.UTF_8);
+    }
+
+    private static Path repositoryRoot() {
+        Path current = Path.of(System.getProperty("user.dir"))
+                .toAbsolutePath().normalize();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isDirectory(current.resolve("taxonomy-app"))
+                    && Files.isDirectory(current.resolve("docs/de"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        throw new IllegalStateException("Unable to locate Taxonomy repository root");
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitFilterSecurityChainTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitFilterSecurityChainTest.java
@@ -1,0 +1,250 @@
+package com.taxonomy.security.config;
+
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** Proves the productive form-login chain observes authoritative authentication outcomes. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "llm.mock=true",
+    "spring.datasource.url=jdbc:hsqldb:mem:login-rate-limit-it",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "taxonomy.admin-password=LoginRateLimit-Integration-Password-2026!",
+    "taxonomy.security.require-password-change=false",
+    "taxonomy.security.login-rate-limit.enabled=true",
+    "taxonomy.security.login-rate-limit.max-attempts=2",
+    "taxonomy.security.login-rate-limit.lockout-seconds=60"
+})
+class LoginRateLimitFilterSecurityChainTest {
+
+    private static final String ADMIN_PASSWORD =
+            "LoginRateLimit-Integration-Password-2026!";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private LoginRateLimitFilter loginRateLimitFilter;
+
+    @Autowired
+    @Qualifier("disableContainerLoginRateLimitFilter")
+    private FilterRegistrationBean<LoginRateLimitFilter> registration;
+
+    @Autowired
+    @Qualifier("springSecurityFilterChain")
+    private FilterChainProxy securityFilterChain;
+
+    @BeforeEach
+    void resetLimiter() {
+        loginRateLimitFilter.clearTrackers();
+    }
+
+    @Test
+    void filterRunsExactlyOnceAfterContextRestoreAndBeforeAuthentication() {
+        List<Filter> filters = securityFilterChain.getFilters("/login");
+
+        int contextIndex = indexOf(filters, SecurityContextHolderFilter.class);
+        int limiterIndex = filters.indexOf(loginRateLimitFilter);
+        int formIndex = indexOf(filters, UsernamePasswordAuthenticationFilter.class);
+        int basicIndex = indexOf(filters, BasicAuthenticationFilter.class);
+
+        assertThat(registration.isEnabled()).isFalse();
+        assertThat(contextIndex).isGreaterThanOrEqualTo(0);
+        assertThat(limiterIndex).isGreaterThan(contextIndex);
+        assertThat(formIndex).isGreaterThan(limiterIndex);
+        assertThat(basicIndex).isGreaterThan(limiterIndex);
+        assertThat(filters.stream().filter(loginRateLimitFilter::equals)).hasSize(1);
+    }
+
+    @Test
+    void missingAndBearerCredentialsDoNotPoisonBasicLockoutState()
+            throws Exception {
+        String peer = "203.0.113.70";
+
+        mockMvc.perform(get("/api/taxonomy").with(remoteAddress(peer)))
+                .andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(remoteAddress(peer))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer rejected"))
+                .andExpect(status().isUnauthorized());
+
+        assertThat(loginRateLimitFilter.trackedPeerCount()).isZero();
+    }
+
+    @Test
+    void realBasicFailuresLockPeerAndValidNewCredentialsCannotBypass()
+            throws Exception {
+        String peer = "203.0.113.71";
+
+        wrongBasic(peer, "198.51.100.10");
+        wrongBasic(peer, "198.51.100.99");
+
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(remoteAddress(peer))
+                        .with(httpBasic("admin", ADMIN_PASSWORD))
+                        .header("X-Forwarded-For", "192.0.2.5")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(423))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(423))
+                .andExpect(content().string(org.hamcrest.Matchers.not(
+                        org.hamcrest.Matchers.containsString(peer))));
+
+        assertThat(loginRateLimitFilter.trackedPeerCount()).isEqualTo(1);
+    }
+
+    @Test
+    void restoredAuthenticatedSessionBypassesAnonymousPeerLockout()
+            throws Exception {
+        String peer = "203.0.113.72";
+        wrongBasic(peer, null);
+        wrongBasic(peer, null);
+
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(remoteAddress(peer))
+                        .with(user("admin").roles("USER"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void realFormLoginFailuresAreObservedBeforeAValidNewLogin()
+            throws Exception {
+        String peer = "203.0.113.73";
+
+        wrongFormLogin(peer);
+        wrongFormLogin(peer);
+
+        mockMvc.perform(post("/login")
+                        .with(remoteAddress(peer))
+                        .with(csrf())
+                        .param("username", "admin")
+                        .param("password", ADMIN_PASSWORD))
+                .andExpect(status().is(423))
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER));
+    }
+
+    @Test
+    void prefixedBasicRequestsUseTheSamePeerLockoutContract()
+            throws Exception {
+        String peer = "203.0.113.74";
+
+        prefixedBasic(peer, "wrong-password").andExpect(status().isUnauthorized());
+        prefixedBasic(peer, "wrong-password").andExpect(status().isUnauthorized());
+        prefixedBasic(peer, ADMIN_PASSWORD)
+                .andExpect(status().is(423))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"));
+    }
+
+    @Test
+    void prefixedFormLoginUsesTheSamePeerLockoutContract() throws Exception {
+        String peer = "203.0.113.75";
+
+        prefixedForm(peer, "wrong-password")
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(
+                        HttpHeaders.LOCATION, containsString("login?error")));
+        prefixedForm(peer, "wrong-password")
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(
+                        HttpHeaders.LOCATION, containsString("login?error")));
+        prefixedForm(peer, ADMIN_PASSWORD)
+                .andExpect(status().is(423))
+                .andExpect(header().exists(HttpHeaders.RETRY_AFTER));
+    }
+
+    private void wrongBasic(String peer, String forwardedFor) throws Exception {
+        MockHttpServletRequestBuilder request = get("/api/taxonomy")
+                .with(remoteAddress(peer))
+                .with(httpBasic("admin", "wrong-password"))
+                .accept(MediaType.APPLICATION_JSON);
+        if (forwardedFor != null) {
+            request.header("X-Forwarded-For", forwardedFor);
+        }
+        mockMvc.perform(request).andExpect(status().isUnauthorized());
+    }
+
+    private void wrongFormLogin(String peer) throws Exception {
+        mockMvc.perform(post("/login")
+                        .with(remoteAddress(peer))
+                        .with(csrf())
+                        .param("username", "admin")
+                        .param("password", "wrong-password"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(header().string(
+                        HttpHeaders.LOCATION, containsString("login?error")));
+    }
+
+    private ResultActions prefixedForm(
+            String peer,
+            String password) throws Exception {
+        return mockMvc.perform(post("/taxonomy/login")
+                .contextPath("/taxonomy")
+                .servletPath("/login")
+                .with(remoteAddress(peer))
+                .with(csrf())
+                .param("username", "admin")
+                .param("password", password));
+    }
+
+    private ResultActions prefixedBasic(
+            String peer,
+            String password) throws Exception {
+        return mockMvc.perform(get("/taxonomy/api/taxonomy")
+                .contextPath("/taxonomy")
+                .servletPath("/api/taxonomy")
+                .with(remoteAddress(peer))
+                .with(httpBasic("admin", password))
+                .accept(MediaType.APPLICATION_JSON));
+    }
+
+    private static RequestPostProcessor remoteAddress(String address) {
+        return request -> {
+            request.setRemoteAddr(address);
+            return request;
+        };
+    }
+
+    private static int indexOf(List<Filter> filters, Class<? extends Filter> type) {
+        for (int index = 0; index < filters.size(); index++) {
+            if (type.isInstance(filters.get(index))) {
+                return index;
+            }
+        }
+        return -1;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/LoginRateLimitFilterTest.java
@@ -1,0 +1,323 @@
+package com.taxonomy.security.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LoginRateLimitFilterTest {
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void missingAndBearerCredentialsDoNotAllocateFailureState() throws Exception {
+        LoginRateLimitFilter filter = filter(3, 60);
+
+        invoke(filter, request("GET", "/api/taxonomy", "203.0.113.10"),
+                response -> response.setStatus(401));
+        MockHttpServletRequest bearer = request(
+                "GET", "/api/taxonomy", "203.0.113.10");
+        bearer.addHeader(HttpHeaders.AUTHORIZATION, "Bearer rejected-token");
+        invoke(filter, bearer, response -> response.setStatus(401));
+
+        assertThat(filter.trackedPeerCount()).isZero();
+        assertThat(filter.overflowFailureCount()).isZero();
+    }
+
+    @Test
+    void basicFailuresLockPeerAndReturnExplicitNoStoreJson() throws Exception {
+        LoginRateLimitFilter filter = filter(2, 60);
+        String peer = "203.0.113.20";
+
+        basicFailure(filter, peer, null);
+        basicFailure(filter, peer, null);
+
+        AtomicInteger downstreamCalls = new AtomicInteger();
+        MockHttpServletResponse response = invoke(
+                filter,
+                basicRequest("/api/taxonomy", peer, null),
+                ignored -> downstreamCalls.incrementAndGet());
+
+        assertThat(downstreamCalls).hasValue(0);
+        assertThat(response.getStatus()).isEqualTo(423);
+        long retryAfter = Long.parseLong(
+                response.getHeader(HttpHeaders.RETRY_AFTER));
+        assertThat(retryAfter).isBetween(1L, 60L);
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL)).isEqualTo("no-store");
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString())
+                .contains("\"status\":423")
+                .contains("\"retryAfterSeconds\":" + retryAfter)
+                .doesNotContain(peer)
+                .doesNotContain("Basic");
+    }
+
+    @Test
+    void authenticatedSessionBypassesLockedPeer() throws Exception {
+        LoginRateLimitFilter filter = filter(2, 60);
+        String peer = "203.0.113.30";
+        basicFailure(filter, peer, null);
+        basicFailure(filter, peer, null);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                UsernamePasswordAuthenticationToken.authenticated(
+                        "alice", "[PROTECTED]",
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        AtomicInteger downstreamCalls = new AtomicInteger();
+        MockHttpServletResponse response = invoke(
+                filter,
+                basicRequest("/api/taxonomy", peer, null),
+                target -> {
+                    downstreamCalls.incrementAndGet();
+                    target.setStatus(200);
+                });
+
+        assertThat(downstreamCalls).hasValue(1);
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void successfulAuthenticationClearsOnlyItsPeerFailureState() throws Exception {
+        LoginRateLimitFilter filter = filter(2, 60);
+        String successfulPeer = "203.0.113.35";
+        String otherPeer = "203.0.113.36";
+        basicFailure(filter, successfulPeer, null);
+        basicFailure(filter, otherPeer, null);
+        assertThat(filter.trackedPeerCount()).isEqualTo(2);
+
+        invoke(filter,
+                basicRequest("/api/taxonomy", successfulPeer, null),
+                response -> {
+                    SecurityContextHolder.getContext().setAuthentication(
+                            UsernamePasswordAuthenticationToken.authenticated(
+                                    "alice", "[PROTECTED]",
+                                    List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+                    response.setStatus(200);
+                });
+
+        assertThat(filter.trackedPeerCount()).isEqualTo(1);
+        SecurityContextHolder.clearContext();
+        basicFailure(filter, otherPeer, null);
+        MockHttpServletResponse otherPeerResponse = invoke(
+                filter,
+                basicRequest("/api/taxonomy", otherPeer, null),
+                response -> response.setStatus(200));
+        assertThat(otherPeerResponse.getStatus()).isEqualTo(423);
+    }
+
+    @Test
+    void forwardingHeaderCannotCreateAnotherPeerIdentity() throws Exception {
+        LoginRateLimitFilter filter = filter(2, 60);
+        String peer = "203.0.113.40";
+
+        basicFailure(filter, peer, "198.51.100.10");
+        basicFailure(filter, peer, "198.51.100.99");
+        MockHttpServletResponse response = invoke(
+                filter,
+                basicRequest("/api/taxonomy", peer, "192.0.2.5"),
+                target -> target.setStatus(200));
+
+        assertThat(filter.trackedPeerCount()).isEqualTo(1);
+        assertThat(response.getStatus()).isEqualTo(423);
+    }
+
+    @Test
+    void servletContextPathUsesTheSameBasicAttemptContract() throws Exception {
+        LoginRateLimitFilter filter = filter(2, 60);
+        String peer = "203.0.113.50";
+
+        basicFailure(filter, "/taxonomy/api/taxonomy",
+                "/taxonomy", "/api/taxonomy", peer);
+        basicFailure(filter, "/taxonomy/api/taxonomy",
+                "/taxonomy", "/api/taxonomy", peer);
+        MockHttpServletResponse response = invoke(
+                filter,
+                basicRequest("/taxonomy/api/taxonomy", "/taxonomy",
+                        "/api/taxonomy", peer),
+                target -> target.setStatus(200));
+
+        assertThat(response.getStatus()).isEqualTo(423);
+    }
+
+    @Test
+    void stalePeersExpireUsingMonotonicTimeBeforeCapacityOverflows() throws Exception {
+        AtomicLong clock = new AtomicLong();
+        LoginRateLimitFilter filter = new LoginRateLimitFilter(
+                clock::get, 1, 2, 60);
+
+        basicFailure(filter, "203.0.113.60", null);
+        clock.addAndGet(Duration.ofSeconds(61).toNanos());
+        basicFailure(filter, "203.0.113.61", null);
+
+        assertThat(filter.trackedPeerCount()).isEqualTo(1);
+        assertThat(filter.overflowFailureCount()).isZero();
+    }
+
+    @Test
+    void concurrentNewPeersNeverExceedCapacityAndOverflowFailsClosed()
+            throws Exception {
+        int capacity = 8;
+        LoginRateLimitFilter filter = new LoginRateLimitFilter(
+                System::nanoTime, capacity, 2, 60);
+        ExecutorService executor = Executors.newFixedThreadPool(12);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Object>> futures = java.util.stream.IntStream.range(0, 64)
+                    .mapToObj(index -> executor.submit(() -> {
+                        start.await();
+                        basicFailure(filter, "198.51.100." + index, null);
+                        return null;
+                    }))
+                    .toList();
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(10, TimeUnit.SECONDS);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(filter.trackedPeerCount()).isLessThanOrEqualTo(capacity);
+        assertThat(filter.overflowFailureCount()).isGreaterThanOrEqualTo(2);
+        MockHttpServletResponse overflowResponse = invoke(
+                filter,
+                basicRequest("/api/taxonomy", "192.0.2.250", null),
+                target -> target.setStatus(200));
+        assertThat(overflowResponse.getStatus()).isEqualTo(423);
+    }
+
+    @Test
+    void invalidConfigurationFailsClosedAtConstruction() {
+        assertThatThrownBy(() -> new LoginRateLimitFilter(
+                System::nanoTime, 10, 0, 60))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("max-attempts");
+        assertThatThrownBy(() -> new LoginRateLimitFilter(
+                System::nanoTime, 10, 2, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("lockout-seconds");
+        assertThatThrownBy(() -> new LoginRateLimitFilter(
+                System::nanoTime, 0, 2, 60))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxTrackedPeers");
+    }
+
+    private static LoginRateLimitFilter filter(
+            int maximumAttempts,
+            int lockoutSeconds) {
+        return new LoginRateLimitFilter(
+                System::nanoTime, 100, maximumAttempts, lockoutSeconds);
+    }
+
+    private static void basicFailure(
+            LoginRateLimitFilter filter,
+            String peer,
+            String forwardedFor) throws Exception {
+        basicFailure(filter, "/api/taxonomy", "", "/api/taxonomy",
+                peer, forwardedFor);
+    }
+
+    private static void basicFailure(
+            LoginRateLimitFilter filter,
+            String requestUri,
+            String contextPath,
+            String servletPath,
+            String peer) throws Exception {
+        basicFailure(filter, requestUri, contextPath, servletPath, peer, null);
+    }
+
+    private static void basicFailure(
+            LoginRateLimitFilter filter,
+            String requestUri,
+            String contextPath,
+            String servletPath,
+            String peer,
+            String forwardedFor) throws Exception {
+        invoke(filter,
+                basicRequest(requestUri, contextPath, servletPath,
+                        peer, forwardedFor),
+                response -> response.setStatus(401));
+    }
+
+    private static MockHttpServletRequest basicRequest(
+            String path,
+            String peer,
+            String forwardedFor) {
+        return basicRequest(path, "", path, peer, forwardedFor);
+    }
+
+    private static MockHttpServletRequest basicRequest(
+            String requestUri,
+            String contextPath,
+            String servletPath,
+            String peer) {
+        return basicRequest(requestUri, contextPath, servletPath, peer, null);
+    }
+
+    private static MockHttpServletRequest basicRequest(
+            String requestUri,
+            String contextPath,
+            String servletPath,
+            String peer,
+            String forwardedFor) {
+        MockHttpServletRequest request = request("GET", requestUri, peer);
+        request.setContextPath(contextPath);
+        request.setServletPath(servletPath);
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Basic dGVzdDpiYWQ=");
+        if (forwardedFor != null) {
+            request.addHeader("X-Forwarded-For", forwardedFor);
+        }
+        return request;
+    }
+
+    private static MockHttpServletRequest request(
+            String method,
+            String path,
+            String peer) {
+        MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+        request.setRequestURI(path);
+        request.setServletPath(path);
+        request.setRemoteAddr(peer);
+        return request;
+    }
+
+    private static MockHttpServletResponse invoke(
+            LoginRateLimitFilter filter,
+            MockHttpServletRequest request,
+            ResponseAction action) throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = (servletRequest, servletResponse) ->
+                action.accept((MockHttpServletResponse) servletResponse);
+        filter.doFilter(request, response, chain);
+        return response;
+    }
+
+    @FunctionalInterface
+    private interface ResponseAction {
+        void accept(MockHttpServletResponse response)
+                throws IOException, ServletException;
+    }
+}


### PR DESCRIPTION
## Problem

`LoginRateLimitFilter` was an implicitly registered servlet filter that normally ran after Spring Security. It therefore could not reliably observe form-login or HTTP-Basic authentication failures, trusted caller-controlled `X-Forwarded-For`, exposed mutable peer state, used wall-clock time and had no hard capacity or fail-closed overflow contract.

Closes #888. Follows the merged #892 documentation correction and the #887 post-authorization LLM quota boundary.

## Security boundary

- disables ordinary servlet-container registration;
- installs the filter exactly once inside the local-user Spring Security chain, after `SecurityContextHolderFilter` and before both form-login and HTTP-Basic authentication;
- lets an already restored authenticated session bypass peer lockout;
- blocks a new credential attempt from a locked peer before credentials are evaluated;
- counts only the authoritative downstream form-login failure response or an HTTP 401 following an explicit Basic Authorization scheme;
- does not allocate state for missing credentials, Bearer credentials or unrelated authorization failures.

## Bounded peer state

- uses only framework-resolved `HttpServletRequest.getRemoteAddr()` and never parses forwarding headers itself;
- retains a fixed-size SHA-256 peer digest rather than a raw address;
- uses monotonic time for failure windows and expiry;
- performs global stale-entry cleanup;
- hard-caps the ordinary table at 10,000 peers per running instance;
- places excess identities into one shared fail-closed overflow budget without clearing existing lockouts;
- rejects zero or negative attempt/window configuration during startup;
- exposes only a bounded peer count for tests, never the identity map.

## HTTP and deployment contract

HTTP 423 responses are explicit UTF-8 JSON with `Retry-After` and `Cache-Control: no-store`, and do not echo peer addresses or credentials. Root and `/taxonomy` context-path deployments use the same route matching. English and German operator references document the trusted-ingress, per-instance capacity and response contracts. The new operator page is registered in the in-app Help table of contents through a dedicated bilingual security message bundle.

## Regression coverage

Focused tests prove chain placement, real form-login and Basic failures, restored-session bypass, locked-peer enforcement for valid new credentials, missing/Bearer isolation, forwarding-header resistance, root/prefixed parity, monotonic expiry, concurrent hard capacity, shared fail-closed overflow, invalid configuration, sanitized HTTP 423, peer-specific successful-authentication cleanup without clearing another peer, bilingual documentation, and synchronization between shipped Help documents, Help metadata and localized titles.

## Exact scope

- first parent: `b11a2109997cdc1902b8da5681eeaeb31f8028d4` (current `main`, merged #892);
- exact head: `874232c6851b59c66103f93f9ddd71297e50a83c`;
- exactly one commit;
- zero commits behind `main`;
- exactly thirteen changed paths;
- no workflow, release request, dependency, database schema or Keycloak behavior change.

## Reconstructed-head corrections

1. The first matrix exposed one compile-only generic assignment in the concurrency test. The branch was rebuilt on the unchanged parent with the type corrected.
2. The second matrix compiled and passed Security Scan, but CodeQL's `java/user-controlled-bypass` heuristic classified the conditionally invoked helper named `isFormLoginFailure` as an authentication method that request-path data could skip. The response is now classified independently (`status` and error redirect) before the server-recognized attempt type is applied. Authentication and lockout semantics are unchanged, while the misleading conditional security-method shape is removed. CodeQL Java and JavaScript both passed on the resulting source.
3. The successful-authentication cleanup test was strengthened: two peer states are created, only the successful peer is removed, and the other peer demonstrably reaches lockout.
4. The full CI/CD and all three database matrices then exposed the existing Help synchronization contract: the newly added English operator document was not registered in `HelpController`. The final reconstruction registers it in the Help table of contents, adds exact English/German `help.toc.LOGIN_BRUTE_FORCE_PROTECTION` values in a dedicated security bundle, and exposes that bundle through the shared `I18nConfig`. The failing contract is corrected rather than weakened.

Only checks on the exact head above are authoritative. Keep this PR in Draft until CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes checks have completed successfully on this unchanged head.