### PR TITLE
Bound WebDAV application-credential lockout

### DIFF
--- a/docs/de/DOCUMENT_TEMPLATES.md
+++ b/docs/de/DOCUMENT_TEMPLATES.md
@@ -125,7 +125,8 @@ gesperrte Anfrage erhält UTF-8-JSON mit HTTP 429, `Retry-After` und
 `Cache-Control: no-store`. Die Verarbeitung von Weiterleitungs-Headern darf nur hinter
 einem vertrauenswürdigen Ingress aktiviert werden, weil der Filter bewusst das
 Framework-Ergebnis `getRemoteAddr()` verwendet und Weiterleitungs-Header niemals
-selbst auswertet.
+selbst auswertet. Der Filter protokolliert weder den übermittelten Basic-Authorization-
+Header noch dessen Zugangsdateninhalt.
 
 Taxonomy weist Makros, ActiveX, eingebettete OLE-Objekte, Signaturen, unsichere
 ZIP-Pfade, nur in Groß-/Kleinschreibung kollidierende Paketbestandteile, fehlerhaftes

--- a/docs/de/DOCUMENT_TEMPLATES.md
+++ b/docs/de/DOCUMENT_TEMPLATES.md
@@ -108,6 +108,25 @@ einen WebDAV-kompatiblen, begrenzten Zugang wie ein App-Passwort implementiert u
 getestet hat. WebDAV-Clients mit Bearer-Token-Unterstützung können den Endpunkt weiter
 verwenden.
 
+Taxonomy-App-Zugangsdaten haben genau ein 71 Zeichen langes ASCII-Format. Der
+WebDAV-Filter weist zu große Basic-Header, ungültiges UTF-8, zu lange decodierte
+Benutzernamen oder Passwörter sowie fehlerhafte `taxdav_`-Kandidaten vor
+Repository-Zugriff oder BCrypt zurück. Normale Kontopasswörter, die nicht mit
+`taxdav_` beginnen, laufen weiterhin durch den gewöhnlichen HTTP-Basic-Pfad von
+Spring Security.
+
+Fehlgeschlagene App-Anmeldungen werden über einen SHA-256-Digest fester Länge aus dem
+vom Framework aufgelösten Peer und dem normalisierten übermittelten Benutzernamen
+gezählt; rohe Identitäten bleiben nicht in der Sperrtabelle. Zehn Fehlversuche innerhalb
+einer Minute sperren diese Identität. Die reguläre Tabelle ist pro Anwendungsinstanz
+hart auf 10.000 Schlüssel begrenzt. Nicht mehr aufnehmbare Identitäten teilen ein
+fehlgeschlossenes Überlaufkontingent, statt bestehende Sperren zu löschen. Eine
+gesperrte Anfrage erhält UTF-8-JSON mit HTTP 429, `Retry-After` und
+`Cache-Control: no-store`. Die Verarbeitung von Weiterleitungs-Headern darf nur hinter
+einem vertrauenswürdigen Ingress aktiviert werden, weil der Filter bewusst das
+Framework-Ergebnis `getRemoteAddr()` verwendet und Weiterleitungs-Header niemals
+selbst auswertet.
+
 Taxonomy weist Makros, ActiveX, eingebettete OLE-Objekte, Signaturen, unsichere
 ZIP-Pfade, nur in Groß-/Kleinschreibung kollidierende Paketbestandteile, fehlerhaftes
 XML, externe Beziehungen außer Hyperlinks, fehlende interne Beziehungsziele, Pakete

--- a/docs/en/DOCUMENT_TEMPLATES.md
+++ b/docs/en/DOCUMENT_TEMPLATES.md
@@ -118,7 +118,8 @@ cannot be admitted share a fail-closed overflow budget instead of clearing exist
 lockouts. A blocked request receives UTF-8 JSON with HTTP 429, `Retry-After`, and
 `Cache-Control: no-store`. Operators must configure forwarding-header processing only
 behind a trusted ingress because the filter deliberately relies on the framework's
-`getRemoteAddr()` result and never parses forwarding headers itself.
+`getRemoteAddr()` result and never parses forwarding headers itself. The filter never
+logs the supplied Basic Authorization header or its credential contents.
 
 Taxonomy rejects macros, ActiveX, embedded OLE objects, signatures, unsafe ZIP paths,
 case-colliding package parts, malformed XML, external non-hyperlink relationships,

--- a/docs/en/DOCUMENT_TEMPLATES.md
+++ b/docs/en/DOCUMENT_TEMPLATES.md
@@ -104,6 +104,22 @@ must not re-enable the links until they provide and test a WebDAV-compatible cre
 flow such as a scoped application password. Bearer-capable WebDAV clients can continue
 to use the endpoint directly.
 
+Taxonomy application credentials have one exact 71-character ASCII format. The WebDAV
+filter rejects oversized Basic headers, invalid UTF-8, overlong decoded usernames or
+passwords, and malformed `taxdav_` candidates before repository lookup or BCrypt.
+Ordinary account passwords that do not start with `taxdav_` continue to the normal
+Spring Security HTTP-Basic flow.
+
+Failed application-credential attempts are tracked by a fixed-size SHA-256 digest of
+the framework-resolved peer and normalized supplied username; raw identities are not
+retained in the lockout table. Ten failures within one minute lock that identity. The
+regular table is capped at 10,000 keys per application instance, and identities that
+cannot be admitted share a fail-closed overflow budget instead of clearing existing
+lockouts. A blocked request receives UTF-8 JSON with HTTP 429, `Retry-After`, and
+`Cache-Control: no-store`. Operators must configure forwarding-header processing only
+behind a trusted ingress because the filter deliberately relies on the framework's
+`getRemoteAddr()` result and never parses forwarding headers itself.
+
 Taxonomy rejects macros, ActiveX, embedded OLE objects, signatures, unsafe ZIP paths,
 case-colliding package parts, malformed XML, external non-hyperlink relationships,
 missing internal relationship targets, packages without exactly one root

--- a/taxonomy-app/src/main/java/com/taxonomy/security/webdav/WebDavApplicationCredentialFilter.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/webdav/WebDavApplicationCredentialFilter.java
@@ -14,42 +14,70 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.Normalizer;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Base64;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
 
 /** Authenticates revocable WebDAV app credentials without exposing account passwords. */
 public final class WebDavApplicationCredentialFilter extends OncePerRequestFilter {
 
+    static final int MAX_FAILURES = 10;
+    static final long FAILURE_WINDOW_NANOS = Duration.ofMinutes(1).toNanos();
+    static final int DEFAULT_MAX_TRACKED_FAILURE_KEYS = 10_000;
+    static final int MAX_AUTHORIZATION_HEADER_CHARS = 4_096;
+    static final int MAX_DECODED_CREDENTIAL_BYTES = 2_048;
+    static final int MAX_USERNAME_CODE_POINTS = 255;
+    static final int MAX_PASSWORD_CODE_POINTS = 255;
+
     private static final Logger log =
             LoggerFactory.getLogger(WebDavApplicationCredentialFilter.class);
     private static final String BASIC_PREFIX = "Basic ";
-    private static final int MAX_FAILURES = 10;
-    private static final Duration FAILURE_WINDOW = Duration.ofMinutes(1);
-    private static final int MAX_TRACKED_FAILURE_KEYS = 10_000;
+    private static final long CLEANUP_INTERVAL_NANOS =
+            Duration.ofSeconds(30).toNanos();
+    private static final long NANOS_PER_SECOND = Duration.ofSeconds(1).toNanos();
 
     private final WebDavApplicationCredentialService credentials;
-    private final Clock clock;
-    private final Map<String, Deque<Instant>> failures = new ConcurrentHashMap<>();
+    private final LongSupplier monotonicNanos;
+    private final int maxTrackedFailureKeys;
+    private final Object stateMonitor = new Object();
+    private final Map<String, FailureTracker> failures = new HashMap<>();
+    private final FailureTracker overflowFailures = new FailureTracker();
+    private long nextCleanupAt;
 
     public WebDavApplicationCredentialFilter(
             WebDavApplicationCredentialService credentials) {
-        this(credentials, Clock.systemUTC());
+        this(credentials, System::nanoTime, DEFAULT_MAX_TRACKED_FAILURE_KEYS);
     }
 
     WebDavApplicationCredentialFilter(
             WebDavApplicationCredentialService credentials,
-            Clock clock) {
-        this.credentials = credentials;
-        this.clock = clock;
+            LongSupplier monotonicNanos,
+            int maxTrackedFailureKeys) {
+        this.credentials = Objects.requireNonNull(credentials, "credentials");
+        this.monotonicNanos =
+                Objects.requireNonNull(monotonicNanos, "monotonicNanos");
+        if (maxTrackedFailureKeys <= 0) {
+            throw new IllegalArgumentException(
+                    "maxTrackedFailureKeys must be positive");
+        }
+        this.maxTrackedFailureKeys = maxTrackedFailureKeys;
+        long now = monotonicNanos.getAsLong();
+        this.nextCleanupAt = now + CLEANUP_INTERVAL_NANOS;
     }
 
     @Override
@@ -63,9 +91,9 @@ public final class WebDavApplicationCredentialFilter extends OncePerRequestFilte
             HttpServletResponse response,
             FilterChain chain) throws ServletException, IOException {
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-        Optional<BasicCredential> basic = parseBasic(authorization);
+        BasicParseResult parsed = parseBasic(authorization);
 
-        if (basic.isEmpty()) {
+        if (!parsed.basicScheme()) {
             if (authorization == null
                     && SecurityContextHolder.getContext().getAuthentication() == null) {
                 unauthorized(response);
@@ -74,45 +102,73 @@ public final class WebDavApplicationCredentialFilter extends OncePerRequestFilte
             chain.doFilter(request, response);
             return;
         }
-        BasicCredential supplied = basic.orElseThrow();
-        if (!WebDavApplicationCredentialService.isApplicationSecret(supplied.password())) {
+        if (parsed.credential() == null) {
+            unauthorized(response);
+            return;
+        }
+
+        BasicCredential supplied = parsed.credential();
+        if (!WebDavApplicationCredentialService.isApplicationSecret(
+                supplied.password())) {
             chain.doFilter(request, response);
+            return;
+        }
+        if (!WebDavApplicationCredentialService.hasExactApplicationSecretFormat(
+                supplied.password())) {
+            unauthorized(response);
             return;
         }
 
         String failureKey = failureKey(request, supplied.username());
-        if (isRateLimited(failureKey)) {
-            response.setHeader("Retry-After", Long.toString(FAILURE_WINDOW.toSeconds()));
-            response.sendError(429, "Too many failed WebDAV authentication attempts");
+        LockState currentLock =
+                currentLock(failureKey, monotonicNanos.getAsLong());
+        if (currentLock.locked()) {
+            rateLimited(response, currentLock.retryAfterSeconds());
             return;
         }
 
         Optional<WebDavApplicationCredentialService.CredentialPrincipal> authenticated =
                 credentials.authenticate(supplied.username(), supplied.password());
         if (authenticated.isEmpty()) {
-            recordFailure(failureKey);
+            int failureCount =
+                    recordFailure(failureKey, monotonicNanos.getAsLong());
+            if (failureCount >= MAX_FAILURES) {
+                log.warn(
+                        "WEBDAV_APPLICATION_CREDENTIAL_LOCKED failureKeyDigest={} attempts={}",
+                        failureKey,
+                        failureCount);
+            }
             unauthorized(response);
             return;
         }
+
         clearFailures(failureKey);
         var principal = authenticated.orElseThrow();
         if (!allowedForMethod(principal, request.getMethod())) {
-            response.sendError(HttpServletResponse.SC_FORBIDDEN,
+            response.sendError(
+                    HttpServletResponse.SC_FORBIDDEN,
                     "The WebDAV application credential does not permit this operation");
             return;
         }
 
         SecurityContext previous = SecurityContextHolder.getContext();
-        SecurityContext applicationContext = SecurityContextHolder.createEmptyContext();
+        SecurityContext applicationContext =
+                SecurityContextHolder.createEmptyContext();
         UsernamePasswordAuthenticationToken authentication =
                 UsernamePasswordAuthenticationToken.authenticated(
-                        principal.username(), "[PROTECTED]", principal.authorities());
-        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        principal.username(),
+                        "[PROTECTED]",
+                        principal.authorities());
+        authentication.setDetails(
+                new WebAuthenticationDetailsSource().buildDetails(request));
         applicationContext.setAuthentication(authentication);
         SecurityContextHolder.setContext(applicationContext);
         try {
-            log.debug("WebDAV application credential accepted id={} user={} method={}",
-                    principal.credentialId(), principal.username(), request.getMethod());
+            log.debug(
+                    "WebDAV application credential accepted id={} user={} method={}",
+                    principal.credentialId(),
+                    principal.username(),
+                    request.getMethod());
             chain.doFilter(request, response);
         } finally {
             SecurityContextHolder.setContext(previous);
@@ -122,9 +178,11 @@ public final class WebDavApplicationCredentialFilter extends OncePerRequestFilte
     private static boolean allowedForMethod(
             WebDavApplicationCredentialService.CredentialPrincipal principal,
             String method) {
-        String normalized = method == null ? "" : method.toUpperCase(Locale.ROOT);
+        String normalized =
+                method == null ? "" : method.toUpperCase(Locale.ROOT);
         return switch (normalized) {
-            case "GET", "HEAD", "OPTIONS", "PROPFIND" -> principal.readAllowed();
+            case "GET", "HEAD", "OPTIONS", "PROPFIND" ->
+                    principal.readAllowed();
             case "PUT", "LOCK", "UNLOCK", "DELETE", "MKCOL", "MOVE", "COPY" ->
                     principal.writeAllowed();
             default -> false;
@@ -137,89 +195,250 @@ public final class WebDavApplicationCredentialFilter extends OncePerRequestFilte
         if (context != null && !context.isBlank() && path.startsWith(context)) {
             path = path.substring(context.length());
         }
-        return path.equals("/dav/templates") || path.startsWith("/dav/templates/");
+        return path.equals("/dav/templates")
+                || path.startsWith("/dav/templates/");
     }
 
-    private static Optional<BasicCredential> parseBasic(String header) {
-        if (header == null || !header.regionMatches(true, 0,
-                BASIC_PREFIX, 0, BASIC_PREFIX.length())) {
-            return Optional.empty();
+    private static BasicParseResult parseBasic(String header) {
+        if (header == null
+                || !header.regionMatches(
+                        true, 0, BASIC_PREFIX, 0, BASIC_PREFIX.length())) {
+            return BasicParseResult.notBasic();
         }
+        if (header.length() > MAX_AUTHORIZATION_HEADER_CHARS) {
+            return BasicParseResult.invalid();
+        }
+
+        String encoded =
+                header.substring(BASIC_PREFIX.length()).strip();
+        if (encoded.isEmpty()) {
+            return BasicParseResult.invalid();
+        }
+
         try {
-            byte[] decoded = Base64.getDecoder().decode(
-                    header.substring(BASIC_PREFIX.length()).strip());
-            String value = new String(decoded, StandardCharsets.UTF_8);
+            byte[] decoded = Base64.getDecoder().decode(encoded);
+            if (decoded.length > MAX_DECODED_CREDENTIAL_BYTES) {
+                return BasicParseResult.invalid();
+            }
+            String value = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(decoded))
+                    .toString();
             int separator = value.indexOf(':');
             if (separator <= 0) {
-                return Optional.empty();
+                return BasicParseResult.invalid();
             }
-            return Optional.of(new BasicCredential(
-                    value.substring(0, separator),
-                    value.substring(separator + 1)));
-        } catch (IllegalArgumentException invalidBase64) {
-            return Optional.empty();
+
+            String username = value.substring(0, separator);
+            String password = value.substring(separator + 1);
+            if (username.isBlank()
+                    || codePointLength(username) > MAX_USERNAME_CODE_POINTS
+                    || codePointLength(password) > MAX_PASSWORD_CODE_POINTS) {
+                return BasicParseResult.invalid();
+            }
+            return BasicParseResult.valid(
+                    new BasicCredential(username, password));
+        } catch (IllegalArgumentException | CharacterCodingException invalid) {
+            return BasicParseResult.invalid();
         }
     }
 
-    private boolean isRateLimited(String key) {
-        Instant cutoff = clock.instant().minus(FAILURE_WINDOW);
-        Deque<Instant> attempts = failures.get(key);
-        if (attempts == null) {
-            return false;
-        }
-        synchronized (attempts) {
-            purge(attempts, cutoff);
-            return attempts.size() >= MAX_FAILURES;
+    private static int codePointLength(String value) {
+        return value.codePointCount(0, value.length());
+    }
+
+    private LockState currentLock(String key, long now) {
+        synchronized (stateMonitor) {
+            cleanupExpired(now, false);
+            FailureTracker tracker = failures.get(key);
+            if (tracker == null && failures.size() >= maxTrackedFailureKeys) {
+                cleanupExpired(now, true);
+                if (failures.size() >= maxTrackedFailureKeys) {
+                    tracker = overflowFailures;
+                }
+            }
+            return tracker == null
+                    ? LockState.unlocked()
+                    : tracker.lockState(now);
         }
     }
 
-    private void recordFailure(String key) {
-        if (failures.size() >= MAX_TRACKED_FAILURE_KEYS) {
-            purgeGlobal();
-            if (failures.size() >= MAX_TRACKED_FAILURE_KEYS) {
-                failures.clear();
+    private int recordFailure(String key, long now) {
+        synchronized (stateMonitor) {
+            cleanupExpired(now, false);
+            FailureTracker tracker = failures.get(key);
+            if (tracker == null) {
+                if (failures.size() >= maxTrackedFailureKeys) {
+                    cleanupExpired(now, true);
+                }
+                if (failures.size() >= maxTrackedFailureKeys) {
+                    tracker = overflowFailures;
+                } else {
+                    tracker = new FailureTracker();
+                    failures.put(key, tracker);
+                }
             }
-        }
-        Deque<Instant> attempts = failures.computeIfAbsent(key,
-                ignored -> new ArrayDeque<>());
-        synchronized (attempts) {
-            purge(attempts, clock.instant().minus(FAILURE_WINDOW));
-            attempts.addLast(clock.instant());
+            return tracker.recordFailure(now);
         }
     }
 
     private void clearFailures(String key) {
-        failures.remove(key);
-    }
-
-    private void purgeGlobal() {
-        Instant cutoff = clock.instant().minus(FAILURE_WINDOW);
-        failures.entrySet().removeIf(entry -> {
-            Deque<Instant> attempts = entry.getValue();
-            synchronized (attempts) {
-                purge(attempts, cutoff);
-                return attempts.isEmpty();
-            }
-        });
-    }
-
-    private static void purge(Deque<Instant> attempts, Instant cutoff) {
-        while (!attempts.isEmpty() && attempts.peekFirst().isBefore(cutoff)) {
-            attempts.removeFirst();
+        synchronized (stateMonitor) {
+            // An overflow identity has no individual entry. Never reset the
+            // shared fail-closed bucket on one successful authentication.
+            failures.remove(key);
         }
     }
 
-    private static String failureKey(HttpServletRequest request, String username) {
-        return String.valueOf(request.getRemoteAddr()) + "|" + username;
+    private void cleanupExpired(long now, boolean force) {
+        if (!force && now - nextCleanupAt < 0) {
+            return;
+        }
+        failures.entrySet().removeIf(
+                entry -> entry.getValue().purgeAndIsEmpty(now));
+        overflowFailures.purge(now);
+        nextCleanupAt = now + CLEANUP_INTERVAL_NANOS;
     }
 
-    private static void unauthorized(HttpServletResponse response) throws IOException {
-        response.setHeader(HttpHeaders.WWW_AUTHENTICATE,
+    int trackedFailureKeyCount() {
+        synchronized (stateMonitor) {
+            return failures.size();
+        }
+    }
+
+    int overflowFailureCount() {
+        synchronized (stateMonitor) {
+            return overflowFailures.failureCount();
+        }
+    }
+
+    private static String failureKey(
+            HttpServletRequest request,
+            String username) {
+        String peer = Objects.toString(request.getRemoteAddr(), "");
+        String normalizedUsername = Normalizer.normalize(
+                        username.strip(), Normalizer.Form.NFKC)
+                .toLowerCase(Locale.ROOT);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(
+                    "taxonomy-webdav-credential-lockout"
+                            .getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+            digest.update(peer.getBytes(StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+            digest.update(
+                    normalizedUsername.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException(
+                    "SHA-256 is unavailable", impossible);
+        }
+    }
+
+    private static void rateLimited(
+            HttpServletResponse response,
+            long retryAfterSeconds) throws IOException {
+        response.setStatus(429);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType("application/json");
+        response.setHeader(
+                HttpHeaders.RETRY_AFTER,
+                Long.toString(retryAfterSeconds));
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.getWriter().write(
+                "{\"error\":\"TOO_MANY_WEBDAV_AUTHENTICATION_ATTEMPTS\","
+                        + "\"status\":429,"
+                        + "\"retryAfterSeconds\":"
+                        + retryAfterSeconds
+                        + "}");
+    }
+
+    private static void unauthorized(
+            HttpServletResponse response) throws IOException {
+        response.setHeader(
+                HttpHeaders.WWW_AUTHENTICATE,
                 "Basic realm=\"Taxonomy WebDAV\", charset=\"UTF-8\"");
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+        response.sendError(
+                HttpServletResponse.SC_UNAUTHORIZED,
                 "A valid WebDAV application credential is required");
     }
 
     private record BasicCredential(String username, String password) {
+    }
+
+    private record BasicParseResult(
+            boolean basicScheme,
+            BasicCredential credential) {
+
+        private static BasicParseResult notBasic() {
+            return new BasicParseResult(false, null);
+        }
+
+        private static BasicParseResult invalid() {
+            return new BasicParseResult(true, null);
+        }
+
+        private static BasicParseResult valid(BasicCredential credential) {
+            return new BasicParseResult(true, credential);
+        }
+    }
+
+    private record LockState(
+            boolean locked,
+            long retryAfterSeconds,
+            int failureCount) {
+
+        private static LockState unlocked() {
+            return new LockState(false, 0, 0);
+        }
+    }
+
+    private static final class FailureTracker {
+
+        private final Deque<Long> attempts = new ArrayDeque<>(MAX_FAILURES);
+
+        private int recordFailure(long now) {
+            purge(now);
+            if (attempts.size() < MAX_FAILURES) {
+                attempts.addLast(now);
+            }
+            return attempts.size();
+        }
+
+        private LockState lockState(long now) {
+            purge(now);
+            if (attempts.size() < MAX_FAILURES) {
+                return LockState.unlocked();
+            }
+            long elapsed = now - attempts.peekFirst();
+            long remaining =
+                    Math.max(1L, FAILURE_WINDOW_NANOS - elapsed);
+            long retryAfterSeconds =
+                    Math.max(
+                            1L,
+                            (remaining + NANOS_PER_SECOND - 1L)
+                                    / NANOS_PER_SECOND);
+            return new LockState(
+                    true, retryAfterSeconds, attempts.size());
+        }
+
+        private boolean purgeAndIsEmpty(long now) {
+            purge(now);
+            return attempts.isEmpty();
+        }
+
+        private void purge(long now) {
+            while (!attempts.isEmpty()
+                    && now - attempts.peekFirst()
+                            >= FAILURE_WINDOW_NANOS) {
+                attempts.removeFirst();
+            }
+        }
+
+        private int failureCount() {
+            return attempts.size();
+        }
     }
 }

--- a/taxonomy-app/src/main/java/com/taxonomy/security/webdav/WebDavApplicationCredentialService.java
+++ b/taxonomy-app/src/main/java/com/taxonomy/security/webdav/WebDavApplicationCredentialService.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 public class WebDavApplicationCredentialService {
 
     public static final String TOKEN_PREFIX = "taxdav_";
+    public static final int TOKEN_LENGTH = 71;
     public static final Duration DEFAULT_LIFETIME = Duration.ofDays(30);
     public static final Duration MAX_LIFETIME = Duration.ofDays(90);
 
@@ -184,6 +185,12 @@ public class WebDavApplicationCredentialService {
 
     public static boolean isApplicationSecret(String value) {
         return value != null && value.startsWith(TOKEN_PREFIX);
+    }
+
+    public static boolean hasExactApplicationSecretFormat(String value) {
+        return value != null
+                && value.length() == TOKEN_LENGTH
+                && TOKEN.matcher(value).matches();
     }
 
     private void updateLastUsedIfNeeded(

--- a/taxonomy-app/src/test/java/com/taxonomy/security/webdav/WebDavApplicationCredentialFilterTest.java
+++ b/taxonomy-app/src/test/java/com/taxonomy/security/webdav/WebDavApplicationCredentialFilterTest.java
@@ -3,6 +3,7 @@ package com.taxonomy.security.webdav;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
@@ -10,23 +11,32 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class WebDavApplicationCredentialFilterTest {
 
     private static final String TOKEN =
-            "taxdav_" + "a".repeat(24) + "_" + "A".repeat(43);
+            token("a".repeat(24), 'A');
 
     @AfterEach
     void clearContext() {
@@ -34,115 +44,499 @@ class WebDavApplicationCredentialFilterTest {
     }
 
     @Test
-    void authenticatesAnApplicationSecretForTheFilterChainAndErasesItAfterward()
+    void authenticatesExactProductionSecretForContextPathAndErasesContextAfterward()
             throws Exception {
+        assertThat(TOKEN)
+                .hasSize(WebDavApplicationCredentialService.TOKEN_LENGTH);
+
         WebDavApplicationCredentialService service =
                 mock(WebDavApplicationCredentialService.class);
-        when(service.authenticate("admin", TOKEN)).thenReturn(Optional.of(principal(true)));
+        when(service.authenticate("admin", TOKEN))
+                .thenReturn(Optional.of(principal("admin", true)));
         WebDavApplicationCredentialFilter filter = filter(service);
-        MockHttpServletRequest request = request("GET");
+        MockHttpServletRequest request = request(
+                "GET", "203.0.113.10", "admin", TOKEN);
         request.setContextPath("/taxonomy");
-        request.setRequestURI("/taxonomy/dav/templates/report.dotx");
-        request.addHeader("Authorization", basic("admin", TOKEN));
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicReference<Authentication> observed = new AtomicReference<>();
+        request.setRequestURI(
+                "/taxonomy/dav/templates/report.dotx");
+        MockHttpServletResponse response =
+                new MockHttpServletResponse();
+        AtomicReference<Authentication> observed =
+                new AtomicReference<>();
         FilterChain chain = (req, res) -> observed.set(
                 SecurityContextHolder.getContext().getAuthentication());
 
         filter.doFilter(request, response, chain);
 
         assertThat(observed.get().getName()).isEqualTo("admin");
-        assertThat(observed.get().getCredentials()).isEqualTo("[PROTECTED]");
+        assertThat(observed.get().getCredentials())
+                .isEqualTo("[PROTECTED]");
         assertThat(observed.get().getAuthorities())
                 .extracting(authority -> authority.getAuthority())
                 .contains("ROLE_ADMIN", "SCOPE_template:write");
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication())
+                .isNull();
+        verify(service).authenticate("admin", TOKEN);
     }
 
     @Test
     void readOnlyCredentialCannotPutLockOrUnlock() throws Exception {
         WebDavApplicationCredentialService service =
                 mock(WebDavApplicationCredentialService.class);
-        when(service.authenticate("admin", TOKEN)).thenReturn(Optional.of(principal(false)));
+        when(service.authenticate("admin", TOKEN))
+                .thenReturn(Optional.of(principal("admin", false)));
         WebDavApplicationCredentialFilter filter = filter(service);
-        MockHttpServletRequest request = request("PUT");
-        request.addHeader("Authorization", basic("admin", TOKEN));
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest request = request(
+                "PUT", "203.0.113.11", "admin", TOKEN);
+        MockHttpServletResponse response =
+                new MockHttpServletResponse();
         AtomicBoolean called = new AtomicBoolean();
 
-        filter.doFilter(request, response, (req, res) -> called.set(true));
+        filter.doFilter(
+                request, response, (req, res) -> called.set(true));
 
         assertThat(response.getStatus()).isEqualTo(403);
         assertThat(called).isFalse();
     }
 
     @Test
-    void invalidOrAbsentCredentialGetsABasicChallengeWithoutLoginHtml()
+    void invalidOrAbsentCredentialGetsBasicChallengeWithoutLoginHtml()
             throws Exception {
         WebDavApplicationCredentialService service =
                 mock(WebDavApplicationCredentialService.class);
-        when(service.authenticate("admin", TOKEN)).thenReturn(Optional.empty());
+        when(service.authenticate("admin", TOKEN))
+                .thenReturn(Optional.empty());
         WebDavApplicationCredentialFilter filter = filter(service);
 
-        MockHttpServletRequest invalid = request("GET");
-        invalid.addHeader("Authorization", basic("admin", TOKEN));
-        MockHttpServletResponse invalidResponse = new MockHttpServletResponse();
+        MockHttpServletRequest invalid = request(
+                "GET", "203.0.113.12", "admin", TOKEN);
+        MockHttpServletResponse invalidResponse =
+                new MockHttpServletResponse();
         filter.doFilter(invalid, invalidResponse, (req, res) -> { });
         assertThat(invalidResponse.getStatus()).isEqualTo(401);
-        assertThat(invalidResponse.getHeader("WWW-Authenticate"))
+        assertThat(invalidResponse.getHeader(HttpHeaders.WWW_AUTHENTICATE))
                 .startsWith("Basic realm=\"Taxonomy WebDAV\"");
 
         MockHttpServletRequest absent = request("OPTIONS");
-        MockHttpServletResponse absentResponse = new MockHttpServletResponse();
+        MockHttpServletResponse absentResponse =
+                new MockHttpServletResponse();
         filter.doFilter(absent, absentResponse, (req, res) -> { });
         assertThat(absentResponse.getStatus()).isEqualTo(401);
-        assertThat(absentResponse.getContentAsString()).doesNotContain("<html");
+        assertThat(absentResponse.getContentAsString())
+                .doesNotContain("<html");
     }
 
     @Test
-    void ordinaryLocalAccountBasicAuthenticationFallsThroughToTheExistingFilter()
+    void ordinaryLocalAccountBasicAuthenticationFallsThrough()
             throws Exception {
         WebDavApplicationCredentialService service =
                 mock(WebDavApplicationCredentialService.class);
         WebDavApplicationCredentialFilter filter = filter(service);
-        MockHttpServletRequest request = request("GET");
-        request.addHeader("Authorization", basic("admin", "ordinary-password"));
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockHttpServletRequest request = request(
+                "GET",
+                "203.0.113.13",
+                "admin",
+                "ordinary-password");
+        MockHttpServletResponse response =
+                new MockHttpServletResponse();
         AtomicBoolean called = new AtomicBoolean();
 
-        filter.doFilter(request, response, (req, res) -> called.set(true));
+        filter.doFilter(
+                request, response, (req, res) -> called.set(true));
 
         assertThat(called).isTrue();
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void oversizedAndMalformedApplicationCandidatesStopBeforeCredentialService()
+            throws Exception {
+        WebDavApplicationCredentialService service =
+                mock(WebDavApplicationCredentialService.class);
+        WebDavApplicationCredentialFilter filter = filter(service);
+        FilterChain chain = mock(FilterChain.class);
+
+        List<MockHttpServletRequest> rejected = List.of(
+                requestWithAuthorization(
+                        "Basic " + "A".repeat(
+                                WebDavApplicationCredentialFilter
+                                        .MAX_AUTHORIZATION_HEADER_CHARS)),
+                requestWithAuthorization(oversizedDecodedAuthorization()),
+                requestWithAuthorization("Basic /w=="),
+                request(
+                        "GET",
+                        "203.0.113.20",
+                        "u".repeat(
+                                WebDavApplicationCredentialFilter
+                                        .MAX_USERNAME_CODE_POINTS + 1),
+                        TOKEN),
+                request(
+                        "GET",
+                        "203.0.113.21",
+                        "admin",
+                        "taxdav_" + "A".repeat(
+                                WebDavApplicationCredentialFilter
+                                        .MAX_PASSWORD_CODE_POINTS)),
+                request(
+                        "GET",
+                        "203.0.113.22",
+                        "admin",
+                        TOKEN.substring(0, TOKEN.length() - 1) + "!"));
+
+        for (MockHttpServletRequest request : rejected) {
+            MockHttpServletResponse response =
+                    new MockHttpServletResponse();
+
+            filter.doFilter(request, response, chain);
+
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getHeader(HttpHeaders.WWW_AUTHENTICATE))
+                    .startsWith("Basic realm=\"Taxonomy WebDAV\"");
+        }
+
+        verifyNoInteractions(service);
+        verify(chain, never()).doFilter(
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void tenFailuresLockIdentityAndReturnSanitizedJson429()
+            throws Exception {
+        WebDavApplicationCredentialService service =
+                rejectingService();
+        WebDavApplicationCredentialFilter filter = filter(service);
+        String peer = "203.0.113.30";
+        String username = "sensitive-user";
+
+        for (int attempt = 0;
+                attempt < WebDavApplicationCredentialFilter.MAX_FAILURES;
+                attempt++) {
+            MockHttpServletRequest failed =
+                    request("GET", peer, username, TOKEN);
+            failed.addHeader(
+                    "X-Forwarded-For",
+                    "198.51.100." + attempt);
+            MockHttpServletResponse response =
+                    execute(filter, failed);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+
+        MockHttpServletResponse limited = execute(
+                filter, request("GET", peer, username, TOKEN));
+
+        assertThat(limited.getStatus()).isEqualTo(429);
+        assertThat(limited.getHeader(HttpHeaders.RETRY_AFTER))
+                .isEqualTo("60");
+        assertThat(limited.getHeader(HttpHeaders.CACHE_CONTROL))
+                .isEqualTo("no-store");
+        assertThat(limited.getContentType())
+                .startsWith("application/json");
+        assertThat(limited.getContentAsString())
+                .contains("\"status\":429")
+                .contains("\"retryAfterSeconds\":60")
+                .doesNotContain(username)
+                .doesNotContain(peer)
+                .doesNotContain(TOKEN);
+        verify(service, times(
+                WebDavApplicationCredentialFilter.MAX_FAILURES))
+                .authenticate(username, TOKEN);
+    }
+
+    @Test
+    void successfulAuthenticationClearsOnlyItsOwnTrackedIdentity()
+            throws Exception {
+        WebDavApplicationCredentialService service =
+                mock(WebDavApplicationCredentialService.class);
+        AtomicBoolean aliceSucceeds = new AtomicBoolean();
+        when(service.authenticate(anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    String username = invocation.getArgument(0);
+                    if ("alice".equals(username)
+                            && aliceSucceeds.get()) {
+                        return Optional.of(principal("alice", true));
+                    }
+                    return Optional.empty();
+                });
+        WebDavApplicationCredentialFilter filter = filter(service);
+
+        for (int attempt = 0; attempt < 9; attempt++) {
+            assertThat(execute(
+                    filter,
+                    request(
+                            "GET",
+                            "203.0.113.40",
+                            "alice",
+                            TOKEN))
+                    .getStatus()).isEqualTo(401);
+            assertThat(execute(
+                    filter,
+                    request(
+                            "GET",
+                            "203.0.113.41",
+                            "bob",
+                            TOKEN))
+                    .getStatus()).isEqualTo(401);
+        }
+
+        aliceSucceeds.set(true);
+        AtomicBoolean called = new AtomicBoolean();
+        MockHttpServletResponse success =
+                new MockHttpServletResponse();
+        filter.doFilter(
+                request("GET", "203.0.113.40", "alice", TOKEN),
+                success,
+                (req, res) -> called.set(true));
+        assertThat(called).isTrue();
+
+        aliceSucceeds.set(false);
+        assertThat(execute(
+                filter,
+                request("GET", "203.0.113.40", "alice", TOKEN))
+                .getStatus()).isEqualTo(401);
+
+        assertThat(execute(
+                filter,
+                request("GET", "203.0.113.41", "bob", TOKEN))
+                .getStatus()).isEqualTo(401);
+        assertThat(execute(
+                filter,
+                request("GET", "203.0.113.41", "bob", TOKEN))
+                .getStatus()).isEqualTo(429);
+    }
+
+    @Test
+    void inactiveTrackedKeysExpireUsingMonotonicTime()
+            throws Exception {
+        WebDavApplicationCredentialService service =
+                rejectingService();
+        AtomicLong now = new AtomicLong();
+        WebDavApplicationCredentialFilter filter =
+                filter(service, now, 4);
+        MockHttpServletRequest request = request(
+                "GET", "203.0.113.50", "admin", TOKEN);
+
+        for (int attempt = 0;
+                attempt < WebDavApplicationCredentialFilter.MAX_FAILURES;
+                attempt++) {
+            assertThat(execute(filter, request(
+                    "GET", "203.0.113.50", "admin", TOKEN))
+                    .getStatus()).isEqualTo(401);
+        }
+        assertThat(execute(filter, request)
+                .getStatus()).isEqualTo(429);
+
+        now.addAndGet(
+                WebDavApplicationCredentialFilter.FAILURE_WINDOW_NANOS + 1);
+
+        assertThat(execute(
+                filter,
+                request("GET", "203.0.113.50", "admin", TOKEN))
+                .getStatus()).isEqualTo(401);
+        assertThat(filter.trackedFailureKeyCount()).isEqualTo(1);
+    }
+
+    @Test
+    void concurrentIdentityFloodNeverExceedsHardCapacity()
+            throws Exception {
+        int capacity = 8;
+        int identities = 64;
+        WebDavApplicationCredentialService service =
+                rejectingService();
+        WebDavApplicationCredentialFilter filter =
+                filter(service, new AtomicLong(), capacity);
+        ExecutorService executor = Executors.newFixedThreadPool(16);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<Integer>> results = new ArrayList<>();
+
+        try {
+            for (int identity = 0; identity < identities; identity++) {
+                int current = identity;
+                results.add(executor.submit(() -> {
+                    start.await();
+                    MockHttpServletResponse response = execute(
+                            filter,
+                            request(
+                                    "GET",
+                                    "198.51.100." + current,
+                                    "user-" + current,
+                                    TOKEN));
+                    return response.getStatus();
+                }));
+            }
+
+            start.countDown();
+            for (Future<Integer> result : results) {
+                assertThat(result.get(30, TimeUnit.SECONDS))
+                        .isIn(401, 429);
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(filter.trackedFailureKeyCount())
+                .isEqualTo(capacity);
+        assertThat(filter.overflowFailureCount())
+                .isEqualTo(
+                        WebDavApplicationCredentialFilter.MAX_FAILURES);
+    }
+
+    @Test
+    void overflowIdentitiesShareFailClosedBudgetWithoutErasingTrackedLockout()
+            throws Exception {
+        WebDavApplicationCredentialService service =
+                rejectingService();
+        WebDavApplicationCredentialFilter filter =
+                filter(service, new AtomicLong(), 1);
+
+        fail(
+                filter,
+                "203.0.113.60",
+                "tracked",
+                WebDavApplicationCredentialFilter.MAX_FAILURES);
+        fail(
+                filter,
+                "203.0.113.61",
+                "overflow-one",
+                WebDavApplicationCredentialFilter.MAX_FAILURES);
+
+        MockHttpServletResponse otherOverflow = execute(
+                filter,
+                request(
+                        "GET",
+                        "203.0.113.62",
+                        "overflow-two",
+                        TOKEN));
+        MockHttpServletResponse tracked = execute(
+                filter,
+                request(
+                        "GET",
+                        "203.0.113.60",
+                        "tracked",
+                        TOKEN));
+
+        assertThat(otherOverflow.getStatus()).isEqualTo(429);
+        assertThat(tracked.getStatus()).isEqualTo(429);
+        assertThat(filter.trackedFailureKeyCount()).isEqualTo(1);
+        assertThat(filter.overflowFailureCount())
+                .isEqualTo(
+                        WebDavApplicationCredentialFilter.MAX_FAILURES);
+    }
+
+    private static void fail(
+            WebDavApplicationCredentialFilter filter,
+            String peer,
+            String username,
+            int count) throws Exception {
+        for (int attempt = 0; attempt < count; attempt++) {
+            assertThat(execute(
+                    filter,
+                    request("GET", peer, username, TOKEN))
+                    .getStatus()).isEqualTo(401);
+        }
+    }
+
+    private static WebDavApplicationCredentialService rejectingService() {
+        WebDavApplicationCredentialService service =
+                mock(WebDavApplicationCredentialService.class);
+        when(service.authenticate(anyString(), anyString()))
+                .thenReturn(Optional.empty());
+        return service;
     }
 
     private static WebDavApplicationCredentialFilter filter(
             WebDavApplicationCredentialService service) {
-        return new WebDavApplicationCredentialFilter(
+        return filter(
                 service,
-                Clock.fixed(Instant.parse("2026-08-23T00:00:00Z"), ZoneOffset.UTC));
+                new AtomicLong(),
+                WebDavApplicationCredentialFilter
+                        .DEFAULT_MAX_TRACKED_FAILURE_KEYS);
+    }
+
+    private static WebDavApplicationCredentialFilter filter(
+            WebDavApplicationCredentialService service,
+            AtomicLong now,
+            int capacity) {
+        return new WebDavApplicationCredentialFilter(
+                service, now::get, capacity);
+    }
+
+    private static MockHttpServletResponse execute(
+            WebDavApplicationCredentialFilter filter,
+            MockHttpServletRequest request) throws Exception {
+        MockHttpServletResponse response =
+                new MockHttpServletResponse();
+        filter.doFilter(request, response, (req, res) -> { });
+        return response;
     }
 
     private static MockHttpServletRequest request(String method) {
-        MockHttpServletRequest request = new MockHttpServletRequest(
-                method, "/dav/templates/report.dotx");
+        MockHttpServletRequest request =
+                new MockHttpServletRequest(
+                        method, "/dav/templates/report.dotx");
         request.setRequestURI("/dav/templates/report.dotx");
+        request.setRemoteAddr("203.0.113.1");
         return request;
     }
 
+    private static MockHttpServletRequest request(
+            String method,
+            String peer,
+            String username,
+            String password) {
+        MockHttpServletRequest request = request(method);
+        request.setRemoteAddr(peer);
+        request.addHeader(
+                HttpHeaders.AUTHORIZATION,
+                basic(username, password));
+        return request;
+    }
+
+    private static MockHttpServletRequest requestWithAuthorization(
+            String authorization) {
+        MockHttpServletRequest request = request("GET");
+        request.addHeader(HttpHeaders.AUTHORIZATION, authorization);
+        return request;
+    }
+
+    private static String oversizedDecodedAuthorization() {
+        byte[] decoded = new byte[
+                WebDavApplicationCredentialFilter
+                        .MAX_DECODED_CREDENTIAL_BYTES + 1];
+        return "Basic "
+                + Base64.getEncoder().encodeToString(decoded);
+    }
+
     private static WebDavApplicationCredentialService.CredentialPrincipal principal(
+            String username,
             boolean write) {
         List<SimpleGrantedAuthority> authorities = write
-                ? List.of(new SimpleGrantedAuthority("ROLE_ADMIN"),
+                ? List.of(
+                    new SimpleGrantedAuthority("ROLE_ADMIN"),
                     new SimpleGrantedAuthority("SCOPE_template:read"),
                     new SimpleGrantedAuthority("SCOPE_template:write"))
-                : List.of(new SimpleGrantedAuthority("ROLE_USER"),
+                : List.of(
+                    new SimpleGrantedAuthority("ROLE_USER"),
                     new SimpleGrantedAuthority("SCOPE_template:read"));
         return new WebDavApplicationCredentialService.CredentialPrincipal(
-                "a".repeat(24), "admin", true, write, List.copyOf(authorities));
+                "a".repeat(24),
+                username,
+                true,
+                write,
+                List.copyOf(authorities));
+    }
+
+    private static String token(String id, char secretCharacter) {
+        return "taxdav_"
+                + id
+                + "_"
+                + String.valueOf(secretCharacter).repeat(39);
     }
 
     private static String basic(String username, String password) {
-        return "Basic " + Base64.getEncoder().encodeToString(
-                (username + ":" + password).getBytes(StandardCharsets.UTF_8));
+        return "Basic "
+                + Base64.getEncoder().encodeToString(
+                        (username + ":" + password)
+                                .getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## Problem

`WebDavApplicationCredentialFilter` retained unauthenticated failure state in an unbounded-by-concurrency map and erased every active lockout with `failures.clear()` when the nominal capacity remained full. It also decoded unbounded Basic credentials and forwarded every `taxdav_` prefix candidate to the credential service, including values outside the productive 71-character token format.

Closes #891. Built directly after merged #894 / #889.

## Input and authentication boundary

- rejects Basic Authorization headers above 4,096 characters before Base64 decoding;
- rejects decoded credential payloads above 2,048 bytes;
- decodes UTF-8 strictly and rejects malformed input;
- bounds supplied usernames and passwords to 255 Unicode code points;
- centralizes and enforces the exact productive 71-character `taxdav_` token syntax before `WebDavApplicationCredentialService.authenticate`;
- sends malformed or oversized application-token candidates through the same input-independent 401 Basic challenge without calling the credential service or BCrypt;
- preserves ordinary local-account HTTP Basic fall-through when the password is not an application-token candidate;
- continues to rely only on the framework-resolved `getRemoteAddr()` value and never parses forwarding headers itself.

## Bounded fail-closed state

- stores only a fixed-size SHA-256 digest of the resolved peer and NFKC/lower-case normalized supplied username;
- uses monotonic time and a sliding one-minute failure window;
- serializes cleanup, admission and overflow selection under one state boundary;
- hard-caps the regular table at 10,000 keys per application instance, including concurrent identity floods;
- expires inactive keys globally;
- replaces `failures.clear()` with one shared fail-closed overflow tracker;
- keeps existing regular-key lockouts intact when overflow identities arrive;
- clears only the successful identity's regular entry and never resets the shared overflow budget on one successful authentication.

## HTTP and authorization contract

After ten failures, the next attempt receives explicit UTF-8 JSON with HTTP 429, `Retry-After`, and `Cache-Control: no-store`. The body contains only a generic error code, status, and remaining seconds; it never echoes peer addresses, usernames or secrets. The filter does not log Basic Authorization headers or their credential contents. Existing 401 Basic challenges and read/write scope enforcement are unchanged.

## Regression coverage

Focused tests prove:

- exact 71-character production-format credentials reach the service under `/taxonomy`;
- oversized raw/decoded input, invalid UTF-8, overlong username/password values and malformed `taxdav_` candidates do not reach the credential service;
- forwarded-header variation cannot evade a lock on the framework-resolved peer;
- ten failures create a sanitized JSON 429;
- a successful authentication clears only its own tracked identity;
- inactive entries expire through a deterministic monotonic test clock;
- 64 concurrent identities cannot exceed a configured hard capacity of eight;
- overflow identities share a fail-closed budget without erasing a separately tracked lockout;
- ordinary local Basic authentication and read-only/write scope behavior remain intact.

English and German Word-template operations documentation describe the exact token, bounded state, trusted-ingress, log-hygiene and HTTP 429 contracts.

## Exact scope

- first parent and merge base: `945365268bcef60b9401b528f99bfd3a98233a60` (merged #894);
- exact current head: `d43abc3318a457d859e2a8e2d6510ebde9837ddd`;
- three branch commits, all zero commits behind `main`;
- exactly five changed paths;
- squash merge required so `main` receives one focused commit;
- no workflow, release request, dependency, database schema, security-chain placement or Keycloak behavior change.

The extra two branch commits are documentation-only pushes used to exercise the normal PR synchronization path after GitHub-App Git-data writes did not enqueue repository workflows. They introduce no additional changed path.

For isolated reproduction, the immutable base source is available as the [exact GitHub source archive](https://github.com/carstenartur/Taxonomy/archive/945365268bcef60b9401b528f99bfd3a98233a60.zip). Only checks and local verification performed against the exact head above are authoritative.