### PR TITLE
Request the final non-publishing Taxonomy 1.4.0 dry run

### DIFF
--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -4,6 +4,6 @@
   "skip_tests": false,
   "dry_run": true,
   "resume_staged_release": false,
-  "request_revision": 8,
-  "requested_after_commit": "b4f2847f0d940803c4d666b5986197362ee04e78"
+  "request_revision": 9,
+  "requested_after_commit": "7c7da4d7e35c49c8b1038941e5eba870557a8884"
 }


### PR DESCRIPTION
## Purpose

Request the final **non-publishing** Taxonomy 1.4.0 dry run from the exact reviewed release-notes candidate.

Tracked by #711.

## Request contract

- `release_version`: `1.4.0`;
- `next_development_version`: `1.4.1-SNAPSHOT`;
- `skip_tests`: `false`;
- `dry_run`: `true`;
- `resume_staged_release`: `false`;
- `request_revision`: `9`, exactly one above the integrated revision `8`;
- `requested_after_commit`: `7c7da4d7e35c49c8b1038941e5eba870557a8884`, the exact first parent and current reviewed `main` candidate.

## Required outcome

Merging this PR must trigger the normal release workflow, execute the full release build and tests, and leave all remote publication state unchanged:

- no `v1.4.0` tag;
- no Taxonomy 1.4.0 GitHub Release;
- no immutable 1.4.0 OCI publication;
- no production deployment hook;
- `main` remains `1.4.0-SNAPSHOT`.

A successful dry run is evidence only for the subsequent, separately reviewed `dry_run: false` request. It is not a release.

## Exact scope

- first parent and merge base: `7c7da4d7e35c49c8b1038941e5eba870557a8884`;
- exact head: `18fcb8bbafe21e10c1652a1b5483c174d00f7418`;
- exactly one commit;
- zero commits behind `main`;
- exactly one changed path: `.github/release-request.json`;
- no release notes, source, dependency, workflow, deployment, version, tag, or publication change.

Keep this PR in Draft until the exact-head PR matrix is green and the parent `main` CI/CD push run has succeeded. Merge only with the exact head SHA above. After the release workflow completes, explicitly verify the negative publication conditions before preparing the publishing request.