### PR TITLE
Isolate release-plan linked-worktree test from global /tmp state

### DIFF
--- a/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
+++ b/taxonomy-tooling/src/test/java/com/taxonomy/tooling/ReleasePlanValidatorTest.java
@@ -247,8 +247,11 @@ class ReleasePlanValidatorTest {
     }
 
     @Test
-    void enforcesCleanOrdinaryAndLinkedWorktreeCheckouts(@TempDir Path root)
-            throws Exception {
+    void enforcesCleanOrdinaryAndLinkedWorktreeCheckouts(
+            @TempDir Path temporaryDirectory) throws Exception {
+        // Both checkouts stay below the invocation-specific TempDir. Its parent
+        // may be the shared system /tmp directory and must never own test state.
+        Path root = temporaryDirectory.resolve("repository");
         writeProject(root, "1.3.0-SNAPSHOT", "1.0.0", List.of("module-a"), "", "");
         commitProject(root);
         assertThat(ReleasePlanValidator.validate(
@@ -262,7 +265,7 @@ class ReleasePlanValidatorTest {
                 .hasMessageContaining("clean checkout");
 
         Files.delete(root.resolve("untracked.txt"));
-        Path worktree = root.getParent().resolve("linked-worktree");
+        Path worktree = temporaryDirectory.resolve("linked-worktree");
         TestGit.run(root, "worktree", "add", "-q", "-b", "qa-worktree",
                 worktree.toString());
         Files.writeString(worktree.resolve("untracked.txt"), "dirty");


### PR DESCRIPTION
## Problem

The final non-publishing 1.4.0 dry run triggered by #904 failed in `ReleasePlanValidatorTest.enforcesCleanOrdinaryAndLinkedWorktreeCheckouts` although the same test had passed in the ordinary PR matrix.

The test received a JUnit `@TempDir` as its repository root, then derived the linked worktree with `root.getParent().resolve("linked-worktree")`. On Linux the parent is the shared `/tmp` directory, so every test invocation used the global path `/tmp/linked-worktree`. The release-state test rerun encountered a leftover directory and `git worktree add` exited 128 before the release suite could continue.

Tracks #711.

## Fix

- Use the JUnit-provided directory as a unique container for the test.
- Create the ordinary repository at `temporaryDirectory/repository`.
- Create the linked worktree at `temporaryDirectory/linked-worktree`.
- Preserve the intended contract: the linked worktree remains outside the repository while both locations are unique per invocation and automatically cleaned by JUnit.
- Document why the parent of `@TempDir` must never own test state.

## Review

Copilot reviewed the complete one-file change and recommended approval with no inline findings.

## Exact scope

- first parent and merge base: `8549cdc9ba22a66689cb1c3594c31957bdf38924` (merged non-publishing request #904);
- exact head: `fa3a654a7db6e3b38aec7a798af82761abde72d1`;
- exactly one commit;
- zero commits behind `main`;
- exactly one changed test file;
- no product source, release request, release notes, workflow, dependency, version, tag, image or publication change.

## Follow-up sequence

After merge, the complete `main` matrix is authoritative. The next request must be **revision 10 with `dry_run: true`**, anchored to the repaired `main`. A publication request is not permitted until that replacement dry run succeeds and again proves that no tag, release, OCI artifact or deployment was created.