### PR TITLE
Make password-change enforcement context-path safe

### DIFF
--- a/docs/de/SECURITY.md
+++ b/docs/de/SECURITY.md
@@ -93,6 +93,10 @@ Wichtige Einstellungen:
 | `TAXONOMY_AUDIT_LOGGING` | Aktiviert Security-Ereignisprotokollierung. |
 | `TAXONOMY_SWAGGER_PUBLIC` | Erlaubt öffentlichen Swagger-Zugriff, sofern SpringDoc aktiv ist. |
 
+Der verpflichtende Passwortwechsel berücksichtigt den Servlet-Kontextpfad. Eine Root-Bereitstellung verwendet `/change-password` und `/api/account/change-password`; unter `/taxonomy` lauten die Pfade `/taxonomy/change-password` und `/taxonomy/api/account/change-password`. Login, Logout, Fehlerbehandlung, Passwortwechsel-Seite und -API, CSS, JavaScript, Bilder und Webjars bleiben während der Einschränkung erreichbar.
+
+Eine eingeschränkte API-Anfrage erhält HTTP `428 Precondition Required`, `Cache-Control: no-store`, den Fehlercode `PASSWORD_CHANGE_REQUIRED` und den Passwortwechsel-Endpunkt innerhalb des aktiven Kontextpfads. Der Erzwingungsfilter ist genau einmal in der lokalen Spring-Security-Kette registriert; die gewöhnliche Servlet-Registrierung ist deaktiviert. Im Keycloak-Profil bleibt dieser Lebenszyklus beim Identitätsanbieter.
+
 ## Zugangsdaten für externes Git
 
 Zugangsdaten eines externen kanonischen Git-Repositorys sind Deployment-Secrets und keine Repository-Daten.

--- a/docs/dev/PASSWORD_CHANGE_ENFORCEMENT.md
+++ b/docs/dev/PASSWORD_CHANGE_ENFORCEMENT.md
@@ -24,17 +24,24 @@ A successful self-service replacement updates the password hash and clears the f
 
 ## Browser behavior
 
-An authenticated restricted user is redirected to `/change-password`. Login, logout, password replacement, error handling, and static assets remain reachable so the user cannot become trapped behind the enforcement filter. After a successful replacement, the browser returns to the application.
+An authenticated restricted user is redirected to the password-change page inside the active servlet context. At the root context this is `/change-password`; below a prefix such as `/taxonomy` it is `/taxonomy/change-password`.
+
+Route comparisons use the application path after removing the servlet context. Login, logout, password replacement, error handling, CSS, JavaScript, images, and webjars therefore remain reachable under both root and prefixed deployments, so the user cannot become trapped behind the enforcement filter. After a successful replacement, the browser returns to the application.
 
 ## REST behavior
 
 Protected API calls authenticated with HTTP Basic return:
 
 - HTTP `428 Precondition Required`;
+- `Cache-Control: no-store`;
 - error code `PASSWORD_CHANGE_REQUIRED`;
-- the replacement endpoint `/api/account/change-password`.
+- a context-aware `changePasswordEndpoint`.
 
-The client submits the current password, new password, and confirmation to that endpoint using the temporary HTTP Basic credential. After success, subsequent API calls use the replacement credential normally.
+The endpoint is `/api/account/change-password` at the root context and `/taxonomy/api/account/change-password` below the example prefix. The client submits the current password, new password, and confirmation to that endpoint using the temporary HTTP Basic credential. After success, subsequent API calls use the replacement credential normally.
+
+## Filter registration
+
+`PasswordChangeRequiredFilter` is registered exactly once inside the local-user Spring Security chain, after form-login and HTTP-Basic authentication can establish the authoritative principal. Ordinary servlet-container registration is explicitly disabled. The filter and its registration configuration remain excluded from the `keycloak` profile.
 
 ## Persistence migration
 
@@ -42,4 +49,4 @@ The idempotent schema-contract migration creates `app_user.must_change_password`
 
 ## Verification
 
-Regression tests cover browser redirection, the real HTTP Basic 428-to-success flow, flag clearing, administrator-created/reset credentials, validation failures, and Keycloak separation. Full CI also exercises database compatibility, container startup, UI, accessibility, CodeQL, Trivy, reactor-wide coverage, and the strict bounded-context architecture gate.
+Regression tests cover root and prefixed browser redirection, reachable lifecycle and static paths, root and prefixed real HTTP Basic 428-to-success flows, non-cacheable context-aware API responses, exactly one Security-chain registration, disabled servlet registration, flag clearing, administrator-created and reset credentials, validation failures, and Keycloak separation. Full CI also exercises database compatibility, container startup, UI, accessibility, CodeQL, Trivy, reactor-wide coverage, and the strict bounded-context architecture gate.

--- a/docs/en/SECURITY.md
+++ b/docs/en/SECURITY.md
@@ -93,6 +93,10 @@ Relevant settings include:
 | `TAXONOMY_AUDIT_LOGGING` | Enable security event logging. |
 | `TAXONOMY_SWAGGER_PUBLIC` | Permit unauthenticated Swagger access when SpringDoc is enabled. |
 
+Mandatory password replacement is servlet-context aware. A root deployment uses `/change-password` and `/api/account/change-password`; a deployment below `/taxonomy` uses `/taxonomy/change-password` and `/taxonomy/api/account/change-password`. Login, logout, error handling, the replacement page and API, CSS, JavaScript, images, and webjars remain reachable while the account is restricted.
+
+A restricted API request returns HTTP `428 Precondition Required`, `Cache-Control: no-store`, error code `PASSWORD_CHANGE_REQUIRED`, and the replacement endpoint inside the active context path. The enforcement filter is registered exactly once in the local-user Spring Security chain; ordinary servlet registration is disabled. Keycloak continues to own this lifecycle when its profile is active.
+
 ## External Git credentials
 
 External canonical-repository credentials are deployment secrets, not repository data.

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,57 +25,115 @@ import java.nio.charset.StandardCharsets;
 @Profile("!keycloak")
 public class PasswordChangeRequiredFilter extends OncePerRequestFilter {
 
+    private static final String CHANGE_PASSWORD_PATH = "/change-password";
+    private static final String CHANGE_PASSWORD_API_PATH =
+            "/api/account/change-password";
+
     private final PasswordChangeService passwordChangeService;
     private final boolean enforcementEnabled;
 
     public PasswordChangeRequiredFilter(
             PasswordChangeService passwordChangeService,
-            @Value("${taxonomy.security.require-password-change:false}") boolean enforcementEnabled) {
+            @Value("${taxonomy.security.require-password-change:false}")
+            boolean enforcementEnabled) {
         this.passwordChangeService = passwordChangeService;
         this.enforcementEnabled = enforcementEnabled;
     }
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        if (!enforcementEnabled) {
-            return true;
+        return !enforcementEnabled || isExemptPath(applicationPath(request));
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())
+                || !passwordChangeService.isPasswordChangeRequired(
+                        authentication.getName())) {
+            filterChain.doFilter(request, response);
+            return;
         }
-        String path = request.getRequestURI();
+
+        String path = applicationPath(request);
+        if (isApiPath(path)) {
+            writePasswordChangeRequired(
+                    response,
+                    externalPath(request, CHANGE_PASSWORD_API_PATH));
+            return;
+        }
+
+        response.sendRedirect(externalPath(request, CHANGE_PASSWORD_PATH));
+    }
+
+    /** Removes the servlet context path before matching application routes. */
+    static String applicationPath(HttpServletRequest request) {
+        String requestUri = request.getRequestURI();
+        if (requestUri == null || requestUri.isBlank()) {
+            return "/";
+        }
+
+        String contextPath = contextPrefix(request);
+        if (contextPath.isEmpty()) {
+            return requestUri;
+        }
+        if (requestUri.equals(contextPath)) {
+            return "/";
+        }
+        if (requestUri.startsWith(contextPath + "/")) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
+    }
+
+    static boolean isExemptPath(String path) {
         return path.equals("/login")
                 || path.startsWith("/login/")
                 || path.equals("/logout")
-                || path.equals("/change-password")
-                || path.equals("/api/account/change-password")
+                || path.equals(CHANGE_PASSWORD_PATH)
+                || path.equals(CHANGE_PASSWORD_API_PATH)
                 || path.equals("/error")
+                || path.startsWith("/error/")
                 || path.startsWith("/css/")
                 || path.startsWith("/js/")
                 || path.startsWith("/images/")
                 || path.startsWith("/webjars/");
     }
 
-    @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain)
-            throws ServletException, IOException {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()
-                || "anonymousUser".equals(authentication.getPrincipal())
-                || !passwordChangeService.isPasswordChangeRequired(authentication.getName())) {
-            filterChain.doFilter(request, response);
-            return;
-        }
+    private static boolean isApiPath(String path) {
+        return path.equals("/api") || path.startsWith("/api/");
+    }
 
-        if (request.getRequestURI().startsWith("/api/")) {
-            response.setStatus(428);
-            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.getWriter().write("{\"error\":\"PASSWORD_CHANGE_REQUIRED\","
-                    + "\"message\":\"Change the temporary password before using the API\","
-                    + "\"changePasswordEndpoint\":\"/api/account/change-password\"}");
-            return;
-        }
+    private static String externalPath(
+            HttpServletRequest request,
+            String applicationPath) {
+        return contextPrefix(request) + applicationPath;
+    }
 
-        response.sendRedirect(request.getContextPath() + "/change-password");
+    private static String contextPrefix(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        return contextPath == null
+                || contextPath.isBlank()
+                || "/".equals(contextPath)
+                ? "" : contextPath;
+    }
+
+    private static void writePasswordChangeRequired(
+            HttpServletResponse response,
+            String changePasswordEndpoint) throws IOException {
+        response.setStatus(428);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.getWriter().write(
+                "{\"error\":\"PASSWORD_CHANGE_REQUIRED\","
+                        + "\"message\":\"Change the temporary password before using the API\","
+                        + "\"changePasswordEndpoint\":\""
+                        + changePasswordEndpoint + "\"}");
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilterConfiguration.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/config/PasswordChangeRequiredFilterConfiguration.java
@@ -1,0 +1,22 @@
+package com.taxonomy.security.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/** Keeps local password-change enforcement exclusively inside Spring Security. */
+@Configuration(proxyBeanMethods = false)
+@Profile("!keycloak")
+public class PasswordChangeRequiredFilterConfiguration {
+
+    @Bean
+    FilterRegistrationBean<PasswordChangeRequiredFilter>
+            disableContainerPasswordChangeRequiredFilter(
+                    PasswordChangeRequiredFilter filter) {
+        FilterRegistrationBean<PasswordChangeRequiredFilter> registration =
+                new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+}

--- a/taxonomy-app/src/test/java/com/taxonomy/security/PasswordChangeEnforcementTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/PasswordChangeEnforcementTest.java
@@ -1,25 +1,35 @@
 package com.taxonomy.security;
 
+import com.taxonomy.security.config.PasswordChangeRequiredFilter;
 import com.taxonomy.security.model.AppRole;
 import com.taxonomy.security.model.AppUser;
 import com.taxonomy.security.repository.RoleRepository;
 import com.taxonomy.security.repository.UserRepository;
+import jakarta.servlet.Filter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -36,12 +46,20 @@ class PasswordChangeEnforcementTest {
     @Autowired private UserRepository userRepository;
     @Autowired private RoleRepository roleRepository;
     @Autowired private PasswordEncoder passwordEncoder;
+    @Autowired private PasswordChangeRequiredFilter passwordChangeRequiredFilter;
+    @Autowired
+    @Qualifier("disableContainerPasswordChangeRequiredFilter")
+    private FilterRegistrationBean<PasswordChangeRequiredFilter> registration;
+    @Autowired
+    @Qualifier("springSecurityFilterChain")
+    private FilterChainProxy securityFilterChain;
 
     @BeforeEach
     void setUp() {
         AppRole userRole = roleRepository.findByName("ROLE_USER")
                 .orElseGet(() -> roleRepository.save(new AppRole("ROLE_USER")));
-        AppUser user = userRepository.findByUsername(USERNAME).orElseGet(AppUser::new);
+        AppUser user = userRepository.findByUsername(USERNAME)
+                .orElseGet(AppUser::new);
         user.setUsername(USERNAME);
         user.setPasswordHash(passwordEncoder.encode(TEMPORARY_PASSWORD));
         user.setEnabled(true);
@@ -62,15 +80,82 @@ class PasswordChangeEnforcementTest {
     }
 
     @Test
-    void basicClientReceivesPreconditionAndCanReplacePasswordThroughApi() throws Exception {
+    @WithMockUser(username = USERNAME, roles = "USER")
+    void prefixedBrowserAndRequiredAssetsRemainReachable() throws Exception {
+        mockMvc.perform(prefixedGet("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/taxonomy/change-password"));
+
+        mockMvc.perform(prefixedGet("/change-password"))
+                .andExpect(status().isOk());
+        mockMvc.perform(prefixedGet("/css/taxonomy.css"))
+                .andExpect(status().isOk());
+        mockMvc.perform(prefixedGet("/js/taxonomy-i18n.js"))
+                .andExpect(status().isOk());
+        mockMvc.perform(prefixedGet(
+                        "/webjars/bootstrap/5.3.8/dist/css/bootstrap.min.css"))
+                .andExpect(status().isOk());
+        mockMvc.perform(prefixedGet("/images/not-present.svg"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void basicClientReceivesPreconditionAndCanReplacePasswordThroughApi()
+            throws Exception {
         mockMvc.perform(get("/api/taxonomy")
                         .with(httpBasic(USERNAME, TEMPORARY_PASSWORD)))
                 .andExpect(status().is(428))
-                .andExpect(jsonPath("$.error").value("PASSWORD_CHANGE_REQUIRED"))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+                .andExpect(jsonPath("$.error")
+                        .value("PASSWORD_CHANGE_REQUIRED"))
                 .andExpect(jsonPath("$.changePasswordEndpoint")
                         .value("/api/account/change-password"));
 
-        mockMvc.perform(post("/api/account/change-password")
+        replacePassword(post("/api/account/change-password"));
+
+        assertReplacementPersisted();
+        mockMvc.perform(get("/api/taxonomy")
+                        .with(httpBasic(USERNAME, REPLACEMENT_PASSWORD)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void prefixedBasicClientUsesContextAwareReplacementEndpoint()
+            throws Exception {
+        mockMvc.perform(prefixedGet("/api/taxonomy")
+                        .with(httpBasic(USERNAME, TEMPORARY_PASSWORD)))
+                .andExpect(status().is(428))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+                .andExpect(jsonPath("$.error")
+                        .value("PASSWORD_CHANGE_REQUIRED"))
+                .andExpect(jsonPath("$.changePasswordEndpoint")
+                        .value("/taxonomy/api/account/change-password"));
+
+        replacePassword(prefixedPost("/api/account/change-password"));
+
+        assertReplacementPersisted();
+        mockMvc.perform(prefixedGet("/api/taxonomy")
+                        .with(httpBasic(USERNAME, REPLACEMENT_PASSWORD)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void filterIsRegisteredOnlyOnceInsideTheSecurityChain() {
+        List<Filter> filters = securityFilterChain.getFilters("/api/taxonomy");
+
+        int basicIndex = indexOf(filters, BasicAuthenticationFilter.class);
+        int enforcementIndex = filters.indexOf(passwordChangeRequiredFilter);
+
+        assertThat(registration.isEnabled()).isFalse();
+        assertThat(basicIndex).isGreaterThanOrEqualTo(0);
+        assertThat(enforcementIndex).isGreaterThan(basicIndex);
+        assertThat(filters.stream().filter(passwordChangeRequiredFilter::equals))
+                .hasSize(1);
+    }
+
+    private void replacePassword(MockHttpServletRequestBuilder request)
+            throws Exception {
+        mockMvc.perform(request
                         .with(httpBasic(USERNAME, TEMPORARY_PASSWORD))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -82,13 +167,35 @@ class PasswordChangeEnforcementTest {
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("PASSWORD_CHANGED"));
+    }
 
+    private void assertReplacementPersisted() {
         AppUser updated = userRepository.findByUsername(USERNAME).orElseThrow();
         assertThat(updated.isMustChangePassword()).isFalse();
-        assertThat(passwordEncoder.matches(REPLACEMENT_PASSWORD, updated.getPasswordHash())).isTrue();
+        assertThat(passwordEncoder.matches(
+                REPLACEMENT_PASSWORD, updated.getPasswordHash())).isTrue();
+    }
 
-        mockMvc.perform(get("/api/taxonomy")
-                        .with(httpBasic(USERNAME, REPLACEMENT_PASSWORD)))
-                .andExpect(status().isOk());
+    private static MockHttpServletRequestBuilder prefixedGet(String path) {
+        return get("/taxonomy" + path)
+                .contextPath("/taxonomy")
+                .servletPath("/".equals(path) ? "" : path);
+    }
+
+    private static MockHttpServletRequestBuilder prefixedPost(String path) {
+        return post("/taxonomy" + path)
+                .contextPath("/taxonomy")
+                .servletPath(path);
+    }
+
+    private static int indexOf(
+            List<Filter> filters,
+            Class<? extends Filter> type) {
+        for (int index = 0; index < filters.size(); index++) {
+            if (type.isInstance(filters.get(index))) {
+                return index;
+            }
+        }
+        return -1;
     }
 }

--- a/taxonomy-app/src/test/java/com/taxonomy/security/config/PasswordChangeRequiredFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/config/PasswordChangeRequiredFilterTest.java
@@ -1,0 +1,151 @@
+package com.taxonomy.security.config;
+
+import com.taxonomy.security.service.PasswordChangeService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordChangeRequiredFilterTest {
+
+    private static final String USERNAME = "restricted-user";
+
+    @Mock
+    private PasswordChangeService passwordChangeService;
+    @Mock
+    private FilterChain filterChain;
+
+    private PasswordChangeRequiredFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+        filter = new PasswordChangeRequiredFilter(passwordChangeService, true);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void prefixedLifecycleAndStaticPathsRemainExempt() {
+        for (String path : List.of(
+                "/login",
+                "/login/oauth2/code/keycloak",
+                "/logout",
+                "/change-password",
+                "/api/account/change-password",
+                "/error",
+                "/css/taxonomy.css",
+                "/js/taxonomy-i18n.js",
+                "/images/taxonomy.svg",
+                "/webjars/bootstrap/5.3.8/dist/css/bootstrap.min.css")) {
+            MockHttpServletRequest request = prefixedRequest("GET", path);
+
+            assertThat(filter.shouldNotFilter(request))
+                    .as("application path %s", path)
+                    .isTrue();
+            assertThat(PasswordChangeRequiredFilter.applicationPath(request))
+                    .isEqualTo(path);
+        }
+    }
+
+    @Test
+    void prefixedProtectedPathStillRequiresEnforcement() {
+        MockHttpServletRequest request =
+                prefixedRequest("GET", "/api/taxonomy");
+
+        assertThat(filter.shouldNotFilter(request)).isFalse();
+        assertThat(PasswordChangeRequiredFilter.applicationPath(request))
+                .isEqualTo("/api/taxonomy");
+    }
+
+    @Test
+    void prefixedApiResponseIsContextAwareAndNotCacheable()
+            throws Exception {
+        authenticateRestrictedUser();
+        MockHttpServletRequest request =
+                prefixedRequest("GET", "/api/taxonomy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(428);
+        assertThat(response.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("no-store");
+        assertThat(response.getContentType()).startsWith("application/json");
+        assertThat(response.getContentAsString())
+                .contains("\"error\":\"PASSWORD_CHANGE_REQUIRED\"")
+                .contains("\"changePasswordEndpoint\":"
+                        + "\"/taxonomy/api/account/change-password\"");
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void prefixedBrowserRedirectStaysInsideContext() throws Exception {
+        authenticateRestrictedUser();
+        MockHttpServletRequest request = prefixedRequest("GET", "/");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(302);
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo("/taxonomy/change-password");
+        verify(filterChain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void rootDeploymentRetainsExistingExternalPaths() throws Exception {
+        authenticateRestrictedUser();
+        MockHttpServletRequest request =
+                new MockHttpServletRequest("GET", "/api/taxonomy");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(428);
+        assertThat(response.getContentAsString())
+                .contains("\"changePasswordEndpoint\":"
+                        + "\"/api/account/change-password\"");
+    }
+
+    private void authenticateRestrictedUser() {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        USERNAME,
+                        "unused",
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+        when(passwordChangeService.isPasswordChangeRequired(USERNAME))
+                .thenReturn(true);
+    }
+
+    private static MockHttpServletRequest prefixedRequest(
+            String method,
+            String applicationPath) {
+        MockHttpServletRequest request = new MockHttpServletRequest(
+                method, "/taxonomy" + applicationPath);
+        request.setContextPath("/taxonomy");
+        request.setServletPath(applicationPath);
+        return request;
+    }
+}


### PR DESCRIPTION
## Problem

`PasswordChangeRequiredFilter` compared the raw request URI with root-only paths. In a supported prefixed deployment such as `/taxonomy`, the password-change page, replacement API and required static resources could therefore be intercepted again. The HTTP 428 response also advertised a replacement endpoint outside the active context path. The component additionally lacked an explicitly disabled servlet registration although it is intentionally installed in the Spring Security chain.

Closes #889. Built directly after merged #893 / #888.

## Runtime contract

- removes the servlet context path before every route comparison;
- redirects restricted browser users to the password-change page inside the active context;
- returns `/api/account/change-password` at root and `/taxonomy/api/account/change-password` below the example prefix;
- adds `Cache-Control: no-store` to HTTP 428 responses;
- keeps login, logout, error handling, password-change page/API, CSS, JavaScript, images and webjars outside the restriction under root and prefixed deployments;
- preserves `PASSWORD_CHANGE_REQUIRED` and the existing real HTTP Basic replacement flow.

## Registration and profile boundary

- adds a disabled `FilterRegistrationBean<PasswordChangeRequiredFilter>`;
- retains the existing authoritative position after `BasicAuthenticationFilter` in the local-user Spring Security chain;
- proves that the productive chain contains the filter exactly once;
- keeps both the filter and registration configuration outside the `keycloak` profile.

## Regression coverage

Focused unit and Spring integration tests cover:

- normalized application paths under `/taxonomy`;
- no self-redirect on `/taxonomy/change-password`;
- prefixed CSS, JavaScript and webjar delivery plus pass-through of image requests;
- root and prefixed browser redirects;
- root and prefixed HTTP Basic 428-to-password-replacement flows;
- context-aware replacement endpoints and `Cache-Control: no-store`;
- disabled servlet registration and exactly one Security-chain instance.

English, German and developer security documentation now describe the same prefix, response and registration contracts.

## Exact scope

- first parent: `d7480a6a3c97223a85fa95eff6d22c39ac538600` (merged #893);
- exact head: `7b83be662c1d39d5cc9aa24b41c3262276663364`;
- exactly one commit;
- zero commits behind `main`;
- exactly seven changed paths;
- no workflow, release request, dependency, database schema or Keycloak behavior change.

## Reconstructed-head correction

The first matrix compiled all production code and the new focused filter test, but the Spring integration helper assigned `/` as a servlet path for the prefixed context root. Spring's mock request builder correctly rejects a servlet path ending in `/`. The branch was reconstructed on the unchanged parent with the context-root request represented by an empty servlet path; product behavior, assertions and scope are unchanged.

Only checks on the exact head above are authoritative. Keep this PR in Draft until CI/CD, PostgreSQL, Oracle, SQL Server, CodeQL, Security Scan, document-template E2E and constrained-Kubernetes checks have completed successfully on this unchanged head.